### PR TITLE
feat(brainstorming): add mandatory API validation step

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -25,6 +25,17 @@ Start by understanding the current project context, then ask questions one at a 
 - Present options conversationally with your recommendation and reasoning
 - Lead with your recommended option and explain why
 
+**Validating external dependencies (MANDATORY when applicable):**
+
+When any approach involves external APIs, OAuth, SDKs, or third-party services:
+1. **Search for deprecation/sunset notices** before recommending:
+   - `"[API name] deprecated [current year] sunset shutdown"`
+   - `"[API name] breaking changes migration"`
+2. **Check official documentation** for deprecation banners, scope changes, auth changes
+3. **Report findings** to user before finalizing the design
+
+Why: Google Photos Library API scopes were deprecated March 2025. 5 minutes of validation saves hours of debugging dead APIs.
+
 **Presenting the design:**
 - Once you believe you understand what you're building, present the design
 - Break it into sections of 200-300 words
@@ -52,3 +63,4 @@ Start by understanding the current project context, then ask questions one at a 
 - **Explore alternatives** - Always propose 2-3 approaches before settling
 - **Incremental validation** - Present design in sections, validate each
 - **Be flexible** - Go back and clarify when something doesn't make sense
+- **Validate external APIs** - Always check for deprecation before recommending third-party services


### PR DESCRIPTION
## Summary

Add a mandatory step to the brainstorming skill that validates external APIs, OAuth scopes, and third-party services for deprecation before recommending them in designs.

## Problem

Without validation, developers can spend hours debugging issues with deprecated APIs. For example:

- **Google Photos Library API**: The `photoslibrary` and `photoslibrary.readonly` scopes were deprecated in March 2025
- A developer following the brainstorming process to design a photo-based app could waste hours debugging OAuth "insufficient scopes" errors, only to discover the API was sunset

## Solution

Add a "Validating external dependencies" step that:
1. Searches for deprecation/sunset notices before recommending any external API
2. Checks official documentation for scope changes, auth changes, or deprecation banners
3. Reports findings to the user before finalizing the design

Also adds "Validate external APIs" to the Key Principles section.

## Changes

- `skills/brainstorming/SKILL.md`: Added validation step and principle

## Why This Matters

**5 minutes of validation saves hours of debugging dead APIs.**

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced brainstorming guidance with a mandatory section on validating external dependencies, including deprecation checks and documentation reviews.
  * Added principle to validate external APIs before recommending third-party services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->