### PR TITLE
feat: add workflow hooks for external skill integration

### DIFF
--- a/hooks/example-workflow-hooks.yaml
+++ b/hooks/example-workflow-hooks.yaml
@@ -1,0 +1,72 @@
+# Example Workflow Hooks Configuration
+# Copy to .claude/workflow-hooks.yaml (project) or ~/.claude/workflow-hooks.yaml (global)
+#
+# This example integrates the dev-ethos skill pack into superpowers workflow.
+# Install dev-ethos first: https://github.com/sbrudz/dev-ethos
+
+hooks:
+  # ─────────────────────────────────────────────────────────────────
+  # DESIGN PHASE (brainstorming skill)
+  # ─────────────────────────────────────────────────────────────────
+
+  before_design:
+    # Apply user-centered design thinking for UI features
+    - skill: dev-ethos:ux-design-principles
+      condition: if_ui
+
+    # Establish ubiquitous language for domain concepts
+    - skill: dev-ethos:domain-driven-design
+
+  after_design:
+    # Capture significant architectural decisions as ADRs
+    - skill: dev-ethos:architecture-decision-records
+
+  # ─────────────────────────────────────────────────────────────────
+  # PLANNING PHASE (writing-plans skill)
+  # ─────────────────────────────────────────────────────────────────
+
+  before_plan:
+    # Check that project has quality tooling before planning implementation
+    - skill: dev-ethos:project-quality-setup
+      mode: check
+
+  # ─────────────────────────────────────────────────────────────────
+  # EXECUTION PHASE (subagent-driven-development skill)
+  # ─────────────────────────────────────────────────────────────────
+
+  before_execute:
+    # Enforce quality tooling is set up before implementing
+    - skill: dev-ethos:project-quality-setup
+      mode: enforce
+
+  after_task:
+    # Apply incremental refactoring after each task
+    - skill: dev-ethos:boy-scout-rule
+
+    # Visually verify UI changes look correct
+    - skill: dev-ethos:visual-feedback-loop
+      condition: if_ui_changed
+
+    # Evaluate visual design quality (after basic visual check passes)
+    - skill: dev-ethos:ux-visual-evaluation
+      condition: if_ui_changed
+
+  before_review:
+    # Add functional core/imperative shell criteria to code review
+    - skill: dev-ethos:functional-core-imperative-shell
+      mode: inject
+
+    # Add React best practices criteria for React code
+    - skill: dev-ethos:react-best-practices
+      condition: if_react
+      mode: inject
+
+# ─────────────────────────────────────────────────────────────────────
+# Custom Conditions (optional - extend built-in conditions)
+# ─────────────────────────────────────────────────────────────────────
+
+# conditions:
+#   if_python:
+#     match: "git diff includes .py files"
+#   if_api:
+#     match: "files in api/ or routes/ directories"

--- a/hooks/workflow-hooks.md
+++ b/hooks/workflow-hooks.md
@@ -1,0 +1,126 @@
+# Workflow Hooks
+
+Extend superpowers workflow skills by registering external skills to be invoked at specific points.
+
+## Overview
+
+Workflow hooks allow skill packs (like `dev-ethos`) to integrate into the superpowers workflow without modifying superpowers itself. When a workflow skill reaches a hook point, it checks the hooks configuration and invokes any registered skills.
+
+## Configuration
+
+Create a hooks configuration file at one of these locations (checked in order):
+1. `.claude/workflow-hooks.yaml` (project-specific)
+2. `~/.claude/workflow-hooks.yaml` (global)
+
+## Hook Points
+
+| Hook | Workflow Skill | When |
+|------|---------------|------|
+| `before_design` | brainstorming | Start of design process |
+| `after_design` | brainstorming | After design validated, before saving |
+| `before_plan` | writing-plans | Start of planning |
+| `after_plan` | writing-plans | After plan saved, before execution choice |
+| `before_execute` | subagent-driven-development | Start of execution, after reading plan |
+| `before_task` | subagent-driven-development | Before dispatching implementer |
+| `after_task` | subagent-driven-development | After task + reviews complete |
+| `before_review` | subagent-driven-development | Before dispatching reviewers |
+| `after_execute` | subagent-driven-development | After all tasks, before finishing |
+
+## Configuration Format
+
+```yaml
+# .claude/workflow-hooks.yaml
+
+hooks:
+  before_design:
+    - skill: dev-ethos:ux-design-principles
+      condition: if_ui
+    - skill: dev-ethos:domain-driven-design
+
+  after_design:
+    - skill: dev-ethos:architecture-decision-records
+
+  before_execute:
+    - skill: dev-ethos:project-quality-setup
+      mode: enforce
+
+  after_task:
+    - skill: dev-ethos:boy-scout-rule
+    - skill: dev-ethos:visual-feedback-loop
+      condition: if_ui_changed
+
+  before_review:
+    - skill: dev-ethos:functional-core-imperative-shell
+      mode: inject
+    - skill: dev-ethos:react-best-practices
+      condition: if_react
+      mode: inject
+
+# Condition definitions (optional - these are built-in)
+conditions:
+  if_ui:
+    match: "files contain *.tsx, *.jsx, *.vue, *.svelte, or components/"
+  if_ui_changed:
+    match: "git diff includes UI file patterns"
+  if_react:
+    match: "git diff includes .tsx or .jsx files"
+```
+
+## Hook Modes
+
+| Mode | Behavior |
+|------|----------|
+| `invoke` (default) | Invoke skill, follow its guidance |
+| `check` | Verify skill criteria are met, warn if not |
+| `enforce` | Block workflow until skill criteria are met |
+| `inject` | Add skill criteria to subagent prompts |
+
+## Built-in Conditions
+
+| Condition | Matches When |
+|-----------|-------------|
+| `always` (default) | Always invoke |
+| `if_ui` | Current task/design involves UI files |
+| `if_ui_changed` | Git diff includes UI file changes |
+| `if_react` | Git diff includes .tsx or .jsx files |
+| `if_backend` | Current task involves backend/API code |
+| `if_new_project` | No existing source files detected |
+
+## How Workflow Skills Check Hooks
+
+Each workflow skill includes a hook check at defined points:
+
+```markdown
+**[HOOK: before_design]** Check workflow hooks configuration:
+1. Look for `.claude/workflow-hooks.yaml` or `~/.claude/workflow-hooks.yaml`
+2. If `before_design` hooks are defined:
+   - For each hook, evaluate the condition
+   - If condition passes, invoke the skill using the Skill tool
+   - Apply the skill's guidance before proceeding
+3. If no config found, proceed without hooks
+```
+
+## Example: dev-ethos Integration
+
+With `dev-ethos` installed and this configuration:
+
+```yaml
+hooks:
+  after_task:
+    - skill: dev-ethos:boy-scout-rule
+    - skill: dev-ethos:visual-feedback-loop
+      condition: if_ui_changed
+```
+
+After each task completes in subagent-driven-development:
+1. `boy-scout-rule` is always invoked - apply refactoring checklist
+2. `visual-feedback-loop` is invoked only if the task changed UI files
+
+## Creating Hook-Compatible Skills
+
+Skills work with hooks if they:
+1. Have clear entry/exit points
+2. Can be invoked mid-workflow without disrupting state
+3. Provide actionable guidance (not just information)
+
+For `inject` mode, skills should have a "criteria" or "checklist" section that can be added to reviewer prompts.

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -13,6 +13,11 @@ Start by understanding the current project context, then ask questions one at a 
 
 ## The Process
 
+**[HOOK: before_design]** Before starting, check for workflow hooks:
+1. Look for `.claude/workflow-hooks.yaml` or `~/.claude/workflow-hooks.yaml`
+2. If `before_design` hooks are defined, invoke each skill where condition passes
+3. Apply guidance from invoked skills to the design process
+
 **Understanding the idea:**
 - Check out the current project state first (files, docs, recent commits)
 - Ask questions one at a time to refine the idea
@@ -34,6 +39,11 @@ Start by understanding the current project context, then ask questions one at a 
 
 ## After the Design
 
+**[HOOK: after_design]** Before saving the design document:
+1. Check workflow hooks configuration for `after_design` hooks
+2. If hooks are defined, invoke each skill where condition passes
+3. Apply guidance (e.g., create ADRs for architectural decisions)
+
 **Documentation:**
 - Write the validated design to `docs/plans/YYYY-MM-DD-<topic>-design.md`
 - Use elements-of-style:writing-clearly-and-concisely skill if available
@@ -52,3 +62,14 @@ Start by understanding the current project context, then ask questions one at a 
 - **Explore alternatives** - Always propose 2-3 approaches before settling
 - **Incremental validation** - Present design in sections, validate each
 - **Be flexible** - Go back and clarify when something doesn't make sense
+
+## Workflow Hooks Reference
+
+This skill supports these hook points (see `hooks/workflow-hooks.md`):
+
+| Hook | When | Example Skills |
+|------|------|----------------|
+| `before_design` | Start of design process | UX principles, domain modeling |
+| `after_design` | After design validated | Architecture decision records |
+
+To configure hooks, create `.claude/workflow-hooks.yaml` or `~/.claude/workflow-hooks.yaml`.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -17,6 +17,16 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
 
+## Before Planning
+
+**[HOOK: before_plan]** Check for workflow hooks before starting:
+1. Look for `.claude/workflow-hooks.yaml` or `~/.claude/workflow-hooks.yaml`
+2. If `before_plan` hooks are defined, invoke each skill where condition passes
+3. For `mode: check` hooks, verify criteria are met and warn if not
+4. For `mode: enforce` hooks, block planning until criteria are met
+
+Example: A `project-quality-setup` hook in check mode would verify linting/formatting/CI are configured before planning implementation.
+
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**
@@ -96,7 +106,11 @@ git commit -m "feat: add specific feature"
 
 ## Execution Handoff
 
-After saving the plan, offer execution choice:
+**[HOOK: after_plan]** After saving the plan, check for workflow hooks:
+1. Check workflow hooks configuration for `after_plan` hooks
+2. If hooks are defined, invoke each skill where condition passes
+
+Then offer execution choice:
 
 **"Plan complete and saved to `docs/plans/<filename>.md`. Two execution options:**
 
@@ -114,3 +128,14 @@ After saving the plan, offer execution choice:
 **If Parallel Session chosen:**
 - Guide them to open new session in worktree
 - **REQUIRED SUB-SKILL:** New session uses superpowers:executing-plans
+
+## Workflow Hooks Reference
+
+This skill supports these hook points (see `hooks/workflow-hooks.md`):
+
+| Hook | When | Example Skills |
+|------|------|----------------|
+| `before_plan` | Start of planning | Project quality setup (check/enforce) |
+| `after_plan` | After plan saved | Plan validation, complexity assessment |
+
+To configure hooks, create `.claude/workflow-hooks.yaml` or `~/.claude/workflow-hooks.yaml`.


### PR DESCRIPTION
## Summary

Add extensibility points to workflow skills, allowing external skill packs (like [dev-ethos](https://github.com/sbrudz/dev-ethos)) to be invoked automatically at key workflow points.

This solves the problem of external skills not being invoked at the right moment - instead of relying on description-based discovery (CSO), hooks provide explicit, deterministic invocation.

## Hook Points

| Hook | Workflow Skill | When |
|------|---------------|------|
| `before_design` | brainstorming | Start of design process |
| `after_design` | brainstorming | After design validated |
| `before_plan` | writing-plans | Start of planning |
| `after_plan` | writing-plans | After plan saved |
| `before_execute` | subagent-driven-development | Start of execution |
| `before_task` | subagent-driven-development | Before each task |
| `after_task` | subagent-driven-development | After task + reviews complete |
| `before_review` | subagent-driven-development | Before dispatching reviewers |
| `after_execute` | subagent-driven-development | After all tasks |

## Configuration

Users create `.claude/workflow-hooks.yaml` (project) or `~/.claude/workflow-hooks.yaml` (global):

```yaml
hooks:
  before_execute:
    - skill: dev-ethos:project-quality-setup
      mode: enforce

  after_task:
    - skill: dev-ethos:boy-scout-rule
    - skill: dev-ethos:visual-feedback-loop
      condition: if_ui_changed

  before_review:
    - skill: dev-ethos:functional-core-imperative-shell
      mode: inject
```

## Hook Modes

| Mode | Behavior |
|------|----------|
| `invoke` (default) | Invoke skill, follow its guidance |
| `check` | Verify criteria met, warn if not |
| `enforce` | Block workflow until criteria met |
| `inject` | Add skill criteria to subagent prompts |

## Files Changed

- `hooks/workflow-hooks.md` - Documentation
- `hooks/example-workflow-hooks.yaml` - Example configuration
- `skills/brainstorming/SKILL.md` - Added before_design, after_design hooks
- `skills/writing-plans/SKILL.md` - Added before_plan, after_plan hooks
- `skills/subagent-driven-development/SKILL.md` - Added all execution hooks

## Test plan

- [ ] Verify workflow skills check for hooks config at each hook point
- [ ] Test with example-workflow-hooks.yaml and dev-ethos skills
- [ ] Verify condition evaluation works (if_ui_changed, if_react)
- [ ] Verify mode: inject correctly appends to reviewer prompts
- [ ] Verify mode: enforce blocks execution when criteria not met

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow hooks now available for configuring skill automation and guidance at key workflow stages (design, planning, execution, and review phases).

* **Documentation**
  * Added workflow hooks configuration reference with supported hook points and modes.
  * Updated skill documentation with workflow hooks integration examples and conditional execution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->