### PR TITLE
Base worktrees on main branch and support background setup

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -85,7 +85,7 @@ project=$(basename "$(git rev-parse --show-toplevel)")
 
 **CRITICAL: Always base worktrees off the main branch unless explicitly stated otherwise.**
 
-By default, `git worktree add` bases the new branch on whatever is currently checked out. This is almost never what you want when on a feature branch!
+By default, `git worktree add` bases the new branch on whatever is currently checked out. This is rarely what you want when on a feature branch!
 
 ```bash
 # Detect the repository's main branch


### PR DESCRIPTION
## Changes

- Always base new worktrees on main/master branch by default (auto-detects which)
- Document background setup optimization for long-running deps/compile
- Add Elixir project support

## Problem

Without specifying a base branch, `git worktree add` inherits the current branch. When on a feature branch, new worktrees are incorrectly based on that feature branch instead of main.

## Solution

Detect repository's main branch automatically and use it as base. Allow user override when explicitly specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Git worktrees guide with explicit base-branch detection and configurable override (defaults to origin/main or origin/master)
  * Reordered flow: detect base branch, create worktree, run project setup; added baseline verification and location reporting
  * Added multi-ecosystem project setup (Node, Rust, Python, Go, Elixir) and background-setup optimization examples
  * Expanded examples, quick-reference table, red flags, common mistakes, and an end-to-end example workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->