### PR TITLE
docs: add one-command installation option via Claude Plugins CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,15 @@ Read the introduction: [Superpowers for Claude Code](https://blog.fsck.com/2025/
 /plugin marketplace add obra/superpowers-marketplace
 /plugin install superpowers@superpowers-marketplace
 ```
-
 The plugin automatically handles skills repository setup on first run.
+
+### Via One-Command Installation 
+Use the [Claude Plugins CLI](https://claude-plugins.dev) to skip the marketplace setup:
+```bash
+npx claude-plugins install @obra/superpowers-marketplace/superpowers
+```
+
+This automatically adds the marketplace and installs the plugin in a single step.
 
 ### Verify Installation
 


### PR DESCRIPTION
## Changes
- Added "One-Command Installation" section to Quick Start
- Preserves existing installation instructions as the primary method
- Links to Claude Plugins CLI documentation

## Rationale

The standard Claude Code workflow requires users to:
1. Add marketplace: `/plugin marketplace add obra/superpowers-marketplace`
2. Install plugin: `/plugin install superpowers@superpowers-marketplace`

This CLI tool automates both steps:
```bash
npx claude-plugins install @obra/superpowers-marketplace/superpowers
```

Benefits:
- Reduces friction for first-time users
- Simplifies one-off installations
- Cleaner for documentation examples

## Notes
- CLI is open-source and maintained at https://github.com/Kamalnrf/claude-plugins
- No changes to plugin functionality or dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a One-Command Installation option that installs and configures the marketplace plugin in a single step via CLI.
  * Provided a clear code example for the new flow and improved installation guidance.
  * Clarified that skills repository setup is handled automatically during installation.
  * Retained the existing marketplace-based installation as an alternative, noting when to use each.
  * No changes to runtime behavior; this update simplifies setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->