### PR TITLE
Codex: clarify subagent tool mapping in bootstrap + README

### DIFF
--- a/.codex/superpowers-bootstrap.md
+++ b/.codex/superpowers-bootstrap.md
@@ -9,7 +9,8 @@ You have superpowers.
 **Tool Mapping for Codex:**
 When skills reference tools you don't have, substitute your equivalent tools:
 - `TodoWrite` → `update_plan` (your planning/task tracking tool)
-- `Task` tool with subagents → Tell the user that subagents aren't available in Codex yet and you'll do the work the subagent would do
+- `Task` tool with subagents → Use Codex collab `spawn_agent` + `wait` when available; if collab is disabled, state that and proceed sequentially
+- `Subagent` / `Agent` tool mentions → Map to `spawn_agent` (collab) or sequential fallback when collab is disabled
 - `Skill` tool → `~/.codex/superpowers/.codex/superpowers-codex use-skill` command (already available)
 - `Read`, `Write`, `Edit`, `Bash` → Use your native tools with similar functions
 

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -107,7 +107,8 @@ The Codex implementation uses the shared `skills-core` module (ES module format)
 Skills written for Claude Code are adapted for Codex with these mappings:
 
 - `TodoWrite` → `update_plan`
-- `Task` with subagents → Tell user subagents aren't available, do work directly
+- `Task` with subagents → Use collab `spawn_agent` + `wait` when available; if collab is disabled, say so and proceed sequentially
+- `Subagent` / `Agent` tool mentions → Map to `spawn_agent` (collab) or sequential fallback when collab is disabled
 - `Skill` tool → `~/.codex/superpowers/.codex/superpowers-codex use-skill`
 - File operations → Native Codex tools
 


### PR DESCRIPTION
## Summary
Minimal Codex-only improvement to the tool-mapping docs so Codex users understand how subagent references should be handled when collab is enabled or disabled.

## Changes
- Update `.codex/superpowers-bootstrap.md` to map `Task`/subagent tool references to Codex collab (`spawn_agent` + `wait`), with a sequential fallback if collab is disabled.
- Update `docs/README.codex.md` to match the same guidance.

## Why
Codex has an experimental "Multi-agents"/"collab" feature. When enabled, Codex can use `spawn_agent`. When disabled (the default), it should fall back to sequential execution. This PR makes the mapping explicit and keeps behavior
consistent across bootstrap and documentation.

## Impact
- Codex users only.
- No behavioral change for Claude users.
- No changes to skills or runtime code.

## Testing
Tested in Codex with collab enabled and disabled. Behavior improved (more consistent `spawn_agent` usage), but reliable multi-agent behavior still depends on explicit guidance in `dispatching-parallel-agents` and `subagent-
driven-development`, which currently requires personal overrides to be fully effective.
