### PR TITLE
feat: add configurable plans directory via SUPERPOWERS_PLANS_DIR

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -35,7 +35,7 @@ Start by understanding the current project context, then ask questions one at a 
 ## After the Design
 
 **Documentation:**
-- Write the validated design to `docs/plans/YYYY-MM-DD-<topic>-design.md`
+- Write the validated design to the configured plans location (see superpowers:writing-plans for path logic based on `SUPERPOWERS_PLANS_DIR` env var)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -15,7 +15,14 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill).
 
-**Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
+**Save plans to:** Determine location based on configuration:
+
+1. **Check for `SUPERPOWERS_PLANS_DIR` environment variable**
+2. **If set:** Save to `$SUPERPOWERS_PLANS_DIR/<project-path>/YYYY-MM-DD-<feature-name>.md`
+   - `<project-path>` is derived from the current working directory relative to `~`
+   - Example: Working in `~/code/myorg/webapp` with `SUPERPOWERS_PLANS_DIR=~/Documents/plans` → save to `~/Documents/plans/code/myorg/webapp/YYYY-MM-DD-<feature-name>.md`
+   - **Create the directory if it doesn't exist** before saving
+3. **If not set:** Use default `docs/plans/YYYY-MM-DD-<feature-name>.md` (current behavior)
 
 ## Bite-Sized Task Granularity
 
@@ -98,7 +105,7 @@ git commit -m "feat: add specific feature"
 
 After saving the plan, offer execution choice:
 
-**"Plan complete and saved to `docs/plans/<filename>.md`. Two execution options:**
+**"Plan complete and saved to `<plan-location>/<filename>.md`. Two execution options:**
 
 **1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
 


### PR DESCRIPTION
Fixes #337

Add configurable plans directory via SUPERPOWERS_PLANS_DIR environment variable

## Motivation and Context
Currently, plan documents are always saved to `docs/plans/` within the project directory. This can clutter the repository with planning documents that may not need to be committed. This change allows users to configure an external location for saving plans, keeping them separate from the codebase while still organizing them by project.

## How Has This Been Tested?
Manual testing with `SUPERPOWERS_PLANS_DIR` set and unset to verify both code paths work correctly.

## Breaking Changes
None. The default behavior remains unchanged - plans are still saved to `docs/plans/` when `SUPERPOWERS_PLANS_DIR` is not set.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
When `SUPERPOWERS_PLANS_DIR` is set, plans are saved to a project-specific subdirectory based on the current working directory path relative to `~`. For example, working in `~/code/myorg/webapp` with `SUPERPOWERS_PLANS_DIR=~/Documents/plans` saves to `~/Documents/plans/code/myorg/webapp/YYYY-MM-DD-<feature-name>.md`. The directory is created automatically if it doesn't exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan save location is now configurable via environment variable, with automatic directory creation.
  * Default behavior preserved when variable is not set.

* **Documentation**
  * Updated guidance with examples for configurable plan locations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->