### PR TITLE
Add project-backlog skill and integrate with planning workflows

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -13,17 +13,8 @@ Start by understanding the current project context, then ask questions one at a 
 
 ## The Process
 
-## FIRST: Check the project backlog
-
-Before ANY exploration, read `docs/BACKLOG.md` (or `docs/backlog.md`). Look for:
-- Items related to the current request
-- Items that could be bundled with this work
-- Context from previous discussions
-
-If you find related items, mention them immediately: "I see this is already tracked in the backlog..." or "The backlog has related items we should consider..."
-
 **Understanding the idea:**
-- Check out the current project state first (files, docs, recent commits)
+- Check out the current project state first (files, docs, recent commits, backlog)
 - Ask questions one at a time to refine the idea
 - Prefer multiple choice questions when possible, but open-ended is fine too
 - Only one question per message - if a topic needs more exploration, break it into multiple questions

--- a/skills/project-backlog/SKILL.md
+++ b/skills/project-backlog/SKILL.md
@@ -11,7 +11,7 @@ Check the project backlog before planning work. Prevents duplicate effort and su
 
 ## Location
 
-`docs/BACKLOG.md` or `docs/backlog.md` in the project root.
+`docs/BACKLOG.md` in the project root. Create it if it doesn't exist.
 
 ## Before Planning Work
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -17,14 +17,6 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
 
-## FIRST: Check the Backlog
-
-Before writing ANY plan, read `docs/BACKLOG.md` (or `docs/backlog.md`):
-
-1. Is this work already tracked? If so, mention it.
-2. Are there related items to bundle together?
-3. Will this work resolve any backlog items? Add cleanup to the plan.
-
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**
@@ -96,6 +88,7 @@ git commit -m "feat: add specific feature"
 ```
 
 ## Remember
+- Check backlog for related items
 - Exact file paths always
 - Complete code in plan (not "add validation")
 - Exact commands with expected output


### PR DESCRIPTION
## Summary

- Adds `project-backlog` skill for managing project backlogs
- Integrates backlog checking into `brainstorming` and `writing-plans` skills

## Changes

### New skill: `project-backlog`

Reference skill for working with project backlogs (`docs/BACKLOG.md`):
- Check backlog before planning work
- Add items when noticing unrelated improvements
- Remove items when work completes

### Modified: `brainstorming`

Added "FIRST: Check the project backlog" section at the start of The Process. Agents now check for related backlog items before exploring requirements.

### Modified: `writing-plans`

Added "FIRST: Check the Backlog" section. Agents verify work isn't already tracked and note items to bundle or clean up.

## Why

Without this, agents start planning work that's already tracked in the backlog, leading to duplicate effort and missed context. Tested with baseline scenarios showing agents don't naturally check backlogs when planning.

## Test plan

- [x] Baseline test: Agent plans work without checking backlog (fails as expected)
- [x] With skill: Agent invokes brainstorming, checks backlog, mentions existing items
- [x] Skill discovery: `superpowers:project-backlog` loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added backlog to the initial brainstorming checklist to broaden context gathering and guidance on what to review
  * Introduced a new Project Backlog skill with guidelines, when to reference backlog items, action scenarios, an add-item template, and common pitfalls/fixes
  * Updated planning/writing workflows with an explicit backlog-check reminder to surface existing or bundleable work

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->