### PR TITLE
feat: gate bootstrap injection on SUPERPOWERS_SKIP_BOOTSTRAP env var

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -5,10 +5,10 @@
  * Skills are discovered via OpenCode's native skill tool from symlinked directory.
  */
 
-import path from 'path';
-import fs from 'fs';
-import os from 'os';
-import { fileURLToPath } from 'url';
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -21,11 +21,14 @@ const extractAndStripFrontmatter = (content) => {
   const body = match[2];
   const frontmatter = {};
 
-  for (const line of frontmatterStr.split('\n')) {
-    const colonIdx = line.indexOf(':');
+  for (const line of frontmatterStr.split("\n")) {
+    const colonIdx = line.indexOf(":");
     if (colonIdx > 0) {
       const key = line.slice(0, colonIdx).trim();
-      const value = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, '');
+      const value = line
+        .slice(colonIdx + 1)
+        .trim()
+        .replace(/^["']|["']$/g, "");
       frontmatter[key] = value;
     }
   }
@@ -35,12 +38,12 @@ const extractAndStripFrontmatter = (content) => {
 
 // Normalize a path: trim whitespace, expand ~, resolve to absolute
 const normalizePath = (p, homeDir) => {
-  if (!p || typeof p !== 'string') return null;
+  if (!p || typeof p !== "string") return null;
   let normalized = p.trim();
   if (!normalized) return null;
-  if (normalized.startsWith('~/')) {
+  if (normalized.startsWith("~/")) {
     normalized = path.join(homeDir, normalized.slice(2));
-  } else if (normalized === '~') {
+  } else if (normalized === "~") {
     normalized = homeDir;
   }
   return path.resolve(normalized);
@@ -48,17 +51,17 @@ const normalizePath = (p, homeDir) => {
 
 export const SuperpowersPlugin = async ({ client, directory }) => {
   const homeDir = os.homedir();
-  const superpowersSkillsDir = path.resolve(__dirname, '../../skills');
+  const superpowersSkillsDir = path.resolve(__dirname, "../../skills");
   const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
-  const configDir = envConfigDir || path.join(homeDir, '.config/opencode');
+  const configDir = envConfigDir || path.join(homeDir, ".config/opencode");
 
   // Helper to generate bootstrap content
   const getBootstrapContent = () => {
     // Try to load using-superpowers skill
-    const skillPath = path.join(superpowersSkillsDir, 'using-superpowers', 'SKILL.md');
+    const skillPath = path.join(superpowersSkillsDir, "using-superpowers", "SKILL.md");
     if (!fs.existsSync(skillPath)) return null;
 
-    const fullContent = fs.readFileSync(skillPath, 'utf8');
+    const fullContent = fs.readFileSync(skillPath, "utf8");
     const { content } = extractAndStripFrontmatter(fullContent);
 
     const toolMapping = `**Tool Mapping for OpenCode:**
@@ -85,12 +88,12 @@ ${toolMapping}
 
   return {
     // Use system prompt transform to inject bootstrap (fixes #226 agent reset bug)
-    'experimental.chat.system.transform': async (_input, output) => {
-      if (process.env.SUPERPOWERS_SKIP_BOOTSTRAP) return;
+    "experimental.chat.system.transform": async (_input, output) => {
+      if (process.env.SUPERPOWERS_SKIP_BOOTSTRAP === "1") return;
       const bootstrap = getBootstrapContent();
       if (bootstrap) {
         (output.system ||= []).push(bootstrap);
       }
-    }
+    },
   };
 };

--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -86,6 +86,7 @@ ${toolMapping}
   return {
     // Use system prompt transform to inject bootstrap (fixes #226 agent reset bug)
     'experimental.chat.system.transform': async (_input, output) => {
+      if (process.env.SUPERPOWERS_SKIP_BOOTSTRAP) return;
       const bootstrap = getBootstrapContent();
       if (bootstrap) {
         (output.system ||= []).push(bootstrap);


### PR DESCRIPTION
Allow headless/CI/autonomous agent sessions to opt out of the using-superpowers bootstrap injection while preserving access to individual skills via the skill tool.

Set `SUPERPOWERS_SKIP_BOOTSTRAP=1` to skip the system prompt injection.

This enables:
- Autonomous agents and CI systems to use individual skills without the mandatory bootstrap that assumes interactive brainstorming approval
- Cleaner system prompts for headless/non-interactive sessions
- Opt-in behavior for the bootstrap injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option (via environment variable) to optionally skip bootstrap initialization.
* **Style**
  * Consistent reformatting and normalization of string quoting and whitespace with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->