### PR TITLE
feat(gemini): Add support for Gemini CLI / Antigravity via Hub Pattern

### DIFF
--- a/.gemini/INSTALL.md
+++ b/.gemini/INSTALL.md
@@ -1,0 +1,76 @@
+# Superpowers for Gemini CLI / Antigravity
+
+Enable superpowers skills in [Gemini CLI](https://geminicli.com) /
+[Antigravity](https://antigravity.google) via global instruction context.
+
+## Quick Install
+
+Tell Gemini (or run locally):
+
+```bash
+git clone https://github.com/obra/superpowers.git ~/.gemini/superpowers && ~/.gemini/superpowers/.gemini/install.sh
+```
+
+## Manual Installation
+
+### Prerequisites
+
+- Gemini CLI / Antigravity environment
+- `git`
+- `~/.gemini/GEMINI.md` (created automatically if missing)
+
+### Steps
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/obra/superpowers.git ~/.gemini/superpowers
+   ```
+
+2. **Run the install script:**
+
+   ```bash
+   ~/.gemini/superpowers/.gemini/install.sh
+   ```
+
+   This script will:
+   - Create `~/.gemini/skills/` if it doesn't exist.
+   - Symlink each skill from the repo into `~/.gemini/skills/` (Hub Pattern).
+   - Append the "Superpowers Context" to your `~/.gemini/GEMINI.md` file.
+
+3. **Reload the Context:**
+   - **Gemini CLI**: Run `/memory refresh` to load the new context immediately,
+     or `/quit` and restart the CLI.
+   - **Antigravity**: Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
+     and run **"Reload Window"**.
+
+## Verification
+
+Ask Gemini:
+
+> "Do you have superpowers?"
+
+It should respond affirmatively and be able to list available skills.
+
+## Uninstallation
+
+1. **Remove the symlinks:**
+
+   ```bash
+   # Remove the specific superpowers symlinks
+   # (Be careful not to delete any custom skills you've added!)
+   find ~/.gemini/skills -type l -lname '*/superpowers/skills/*' -delete
+
+   # Or remove them individually if you prefer
+   # rm ~/.gemini/skills/brainstorming ~/.gemini/skills/testing ...
+   ```
+
+2. **Remove the Repo:**
+
+   ```bash
+   rm -rf ~/.gemini/superpowers
+   ```
+
+3. **Clean up GEMINI.md:** Edit `~/.gemini/GEMINI.md` and remove the
+   "Superpowers Context" block (marked with `<!-- SUPERPOWERS-CONTEXT-START -->`
+   tags).

--- a/.gemini/install.sh
+++ b/.gemini/install.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -e
+
+# Configuration
+GEMINI_DIR="$HOME/.gemini"
+SKILLS_LINK="$GEMINI_DIR/skills"
+GEMINI_MD="$GEMINI_DIR/GEMINI.md"
+REPO_SKILLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../skills" && pwd)"
+
+# Check if the repo skills directory actually exists
+if [ ! -d "$REPO_SKILLS_DIR" ]; then
+    echo "Error: Skills directory not found at $REPO_SKILLS_DIR"
+    exit 1
+fi
+
+# Ensure .gemini directory exists
+if [ ! -d "$GEMINI_DIR" ]; then
+    echo "Creating $GEMINI_DIR..."
+    mkdir -p "$GEMINI_DIR"
+fi
+
+# Link skills (Hub Pattern)
+echo "Linking skills from $REPO_SKILLS_DIR to $SKILLS_LINK..."
+
+# Ensure skills directory exists as a directory
+if [ -L "$SKILLS_LINK" ]; then
+    echo "Converting $SKILLS_LINK from symlink to directory..."
+    rm "$SKILLS_LINK"
+fi
+
+if [ -e "$SKILLS_LINK" ] && [ ! -d "$SKILLS_LINK" ]; then
+    echo "Error: $SKILLS_LINK exists but is not a directory."
+    echo "Please remove this file/link and try again:"
+    echo "  rm $SKILLS_LINK"
+    exit 1
+fi
+mkdir -p "$SKILLS_LINK"
+
+# iterate through skills in the repo and symlink them individually
+for skill_path in "$REPO_SKILLS_DIR"/*; do
+    if [ -d "$skill_path" ]; then
+        skill_name=$(basename "$skill_path")
+        target_path="$SKILLS_LINK/$skill_name"
+        
+        # Safety check: Only replace if it's a symlink or doesn't exist
+        if [ -e "$target_path" ] || [ -L "$target_path" ]; then
+            if [ -L "$target_path" ]; then
+                rm "$target_path"
+            else
+                echo "Warning: $target_path exists and is not a symlink. Skipping to protect user data."
+                continue
+            fi
+        fi
+        
+        ln -s "$skill_path" "$target_path"
+        echo "  - Linked $skill_name"
+    fi
+done
+
+# Context Injection Block
+CONTEXT_HEADER="<!-- SUPERPOWERS-CONTEXT-START -->"
+CONTEXT_FOOTER="<!-- SUPERPOWERS-CONTEXT-END -->"
+
+read -r -d '' CONTEXT_BLOCK << EOM || true
+$CONTEXT_HEADER
+# Superpowers Configuration
+
+You have been granted Superpowers. These are specialized skills located in \`~/.gemini/skills\`.
+
+## Skill Discovery & Usage
+- **ALWAYS** check for relevant skills in \`~/.gemini/skills\` before starting a task.
+- If a skill applies (e.g., "brainstorming", "testing"), you **MUST** follow it.
+- To "use" a skill, read its content and follow the instructions.
+
+## Terminology Mapping (Bootstrap)
+The skills were originally written for Claude Code. You will interpret them as follows:
+- **"Claude"** or **"Claude Code"** -> **"Gemini"** (You).
+- **"Task" tool** -> **Sequential Execution**. You do not have parallel sub-agents yet. Perform tasks sequentially yourself.
+- **"Skill" tool** -> **ReadFile**. To "invoke" a skill, read the markdown file at \`~/.gemini/skills/<skill-name>/SKILL.md\`.
+
+$CONTEXT_FOOTER
+EOM
+
+# Update GEMINI.md
+if [ ! -f "$GEMINI_MD" ]; then
+    echo "Creating $GEMINI_MD..."
+    touch "$GEMINI_MD"
+fi
+
+# Remove existing context block if present (idempotent update)
+if grep -q "$CONTEXT_HEADER" "$GEMINI_MD"; then
+    echo "Updating Superpowers context in $GEMINI_MD..."
+    # Use sed to delete the block. Handles both macOS (BSD) and GNU sed.
+    # We create a backup file and then delete it to be portable.
+    sed -i.bak "/$CONTEXT_HEADER/,/$CONTEXT_FOOTER/d" "$GEMINI_MD"
+    rm "${GEMINI_MD}.bak"
+else
+    echo "Injecting Superpowers context into $GEMINI_MD..."
+fi
+
+# Trim trailing whitespace from the file to prevent accumulation of blank lines
+# awk is used here as a portable way to trim trailing newlines
+awk 'NF{p=1} p' "$GEMINI_MD" > "${GEMINI_MD}.tmp" && mv "${GEMINI_MD}.tmp" "$GEMINI_MD"
+
+# Append the current/updated block with exactly one newline separator
+echo -e "\n\n$CONTEXT_BLOCK" >> "$GEMINI_MD"
+
+echo "Installation complete! Restart your session to activate Superpowers."
+echo "Try asking: 'Do you have superpowers?'"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ Fetch and follow instructions from https://raw.githubusercontent.com/obra/superp
 
 **Detailed docs:** [docs/README.opencode.md](docs/README.opencode.md)
 
+### Gemini CLI / Antigravity
+
+[Gemini CLI](https://geminicli.com) / [Antigravity](https://antigravity.google)
+
+Tell Gemini (or run locally):
+
+```bash
+# Clone the repo
+git clone https://github.com/obra/superpowers.git ~/.gemini/superpowers
+
+# Run the installer
+~/.gemini/superpowers/.gemini/install.sh
+```
+
+**Detailed docs:** [.gemini/INSTALL.md](.gemini/INSTALL.md)
+
 ### Verify Installation
 
 Start a new session in your chosen platform and ask for something that should trigger a skill (for example, "help me plan this feature" or "let's debug this issue"). The agent should automatically invoke the relevant superpowers skill.


### PR DESCRIPTION
## Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a complete installation guide covering quick install, manual setup, verification, reload/context refresh, and uninstallation.
  * Added setup instructions for integrating with the Gemini CLI / Antigravity in the main README.

* **Chores**
  * Added an installer that sets up required directories, registers available skills via safe links, and appends the Superpowers context block to the GEMINI context file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Issues Addressed

May adequately address Issue https://github.com/obra/superpowers/issues/128 : Gemini CLI now supports skills natively, so an extension isn't required.

Would also address Issue https://github.com/obra/superpowers/issues/270: Gemini CLI and Antigravity share the same centralized config for skills.