### PR TITLE
fix(hooks): fix Windows hooks for Claude Code 2.1.x

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start"
           }
         ]
       }


### PR DESCRIPTION
## Problem

Claude Code 2.1.x changed the Windows execution model for hooks. It now auto-detects `.sh` files in hook commands and prepends `bash ` on Windows.

However, there are two issues:

### Issue 1: Polyglot wrapper broken by auto-detection

When the command contains `.sh` suffix:
```
"run-hook.cmd" session-start.sh
→ bash "run-hook.cmd" session-start.sh
→ bash cannot execute .cmd files
```

### Issue 2: `CLAUDE_PLUGIN_ROOT` not normalized on Windows

Claude Code does not normalize `${CLAUDE_PLUGIN_ROOT}` to Unix-style paths on Windows. The variable expands to a Windows path with backslashes:

```
${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh
→ C:\Users\...\superpowers\4.1.1/hooks/session-start.sh
```

This mixed path format (Windows backslashes + Unix forward slashes) causes bash to fail:
```
/bin/bash: C:\Users\...\superpowers\4.1.1/hooks/session-start.sh: No such file or directory
```

So even calling `.sh` directly doesn't work on Windows.

## Solution

Use the polyglot wrapper `run-hook.cmd` which:
1. Handles path conversion using `cygpath -u` to convert Windows paths to Unix format
2. Accepts script names WITHOUT `.sh` suffix to avoid Claude Code's auto-detection
3. Auto-appends `.sh` suffix internally

```json
"command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start"
```

## Changes

- `hooks/hooks.json`: Use `run-hook.cmd` wrapper with script name without `.sh` suffix
- `hooks/run-hook.cmd`: Update comments to reflect current usage; auto-append `.sh` suffix

## Testing

Tested on Windows 11 with Claude Code 2.1.25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated hook invocation wrapper to improve cross-platform behavior between Windows and Unix, including clearer invocation rules and suffix handling.
  * Adjusted SessionStart hook configuration to use the updated wrapper for more consistent execution across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->