### PR TITLE
fix(writing-plans): use 4-backtick fence for nested code blocks in Task Structure template

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -46,7 +46,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 ## Task Structure
 
-```markdown
+````markdown
 ### Task N: [Component Name]
 
 **Files:**
@@ -85,7 +85,7 @@ Expected: PASS
 git add tests/path/test.py src/path/file.py
 git commit -m "feat: add specific feature"
 ```
-```
+````
 
 ## Remember
 - Exact file paths always


### PR DESCRIPTION
## Summary

The Task Structure template in `skills/writing-plans/SKILL.md` (lines 49-88) uses a 3-backtick `` ```markdown `` outer fence containing inner 3-backtick code blocks (`` ```python ``, `` ```bash ``). Since both use the same fence length, the first inner closing `` ``` `` prematurely terminates the outer fence, breaking the template rendering on GitHub and other markdown viewers.

## Fix

Change the outer fence from 3-backtick to 4-backtick (`` ```` ``), per [CommonMark Spec §4.5 — Fenced Code Blocks](https://spec.commonmark.org/0.31.2/#fenced-code-blocks):

> "The closing code fence must be at least as long as the opening fence."

This is the same pattern already used throughout `skills/writing-skills/anthropic-best-practices.md` in this project.

## Changes

- `skills/writing-plans/SKILL.md` line 49: `` ``` `` → `` ```` `` (opening fence)
- `skills/writing-plans/SKILL.md` line 88: `` ``` `` → `` ```` `` (closing fence)