### PR TITLE
Fix Windows/PowerShell invocation of superpowers-codex

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -21,7 +21,7 @@ Quick setup to enable superpowers skills in Codex.
    ## Superpowers System
 
    <EXTREMELY_IMPORTANT>
-   You have superpowers. Superpowers teach you new skills and capabilities. RIGHT NOW run: `~/.codex/superpowers/.codex/superpowers-codex bootstrap` and follow the instructions it returns.
+   You have superpowers. Superpowers teach you new skills and capabilities. RIGHT NOW run: `node ~/.codex/superpowers/.codex/superpowers-codex bootstrap` and follow the instructions it returns.
    </EXTREMELY_IMPORTANT>
    ```
 
@@ -29,7 +29,7 @@ Quick setup to enable superpowers skills in Codex.
 
 Test the installation:
 ```bash
-~/.codex/superpowers/.codex/superpowers-codex bootstrap
+node ~/.codex/superpowers/.codex/superpowers-codex bootstrap
 ```
 
 You should see skill listings and bootstrap instructions. The system is now ready for use.

--- a/.codex/superpowers-bootstrap.md
+++ b/.codex/superpowers-bootstrap.md
@@ -4,14 +4,14 @@
 You have superpowers.
 
 **Tool for running skills:**
-- `~/.codex/superpowers/.codex/superpowers-codex use-skill <skill-name>`
+- `node ~/.codex/superpowers/.codex/superpowers-codex use-skill <skill-name>`
 
 **Tool Mapping for Codex:**
 When skills reference tools you don't have, substitute your equivalent tools:
 - `TodoWrite` → `update_plan` (your planning/task tracking tool)
 - `Task` tool with subagents → Use Codex collab `spawn_agent` + `wait` when available; if collab is disabled, state that and proceed sequentially
 - `Subagent` / `Agent` tool mentions → Map to `spawn_agent` (collab) or sequential fallback when collab is disabled
-- `Skill` tool → `~/.codex/superpowers/.codex/superpowers-codex use-skill` command (already available)
+- `Skill` tool → `node ~/.codex/superpowers/.codex/superpowers-codex use-skill` command (already available)
 - `Read`, `Write`, `Edit`, `Bash` → Use your native tools with similar functions
 
 **Skills naming:**
@@ -21,7 +21,7 @@ When skills reference tools you don't have, substitute your equivalent tools:
 
 **Critical Rules:**
 - Before ANY task, review the skills list (shown below)
-- If a relevant skill exists, you MUST use `~/.codex/superpowers/.codex/superpowers-codex use-skill` to load it
+- If a relevant skill exists, you MUST use `node ~/.codex/superpowers/.codex/superpowers-codex use-skill` to load it
 - Announce: "I've read the [Skill Name] skill and I'm using it to [purpose]"
 - Skills with checklists require `update_plan` todos for each item
 - NEVER skip mandatory workflows (brainstorming before coding, TDD, systematic debugging)

--- a/.codex/superpowers-codex.cmd
+++ b/.codex/superpowers-codex.cmd
@@ -1,0 +1,1 @@
+@node "%~dp0superpowers-codex" %*

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -35,7 +35,7 @@ The bootstrap file is included in the repository at `.codex/superpowers-bootstra
 Tell Codex:
 
 ```
-Run ~/.codex/superpowers/.codex/superpowers-codex find-skills to show available skills
+Run node ~/.codex/superpowers/.codex/superpowers-codex find-skills to show available skills
 ```
 
 You should see a list of available skills with descriptions.
@@ -45,19 +45,19 @@ You should see a list of available skills with descriptions.
 ### Finding Skills
 
 ```
-Run ~/.codex/superpowers/.codex/superpowers-codex find-skills
+Run node ~/.codex/superpowers/.codex/superpowers-codex find-skills
 ```
 
 ### Loading a Skill
 
 ```
-Run ~/.codex/superpowers/.codex/superpowers-codex use-skill superpowers:brainstorming
+Run node ~/.codex/superpowers/.codex/superpowers-codex use-skill superpowers:brainstorming
 ```
 
 ### Bootstrap All Skills
 
 ```
-Run ~/.codex/superpowers/.codex/superpowers-codex bootstrap
+Run node ~/.codex/superpowers/.codex/superpowers-codex bootstrap
 ```
 
 This loads the complete bootstrap with all skill information.
@@ -109,7 +109,7 @@ Skills written for Claude Code are adapted for Codex with these mappings:
 - `TodoWrite` → `update_plan`
 - `Task` with subagents → Use collab `spawn_agent` + `wait` when available; if collab is disabled, say so and proceed sequentially
 - `Subagent` / `Agent` tool mentions → Map to `spawn_agent` (collab) or sequential fallback when collab is disabled
-- `Skill` tool → `~/.codex/superpowers/.codex/superpowers-codex use-skill`
+- `Skill` tool → `node ~/.codex/superpowers/.codex/superpowers-codex use-skill`
 - File operations → Native Codex tools
 
 ## Updating
@@ -124,7 +124,7 @@ git pull
 ### Skills not found
 
 1. Verify installation: `ls ~/.codex/superpowers/skills`
-2. Check CLI works: `~/.codex/superpowers/.codex/superpowers-codex find-skills`
+2. Check CLI works: `node ~/.codex/superpowers/.codex/superpowers-codex find-skills`
 3. Verify skills have SKILL.md files
 
 ### CLI script not executable


### PR DESCRIPTION
Windows doesn't respect shebangs, so directly invoking the extensionless
superpowers-codex script triggers an "Open with" dialog. Prefix all
invocations with `node` (harmless on Unix, required on Windows) and add
a .cmd wrapper for manual invocation on Windows.

Fixes #285, #243

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation, bootstrap, and skill invocation instructions to use Node.js-based commands across all documentation and reference files.

* **New Features**
  * Added Windows command script wrapper to support running Codex CLI operations on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->