### PR TITLE
Add Cursor plugin compatibility and install docs

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "superpowers",
+  "displayName": "Superpowers",
+  "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
+  "version": "4.3.0",
+  "author": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "homepage": "https://github.com/obra/superpowers",
+  "repository": "https://github.com/obra/superpowers",
+  "license": "MIT",
+  "keywords": ["skills", "tdd", "debugging", "collaboration", "best-practices", "workflows"],
+  "skills": "./skills/",
+  "agents": "./agents/",
+  "commands": "./commands/",
+  "hooks": "./hooks/hooks.json"
+}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Thanks!
 
 ## Installation
 
-**Note:** Installation differs by platform. Claude Code has a built-in plugin system. Codex and OpenCode require manual setup.
+**Note:** Installation differs by platform. Claude Code or Cursor have built-in plugin marketplaces. Codex and OpenCode require manual setup.
+
 
 ### Claude Code (via Plugin Marketplace)
 
@@ -42,9 +43,17 @@ Then install the plugin from this marketplace:
 /plugin install superpowers@superpowers-marketplace
 ```
 
+### Cursor (via Plugin Marketplace)
+
+In Cursor Agent chat, install from marketplace:
+
+```text
+/plugin-add superpowers
+```
+
 ### Verify Installation
 
-Start a new session and ask Claude to help with something that would trigger a skill (e.g., "help me plan this feature" or "let's debug this issue"). Claude should automatically invoke the relevant superpowers skill.
+Start a new session in Claude or Cursor and ask for something that should trigger a skill (for example, "help me plan this feature" or "let's debug this issue"). The agent should automatically invoke the relevant superpowers skill.
 
 ### Codex
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -32,13 +32,18 @@ escape_for_json() {
 
 using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
 warning_escaped=$(escape_for_json "$warning_message")
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
 
-# Output context injection as JSON
+# Output context injection as JSON.
+# Keep both shapes for compatibility:
+# - Cursor hooks expect additional_context.
+# - Claude hooks expect hookSpecificOutput.additionalContext.
 cat <<EOF
 {
+  "additional_context": "${session_context}",
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+    "additionalContext": "${session_context}"
   }
 }
 EOF


### PR DESCRIPTION
## Summary
- add a root `.cursor-plugin/plugin.json` manifest so Superpowers is discoverable as a Cursor plugin without changing existing Claude packaging
- update `hooks/session-start.sh` to emit both Cursor (`additional_context`) and Claude (`hookSpecificOutput.additionalContext`) response shapes for cross-platform hook compatibility
- add Cursor installation instructions to `README.md` with Claude-first wording in shared guidance

## Test plan
- [x] Run `bash hooks/session-start.sh` and assert output JSON contains both `additional_context` and `hookSpecificOutput.additionalContext`
- [x] Parse `.cursor-plugin/plugin.json` with `python3` JSON load to verify manifest validity
- [ ] Install via Cursor marketplace command and verify skill auto-invocation in a fresh session

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for plugin marketplace installation via Cursor.

* **Documentation**
  * Updated installation instructions for Claude Code, Cursor, Codex, and OpenCode environments.
  * Added Cursor-specific plugin marketplace section with setup guidance.
  * Enhanced verification steps for triggering plugin functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->