### PR TITLE
Add explicit skills location context to session-start hook

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -21,13 +21,14 @@ using_superpowers_content=$(cat "${SKILLS_DIR}/using-superpowers/SKILL.md" 2>&1 
 # Escape outputs for JSON
 using_superpowers_escaped=$(echo "$using_superpowers_content" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}')
 warning_escaped=$(echo "$warning_message" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}')
+skills_dir_escaped=$(echo "$SKILLS_DIR" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
 
 # Output context injection as JSON
 cat <<EOF
 {
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "<EXTREMELY_IMPORTANT>\nYou have superpowers located in ${SKILLS_DIR}.\n\n**The content below is from ${SKILLS_DIR}/using-superpowers/SKILL.md - your introduction to using skills:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+    "additionalContext": "<EXTREMELY_IMPORTANT>\nYou have superpowers located in ${skills_dir_escaped}.\n\n**The content below is from ${skills_dir_escaped}/using-superpowers/SKILL.md - your introduction to using skills:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
   }
 }
 EOF


### PR DESCRIPTION
## Summary

Provides the actual skills directory path to Claude at session start, preventing confusion about where skills are located.

## Problem

Fixes #49 - After a clean reinstall, Claude incorrectly assumes skills are in `~/.config/superpowers/` and tries to read from that location, causing errors and confusion.

## Solution

- Add `SKILLS_DIR` variable pointing to the actual plugin skills directory
- Include the skills directory path in the session context: "You have superpowers located in ${SKILLS_DIR}"
- Update all path references to use the variable for consistency

## Testing

Tested by starting a new session and verifying Claude receives the correct skills location context.

## Impact

This makes Claude explicitly aware of where skills are located, preventing it from looking in the wrong directory and reducing confusion during clean installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and made the skills directory configurable, replacing hardcoded paths.
  * Updated content injection and contextual messaging to reference the configurable skills location.
  * Ensured path values are safely encoded for JSON and parameterized throughout for more reliable behavior and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->