### PR TITLE
Align writing-skills with Anthropic's new Complete Guide to Building Skills

### DIFF
--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -17,7 +17,7 @@ You write test cases (pressure scenarios with subagents), watch them fail (basel
 
 **REQUIRED BACKGROUND:** You MUST understand superpowers:test-driven-development before using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle. This skill adapts TDD to documentation.
 
-**Official guidance:** For Anthropic's official skill authoring best practices, see anthropic-best-practices.md. This document provides additional patterns and guidelines that complement the TDD-focused approach in this skill.
+**Official guidance:** For Anthropic's official skill authoring best practices, see anthropic-best-practices.md. This document provides additional patterns and guidelines that complement the TDD-focused approach in this skill. For the comprehensive guide covering planning, testing, distribution, and patterns, see [The Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf).
 
 ## What is a Skill?
 
@@ -76,7 +76,9 @@ API docs, syntax guides, tool documentation (office docs)
 skills/
   skill-name/
     SKILL.md              # Main reference (required)
-    supporting-file.*     # Only if needed
+    scripts/              # Optional - executable code (Python, Bash, etc.)
+    references/           # Optional - documentation loaded as needed
+    assets/               # Optional - templates, fonts, icons used in output
 ```
 
 **Flat namespace** - all skills in one searchable namespace
@@ -93,14 +95,14 @@ skills/
 ## SKILL.md Structure
 
 **Frontmatter (YAML):**
-- Only two fields supported: `name` and `description`
-- Max 1024 characters total
-- `name`: Use letters, numbers, and hyphens only (no parentheses, special chars)
-- `description`: Third-person, describes ONLY when to use (NOT what it does)
-  - Start with "Use when..." to focus on triggering conditions
-  - Include specific symptoms, situations, and contexts
-  - **NEVER summarize the skill's process or workflow** (see CSO section for why)
+- Two required fields: `name` and `description`; optional: `license`, `compatibility`, `allowed-tools`, `metadata`
+- Max 1024 characters for description
+- `name`: Kebab-case only, no spaces or capitals (must match folder name). No "claude" or "anthropic" prefix (reserved).
+- `description`: Third-person, includes WHAT it does + WHEN to use it + key capabilities
+  - Include specific symptoms, situations, and trigger phrases users would say
+  - **NEVER summarize the skill's workflow/process steps** (see CSO section for why)
   - Keep under 500 characters if possible
+- No XML angle brackets (`<` or `>`) in frontmatter (security restriction)
 
 ```markdown
 ---
@@ -147,27 +149,35 @@ Concrete results
 
 **Format:** Start with "Use when..." to focus on triggering conditions
 
-**CRITICAL: Description = When to Use, NOT What the Skill Does**
+**CRITICAL: Description = WHAT + WHEN, never HOW**
 
-The description should ONLY describe triggering conditions. Do NOT summarize the skill's process or workflow in the description.
+The description should include what the skill does and when to use it, following the formula: `[What it does] + [When to use it] + [Key capabilities]`. However, it must NOT describe the skill's internal workflow or process steps.
 
 **Why this matters:** Testing revealed that when a description summarizes the skill's workflow, Claude may follow the description instead of reading the full skill content. A description saying "code review between tasks" caused Claude to do ONE review, even though the skill's flowchart clearly showed TWO reviews (spec compliance then code quality).
 
 When the description was changed to just "Use when executing implementation plans with independent tasks" (no workflow summary), Claude correctly read the flowchart and followed the two-stage review process.
 
+**The distinction:**
+- WHAT it does (capabilities) = Good ✅ — helps Claude decide relevance
+- WHEN to use it (triggers) = Good ✅ — helps Claude decide timing
+- HOW it works (workflow steps) = Bad ❌ — creates a shortcut Claude will take
+
 **The trap:** Descriptions that summarize workflow create a shortcut Claude will take. The skill body becomes documentation Claude skips.
 
 ```yaml
-# ❌ BAD: Summarizes workflow - Claude may follow this instead of reading skill
+# ❌ BAD: Summarizes workflow (HOW) - Claude may follow this instead of reading skill
 description: Use when executing plans - dispatches subagent per task with code review between tasks
 
-# ❌ BAD: Too much process detail
+# ❌ BAD: Too much process detail (HOW)
 description: Use for TDD - write test first, watch it fail, write minimal code, refactor
 
-# ✅ GOOD: Just triggering conditions, no workflow summary
+# ✅ GOOD: WHAT + WHEN, no workflow summary
 description: Use when executing implementation plans with independent tasks in the current session
 
-# ✅ GOOD: Triggering conditions only
+# ✅ GOOD: WHAT + WHEN + key capabilities
+description: Analyzes Figma design files and generates developer handoff documentation. Use when user uploads .fig files, asks for "design specs", "component documentation", or "design-to-code handoff".
+
+# ✅ GOOD: WHAT + WHEN with trigger phrases
 description: Use when implementing any feature or bugfix, before writing implementation code
 ```
 
@@ -370,6 +380,11 @@ pptx/
   scripts/       # Executable tools
 ```
 When: Reference material too large for inline
+
+**See also:** For skill patterns, troubleshooting, and planning guidance from Anthropic's Complete Guide:
+- [skill-patterns.md](skill-patterns.md) — 5 named patterns (sequential workflow, multi-MCP, iterative refinement, context-aware, domain-specific)
+- [troubleshooting.md](troubleshooting.md) — Common issues and fixes
+- [planning-and-design.md](planning-and-design.md) — Use cases, success criteria, testing, distribution
 
 ## The Iron Law (Same as TDD)
 

--- a/skills/writing-skills/anthropic-best-practices.md
+++ b/skills/writing-skills/anthropic-best-practices.md
@@ -4,7 +4,12 @@
 
 Good Skills are concise, well-structured, and tested with real usage. This guide provides practical authoring decisions to help you write Skills that Claude can discover and use effectively.
 
-For conceptual background on how Skills work, see the [Skills overview](/en/docs/agents-and-tools/agent-skills/overview).
+For conceptual background on how Skills work, see the [Skills overview](/en/docs/agents-and-tools/agent-skills/overview). For the comprehensive guide covering planning, testing, distribution, and patterns, see Anthropic's [Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf).
+
+**Additional reference files in this skill:**
+- [planning-and-design.md](planning-and-design.md) — Use case categories, success criteria, testing approach, distribution
+- [skill-patterns.md](skill-patterns.md) — 5 named patterns (sequential workflow, multi-MCP, iterative refinement, context-aware, domain-specific)
+- [troubleshooting.md](troubleshooting.md) — Common issues and fixes (upload errors, triggering problems, instructions not followed)
 
 ## Core principles
 
@@ -143,14 +148,15 @@ What works perfectly for Opus might need more detail for Haiku. If you plan to u
 
 ## Skill structure
 
-<Note>
-  **YAML Frontmatter**: The SKILL.md frontmatter supports two fields:
+**YAML Frontmatter** — Two required fields, several optional:
 
-  * `name` - Human-readable name of the Skill (64 characters maximum)
-  * `description` - One-line description of what the Skill does and when to use it (1024 characters maximum)
+**Required:**
+* `name` - Kebab-case only, no spaces or capitals, must match folder name (64 chars max). No "claude" or "anthropic" prefix (reserved).
+* `description` - What the Skill does and when to use it (1024 chars max)
 
-  For complete Skill structure details, see the [Skills overview](/en/docs/agents-and-tools/agent-skills/overview#skill-structure).
-</Note>
+**Optional:** `license` (MIT, Apache-2.0, etc.), `compatibility` (environment requirements, 1-500 chars), `allowed-tools` (restrict tool access), `metadata` (custom key-value pairs: author, version, mcp-server, category, tags)
+
+**Security restrictions:** No XML angle brackets (`<` or `>`) in frontmatter — it appears in Claude's system prompt.
 
 ### Naming conventions
 
@@ -182,6 +188,12 @@ Consistent naming makes it easier to:
 * Organize and search through multiple Skills
 * Maintain a professional, cohesive skill library
 
+### Critical naming and file rules
+
+* `SKILL.md` must be exact case (not SKILL.MD, skill.md, etc.)
+* Folder names: kebab-case only (`notion-project-setup` ✅, `Notion Project Setup` ❌, `notion_project_setup` ❌)
+* No README.md inside skill folders — all documentation goes in SKILL.md or references/
+
 ### Writing effective descriptions
 
 The `description` field enables Skill discovery and should include both what the Skill does and when to use it.
@@ -197,6 +209,10 @@ The `description` field enables Skill discovery and should include both what the
 **Be specific and include key terms**. Include both what the Skill does and specific triggers/contexts for when to use it.
 
 Each Skill has exactly one description field. The description is critical for skill selection: Claude uses it to choose the right Skill from potentially 100+ available Skills. Your description must provide enough detail for Claude to know when to select this Skill, while the rest of SKILL.md provides the implementation details.
+
+**Description formula:** `[What it does] + [When to use it] + [Key capabilities]`
+
+Include WHAT and WHEN, but NOT HOW (workflow steps in descriptions cause Claude to shortcut the actual skill content — see the SKILL.md CSO section for details).
 
 Effective examples:
 

--- a/skills/writing-skills/planning-and-design.md
+++ b/skills/writing-skills/planning-and-design.md
@@ -1,0 +1,129 @@
+# Planning and Design
+
+> From Anthropic's [Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
+
+## Start with use cases
+
+Before writing any code, identify 2-3 concrete use cases your skill should enable.
+
+**Good use case definition:**
+```
+Use Case: Project Sprint Planning
+Trigger: User says "help me plan this sprint" or "create sprint tasks"
+Steps:
+1. Fetch current project status from Linear (via MCP)
+2. Analyze team velocity and capacity
+3. Suggest task prioritization
+4. Create tasks in Linear with proper labels and estimates
+Result: Fully planned sprint with tasks created
+```
+
+Ask yourself:
+* What does a user want to accomplish?
+* What multi-step workflows does this require?
+* Which tools are needed (built-in or MCP)?
+* What domain knowledge or best practices should be embedded?
+
+## Common skill use case categories
+
+At Anthropic, three common categories have been observed:
+
+### Category 1: Document & Asset Creation
+
+Creating consistent, high-quality output including documents, presentations, apps, designs, code, etc.
+
+**Key techniques:** Embedded style guides and brand standards, template structures for consistent output, quality checklists before finalizing, no external tools required — uses Claude's built-in capabilities.
+
+### Category 2: Workflow Automation
+
+Multi-step processes that benefit from consistent methodology, including coordination across multiple MCP servers.
+
+**Key techniques:** Step-by-step workflow with validation gates, templates for common structures, built-in review and improvement suggestions, iterative refinement loops.
+
+### Category 3: MCP Enhancement
+
+Workflow guidance to enhance the tool access an MCP server provides.
+
+**Key techniques:** Coordinates multiple MCP calls in sequence, embeds domain expertise, provides context users would otherwise need to specify, error handling for common MCP issues.
+
+## Define success criteria
+
+These are aspirational targets — rough benchmarks rather than precise thresholds. Aim for rigor but accept that there will be an element of vibes-based assessment.
+
+### Quantitative metrics
+
+* **Skill triggers on 90% of relevant queries** — Run 10-20 test queries that should trigger your skill. Track how many times it loads automatically vs. requires explicit invocation.
+* **Completes workflow in X tool calls** — Compare the same task with and without the skill enabled. Count tool calls and total tokens consumed.
+* **0 failed API calls per workflow** — Monitor MCP server logs during test runs. Track retry rates and error codes.
+
+### Qualitative metrics
+
+* **Users don't need to prompt Claude about next steps** — During testing, note how often you need to redirect or clarify. Ask beta users for feedback.
+* **Workflows complete without user correction** — Run the same request 3-5 times. Compare outputs for structural consistency and quality.
+* **Consistent results across sessions** — Can a new user accomplish the task on first try with minimal guidance?
+
+## Testing approach
+
+**Pro Tip:** Iterate on a single task before expanding. The most effective skill creators iterate on a single challenging task until Claude succeeds, then extract the winning approach into a skill.
+
+Skills can be tested at varying levels of rigor:
+* **Manual testing in Claude.ai** — Run queries directly and observe behavior. Fast iteration, no setup required.
+* **Scripted testing in Claude Code** — Automate test cases for repeatable validation across changes.
+* **Programmatic testing via skills API** — Build evaluation suites that run systematically against defined test sets.
+
+### Three areas to test
+
+**1. Triggering tests** — Ensure your skill loads at the right times:
+* ✅ Triggers on obvious tasks
+* ✅ Triggers on paraphrased requests
+* ❌ Doesn't trigger on unrelated topics
+
+**2. Functional tests** — Verify the skill produces correct outputs:
+* Valid outputs generated
+* API calls succeed
+* Error handling works
+* Edge cases covered
+
+**3. Performance comparison** — Prove the skill improves results vs. baseline. Compare with and without the skill for the same task.
+
+## Using the skill-creator tool
+
+The `skill-creator` skill — available in Claude.ai via plugin directory or download for Claude Code — helps you build and iterate on skills:
+
+**Creating skills:** Generate from natural language descriptions, produce properly formatted SKILL.md with frontmatter, suggest trigger phrases and structure.
+
+**Reviewing skills:** Flag common issues (vague descriptions, missing triggers, structural problems), identify potential over/under-triggering risks, suggest test cases based on the skill's stated purpose.
+
+**Iterative improvement:** After using your skill and encountering edge cases or failures, bring those examples back to skill-creator. Example: "Use the issues & solution identified in this chat to improve how the skill handles [specific edge case]"
+
+To use: "Use the skill-creator skill to help me build a skill for [your use case]"
+
+## Distribution and sharing
+
+### Current distribution model
+
+**How individual users get skills:**
+1. Download the skill folder
+2. Zip the folder (if needed)
+3. Upload to Claude.ai via Settings > Capabilities > Skills
+4. Or place in Claude Code skills directory
+
+**Organization-level skills:** Admins can deploy skills workspace-wide with automatic updates and centralized management.
+
+### Using skills via API
+
+For programmatic use cases — building applications, agents, or automated workflows — the API provides direct control:
+* `/v1/skills` endpoint for listing and managing skills
+* Add skills to Messages API requests via the `container.skills` parameter
+* Version control and management through the Claude Console
+* Works with the Claude Agent SDK for building custom agents
+
+### Positioning your skill
+
+Focus on outcomes, not features:
+* ✅ "Enables teams to set up complete project workspaces in seconds — including pages, databases, and templates — instead of spending 30 minutes on manual setup."
+* ❌ "A folder containing YAML frontmatter and Markdown instructions that calls MCP server tools."
+
+### Skills as an open standard
+
+Skills are designed to be portable across tools and platforms — the same skill should work whether you're using Claude or other AI platforms. Authors can note platform-specific capabilities in the `compatibility` field.

--- a/skills/writing-skills/skill-patterns.md
+++ b/skills/writing-skills/skill-patterns.md
@@ -1,0 +1,162 @@
+# Skill Patterns
+
+> From Anthropic's [Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) — patterns observed from early adopters and internal teams.
+
+## Choosing your approach: Problem-first vs. tool-first
+
+Think of it like Home Depot. You might walk in with a problem — "I need to fix a kitchen cabinet" — and an employee points you to the right tools. Or you might pick out a new drill and ask how to use it for your specific job.
+
+* **Problem-first:** "I need to set up a project workspace" → Your skill orchestrates the right MCP calls in the right sequence. Users describe outcomes; the skill handles the tools.
+* **Tool-first:** "I have Notion MCP connected" → Your skill teaches Claude the optimal workflows and best practices. Users have access; the skill provides expertise.
+
+Most skills lean one direction. Knowing which framing fits your use case helps you choose the right pattern.
+
+## Pattern 1: Sequential workflow orchestration
+
+**Use when:** Your users need multi-step processes in a specific order.
+
+**Example structure:**
+```
+## Workflow: Onboard New Customer
+
+### Step 1: Create Account
+Call MCP tool: `create_customer`
+Parameters: name, email, company
+
+### Step 2: Setup Payment
+Call MCP tool: `setup_payment_method`
+Wait for: payment method verification
+
+### Step 3: Create Subscription
+Call MCP tool: `create_subscription`
+Parameters: plan_id, customer_id (from Step 1)
+
+### Step 4: Send Welcome Email
+Call MCP tool: `send_email`
+Template: welcome_email_template
+```
+
+**Key techniques:** Explicit step ordering, dependencies between steps, validation at each stage, rollback instructions for failures.
+
+## Pattern 2: Multi-MCP coordination
+
+**Use when:** Workflows span multiple services.
+
+**Example: Design-to-development handoff**
+```
+### Phase 1: Design Export (Figma MCP)
+1. Export design assets from Figma
+2. Generate design specifications
+3. Create asset manifest
+
+### Phase 2: Asset Storage (Drive MCP)
+1. Create project folder in Drive
+2. Upload all assets
+3. Generate shareable links
+
+### Phase 3: Task Creation (Linear MCP)
+1. Create development tasks
+2. Attach asset links to tasks
+3. Assign to engineering team
+
+### Phase 4: Notification (Slack MCP)
+1. Post handoff summary to #engineering
+2. Include asset links and task references
+```
+
+**Key techniques:** Clear phase separation, data passing between MCPs, validation before moving to next phase, centralized error handling.
+
+## Pattern 3: Iterative refinement
+
+**Use when:** Output quality improves with iteration.
+
+**Example: Report generation**
+```
+## Iterative Report Creation
+
+### Initial Draft
+1. Fetch data via MCP
+2. Generate first draft report
+3. Save to temporary file
+
+### Quality Check
+1. Run validation script: `scripts/check_report.py`
+2. Identify issues:
+   - Missing sections
+   - Inconsistent formatting
+   - Data validation errors
+
+### Refinement Loop
+1. Address each identified issue
+2. Regenerate affected sections
+3. Re-validate
+4. Repeat until quality threshold met
+
+### Finalization
+1. Apply final formatting
+2. Generate summary
+3. Save final version
+```
+
+**Key techniques:** Explicit quality criteria, iterative improvement loops, validation scripts, knowing when to stop iterating.
+
+## Pattern 4: Context-aware tool selection
+
+**Use when:** Same outcome, different tools depending on context.
+
+**Example: File storage**
+```
+## Smart File Storage
+
+### Decision Tree
+1. Check file type and size
+2. Determine best storage location:
+   - Large files (>10MB): Use cloud storage MCP
+   - Collaborative docs: Use Notion/Docs MCP
+   - Code files: Use GitHub MCP
+   - Temporary files: Use local storage
+
+### Execute Storage
+Based on decision:
+- Call appropriate MCP tool
+- Apply service-specific metadata
+- Generate access link
+
+### Provide Context to User
+Explain why that storage was chosen
+```
+
+**Key techniques:** Clear decision criteria, fallback options, transparency about choices.
+
+## Pattern 5: Domain-specific intelligence
+
+**Use when:** Your skill adds specialized knowledge beyond tool access.
+
+**Example: Financial compliance**
+```
+## Payment Processing with Compliance
+
+### Before Processing (Compliance Check)
+1. Fetch transaction details via MCP
+2. Apply compliance rules:
+   - Check sanctions lists
+   - Verify jurisdiction allowances
+   - Assess risk level
+3. Document compliance decision
+
+### Processing
+IF compliance passed:
+  - Call payment processing MCP tool
+  - Apply appropriate fraud checks
+  - Process transaction
+ELSE:
+  - Flag for review
+  - Create compliance case
+
+### Audit Trail
+- Log all compliance checks
+- Record processing decisions
+- Generate audit report
+```
+
+**Key techniques:** Domain expertise embedded in logic, compliance before action, comprehensive documentation, clear governance.

--- a/skills/writing-skills/troubleshooting.md
+++ b/skills/writing-skills/troubleshooting.md
@@ -1,0 +1,123 @@
+# Troubleshooting Skills
+
+> From Anthropic's [Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
+
+## Skill won't upload
+
+**Error: "Could not find SKILL.md"** — File not named exactly SKILL.md (case-sensitive). Verify with `ls -la`.
+
+**Error: "Invalid frontmatter"** — YAML formatting issue. Common mistakes:
+```yaml
+# Wrong - missing delimiters
+name: my-skill
+description: Does things
+
+# Wrong - unclosed quotes
+---
+name: my-skill
+description: "Does things
+---
+
+# Correct
+---
+name: my-skill
+description: Does things
+---
+```
+
+**Error: "Invalid skill name"** — Name has spaces or capitals. Use kebab-case: `my-cool-skill` not `My Cool Skill`.
+
+## Skill doesn't trigger
+
+**Symptom:** Skill never loads automatically.
+
+**Fix:** Revise your description field. Quick checklist:
+* Is it too generic? ("Helps with projects" won't work)
+* Does it include trigger phrases users would actually say?
+* Does it mention relevant file types if applicable?
+
+**Debugging approach:** Ask Claude: "When would you use the [skill name] skill?" Claude will quote the description back. Adjust based on what's missing.
+
+## Skill triggers too often
+
+**Symptom:** Skill loads for unrelated queries.
+
+**Solutions:**
+1. **Add negative triggers:**
+   ```
+   description: Advanced data analysis for CSV files. Use for statistical modeling,
+   regression, clustering. Do NOT use for simple data exploration (use data-viz skill instead).
+   ```
+2. **Be more specific:**
+   ```
+   # Too broad
+   description: Processes documents
+   # More specific
+   description: Processes PDF legal documents for contract review
+   ```
+3. **Clarify scope:**
+   ```
+   description: PayFlow payment processing for e-commerce. Use specifically for online
+   payment workflows, not for general financial queries.
+   ```
+
+## Instructions not followed
+
+**Symptom:** Skill loads but Claude doesn't follow instructions.
+
+**Common causes:**
+
+1. **Instructions too verbose** — Keep concise, use bullet points and numbered lists, move detailed reference to separate files
+2. **Instructions buried** — Put critical instructions at the top, use `## Important` or `## Critical` headers, repeat key points if needed
+3. **Ambiguous language:**
+   ```
+   # Bad
+   Make sure to validate things properly
+
+   # Good
+   CRITICAL: Before calling create_project, verify:
+   - Project name is non-empty
+   - At least one team member assigned
+   - Start date is not in the past
+   ```
+4. **Model "laziness"** — Add explicit encouragement:
+   ```
+   ## Performance Notes
+   - Take your time to do this thoroughly
+   - Quality is more important than speed
+   - Do not skip validation steps
+   ```
+   Note: Adding this to user prompts is more effective than in SKILL.md
+
+**Advanced technique:** For critical validations, consider bundling a script that performs the checks programmatically rather than relying on language instructions. Code is deterministic; language interpretation isn't.
+
+## MCP connection issues
+
+**Symptom:** Skill loads but MCP calls fail.
+
+**Checklist:**
+1. **Verify MCP server is connected** — Claude.ai: Settings > Extensions > [Your Service], should show "Connected" status
+2. **Check authentication** — API keys valid and not expired, proper permissions/scopes granted, OAuth tokens refreshed
+3. **Test MCP independently** — Ask Claude to call MCP directly (without skill): "Use [Service] MCP to fetch my projects". If this fails, issue is MCP not skill.
+4. **Verify tool names** — Skill references correct MCP tool names, check MCP server documentation, tool names are case-sensitive
+
+## Large context issues
+
+**Symptom:** Skill seems slow or responses degraded.
+
+**Causes:** Skill content too large, too many skills enabled simultaneously, all content loaded instead of progressive disclosure.
+
+**Solutions:**
+1. **Optimize SKILL.md size** — Move detailed docs to references/, link instead of inline, keep SKILL.md under 5,000 words
+2. **Reduce enabled skills** — Evaluate if you have more than 20-50 skills enabled simultaneously, recommend selective enablement, consider skill "packs" for related capabilities
+
+## Iteration signals
+
+**Undertriggering signals:** Skill doesn't load when it should, users manually enabling it, support questions about when to use it.
+**Solution:** Add more detail and nuance to the description — include keywords particularly for technical terms.
+
+**Overtriggering signals:** Skill loads for irrelevant queries, users disabling it, confusion about purpose.
+**Solution:** Add negative triggers, be more specific.
+
+**Execution issues:** Inconsistent results, API call failures, user corrections needed.
+**Solution:** Improve instructions, add error handling.


### PR DESCRIPTION
First off — thanks for building superpowers, @obra. I use it every day and it's genuinely changed how I work with Claude. Really appreciate you maintaining this.

---

Anthropic just dropped their official skill-authoring playbook today — [The Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) — and it's packed with stuff that wasn't in the docs before. This PR brings all that new goodness into the writing-skills skill.

## What's actually in the guide that we were missing?

Turns out Anthropic has been watching how early adopters and internal teams build skills, and they've codified a bunch of patterns and practical guidance that goes way beyond the existing docs page. Things like:

- **5 named skill patterns** they've seen work well (sequential workflows, multi-MCP coordination, iterative refinement, etc.)
- **A proper troubleshooting guide** for when skills won't upload, don't trigger, trigger too much, or just get ignored
- **Planning guidance** — use case categories, success criteria with actual metrics, the problem-first vs tool-first framing
- **Extended YAML frontmatter** — there are optional fields now (`license`, `compatibility`, `allowed-tools`, `metadata`) plus security rules we should know about
- **The description formula** — `[What it does] + [When to use it] + [Key capabilities]` — which nicely complements the CSO insight we already had about not putting workflow steps in descriptions
- **Distribution and API guidance** — `/v1/skills` endpoint, org-level deployment, the open standard vision
- **The skill-creator tool** — a built-in way to generate and review skills

## How this PR is structured (eating our own cooking)

Rather than dumping 300+ lines into `anthropic-best-practices.md` (which would violate the progressive disclosure principle the guide itself teaches), the new content lives in **focused reference files**:

| File | Lines | What's in it |
|------|-------|-------------|
| `planning-and-design.md` | 129 | Use case categories, success criteria, testing approach, distribution |
| `skill-patterns.md` | 162 | The 5 patterns with examples |
| `troubleshooting.md` | 123 | Common issues and fixes |

The existing files get **concise cross-references** instead of bloat:
- `anthropic-best-practices.md` — only +16 lines (was 1,150 → now 1,166). Adds the frontmatter fields, naming rules, description formula, and links to the new files.
- `SKILL.md` — only +15 lines. Reconciles the description guidance and adds cross-references.

## The one interesting nuance

The Anthropic guide says descriptions should include "what it does + when to use it", but our SKILL.md previously said "NEVER include what the skill does — only triggering conditions." These aren't actually contradictory once you split it three ways:

- **WHAT** it does (capabilities) = good, helps Claude decide relevance
- **WHEN** to use it (triggers) = good, helps Claude decide timing  
- **HOW** it works (workflow steps) = bad, creates a shortcut Claude will take

The updated SKILL.md now frames it as **"WHAT + WHEN, never HOW"** — which keeps the critical CSO insight while aligning with Anthropic's formula.

## Test plan
- [x] Verify markdown renders correctly in all files
- [x] Check cross-references between files are valid
- [x] Confirm no existing guidance was removed (this is purely additive)
- [x] Verify the new reference files follow the same patterns as existing ones (testing-skills-with-subagents.md, persuasion-principles.md, etc.)