### PR TITLE
Improve using-superpowers skill description and conciseness

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,15 +1,14 @@
 ---
 name: using-superpowers
-description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+description: >
+  Searches available skills, matches user requests to the right skill, and
+  loads skill instructions before responding. Enforces skill-first workflow
+  so the agent checks capabilities before acting. Use when the user asks
+  "what skills do you have", "list available capabilities", "find a skill for X",
+  "how should I approach this task", or when starting a new task that may
+  match an existing skill. Also activates when the agent is about to respond
+  without checking for applicable skills first.
 ---
-
-<EXTREMELY-IMPORTANT>
-If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
-
-IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
-
-This is not negotiable. This is not optional. You cannot rationalize your way out of this.
-</EXTREMELY-IMPORTANT>
 
 ## How to Access Skills
 
@@ -51,18 +50,11 @@ These thoughts mean STOP—you're rationalizing:
 
 | Thought | Reality |
 |---------|---------|
-| "This is just a simple question" | Questions are tasks. Check for skills. |
 | "I need more context first" | Skill check comes BEFORE clarifying questions. |
 | "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
-| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
-| "Let me gather information first" | Skills tell you HOW to gather information. |
 | "This doesn't need a formal skill" | If a skill exists, use it. |
 | "I remember this skill" | Skills evolve. Read current version. |
-| "This doesn't count as a task" | Action = task. Check for skills. |
-| "The skill is overkill" | Simple things become complex. Use it. |
 | "I'll just do this one thing first" | Check BEFORE doing anything. |
-| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
-| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
 
 ## Skill Priority
 
@@ -81,6 +73,13 @@ When multiple skills could apply, use this order:
 **Flexible** (patterns): Adapt principles to context.
 
 The skill itself tells you which.
+
+## Output
+
+After skill resolution, the agent produces:
+1. Skill announcement: "Using [skill-name] to [purpose]"
+2. TodoWrite items if the skill contains a checklist
+3. The task response following the loaded skill's instructions
 
 ## User Instructions
 


### PR DESCRIPTION
Hey @obra, thanks for publishing superpowers. Appreciate you sharing your workflos, and kudos on soon hitting `50k` stars! I just starred it. Side note, I shared one of your blogs on the newsletter I take care of (perhaps you heard of the ai native dev newsletter?) - kudos for the fantastic content.

was running your skills through some evals and noticed a few things on using-superpowers that were pretty quick to improve (moving from `~61%` to `~100%` agent performance):

- frontmatter description conflicting with other skill since the trigger covers all conversations. expanded it with specific actions

- redundancy over "check skills first" in different words with red flags, trimmed to the 5 most distinct patterns

- added an output section so the agent knows exactly what to produce after skill resolution.

these were easy changes to bring the skill in line with what performs well against **Anthropic's best practices**. honest disclosure, I work at a company where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `41` skills here, if you want to do it yourself, evals are free and open to run: [link](https://tessl.io/skills/github/obra/superpowers/using-superpowers/review) otherwise happy to make the improvements for you.