### PR TITLE
fix: respect OPENCODE_CONFIG_DIR for personal skills lookup

### DIFF
--- a/.opencode/plugin/superpowers.js
+++ b/.opencode/plugin/superpowers.js
@@ -14,13 +14,29 @@ import * as skillsCore from '../../lib/skills-core.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Normalize a path: trim whitespace, expand ~, resolve to absolute
+const normalizePath = (p, homeDir) => {
+  if (!p || typeof p !== 'string') return null;
+  let normalized = p.trim();
+  if (!normalized) return null;
+  // Expand ~ to home directory
+  if (normalized.startsWith('~/')) {
+    normalized = path.join(homeDir, normalized.slice(2));
+  } else if (normalized === '~') {
+    normalized = homeDir;
+  }
+  // Resolve to absolute path
+  return path.resolve(normalized);
+};
+
 export const SuperpowersPlugin = async ({ client, directory }) => {
   const homeDir = os.homedir();
   const projectSkillsDir = path.join(directory, '.opencode/skills');
   // Derive superpowers skills dir from plugin location (works for both symlinked and local installs)
   const superpowersSkillsDir = path.resolve(__dirname, '../../skills');
   // Respect OPENCODE_CONFIG_DIR if set, otherwise fall back to default
-  const configDir = process.env.OPENCODE_CONFIG_DIR || path.join(homeDir, '.config/opencode');
+  const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
+  const configDir = envConfigDir || path.join(homeDir, '.config/opencode');
   const personalSkillsDir = path.join(configDir, 'skills');
 
   // Helper to generate bootstrap content


### PR DESCRIPTION
## Summary
- Fix personal skills directory to respect `OPENCODE_CONFIG_DIR` environment variable

Fixes #298

## Problem
The plugin hardcodes `~/.config/opencode/skills` for personal skills lookup, ignoring users who set `OPENCODE_CONFIG_DIR` to a custom path (e.g., for dotfiles management).

## Solution
- Use `process.env.OPENCODE_CONFIG_DIR` if set, falling back to the default `~/.config/opencode` path
- Normalize the path: trim whitespace, expand `~`, resolve to absolute
- Update help text to show the actual configured path dynamically

## Testing
Verified that personal skills are now discovered when using a custom `OPENCODE_CONFIG_DIR`.