### PR TITLE
Fix: add --verbose flag for stream-json output in SDD test runner

### DIFF
--- a/tests/subagent-driven-dev/run-test.sh
+++ b/tests/subagent-driven-dev/run-test.sh
@@ -77,6 +77,7 @@ claude -p "$PROMPT" \
   --plugin-dir "$PLUGIN_DIR" \
   --dangerously-skip-permissions \
   --output-format stream-json \
+  --verbose \
   > "$LOG_FILE" 2>&1 || true
 
 # Extract final stats


### PR DESCRIPTION
## Problem

Running `./run-test.sh go-fractals` fails with:

```
Error: When using --print, --output-format=stream-json requires --verbose
```

Claude CLI now requires `--verbose` when using `--output-format stream-json` in print mode (`-p`).

## Fix

Add `--verbose` flag to the `claude` invocation in `tests/subagent-driven-dev/run-test.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test output verbosity to provide more detailed diagnostic information during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->