### PR TITLE
fix: use git check-ignore for worktree gitignore verification

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -155,19 +155,23 @@ Ready to implement <feature-name>
 
 ## Common Mistakes
 
-**Skipping ignore verification**
+### Skipping ignore verification
+
 - **Problem:** Worktree contents get tracked, pollute git status
 - **Fix:** Always use `git check-ignore` before creating project-local worktree
 
-**Assuming directory location**
+### Assuming directory location
+
 - **Problem:** Creates inconsistency, violates project conventions
 - **Fix:** Follow priority: existing > CLAUDE.md > ask
 
-**Proceeding with failing tests**
+### Proceeding with failing tests
+
 - **Problem:** Can't distinguish new bugs from pre-existing issues
 - **Fix:** Report failures, get explicit permission to proceed
 
-**Hardcoding setup commands**
+### Hardcoding setup commands
+
 - **Problem:** Breaks on projects using different tools
 - **Fix:** Auto-detect from project files (package.json, etc.)
 


### PR DESCRIPTION
## Summary

Fixes #101

The `using-git-worktrees` skill previously used `grep` to check only the local `.gitignore` file, missing patterns in global gitignore configurations (`core.excludesfile`). This caused unnecessary modifications to local `.gitignore` when the directory was already globally ignored.

Changed verification from `grep` to `git check-ignore`, which respects Git's full ignore hierarchy (local, global, and system gitignore files).

## Changes

- Safety Verification command: `grep` → `git check-ignore -q`
- Updated Quick Reference table, Common Mistakes, Example Workflow, Red Flags, and Always sections for consistency

## Testing

Followed TDD process per the writing-skills skill:
- **RED:** Baseline test with subagent showed agent would incorrectly conclude directory NOT ignored when using global gitignore, then unnecessarily modify local `.gitignore`
- **GREEN:** After fix, agent correctly uses `git check-ignore` and recognizes globally-ignored directories
- **REFACTOR:** Verified fix works correctly - agent no longer attempts to modify `.gitignore` when directory is already globally ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Git worktrees guide to emphasize verifying that directories are ignored (rather than merely listed in .gitignore) before creating worktrees.
  * Guidance and examples now recommend confirming ignore status using the appropriate check command and use "ignored"/"not ignored" phrasing throughout.
  * Minor wording and formatting tweaks to align quick-reference, examples, and red-flag guidance with the new verification approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->