### PR TITLE
feat: add model-selection skill for cost-efficient agent spawning

### DIFF
--- a/skills/model-selection/SKILL.md
+++ b/skills/model-selection/SKILL.md
@@ -13,7 +13,7 @@ description: Use when spawning Task agents or choosing response depth - prevents
 | Variants/drafts | Haiku | Copy options, UI text, boilerplate |
 | Quick lookups | Haiku | File searches, fact Q&A, exploration |
 | Most coding | Sonnet | Features, bug fixes, refactors (<5 files) |
-| High-leverage | Opus | Architecture, security, critical specs |
+| High-leverage | Opus | Architecture, security, critical specs, refactors (5+ files) |
 | After 2 failures | Escalate | Haiku→Sonnet→Opus |
 
 ## Default: Sonnet
@@ -66,11 +66,11 @@ Example Task call with Opus:
 
 **What counts as failure:**
 1. Agent returns error or says it couldn't complete
-2. Output is clearly wrong or low quality
+2. Output is clearly wrong or low-quality
 3. User says result isn't good enough
 
 **Escalation flow:**
-```
+```text
 Attempt 1: Use model per rules above
     ↓ failure
 Attempt 2: Same model, adjust prompt
@@ -120,7 +120,7 @@ User: "Where is error handling done?"
 
 ### Correct: Sonnet for feature work
 User: "Add a logout button"
-→ Default Sonnet (no model param needed, or explicit `model: sonnet`)
+→ Spawn agent with explicit `model: sonnet` - standard feature work
 
 ### Correct: Opus for architecture
 User: "Design the payment processing system"


### PR DESCRIPTION
## Summary

Adds a new skill that guides model selection when spawning Task agents, optimizing for cost efficiency while maintaining quality:

- **Haiku**: bulk/mechanical tasks, file searches, quick lookups, summarizing docs
- **Sonnet**: most coding tasks, features, bug fixes, refactors (<5 files)
- **Opus**: architecture, security-sensitive code, critical specs, complex refactors (5+ files)

## Features

- Quick reference table for fast decision-making
- Escalation rules: Haiku→Sonnet→Opus after 2 failures
- User override handling with cost warnings
- Common mistakes table
- Concrete examples for each model tier

## Testing

Skill was developed and tested using RED-GREEN-REFACTOR methodology per `writing-skills`:

1. **RED (baseline)**: Tested agent behavior without skill - agents made reasonable choices but under pressure ignored model selection entirely
2. **GREEN**: With skill loaded, agents correctly selected appropriate models even when user said "don't care about cost"
3. **REFACTOR**: Fixed description per CSO guidelines, added Common Mistakes section

## Test plan

- [ ] Load skill and spawn Task agents for file searches → should use Haiku
- [ ] Spawn Task agents for standard feature work → should use Sonnet
- [ ] Spawn Task agents for architecture/security work → should use Opus
- [ ] Test user override with warning message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive model-selection guide: task-type recommendations, model-specific guidance and examples, escalation and failure-tracking rules, enforcement vs advisory behaviors, user-override warnings, common pitfalls with fixes, and concrete task-call examples illustrating correct model usage and escalation workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->