### PR TITLE
Fix run-hook.cmd script directory resolution on Unix

### DIFF
--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -39,8 +39,15 @@ REM (plugin still works, just without SessionStart context injection)
 exit /b 0
 CMDBLOCK
 
-# Unix: run the named script directly
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# Unix: run the named script directly.
+# Prefer CLAUDE_PLUGIN_ROOT (set by Claude Code) over deriving from $0,
+# which resolves to the cwd instead of the script location when Claude Code
+# invokes the command via sh -c (BASH_SOURCE unavailable, $0 unreliable).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SCRIPT_DIR="${CLAUDE_PLUGIN_ROOT}/hooks"
+else
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+fi
 SCRIPT_NAME="$1"
 shift
 exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"


### PR DESCRIPTION
## Summary

- `run-hook.cmd` uses `${BASH_SOURCE[0]:-$0}` to find its own directory, but when Claude Code invokes the command via `sh -c`, `BASH_SOURCE` is unavailable and `$0` resolves to the cwd instead of the script's location
- This causes `exec bash "${SCRIPT_DIR}/session-start"` to look in the wrong directory, producing `SessionStart:startup hook error` on every session start
- Fix: prefer `$CLAUDE_PLUGIN_ROOT` (which Claude Code sets as an env var) when available, falling back to the existing `$0`-based resolution for direct invocation

## How it was diagnosed

- Debug instrumentation revealed `SCRIPT_DIR` resolving to the user's cwd (e.g. `~/Source/some-project`) rather than the plugin cache directory
- The `session-start` script never executed — the wrapper failed before reaching it
- Confirmed by testing in a tmux child session where the cwd differed from the plugin cache path

## Test plan

- [ ] Start a Claude Code session from a directory that is NOT the plugin cache — no `SessionStart:startup hook error` should appear
- [ ] Verify the superpowers skill content is injected into the session context
- [ ] Direct invocation of `run-hook.cmd session-start` from CLI should still work (fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)