### PR TITLE
fix: correct context window documentation link

### DIFF
--- a/skills/writing-skills/anthropic-best-practices.md
+++ b/skills/writing-skills/anthropic-best-practices.md
@@ -10,7 +10,7 @@ For conceptual background on how Skills work, see the [Skills overview](/en/docs
 
 ### Concise is key
 
-The [context window](/en/docs/build-with-claude/context-windows) is a public good. Your Skill shares the context window with everything else Claude needs to know, including:
+The [context window](https://platform.claude.com/docs/en/build-with-claude/context-windows) is a public good. Your Skill shares the context window with everything else Claude needs to know, including:
 
 * The system prompt
 * Conversation history


### PR DESCRIPTION
  ## Motivation and Context
  The context window documentation link in `skills/writing-skills/anthropic-best-practices.md` was using a relative path
  (`/en/docs/build-with-claude/context-windows`) which doesn't resolve correctly since it points to external Anthropic documentation, not a file within this
  repository. Changed to the absolute URL to ensure the link works properly.

  ## How Has This Been Tested?
  Verified the new URL (`https://platform.claude.com/docs/en/build-with-claude/context-windows`) resolves to the correct Anthropic documentation page.

  ## Breaking Changes
  None. This is a documentation-only change.

  ## Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update

  ## Checklist
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [x] I have added appropriate error handling
  - [x] I have added or updated documentation as needed

  ## Additional context
  Single-line change fixing a broken link in the skills documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference links in best practices guide for improved accessibility.
  * Expanded context window documentation to include additional information items, providing more comprehensive guidance on token considerations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->