### PR TITLE
feat: add Factory Droid support

### DIFF
--- a/.factory/INSTALL.md
+++ b/.factory/INSTALL.md
@@ -1,0 +1,89 @@
+# Superpowers Installation for Factory Droid
+
+Follow these steps to install Superpowers for Factory Droid using the plugin system.
+
+## Quick Install (Plugin Marketplace)
+
+In Droid, register the marketplace first:
+
+```bash
+/plugin marketplace add obra/superpowers
+```
+
+Then install the plugin:
+
+```bash
+/plugin install superpowers@superpowers
+```
+
+## Manual Installation (Development)
+
+If you want to develop or modify Superpowers locally:
+
+1. Clone Superpowers:
+
+```bash
+git clone https://github.com/obra/superpowers.git ~/.factory/superpowers
+```
+
+2. Load as a local plugin:
+
+```bash
+droid --plugin-dir ~/.factory/superpowers
+```
+
+## Verification
+
+After installation, check that commands appear:
+
+```bash
+/help
+```
+
+You should see:
+- `/superpowers:brainstorm` - Interactive design refinement
+- `/superpowers:write-plan` - Create implementation plan
+- `/superpowers:execute-plan` - Execute plan in batches
+
+## What Gets Installed
+
+The plugin provides:
+
+**Skills** (auto-invoked based on task):
+- **brainstorming** - Socratic design refinement
+- **writing-plans** - Detailed implementation plans
+- **executing-plans** - Batch execution with checkpoints
+- **test-driven-development** - RED-GREEN-REFACTOR cycle
+- **systematic-debugging** - 4-phase root cause process
+- **subagent-driven-development** - Fast iteration with two-stage review
+- And more...
+
+**Commands** (user-invoked):
+- `/superpowers:brainstorm` - Start interactive design session
+- `/superpowers:write-plan` - Create implementation plan
+- `/superpowers:execute-plan` - Execute plan with checkpoints
+
+**Agents**:
+- Specialized subagents for code review and task execution
+
+## Updating
+
+Update via the plugin system:
+
+```bash
+/plugin update superpowers
+```
+
+Or if installed manually:
+
+```bash
+cd ~/.factory/superpowers
+git pull
+```
+
+Then restart Droid.
+
+## More Information
+
+- Full documentation: https://github.com/obra/superpowers/blob/main/docs/README.droid.md
+- Factory Droid: https://factory.ai

--- a/.factory/marketplace.json
+++ b/.factory/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "superpowers-droid",
+  "description": "Development marketplace for Superpowers core skills library (Factory Droid)",
+  "owner": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "plugins": [
+    {
+      "name": "superpowers",
+      "description": "Core skills library for Factory Droid: TDD, debugging, collaboration patterns, and proven techniques",
+      "version": "4.1.1",
+      "source": "./",
+      "author": {
+        "name": "Jesse Vincent",
+        "email": "jesse@fsck.com"
+      }
+    }
+  ]
+}

--- a/.factory/plugin.json
+++ b/.factory/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "superpowers",
+  "description": "Core skills library for Factory Droid: TDD, debugging, collaboration patterns, and proven techniques",
+  "version": "4.1.1",
+  "author": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "homepage": "https://github.com/obra/superpowers",
+  "repository": "https://github.com/obra/superpowers",
+  "license": "MIT",
+  "keywords": ["skills", "tdd", "debugging", "collaboration", "best-practices", "workflows"]
+}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ Fetch and follow instructions from https://raw.githubusercontent.com/obra/superp
 
 **Detailed docs:** [docs/README.codex.md](docs/README.codex.md)
 
+### Factory Droid
+
+In Droid, register the marketplace first:
+
+```bash
+/plugin marketplace add obra/superpowers
+```
+
+Then install the plugin from this marketplace:
+
+```bash
+/plugin install superpowers@superpowers
+```
+
+**Detailed docs:** [docs/README.droid.md](docs/README.droid.md)
+
 ### OpenCode
 
 Tell OpenCode:

--- a/docs/README.droid.md
+++ b/docs/README.droid.md
@@ -1,0 +1,127 @@
+# Superpowers for Factory Droid
+
+Complete guide for using Superpowers with [Factory Droid](https://factory.ai).
+
+## Quick Install (Plugin Marketplace)
+
+In Droid, register the marketplace first:
+
+```bash
+/plugin marketplace add obra/superpowers
+```
+
+Then install the plugin from this marketplace:
+
+```bash
+/plugin install superpowers@superpowers
+```
+
+### Verify Installation
+
+Check that commands appear:
+
+```bash
+/help
+```
+
+```
+# Should see:
+# /superpowers:brainstorm - Interactive design refinement
+# /superpowers:write-plan - Create implementation plan
+# /superpowers:execute-plan - Execute plan in batches
+```
+
+## Alternative: Agent-Guided Install
+
+Tell Droid:
+
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.factory/INSTALL.md
+```
+
+## Manual Installation (Development)
+
+For local development or modification of Superpowers:
+
+### Prerequisites
+
+- [Factory Droid](https://factory.ai) installed
+- Git installed
+
+### Clone and Load
+
+```bash
+# Clone Superpowers
+git clone https://github.com/obra/superpowers.git ~/.factory/superpowers
+
+# Load as local plugin
+droid --plugin-dir ~/.factory/superpowers
+```
+
+### Verify
+
+After starting Droid with the plugin, check commands are available:
+
+```bash
+/help
+```
+
+You should see the `/superpowers:*` commands listed.
+
+## Usage
+
+### How It Works
+
+Once installed, Superpowers provides:
+
+**Skills** (auto-invoked based on task context):
+- **brainstorming** activates when you describe a feature to build
+- **writing-plans** activates when you have an approved design
+- **test-driven-development** activates during implementation
+- **systematic-debugging** activates when troubleshooting
+
+**Commands** (user-invoked):
+- `/superpowers:brainstorm` - Start interactive design session
+- `/superpowers:write-plan` - Create implementation plan
+- `/superpowers:execute-plan` - Execute plan with checkpoints
+
+**Agents**:
+- Specialized subagents for code review and task execution
+
+You don't need to explicitly invoke skills - Droid uses them automatically based on your task.
+
+## Updating
+
+Update via the plugin system:
+
+```bash
+/plugin update superpowers
+```
+
+Or if using manual installation:
+
+```bash
+cd ~/.factory/superpowers
+git pull
+```
+
+Then restart Droid.
+
+## Troubleshooting
+
+### Commands not appearing
+
+1. Verify plugin is installed: `/plugin` and check the Installed tab
+2. Restart Droid after installation
+3. Check for errors: `/plugin` and check the Errors tab
+
+### Skills not activating
+
+1. Skills activate based on task context - describe your task clearly
+2. Use `/superpowers:brainstorm` to explicitly start a workflow
+
+## Getting Help
+
+- Report issues: https://github.com/obra/superpowers/issues
+- Main documentation: https://github.com/obra/superpowers
+- Factory docs: https://docs.factory.ai


### PR DESCRIPTION
## Summary

Add full plugin support for Factory Droid, enabling Superpowers to work as a native plugin with the same installation experience as Claude Code.

## Changes

### New Files

- **`.factory/plugin.json`** - Plugin manifest (mirrors `.claude-plugin/plugin.json`)
- **`.factory/marketplace.json`** - Marketplace manifest for plugin discovery
- **`.factory/INSTALL.md`** - Agent-readable installation instructions
- **`docs/README.droid.md`** - Complete installation guide

### Updated Files

- **`README.md`** - Added Droid to Installation section with plugin commands

## Installation

Same pattern as Claude Code:

```bash
/plugin marketplace add obra/superpowers
/plugin install superpowers@superpowers
```

After installation, users get:
- `/superpowers:brainstorm` - Interactive design refinement
- `/superpowers:write-plan` - Create implementation plan
- `/superpowers:execute-plan` - Execute plan in batches
- All skills auto-invoked based on task context

## Why

Factory Droid is fully compatible with Claude Code's plugin system. Since Superpowers already has `.claude-plugin/` configuration, adding `.factory/` with the same structure provides native plugin support for Droid users.

## Related

- Factory Droid: https://factory.ai
- Factory Docs: https://docs.factory.ai