### PR TITLE
Add GitHub response placement guidance to receiving-code-review

### DIFF
--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -97,6 +97,47 @@ IF reviewer suggests "implementing properly":
 
 **your human partner's rule:** "You and reviewer both report to me. If we don't need this feature, don't add it."
 
+## Posting Responses on GitHub
+
+```
+WHEN responding to code review feedback on GitHub:
+
+IF feedback is from a specific review comment thread:
+  ✅ Reply IN that thread
+  ❌ NEVER post as top-level PR comment
+
+IF addressing general PR discussion (not tied to specific code):
+  ✅ Post as top-level comment
+```
+
+### Replying to Review Comment Threads
+
+**To reply to a review comment thread:**
+
+```bash
+# Get the comment ID from the review comment URL
+# Example: github.com/.../pull/268#discussion_r1234567890
+# The comment ID is: 1234567890
+
+gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
+  -f body="Your response here"
+```
+
+**Why threaded replies matter:**
+- Maintains conversation context
+- Shows resolution status in GitHub UI
+- Easier for reviewers to track discussions
+- Keeps PR timeline clean
+
+**Common mistake:**
+```bash
+# ❌ WRONG - creates top-level comment
+gh pr comment 268 -b "Response to threaded review feedback"
+
+# ✅ RIGHT - replies in thread
+gh api repos/owner/repo/pulls/268/comments/123/replies -f body="Response"
+```
+
 ## Implementation Order
 
 ```


### PR DESCRIPTION
## Summary

The receiving-code-review skill previously lacked guidance on WHERE to post responses on GitHub, leading to agents posting top-level PR comments when they should reply in specific review comment threads.

## Changes

- Decision tree for threaded vs. top-level comments
- Correct `gh api` command for threaded replies  
- Common mistakes section showing wrong approach
- Test scenario documenting expected behavior

## Real-world failure case

PR konflux-ci/architecture#268 comment #3472979081 where an agent using this skill posted to the top-level PR instead of replying in the review thread.

## Test plan

- [ ] Review the new "Posting Responses on GitHub" section
- [ ] Verify the API endpoint is correct: `/repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies`
- [ ] Test scenario provided in TEST-SCENARIO.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on posting responses to GitHub code reviews, distinguishing between threaded comment replies and general PR discussions.
  * Included practical command examples, common mistakes, and best practices for structuring effective responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->