### PR TITLE
Use more generic "#!/usr/bin/env bash" instead of "#!/bin/bash"

### DIFF
--- a/skills/root-cause-tracing/find-polluter.sh
+++ b/skills/root-cause-tracing/find-polluter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Bisection script to find which test creates unwanted files/state
 # Usage: ./find-polluter.sh <file_or_dir_to_check> <test_pattern>
 # Example: ./find-polluter.sh '.git' 'src/**/*.test.ts'


### PR DESCRIPTION
"#!/bin/bash" does not work with nixos.

## Motivation and Context
"#!/bin/bash" does not work with nixos.

## How Has This Been Tested?
I ran the changed script.

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated script compatibility for improved system portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->