### PR TITLE
Add principles of phase design to writing-plans skill

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -17,6 +17,12 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
 
+## Phase Design
+
+**"Something simple working soon."** This is the core principle. Close a working loop of value fast - boilerplate, hello world, a minimal slice - then add concentric layers of functionality.
+
+**Stoppable phases:** Each phase is self-contained. You can pause after any phase and have working software. Avoid patterns like "write all tests at the end" - do hygiene incrementally within each phase.
+
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**


### PR DESCRIPTION
## Motivation and Context

The writing plan skill has good micro instructions, and I think it could benefit from macro principles of planning and execution. Mainly the principle of "something simple working soon" and adding concentric circles of functionality over that.

## How Has This Been Tested?
I've been using these instructions in my own repo for functional prototyping, and it's been something I really appreciate about making the phases less all-or-nothing 

## Breaking Changes
nope

## Types of changes
Improving an existing skill
