### PR TITLE
feat: add conventional commits support to finishing-a-development-branch

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -92,10 +92,21 @@ Then: Cleanup worktree (Step 5)
 # Push branch
 git push -u origin <feature-branch>
 
-# Create PR
-gh pr create --title "<title>" --body "$(cat <<'EOF'
+# Create PR with conventional commit title
+gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
 ## Summary
 <2-3 bullets of what changed>
+
+## Change Type
+<!-- Check ONE that applies -->
+- [ ] `fix:` - Bug fix (PATCH: x.x.X)
+- [ ] `feat:` - New feature (MINOR: x.X.0)
+- [ ] `feat!:` or `fix!:` or `BREAKING CHANGE:` - Breaking change (MAJOR: X.0.0)
+- [ ] `docs:` / `chore:` / `refactor:` / `test:` - No version change
+
+## Breaking Changes
+<!-- If this is a breaking change, describe what breaks and migration path -->
+N/A
 
 ## Test Plan
 - [ ] <verification steps>
@@ -157,6 +168,25 @@ git worktree remove <worktree-path>
 | 2. Create PR | - | ✓ | ✓ | - |
 | 3. Keep as-is | - | - | ✓ | - |
 | 4. Discard | - | - | - | ✓ (force) |
+
+## Conventional Commits for PR Titles
+
+Use conventional commit format for PR titles to enable automated versioning:
+
+| Prefix | When to Use | Version Impact |
+|--------|-------------|----------------|
+| `fix:` | Bug fixes | PATCH (x.x.X) |
+| `feat:` | New features | MINOR (x.X.0) |
+| `feat!:` / `fix!:` | Breaking changes | MAJOR (X.0.0) |
+| `docs:` | Documentation only | None |
+| `chore:` | Build, deps, config | None |
+| `refactor:` | Code restructure | None |
+| `test:` | Adding/fixing tests | None |
+
+**Examples:**
+- `fix: resolve crash when user cancels purchase`
+- `feat: add export to PDF functionality`
+- `feat!: change API response format for /users endpoint`
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Summary
- Updated PR template in `finishing-a-development-branch` skill to use conventional commit title format
- Added Change Type checklist showing semantic versioning impact (PATCH/MINOR/MAJOR)
- Added Breaking Changes section for explicit documentation of breaking changes
- Added quick reference table for conventional commit prefixes with examples

Closes #135

## Change Type
- [x] `feat:` - New feature (MINOR: x.X.0)

## Breaking Changes
N/A - This is an additive enhancement to the existing skill.

## Test Plan
- [x] Verified skill file syntax is correct
- [x] Confirmed conventional commit examples are accurate per [Conventional Commits spec](https://www.conventionalcommits.org/)
- [x] Verified semantic versioning mappings match standard-version/semantic-release behavior

## Context
This enhancement addresses the feature request in #135 to help guide contributors toward proper conventional commit conventions without requiring project-specific PR templates. The changes integrate well with automated tools like `standard-version` and `semantic-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR creation guidance to require conventional commit titles using the format `<type>: <description>`.
  * Added comprehensive guidance section on conventional commits for PR titles, including prefix usage (fix, feat, feat!, fix!), version impact details, and practical examples.
  * Updated Quick Reference section with standardized examples for consistent PR formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->