### PR TITLE
docs(writing-plans): add explicit TDD sub-skill requirements

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -17,6 +17,18 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
 
+## Required Sub-Skills
+
+Plans follow strict TDD. Before executing any task from a plan:
+
+- **REQUIRED:** `superpowers:test-driven-development` - Every task uses RED-GREEN-REFACTOR. If you haven't read this skill, read it first. It covers:
+  - The Iron Law: no production code without a failing test first
+  - How to verify tests fail for the right reason
+  - Common rationalizations and red flags
+  - When to delete code and start over
+
+- **REQUIRED:** `superpowers:testing-anti-patterns` - Prevents testing mock behavior instead of real code
+
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**


### PR DESCRIPTION
## Summary

The `writing-plans` skill mentions TDD in the overview but doesn't explicitly reference the `test-driven-development` skill. This creates a gap where engineers executing plans might:

- Follow RED-GREEN-REFACTOR steps mechanically without understanding the "why"
- Not know about the Iron Law ("no production code without a failing test first")
- Miss the common rationalizations and red flags that indicate TDD is being skipped

## Changes

Added a **"Required Sub-Skills"** section after the overview that:

- Makes the dependency on `superpowers:test-driven-development` explicit
- Lists what the TDD skill covers (Iron Law, verification, rationalizations, red flags)
- Includes `superpowers:testing-anti-patterns` to prevent testing mock behavior

## Before

```markdown
**Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`

## Bite-Sized Task Granularity
```

## After

```markdown
**Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`

## Required Sub-Skills

Plans follow strict TDD. Before executing any task from a plan:

- **REQUIRED:** `superpowers:test-driven-development` - Every task uses RED-GREEN-REFACTOR...
- **REQUIRED:** `superpowers:testing-anti-patterns` - Prevents testing mock behavior...

## Bite-Sized Task Granularity
```

## Testing

Validated that the change makes the skill dependencies explicit and guides engineers to read the TDD skill before executing plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated writing-plans skill documentation with a new Required Sub-Skills section specifying test-driven development and testing anti-patterns expectations, including detailed guidance and bite-sized task references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->