### PR TITLE
Fix Windows startup hook failure caused by inherited SHELLOPTS

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+            "command": "env -u SHELLOPTS bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Problem

On Windows with Git Bash, the superpowers `SessionStart` hook fails with:
```
SessionStart:startup hook error
```

This happens because Claude Code's shell environment exports `SHELLOPTS` with the `onecmd` option enabled:
```
SHELLOPTS=braceexpand:hashall:igncr:interactive-comments:monitor:onecmd
```

When bash inherits this exported variable and runs `session-start.sh`, the `onecmd` option causes bash to exit after processing one compound command. Combined with `set -euo pipefail` in the script, this causes the script to exit before producing any output.

## Root Cause Analysis

1. Claude Code on Windows runs in an environment where `SHELLOPTS` is exported with `onecmd`
2. When the hook runs `bash session-start.sh`, bash inherits `SHELLOPTS` and enables all those options
3. The `onecmd` option (equivalent to `set -t`) causes bash to "exit after reading and executing one command"
4. When `set -euo pipefail` runs, the script exits immediately
5. No JSON output is produced, so Claude Code reports a hook error

## Reproduction

```bash
# With SHELLOPTS containing onecmd:
$ bash session-start.sh
# (no output, exits silently)

# Without SHELLOPTS:
$ env -u SHELLOPTS bash session-start.sh
{
  "hookSpecificOutput": {
    "hookEventName": "SessionStart",
    ...
  }
}
```

## Solution

Use `env -u SHELLOPTS` to unset the problematic environment variable before invoking bash. This ensures the script runs in a clean environment regardless of what shell options are inherited.

## Testing

Tested on Windows 11 with Git Bash 5.1.16 and Claude Code 2.1.x. After applying this fix, the startup hook works correctly and the "SessionStart:startup hook error" message no longer appears.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session initialization hook environment handling to ensure consistent shell configuration during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->