### PR TITLE
fix: properly inherit agent model from main

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: |
   Use this agent when a major project step has been completed and needs to be reviewed against the original plan and coding standards. Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the code-reviewer agent should review the work.</commentary></example>
+model: inherit
 ---
 
 You are a Senior Code Reviewer with expertise in software architecture, design patterns, and best practices. Your role is to review completed project steps against original plans and ensure code quality standards are met.


### PR DESCRIPTION
#120 removed model name from subagent which made it to default to sonnet instead of a model from global user settings. According to the [docs](https://code.claude.com/docs/en/sub-agents), to properly inherit model from the main conversation, subagent model should be specified as `inherit`.

## Motivation and Context
Discussed in the #120.

## How Has This Been Tested?
<img width="1034" height="207" alt="image" src="https://github.com/user-attachments/assets/88e1cbc0-bab7-47af-b5d4-b8a0a043d5b9" />

<img width="1241" height="167" alt="image" src="https://github.com/user-attachments/assets/8a0dd5ee-543f-4b19-a5cf-3db07ed19478" />

## Breaking Changes
No.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded code-review agent guidance into a comprehensive implementation plan: multi-section guidelines covering plan alignment analysis, code quality assessment, architecture and design review, documentation and standards, issue identification with recommendations, and communication protocol. Retains original problem description while detailing the expected evaluation workflow and output structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->