### PR TITLE
fix: handle WSL bash as default shell on Windows

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start.sh"
+            "command": "\"$(wslpath -u '${CLAUDE_PLUGIN_ROOT}')/hooks/run-hook.cmd\" session-start.sh || \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Fixes SessionStart hook error when WSL's bash.exe is the default shell on Windows
- Uses `wslpath` to convert Windows paths to WSL format, with fallback for non-WSL environments

## Problem
When WSL's bash.exe is in PATH (either alone or before Git's bash.exe), Claude Code passes Windows-style paths that WSL bash cannot resolve, causing "No such file or directory" errors.

## How to reproduce
- PATH contains only WSL's bash.exe path, OR
- PATH contains both WSL and Git bash.exe paths but WSL comes first

Fixes #275

## Test plan
- [ ] Test on Windows with WSL bash as default shell
- [ ] Test on Windows with Git Bash only
- [ ] Test on native Linux/macOS

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Subsystem for Linux compatibility when running hooks by preferring a WSL-friendly path and automatically falling back to the original path if conversion fails, ensuring more reliable hook execution across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->