### PR TITLE
Update assert_order to support patterns on the same line

### DIFF
--- a/tests/claude-code/test-helpers.sh
+++ b/tests/claude-code/test-helpers.sh
@@ -114,6 +114,21 @@ assert_order() {
     if [ "$line_a" -lt "$line_b" ]; then
         echo "  [PASS] $test_name (A at line $line_a, B at line $line_b)"
         return 0
+    elif [ "$line_a" -eq "$line_b" ]; then
+        # Same line - check column positions
+        local the_line=$(echo "$output" | sed -n "${line_a}p")
+        local col_a=$(echo "$the_line" | grep -bo "$pattern_a" | head -1 | cut -d: -f1)
+        local col_b=$(echo "$the_line" | grep -bo "$pattern_b" | head -1 | cut -d: -f1)
+
+        if [ "$col_a" -lt "$col_b" ]; then
+            echo "  [PASS] $test_name (both at line $line_a, A at col $col_a, B at col $col_b)"
+            return 0
+        else
+            echo "  [FAIL] $test_name"
+            echo "  Expected '$pattern_a' before '$pattern_b' on line $line_a"
+            echo "  But found A at col $col_a, B at col $col_b"
+            return 1
+        fi
     else
         echo "  [FAIL] $test_name"
         echo "  Expected '$pattern_a' before '$pattern_b'"


### PR DESCRIPTION
Update assert_order in test-helpers to support checking patterns order on the same line

## Motivation and Context
assert_order in test-helpers currently checks for patterns on different lines. If the patterns are in the correct order on the same line, it will still fail. This fix is to check the column order if they are on the same line.

## How Has This Been Tested?
Tested by tests/claude-code/test-subagent-driven-development.sh

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with enhanced validation capabilities for handling complex assertion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->