### PR TITLE
fix(windows): SessionStart hook fails with Git Bash paths

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "command": "bash -lc 'ROOT=\"$CLAUDE_PLUGIN_ROOT\"; if command -v cygpath >/dev/null 2>&1; then ROOT=\"$(cygpath -u \"$ROOT\")\"; fi; \"$ROOT/hooks/session-start.sh\"'",
             "async": false
           }
         ]


### PR DESCRIPTION
## Motivation and Context

On Windows, the `SessionStart` hook fails because `${CLAUDE_PLUGIN_ROOT}` resolves to a Windows-style path (e.g. `C:\Users\...`), which Git Bash cannot execute directly as a script path.

This causes `session-start.sh` to fail on every Claude startup.

This change runs the hook through `bash -lc` and converts the plugin root to a Unix-style path using `cygpath -u` when available.

## How Has This Been Tested?

- Verified JSON structure is valid
- Confirmed no behavior change on macOS
- The `cygpath` conversion only executes when available (Windows Git Bash)
- On systems without `cygpath`, behavior remains unchanged

## Breaking Changes

None.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Context

This provides a minimal cross-platform fix without introducing OS-specific branching or additional wrapper scripts.

Fixes #504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows compatibility for session initialization to improve reliability across different operating systems. The session startup functionality now works properly on Windows while maintaining consistent behavior on macOS and Linux platforms. Improved path handling ensures proper execution in various system environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->