### PR TITLE
fix(skills): restore worktree step in brainstorming workflow

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -28,7 +28,8 @@ You MUST create a task for each of these items and complete them in order:
 3. **Propose 2-3 approaches** — with trade-offs and your recommendation
 4. **Present design** — in sections scaled to their complexity, get user approval after each section
 5. **Write design doc** — save to `docs/plans/YYYY-MM-DD-<topic>-design.md` and commit
-6. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+6. **Set up worktree** — invoke using-git-worktrees to create isolated implementation workspace
+7. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -40,6 +41,7 @@ digraph brainstorming {
     "Present design sections" [shape=box];
     "User approves design?" [shape=diamond];
     "Write design doc" [shape=box];
+    "Set up worktree (using-git-worktrees)" [shape=box];
     "Invoke writing-plans skill" [shape=doublecircle];
 
     "Explore project context" -> "Ask clarifying questions";
@@ -48,11 +50,12 @@ digraph brainstorming {
     "Present design sections" -> "User approves design?";
     "User approves design?" -> "Present design sections" [label="no, revise"];
     "User approves design?" -> "Write design doc" [label="yes"];
-    "Write design doc" -> "Invoke writing-plans skill";
+    "Write design doc" -> "Set up worktree (using-git-worktrees)";
+    "Set up worktree (using-git-worktrees)" -> "Invoke writing-plans skill";
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+**The terminal state is invoking writing-plans.** Do NOT invoke any implementation skill directly. After design approval, invoke using-git-worktrees for workspace isolation, then invoke writing-plans.
 
 ## The Process
 
@@ -81,6 +84,10 @@ digraph brainstorming {
 - Write the validated design to `docs/plans/YYYY-MM-DD-<topic>-design.md`
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
+
+**Workspace isolation:**
+- Invoke the using-git-worktrees skill to create an isolated workspace for implementation
+- All subsequent implementation work happens in this worktree
 
 **Implementation:**
 - Invoke the writing-plans skill to create a detailed implementation plan

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -209,7 +209,7 @@ Ready to implement auth feature
 ## Integration
 
 **Called by:**
-- **brainstorming** (Phase 4) - REQUIRED when design is approved and implementation follows
+- **brainstorming** (Step 6) - REQUIRED after writing design doc, before invoking writing-plans
 - **subagent-driven-development** - REQUIRED before executing any tasks
 - **executing-plans** - REQUIRED before executing any tasks
 - Any skill needing isolated workspace


### PR DESCRIPTION
## Summary

- Restore the `using-git-worktrees` invocation lost during brainstorming skill simplification (8e38ab8, 7f2ee61)
- Fix stale "Phase 4" cross-reference in `using-git-worktrees` Integration section
- Update terminal state note to reflect the restored worktree step

## Problem

`writing-plans` expects to run in a worktree created by brainstorming (`"This should be run in a dedicated worktree (created by brainstorming skill)."`), but brainstorming never invokes `using-git-worktrees`. The step was unintentionally dropped during two rounds of simplification. Related: #186

## Changes

**`skills/brainstorming/SKILL.md`:**
- Checklist: insert step 6 (Set up worktree) between design doc and writing-plans
- Process flow diagram: add worktree node with correct edges
- "After the Design": add Workspace isolation section
- Terminal state note: replace "The ONLY skill" with explicit worktree → writing-plans flow

**`skills/using-git-worktrees/SKILL.md`:**
- Integration: fix "brainstorming (Phase 4)" → "brainstorming (Step 6)"

## Test Plan

- [ ] Invoke brainstorming skill and verify worktree step appears in task checklist
- [ ] Verify writing-plans runs inside the created worktree
- [ ] Verify using-git-worktrees Integration section references correct step number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated brainstorming workflow to include an isolated workspace setup step before implementation planning
  * Restructured process flow with enhanced workspace isolation guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->