### PR TITLE
docs(pi): add experimental pi support (Phase 1)

### DIFF
--- a/.pi/INSTALL.md
+++ b/.pi/INSTALL.md
@@ -33,10 +33,10 @@ Then start pi and use `/skill:brainstorming` to confirm skills load.
 
 ## Updating
 
-Update superpowers (and any other installed packages):
+Update superpowers:
 
 ```bash
-pi update
+pi update https://github.com/obra/superpowers
 ```
 
 Or pull manually if using a local path:

--- a/.pi/INSTALL.md
+++ b/.pi/INSTALL.md
@@ -31,6 +31,32 @@ pi list
 
 Then start pi and use `/skill:brainstorming` to confirm skills load.
 
+## Configure Required Subagents
+
+Some Superpowers skills call a `code-reviewer` subagent.
+
+Pi packages do not install agent profiles automatically, so install the bundled profile once:
+
+If installed from GitHub:
+
+```bash
+mkdir -p ~/.pi/agent/agents
+ln -sf ~/.pi/agent/git/github.com/obra/superpowers/.pi/agents/code-reviewer.md ~/.pi/agent/agents/code-reviewer.md
+```
+
+If installed from a local path:
+
+```bash
+mkdir -p ~/.pi/agent/agents
+ln -sf /path/to/superpowers/.pi/agents/code-reviewer.md ~/.pi/agent/agents/code-reviewer.md
+```
+
+Verify:
+
+```bash
+ls ~/.pi/agent/agents/code-reviewer.md
+```
+
 ## Updating
 
 Update superpowers:

--- a/.pi/INSTALL.md
+++ b/.pi/INSTALL.md
@@ -50,3 +50,9 @@ cd /path/to/superpowers && git pull
 ```bash
 pi remove https://github.com/obra/superpowers
 ```
+
+Or, if installed from a local path:
+
+```bash
+pi remove /path/to/superpowers
+```

--- a/.pi/INSTALL.md
+++ b/.pi/INSTALL.md
@@ -1,0 +1,52 @@
+# Installing Superpowers for Pi
+
+## Prerequisites
+
+- [Pi](https://github.com/mariozechner/pi-coding-agent) installed
+- Git
+
+## Installation
+
+```bash
+pi install https://github.com/obra/superpowers
+```
+
+Pi clones the repo and discovers all skills from the `skills/` directory automatically.
+
+### Alternative: Local Clone
+
+If you already have a local clone:
+
+```bash
+pi install /path/to/superpowers
+```
+
+## Verify
+
+Check that the package appears:
+
+```bash
+pi list
+```
+
+Then start pi and use `/skill:brainstorming` to confirm skills load.
+
+## Updating
+
+Update superpowers (and any other installed packages):
+
+```bash
+pi update
+```
+
+Or pull manually if using a local path:
+
+```bash
+cd /path/to/superpowers && git pull
+```
+
+## Uninstalling
+
+```bash
+pi remove https://github.com/obra/superpowers
+```

--- a/.pi/agents/README.md
+++ b/.pi/agents/README.md
@@ -1,0 +1,18 @@
+# Pi Agent Profiles for Superpowers
+
+This directory contains Pi-specific agent profiles used by Superpowers subagent workflows.
+
+## Included profiles
+
+- `code-reviewer.md` — used by `requesting-code-review` and workflows that depend on it.
+
+## Installation
+
+Install these profiles into your Pi user agents directory:
+
+```bash
+mkdir -p ~/.pi/agent/agents
+ln -sf ~/.pi/agent/git/github.com/obra/superpowers/.pi/agents/code-reviewer.md ~/.pi/agent/agents/code-reviewer.md
+```
+
+If Superpowers is installed from a local path, replace the source path accordingly.

--- a/.pi/agents/code-reviewer.md
+++ b/.pi/agents/code-reviewer.md
@@ -1,0 +1,48 @@
+---
+name: code-reviewer
+description: |
+  Use this agent when a major project step has been completed and needs to be reviewed against the original plan and coding standards. Examples: <example>Context: The user is creating a code-review agent that should be called after a logical chunk of code is written. user: "I've finished implementing the user authentication system as outlined in step 3 of our plan" assistant: "Great work! Now let me use the code-reviewer agent to review the implementation against our plan and coding standards" <commentary>Since a major project step has been completed, use the code-reviewer agent to validate the work against the plan and identify any issues.</commentary></example> <example>Context: User has completed a significant feature implementation. user: "The API endpoints for the task management system are now complete - that covers step 2 from our architecture document" assistant: "Excellent! Let me have the code-reviewer agent examine this implementation to ensure it aligns with our plan and follows best practices" <commentary>A numbered step from the planning document has been completed, so the code-reviewer agent should review the work.</commentary></example>
+model: inherit
+---
+
+You are a Senior Code Reviewer with expertise in software architecture, design patterns, and best practices. Your role is to review completed project steps against original plans and ensure code quality standards are met.
+
+When reviewing completed work, you will:
+
+1. **Plan Alignment Analysis**:
+   - Compare the implementation against the original planning document or step description
+   - Identify any deviations from the planned approach, architecture, or requirements
+   - Assess whether deviations are justified improvements or problematic departures
+   - Verify that all planned functionality has been implemented
+
+2. **Code Quality Assessment**:
+   - Review code for adherence to established patterns and conventions
+   - Check for proper error handling, type safety, and defensive programming
+   - Evaluate code organization, naming conventions, and maintainability
+   - Assess test coverage and quality of test implementations
+   - Look for potential security vulnerabilities or performance issues
+
+3. **Architecture and Design Review**:
+   - Ensure the implementation follows SOLID principles and established architectural patterns
+   - Check for proper separation of concerns and loose coupling
+   - Verify that the code integrates well with existing systems
+   - Assess scalability and extensibility considerations
+
+4. **Documentation and Standards**:
+   - Verify that code includes appropriate comments and documentation
+   - Check that file headers, function documentation, and inline comments are present and accurate
+   - Ensure adherence to project-specific coding standards and conventions
+
+5. **Issue Identification and Recommendations**:
+   - Clearly categorize issues as: Critical (must fix), Important (should fix), or Suggestions (nice to have)
+   - For each issue, provide specific examples and actionable recommendations
+   - When you identify plan deviations, explain whether they're problematic or beneficial
+   - Suggest specific improvements with code examples when helpful
+
+6. **Communication Protocol**:
+   - If you find significant deviations from the plan, ask the coding agent to review and confirm the changes
+   - If you identify issues with the original plan itself, recommend plan updates
+   - For implementation problems, provide clear guidance on fixes needed
+   - Always acknowledge what was done well before highlighting issues
+
+Your output should be structured, actionable, and focused on helping maintain high code quality while ensuring project goals are met. Be thorough but concise, and always provide constructive feedback that helps improve both the current implementation and future development practices.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ To update:
 gemini extensions update superpowers
 ```
 
+### Pi (experimental)
+
+```bash
+pi install https://github.com/obra/superpowers
+```
+
+Pi discovers skills from the `skills/` directory automatically. No plugins or bootstrap required for skills. For subagent-based workflows, install the bundled Pi agent profile from `.pi/agents/` (see docs).
+
+**Detailed docs:** [docs/README.pi.md](docs/README.pi.md)
+
 ## The Basic Workflow
 
 1. **brainstorming** - Activates before writing code. Refines rough ideas through questions, explores alternatives, presents design in sections for validation. Saves design document.

--- a/docs/README.pi.md
+++ b/docs/README.pi.md
@@ -143,6 +143,12 @@ Pi discovers skills from multiple locations. On name collision, the first skill 
 pi update
 ```
 
+`pi update` updates all installed packages. To update only Superpowers:
+
+```bash
+pi update https://github.com/obra/superpowers
+```
+
 For local path installs, pull manually:
 
 ```bash

--- a/docs/README.pi.md
+++ b/docs/README.pi.md
@@ -1,0 +1,191 @@
+# Superpowers for Pi
+
+> **Experimental.** Pi support is new. Report issues at <https://github.com/obra/superpowers/issues>.
+
+Complete guide for using Superpowers with [pi](https://github.com/mariozechner/pi-coding-agent).
+
+## Quick Install
+
+```bash
+pi install https://github.com/obra/superpowers
+```
+
+Pi clones the repository and discovers all skills from the `skills/` directory automatically. No plugins, hooks, or bootstrap scripts required.
+
+## Installation Options
+
+### Prerequisites
+
+- [Pi](https://github.com/mariozechner/pi-coding-agent) installed
+- Git
+
+### Option A: Git Package (recommended)
+
+```bash
+pi install https://github.com/obra/superpowers
+```
+
+This clones to `~/.pi/agent/git/github.com/obra/superpowers/` and adds the package to `~/.pi/agent/settings.json`.
+
+### Option B: Local Path
+
+If you already have a local clone:
+
+```bash
+pi install /path/to/superpowers
+```
+
+### Option C: Symlink Skills Only
+
+To add superpowers skills alongside an existing skill tree:
+
+```bash
+ln -s /path/to/superpowers/skills ~/.pi/agent/skills/superpowers
+```
+
+> **Note:** Symlinked skills are not managed by `pi update` or shown by `pi list`. Update manually with `git pull`.
+
+### Verify Installation
+
+Check the package appears:
+
+```bash
+pi list
+```
+
+Then start pi and type `/skill:brainstorming` to confirm skills load.
+
+## Usage
+
+### Finding Skills
+
+Pi lists available skills at startup in the `<available_skills>` section of the system prompt. The agent sees skill names and descriptions automatically.
+
+### Loading a Skill
+
+Three ways:
+
+1. **Automatic** — the agent reads a matching skill when a task fits its description
+2. **Command** — type `/skill:brainstorming` (or any skill name)
+3. **Direct** — the agent uses `read` on the SKILL.md file
+
+### Personal Skills
+
+Create skills in `~/.pi/agent/skills/`:
+
+```bash
+mkdir -p ~/.pi/agent/skills/my-skill
+```
+
+Create `~/.pi/agent/skills/my-skill/SKILL.md`:
+
+```markdown
+---
+name: my-skill
+description: Use when [condition] - [what it does]
+---
+
+# My Skill
+
+[Your skill content here]
+```
+
+### Project Skills
+
+Create project-specific skills in `.pi/skills/` within your project.
+
+## Tool Mapping
+
+Skills are written for Claude Code. Pi equivalents:
+
+| Claude Code | Pi | Notes |
+|---|---|---|
+| `Skill` tool | `read` tool / `/skill:name` | Pi loads skill content via `read` |
+| `TodoWrite` | — | No direct equivalent; use markdown checklists |
+| `Task` with subagents | `subagent` tool | Pi's native delegation system |
+| `Read` | `read` | Same |
+| `Write` | `write` | Same |
+| `Edit` | `edit` | Same |
+| `Bash` | `bash` | Same |
+
+### Subagent Differences
+
+Claude Code's `Task` tool spawns a subagent with isolated context. Pi's `subagent` tool provides similar functionality with three modes:
+
+- **single** — one agent, one task (closest to Claude Code's `Task`)
+- **parallel** — multiple independent tasks
+- **chain** — sequential tasks where each receives prior output
+
+## Architecture
+
+Pi's package system discovers superpowers with zero integration code:
+
+1. `pi install` clones the repo
+2. Pi scans the `skills/` directory (convention-based discovery)
+3. Each `SKILL.md` frontmatter is parsed for name and description
+4. Skills appear in the system prompt's `<available_skills>` XML
+5. The agent loads full skill content on demand via `read`
+
+No plugins, hooks, bootstrap scripts, or CLI wrappers needed.
+
+### Skill Locations
+
+Pi discovers skills from multiple locations. On name collision, the first skill found wins. See [pi's skill documentation](https://github.com/mariozechner/pi-coding-agent/blob/main/docs/skills.md) for authoritative loading order.
+
+- **Global** — `~/.pi/agent/skills/`
+- **Project** — `.pi/skills/`
+- **Settings/Packages** — `skills` array and installed packages
+- **CLI** — `--skill <path>`
+
+## Updating
+
+```bash
+pi update
+```
+
+For local path installs, pull manually:
+
+```bash
+cd /path/to/superpowers && git pull
+```
+
+## Uninstalling
+
+```bash
+pi remove https://github.com/obra/superpowers
+```
+
+For symlink installs:
+
+```bash
+rm ~/.pi/agent/skills/superpowers
+```
+
+## Troubleshooting
+
+### Skills not found
+
+1. Check package is installed: `pi list`
+2. Check skills exist: `ls ~/.pi/agent/git/github.com/obra/superpowers/skills/`
+3. Verify each skill has a `SKILL.md` with valid frontmatter
+
+### Skill not triggering automatically
+
+Pi includes skill descriptions in the system prompt but relies on the model to decide when to load them. Use `/skill:name` to load explicitly.
+
+### Tool mapping confusion
+
+If the agent attempts a Claude Code tool that doesn't exist in pi, remind it of the mapping above.
+
+## Known Differences from Claude Code
+
+- **No `TodoWrite`** — Pi has no built-in task tracking tool. Skills that use `TodoWrite` checklists produce markdown checklists instead.
+- **No hooks system** — Pi doesn't inject bootstrap content on session start. The `using-superpowers` skill triggers via its description in `<available_skills>`.
+- **Skill loading** — Claude Code has a dedicated `Skill` tool. Pi uses `read` on SKILL.md files. Functionally equivalent, syntactically different.
+- **Subagent model** — Pi's `subagent` tool supports single/parallel/chain modes. Claude Code's `Task` maps to single mode.
+
+## Getting Help
+
+- Report issues: <https://github.com/obra/superpowers/issues>
+- Main documentation: <https://github.com/obra/superpowers>
+- Pi documentation: <https://github.com/mariozechner/pi-coding-agent>

--- a/docs/README.pi.md
+++ b/docs/README.pi.md
@@ -10,7 +10,7 @@ Complete guide for using Superpowers with [pi](https://github.com/mariozechner/p
 pi install https://github.com/obra/superpowers
 ```
 
-Pi clones the repository and discovers all skills from the `skills/` directory automatically. No plugins, hooks, or bootstrap scripts required.
+Pi clones the repository and discovers all skills from the `skills/` directory automatically. No plugins, hooks, or bootstrap scripts required for skill loading. For subagent-based workflows, install the bundled agent profile from `.pi/agents/`.
 
 ## Installation Options
 
@@ -54,6 +54,36 @@ pi list
 ```
 
 Then start pi and type `/skill:brainstorming` to confirm skills load.
+
+### Configure Required Subagent Profiles
+
+Some Superpowers skills dispatch a `code-reviewer` subagent.
+
+| Agent profile | Used by |
+|---|---|
+| `code-reviewer` | `requesting-code-review` and workflows that depend on it |
+
+Pi packages do not auto-install agent profiles, so install the bundled profile once:
+
+If installed from GitHub:
+
+```bash
+mkdir -p ~/.pi/agent/agents
+ln -sf ~/.pi/agent/git/github.com/obra/superpowers/.pi/agents/code-reviewer.md ~/.pi/agent/agents/code-reviewer.md
+```
+
+If installed from a local path:
+
+```bash
+mkdir -p ~/.pi/agent/agents
+ln -sf /path/to/superpowers/.pi/agents/code-reviewer.md ~/.pi/agent/agents/code-reviewer.md
+```
+
+Verify:
+
+```bash
+ls ~/.pi/agent/agents/code-reviewer.md
+```
 
 ## Usage
 
@@ -102,7 +132,7 @@ Skills are written for Claude Code. Pi equivalents:
 |---|---|---|
 | `Skill` tool | `read` tool / `/skill:name` | Pi loads skill content via `read` |
 | `TodoWrite` | — | No direct equivalent; use markdown checklists |
-| `Task` with subagents | `subagent` tool | Pi's native delegation system |
+| `Task` with subagents | `subagent` tool | Requires a subagent extension and matching agent profiles (for example `code-reviewer`) |
 | `Read` | `read` | Same |
 | `Write` | `write` | Same |
 | `Edit` | `edit` | Same |
@@ -110,7 +140,9 @@ Skills are written for Claude Code. Pi equivalents:
 
 ### Subagent Differences
 
-Claude Code's `Task` tool spawns a subagent with isolated context. Pi's `subagent` tool provides similar functionality with three modes:
+Pi core does not include built-in subagents. If your Pi harness provides a `subagent` tool, it maps to Claude Code's `Task` behavior.
+
+Pi `subagent` tools typically provide three modes:
 
 - **single** — one agent, one task (closest to Claude Code's `Task`)
 - **parallel** — multiple independent tasks
@@ -136,6 +168,15 @@ Pi discovers skills from multiple locations. On name collision, the first skill 
 - **Project** — `.pi/skills/`
 - **Settings/Packages** — `skills` array and installed packages
 - **CLI** — `--skill <path>`
+
+### Harness-Specific Files
+
+Pi-specific resources live in `.pi/` in this repository:
+
+- `.pi/INSTALL.md`
+- `.pi/agents/code-reviewer.md`
+
+If we add Pi-specific extensions later, they should live under `.pi/extensions/`.
 
 ## Updating
 
@@ -188,7 +229,8 @@ If the agent attempts a Claude Code tool that doesn't exist in pi, remind it of 
 - **No `TodoWrite`** — Pi has no built-in task tracking tool. Skills that use `TodoWrite` checklists produce markdown checklists instead.
 - **No hooks system** — Pi doesn't inject bootstrap content on session start. The `using-superpowers` skill triggers via its description in `<available_skills>`.
 - **Skill loading** — Claude Code has a dedicated `Skill` tool. Pi uses `read` on SKILL.md files. Functionally equivalent, syntactically different.
-- **Subagent model** — Pi's `subagent` tool supports single/parallel/chain modes. Claude Code's `Task` maps to single mode.
+- **Subagent model** — Pi core does not include built-in subagents. If your harness provides a `subagent` tool, Claude Code's `Task` usually maps to single mode.
+- **Agent profiles** — Pi packages do not auto-install agent profiles. Superpowers ships required Pi profiles in `.pi/agents/`; install them in `~/.pi/agent/agents/`.
 
 ## Getting Help
 

--- a/tests/pi/README.md
+++ b/tests/pi/README.md
@@ -1,0 +1,28 @@
+# Pi smoke tests
+
+Run from repository root:
+
+```bash
+./tests/pi/run-tests.sh
+```
+
+Run only the smoke test directly:
+
+```bash
+./tests/pi/test-smoke.sh
+```
+
+What this smoke test verifies:
+
+1. `pi install` works with an isolated `PI_CODING_AGENT_DIR` (temp directory)
+2. The install writes package settings into that isolated directory
+3. Pi package resolution can discover
+   `skills/brainstorming/SKILL.md` from this repo
+4. `pi list` shows the installed local package
+5. `~/.pi/agent/settings.json` is unchanged
+   (guard against accidental global writes)
+
+Requirements:
+
+- `pi` in `PATH`
+- `node` in `PATH`

--- a/tests/pi/run-tests.sh
+++ b/tests/pi/run-tests.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Pi test runner
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "========================================"
+echo " Pi Test Suite"
+echo "========================================"
+echo ""
+echo "Repository: $(cd ../.. && pwd)"
+echo "Test time: $(date)"
+echo ""
+
+VERBOSE=false
+SPECIFIC_TEST=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --verbose|-v)
+            VERBOSE=true
+            shift
+            ;;
+        --test|-t)
+            SPECIFIC_TEST="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 [options]"
+            echo ""
+            echo "Options:"
+            echo "  --verbose, -v      Show verbose output"
+            echo "  --test, -t NAME    Run only the specified test"
+            echo "  --help, -h         Show this help"
+            echo ""
+            echo "Tests:"
+            echo "  test-smoke.sh      Isolated install + skill discovery smoke test"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+tests=(
+    "test-smoke.sh"
+)
+
+if [ -n "$SPECIFIC_TEST" ]; then
+    tests=("$SPECIFIC_TEST")
+fi
+
+passed=0
+failed=0
+skipped=0
+
+for test in "${tests[@]}"; do
+    echo "----------------------------------------"
+    echo "Running: $test"
+    echo "----------------------------------------"
+
+    test_path="$SCRIPT_DIR/$test"
+
+    if [ ! -f "$test_path" ]; then
+        echo "  [SKIP] Test file not found: $test"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    if [ ! -x "$test_path" ]; then
+        chmod +x "$test_path"
+    fi
+
+    start_time=$(date +%s)
+
+    if [ "$VERBOSE" = true ]; then
+        if bash "$test_path"; then
+            end_time=$(date +%s)
+            duration=$((end_time - start_time))
+            echo ""
+            echo "  [PASS] $test (${duration}s)"
+            passed=$((passed + 1))
+        else
+            end_time=$(date +%s)
+            duration=$((end_time - start_time))
+            echo ""
+            echo "  [FAIL] $test (${duration}s)"
+            failed=$((failed + 1))
+        fi
+    else
+        if output=$(bash "$test_path" 2>&1); then
+            end_time=$(date +%s)
+            duration=$((end_time - start_time))
+            echo "  [PASS] (${duration}s)"
+            passed=$((passed + 1))
+        else
+            end_time=$(date +%s)
+            duration=$((end_time - start_time))
+            echo "  [FAIL] (${duration}s)"
+            echo ""
+            echo "  Output:"
+            while IFS= read -r line; do
+                echo "    $line"
+            done <<< "$output"
+            failed=$((failed + 1))
+        fi
+    fi
+
+    echo ""
+done
+
+echo "========================================"
+echo " Test Results Summary"
+echo "========================================"
+echo ""
+echo "  Passed:  $passed"
+echo "  Failed:  $failed"
+echo "  Skipped: $skipped"
+echo ""
+
+if [ $failed -gt 0 ]; then
+    echo "STATUS: FAILED"
+    exit 1
+fi
+
+echo "STATUS: PASSED"
+exit 0

--- a/tests/pi/test-smoke.sh
+++ b/tests/pi/test-smoke.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+info() {
+    echo "[INFO] $*"
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+require_command() {
+    local cmd="$1"
+    command -v "$cmd" >/dev/null 2>&1 || fail "missing required command: $cmd"
+}
+
+hash_file() {
+    local path="$1"
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$path" | awk '{print $1}'
+        return
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$path" | awk '{print $1}'
+        return
+    fi
+
+    fail "missing required command: shasum or sha256sum"
+}
+
+file_state() {
+    local path="$1"
+    if [ -f "$path" ]; then
+        local digest
+        digest="$(hash_file "$path")"
+        printf 'file:%s\n' "$digest"
+    else
+        printf 'missing\n'
+    fi
+}
+
+info "Pi smoke test: isolated install + skill discovery"
+
+require_command pi
+require_command node
+
+DEFAULT_SETTINGS="$HOME/.pi/agent/settings.json"
+DEFAULT_STATE_BEFORE="$(file_state "$DEFAULT_SETTINGS")"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/superpowers-pi-smoke.XXXXXX")"
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+export PI_CODING_AGENT_DIR="$TMP_ROOT/agent"
+mkdir -p "$PI_CODING_AGENT_DIR"
+
+PI_BIN="$(command -v pi)"
+if ! PI_REALPATH="$(node -e 'const fs=require("fs");console.log(fs.realpathSync(process.argv[1]))' "$PI_BIN" 2>/dev/null)"; then
+    fail "unable to resolve pi binary path"
+fi
+PI_PACKAGE_ROOT="$(cd "$(dirname "$PI_REALPATH")/.." && pwd)"
+
+info "Using isolated PI_CODING_AGENT_DIR: $PI_CODING_AGENT_DIR"
+info "Installing package from: $REPO_ROOT"
+
+if INSTALL_OUTPUT="$(pi install "$REPO_ROOT" 2>&1)"; then
+    echo "$INSTALL_OUTPUT"
+    pass "pi install succeeded in isolated agent dir"
+else
+    echo "$INSTALL_OUTPUT" >&2
+    fail "pi install failed"
+fi
+
+SETTINGS_FILE="$PI_CODING_AGENT_DIR/settings.json"
+[ -f "$SETTINGS_FILE" ] || fail "expected settings file not found: $SETTINGS_FILE"
+pass "isolated settings file created"
+
+export REPO_ROOT PI_PACKAGE_ROOT SETTINGS_FILE
+if DISCOVERY_OUTPUT="$(node --input-type=module <<'NODE'
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const repoRoot = path.resolve(process.env.REPO_ROOT);
+const settingsPath = process.env.SETTINGS_FILE;
+const packageRoot = process.env.PI_PACKAGE_ROOT;
+const agentDir = process.env.PI_CODING_AGENT_DIR;
+
+const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+const packages = Array.isArray(settings.packages) ? settings.packages : [];
+const sources = packages
+  .map((entry) => (typeof entry === 'string' ? entry : entry?.source))
+  .filter(Boolean);
+
+const hasRepoSource = sources.some((source) => path.resolve(agentDir, source) === repoRoot);
+if (!hasRepoSource) {
+  console.error(`settings.json does not contain repository source for ${repoRoot}`);
+  process.exit(1);
+}
+
+const { SettingsManager } = await import(
+  pathToFileURL(path.join(packageRoot, 'dist/core/settings-manager.js')).href
+);
+const { DefaultPackageManager } = await import(
+  pathToFileURL(path.join(packageRoot, 'dist/core/package-manager.js')).href
+);
+
+const settingsManager = SettingsManager.create(repoRoot, agentDir);
+const packageManager = new DefaultPackageManager({
+  cwd: repoRoot,
+  agentDir,
+  settingsManager,
+});
+
+const resolved = await packageManager.resolve();
+const enabledSkillPaths = resolved.skills.filter((skill) => skill.enabled).map((skill) => path.resolve(skill.path));
+const brainstormingSkill = path.join(repoRoot, 'skills', 'brainstorming', 'SKILL.md');
+
+if (!enabledSkillPaths.includes(brainstormingSkill)) {
+  console.error('brainstorming skill was not discoverable in resolved skills');
+  process.exit(1);
+}
+
+console.log(`Resolved skills: ${enabledSkillPaths.length}`);
+console.log(`Found: ${brainstormingSkill}`);
+NODE
+)"; then
+    echo "$DISCOVERY_OUTPUT"
+    pass "Pi resolves brainstorming skill from installed package"
+else
+    echo "$DISCOVERY_OUTPUT" >&2
+    fail "skill discovery check failed"
+fi
+
+if LIST_OUTPUT="$(pi list 2>&1)"; then
+    echo "$LIST_OUTPUT"
+else
+    echo "$LIST_OUTPUT" >&2
+    fail "pi list failed"
+fi
+
+echo "$LIST_OUTPUT" | grep -Fq "$REPO_ROOT" || fail "pi list output did not include installed repository path"
+pass "pi list reports installed package"
+
+DEFAULT_STATE_AFTER="$(file_state "$DEFAULT_SETTINGS")"
+[ "$DEFAULT_STATE_BEFORE" = "$DEFAULT_STATE_AFTER" ] || fail "global ~/.pi/agent/settings.json changed; install was not isolated"
+pass "global ~/.pi/agent/settings.json unchanged"
+
+echo "All Pi smoke checks passed."


### PR DESCRIPTION
## Summary

Add experimental support for [pi](https://github.com/mariozechner/pi-coding-agent) (`@mariozechner/pi-coding-agent`) as **Phase 1 of #435**.

Pi already discovers package `skills/` directories automatically, so baseline support is lightweight. This PR adds Pi installation docs, a bundled Pi agent profile for current subagent workflows, and smoke tests for isolated install plus skill discovery.

## Changes

### Documentation

- **`.pi/INSTALL.md`** — machine-readable install/update/remove instructions, matching the `.codex/INSTALL.md` and `.opencode/INSTALL.md` pattern
- **`docs/README.pi.md`** — full Pi guide covering installation options, required `code-reviewer` profile setup, tool mapping, architecture notes, troubleshooting, and known differences
- **`README.md`** — add Pi to the top-level installation matrix
- **`.pi/agents/README.md`** — Pi agent-profile installation docs
- **`.pi/agents/code-reviewer.md`** — bundled `code-reviewer` profile for `requesting-code-review` and workflows that depend on it

### Smoke tests (Phase 1 requirement)

- **`tests/pi/test-smoke.sh`**
  - installs into an isolated `PI_CODING_AGENT_DIR`
  - verifies package registration in isolated settings
  - verifies `brainstorming` skill discoverability through Pi package resolution
  - verifies `pi list` includes the installed package
  - verifies `~/.pi/agent/settings.json` is unchanged
- **`tests/pi/run-tests.sh`** — runner wrapper consistent with other `tests/*/run-tests.sh` suites
- **`tests/pi/README.md`** — run instructions and requirements

## Why no repo-local integration code?

Unlike Codex and OpenCode, Pi does not need repo-local bootstrap or plugin glue for basic skill loading:

- Pi discovers package `skills/` by convention.
- No `.opencode/plugins/*` equivalent is required for baseline compatibility.

## Smoke test scope

This smoke test validates deterministic package install and skill discoverability, and it runs locally without model credentials.

It does **not** validate interactive runtime UI behavior such as `/skill:brainstorming` appearing in-session.

## Tool mapping

| Claude Code | Pi | Notes |
|---|---|---|
| `Skill` tool | `read` / `/skill:name` | Pi loads `SKILL.md` via `read` |
| `TodoWrite` | — | Use markdown checklists instead |
| `Task` (subagents) | `subagent` | Requires harness support plus matching agent profiles |
| `Read`, `Write`, `Edit`, `Bash` | Same names | Direct equivalents |

## Phase tracking

- ✅ **Phase 1 (#435):** docs + smoke tests (this PR)
- ⏭️ **Phase 2 (#435):** deeper integration, workflow mapping, and end-to-end tests (follow-up)
