### PR TITLE
fix: add Windows compatibility for SessionStart hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.js\""
           }
         ]
       }

--- a/hooks/session-start.js
+++ b/hooks/session-start.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// SessionStart hook for superpowers plugin
+// Cross-platform Node.js implementation (works on Windows, macOS, Linux)
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Determine plugin root directory
+const SCRIPT_DIR = __dirname;
+const PLUGIN_ROOT = path.dirname(SCRIPT_DIR);
+
+// Check if legacy skills directory exists and build warning
+let warningMessage = '';
+const legacySkillsDir = path.join(os.homedir(), '.config', 'superpowers', 'skills');
+if (fs.existsSync(legacySkillsDir)) {
+    warningMessage = '\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER:⚠️ **WARNING:** Superpowers now uses Claude Code\'s skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>';
+}
+
+// Read using-superpowers content
+let usingSuperPowersContent;
+const skillPath = path.join(PLUGIN_ROOT, 'skills', 'using-superpowers', 'SKILL.md');
+try {
+    usingSuperPowersContent = fs.readFileSync(skillPath, 'utf8');
+} catch (err) {
+    usingSuperPowersContent = `Error reading using-superpowers skill: ${err.message}`;
+}
+
+// Build the output JSON
+const output = {
+    hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: `<EXTREMELY_IMPORTANT>
+You have superpowers.
+
+**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**
+
+${usingSuperPowersContent}
+${warningMessage}
+</EXTREMELY_IMPORTANT>`
+    }
+};
+
+// Output as JSON
+console.log(JSON.stringify(output, null, 2));


### PR DESCRIPTION
## Summary

- Adds cross-platform Node.js implementation of `session-start` hook
- Fixes Windows path handling issue where backslashes were being stripped
- Node.js is guaranteed available since Claude Code runs on Node.js

## Problem

On Windows, the bash-based `session-start.sh` hook fails with:
```
/bin/bash:C:Usersdan.claudepluginscachesuperpowers/hooks/session-start.sh: No such file or directory
```

**Root cause:** `${CLAUDE_PLUGIN_ROOT}` expands to Windows paths with backslashes (e.g., `C:\Users\dan\...`). When passed through shell command parsing, backslashes are interpreted as escape characters and stripped, resulting in malformed paths like `C:Usersdan...`.

## Solution

Added `session-start.js` - a Node.js implementation that:
- Uses `path.join()` for proper cross-platform path handling
- Has identical functionality to the bash version
- Properly reads SKILL.md and checks for legacy skills directory
- Outputs the same JSON structure for hook injection

## Test plan

- [x] Tested on Windows with Git Bash environment
- [x] Hook executes without errors
- [x] Skill context properly injected at session start
- [x] Verified skills are accessible after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session initialization now displays relevant skill documentation and contextual guidance upon startup.

* **Chores**
  * Updated internal hook execution mechanism for improved performance.
  * Added legacy configuration detection and notification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->