### PR TITLE
Fix session-start hook execution in plugin context

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 export SUPERPOWERS_SKILLS_ROOT="${HOME}/.config/superpowers/skills"
 
 # Run skills initialization script (handles clone/fetch/auto-update)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 init_output=$("${PLUGIN_ROOT}/lib/initialize-skills.sh" 2>&1 || echo "")
 
@@ -15,7 +15,7 @@ init_output=$("${PLUGIN_ROOT}/lib/initialize-skills.sh" 2>&1 || echo "")
 skills_updated=$(echo "$init_output" | grep "SKILLS_UPDATED=true" || echo "")
 skills_behind=$(echo "$init_output" | grep "SKILLS_BEHIND=true" || echo "")
 # Remove status flags from display output
-init_output=$(echo "$init_output" | grep -v "SKILLS_UPDATED=true" | grep -v "SKILLS_BEHIND=true")
+init_output=$(echo "$init_output" | grep -v "SKILLS_UPDATED=true" | grep -v "SKILLS_BEHIND=true" || true)
 
 # Run find-skills to show all available skills
 find_skills_output=$("${SUPERPOWERS_SKILLS_ROOT}/skills/using-skills/find-skills" 2>&1 || echo "Error running find-skills")


### PR DESCRIPTION
## Problem
The `session-start.sh` hook fails silently when executed by Claude Code with error "⏺ Plugin hook error:" preventing skills context from loading.

## Root Cause
1. `BASH_SOURCE[0]` is unbound in Claude Code's execution context (fails with `set -u`)
2. Empty `grep` results return exit code 1 (fails with `set -e`)

## Solution
1. Use `${BASH_SOURCE[0]:-$0}` to fallback to `$0` when `BASH_SOURCE` unavailable  
2. Add `|| true` to handle empty grep results gracefully

## Testing
✅ Direct execution produces valid JSON  
✅ Claude Code plugin execution now works  
✅ No breaking changes to existing functionality

## Changes
- `hooks/session-start.sh`: 2 lines changed
  - Line 10: Add `${BASH_SOURCE[0]:-$0}` fallback
  - Line 18: Add `|| true` for empty grep results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured reliable startup by correctly resolving the script location across environments, even when path variables are unset.
  * Prevented errors during initialization when clearing update/status flags that may not exist, allowing sessions to proceed smoothly.

* **Chores**
  * Hardened session initialization for improved robustness and resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->