### PR TITLE
update Codex subagent mapping

### DIFF
--- a/.codex/superpowers-bootstrap.md
+++ b/.codex/superpowers-bootstrap.md
@@ -9,7 +9,7 @@ You have superpowers.
 **Tool Mapping for Codex:**
 When skills reference tools you don't have, substitute your equivalent tools:
 - `TodoWrite` → `update_plan` (your planning/task tracking tool)
-- `Task` tool with subagents → Tell the user that subagents aren't available in Codex yet and you'll do the work the subagent would do
+- `Task` tool with subagents → Use Codex subagents via `spawn_agent`, `send_input`, `wait`, and `close_agent`
 - `Skill` tool → `~/.codex/superpowers/.codex/superpowers-codex use-skill` command (already available)
 - `Read`, `Write`, `Edit`, `Bash` → Use your native tools with similar functions
 

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -107,7 +107,7 @@ The Codex implementation uses the shared `skills-core` module (ES module format)
 Skills written for Claude Code are adapted for Codex with these mappings:
 
 - `TodoWrite` → `update_plan`
-- `Task` with subagents → Tell user subagents aren't available, do work directly
+- `Task` with subagents → Use Codex subagents via `spawn_agent`, `send_input`, `wait`, and `close_agent`
 - `Skill` tool → `~/.codex/superpowers/.codex/superpowers-codex use-skill`
 - File operations → Native Codex tools
 


### PR DESCRIPTION
Codex now supports subagents, so superpowers prompts can be updated

## Motivation and Context
Previously Codex used subagents in ~20% of tasks. In other cases it printed that subagents unavailable, so I had to say it to use subagents explicitly. I've read prompts and found out that they have outdated info about subagents.

## How Has This Been Tested?
I've asked Codex to create simple game and it works with subagents

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Task tool documentation has been updated with clear, comprehensive instructions for using subagents and executing their core operations effectively. This replaces previous messaging that indicated subagent functionality was unavailable, giving users the guidance needed to understand and leverage these capabilities in their workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->