### PR TITLE
fix: prevent && command chaining in code reviewer

### DIFF
--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -22,10 +22,17 @@ You are reviewing code changes for production readiness.
 **Base:** {BASE_SHA}
 **Head:** {HEAD_SHA}
 
+**IMPORTANT: Run these commands SEPARATELY, not chained with &&:**
 ```bash
 git diff --stat {BASE_SHA}..{HEAD_SHA}
+```
+
+Then run:
+```bash
 git diff {BASE_SHA}..{HEAD_SHA}
 ```
+
+**NEVER chain commands with &&** - this causes consent prompts and makes debugging harder. Always use separate Bash calls.
 
 ## Review Checklist
 


### PR DESCRIPTION
## Summary
- Adds guidance to run git diff commands separately instead of chaining with &&
- Prevents consent prompts that occur when Claude chains commands

Fixes #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated code review documentation with improved guidance on running diagnostic commands.
* Added explicit instructions emphasizing proper command execution best practices.
* Enhanced clarity through formatted examples demonstrating correct usage patterns.
* Includes important notes highlighting common pitfalls to avoid during workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->