### PR TITLE
feat: add persistent-planning skill for shared file-based memory

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -14,6 +14,19 @@ if [ -d "$legacy_skills_dir" ]; then
     warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER:⚠️ **WARNING:** Superpowers now uses Claude Code's skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
 fi
 
+# Detect active plans for session recovery
+active_plan_message=""
+if [ -d "docs/plans" ]; then
+    for pf in docs/plans/*-progress.md; do
+        [ -f "$pf" ] || continue
+        if grep -q '^\- \[ \]' "$pf"; then
+            PLAN_BASE=$(basename "$pf" | sed 's/-progress\.md$//')
+            active_plan_message="\n\n<important-reminder>Active plan detected: ${PLAN_BASE}\nUse @persistent-planning session recovery protocol.\nRead: docs/plans/${PLAN_BASE}-progress.md and docs/plans/${PLAN_BASE}-findings.md</important-reminder>"
+            break
+        fi
+    done
+fi
+
 # Read using-superpowers content
 using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
 
@@ -32,7 +45,8 @@ escape_for_json() {
 
 using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
 warning_escaped=$(escape_for_json "$warning_message")
-session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+active_plan_escaped=$(escape_for_json "$active_plan_message")
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}${active_plan_escaped}\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
 # Keep both shapes for compatibility:

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -49,6 +49,25 @@ After all tasks complete and verified:
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice
 
+## Persistent Planning Integration
+
+Before starting execution:
+1. Verify companion files exist (`*-findings.md`, `*-progress.md`)
+2. If missing, generate them from @persistent-planning templates
+
+After each task in a batch:
+1. Update `*-progress.md` task status with timestamp
+
+Between batches (during report):
+1. Include progress summary from `*-progress.md`
+2. Note any findings or error patterns from `*-findings.md`
+3. Update Session Log in progress.md
+
+On session recovery (after `/clear`):
+1. Read `*-progress.md` to find last completed task
+2. Resume from next unchecked task
+3. Follow @persistent-planning session-recovery.md protocol
+
 ## When to Stop and Ask for Help
 
 **STOP executing immediately when:**

--- a/skills/persistent-planning/SKILL.md
+++ b/skills/persistent-planning/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: persistent-planning
+description: Use during plan writing, plan execution, or session recovery to maintain shared file-based memory across tasks and sessions via findings, progress, and error tracking
+---
+
+# Persistent Planning
+
+## Overview
+
+Give the orchestrator and subagents a shared, file-based memory so later tasks benefit from earlier discoveries, progress survives `/clear`, and errors aren't repeated.
+
+**Core principle:** Orchestrator-mediated — only the orchestrator reads/writes planning files; subagents receive findings via prompt injection and report back in their output.
+
+**Announce at start:** "I'm using the persistent-planning skill to maintain shared context across tasks."
+
+## When It Applies
+
+- During plan writing (companion file generation)
+- During plan execution (progress tracking, findings accumulation)
+- On session recovery after `/clear` (detecting and resuming active plans)
+
+## The 3-File Pattern
+
+Every plan has three companion files in `docs/plans/`:
+
+| File | Purpose | Who Writes |
+|------|---------|------------|
+| `YYYY-MM-DD-<feature>.md` | The implementation plan | writing-plans skill |
+| `YYYY-MM-DD-<feature>-findings.md` | Shared discoveries, decisions, errors | Orchestrator (from subagent reports) |
+| `YYYY-MM-DD-<feature>-progress.md` | Task status, session log, review results | Orchestrator |
+
+## Orchestrator Rules
+
+### Before Each Subagent Dispatch
+
+1. Read `*-findings.md` for the active plan
+2. If findings > ~200 lines, use only the Summary section
+3. Include findings content in subagent prompt under `## Context from Previous Tasks`
+4. Check Error Log for failures relevant to this task's domain
+
+### After Each Task Completion
+
+1. Update `*-progress.md`: check off task with timestamp
+2. Append any new findings from implementer's report to `*-findings.md`
+3. Record review results in progress.md Review Results table
+
+### The 2-Action Rule
+
+Every 2 completed tasks, the orchestrator asks itself:
+
+> "Did these subagents discover something future tasks need?"
+
+If yes:
+- Append to findings under appropriate section
+- If findings is growing large, update the Summary section
+
+If no:
+- Continue to next task
+
+### Plan Deviation Protocol
+
+When the implementation needs to deviate from the plan:
+
+1. **Do NOT edit the plan file** — it's the original spec
+2. Record the decision in findings.md Decisions Log with rationale and task number
+3. Future spec reviewers will check Decisions Log before flagging deviations
+
+### 3-Strike Error Protocol
+
+When a task or approach fails:
+
+| Strike | Action |
+|--------|--------|
+| 1st failure | Diagnose root cause, fix, log in findings Error Log |
+| 2nd failure | Try alternative approach, log both attempts in Error Log |
+| 3rd failure | **STOP.** Escalate to user. Do not attempt again without guidance. |
+
+The Error Log ensures future subagents don't repeat the same failed approaches.
+
+## Findings Growth Management
+
+When `*-findings.md` exceeds ~200 lines:
+
+1. Orchestrator maintains a **Summary** section at the top (10-20 lines)
+2. Summary contains: key decisions, critical gotchas, important patterns
+3. When injecting findings into subagent prompts, use **only the Summary**
+4. Full findings remain in the file for human reference
+
+## Templates
+
+- `./findings-template.md` — Template for new findings files
+- `./progress-template.md` — Template for new progress files
+- `./session-recovery.md` — Instructions for recovering from `/clear`
+
+## Integration
+
+**Used by:**
+- **superpowers:writing-plans** — Generates companion files after plan creation
+- **superpowers:subagent-driven-development** — Reads/writes findings and progress per task
+- **superpowers:executing-plans** — Updates progress between batches
+- **hooks/session-start.sh** — Detects active plans for recovery
+
+**Pairs with:**
+- **superpowers:brainstorming** — Discoveries from brainstorming can seed initial findings

--- a/skills/persistent-planning/findings-template.md
+++ b/skills/persistent-planning/findings-template.md
@@ -1,0 +1,18 @@
+# Findings: {FEATURE_NAME}
+
+## Summary
+<!-- Orchestrator maintains this as a condensed version when findings grow large -->
+
+## Technical Discoveries
+<!-- Architecture insights, API behaviors, gotchas discovered during implementation -->
+
+## Decisions Log
+| # | Decision | Rationale | Task |
+|---|----------|-----------|------|
+
+## Error Log
+| Task | Attempt | What Failed | Why | Resolution |
+|------|---------|-------------|-----|------------|
+
+## Resources
+<!-- Useful files, docs, URLs discovered during implementation -->

--- a/skills/persistent-planning/progress-template.md
+++ b/skills/persistent-planning/progress-template.md
@@ -1,0 +1,25 @@
+# Progress: {FEATURE_NAME}
+
+## Task Status
+<!-- Mirrors plan task list. Orchestrator updates after each task. -->
+
+## Session Log
+### Session 1 ({DATE})
+- Started:
+- Completed:
+- Blocked:
+
+## Review Results
+| Task | Spec Review | Quality Review | Issues Found |
+|------|-------------|----------------|--------------|
+
+## Test Results
+<!-- Latest test suite output summary -->
+
+## Reboot Check
+<!-- Filled by orchestrator on session recovery -->
+1. Current phase:
+2. Last completed task:
+3. Active blockers:
+4. Error patterns: (see findings.md)
+5. Next task:

--- a/skills/persistent-planning/session-recovery.md
+++ b/skills/persistent-planning/session-recovery.md
@@ -1,0 +1,62 @@
+# Session Recovery Protocol
+
+Instructions for recovering an active plan after `/clear` or a new session.
+
+## Detection (via session-start hook)
+
+The session-start hook scans for active plans:
+
+1. Check if `docs/plans/` directory exists
+2. Look for `*-progress.md` files containing unchecked items (`- [ ]`)
+3. If found, signal the active plan to the session context
+
+## Recovery Steps
+
+When an active plan is detected:
+
+### Step 1: Read State Files
+
+Read all three companion files:
+- `docs/plans/<plan>-progress.md` — What's done, what's next
+- `docs/plans/<plan>-findings.md` — Accumulated discoveries and errors
+- `docs/plans/<plan>.md` — The original plan
+
+### Step 2: Fill Reboot Check
+
+Update the Reboot Check section in `*-progress.md`:
+
+```markdown
+## Reboot Check
+1. Current phase: [derived from Task Status — which tasks are checked]
+2. Last completed task: [last `- [x]` entry]
+3. Active blockers: [any tasks marked blocked in Session Log]
+4. Error patterns: (see findings.md) [summarize Error Log patterns]
+5. Next task: [first `- [ ]` entry]
+```
+
+### Step 3: Present Recovery Summary
+
+Show the user a concise recovery summary:
+
+```
+Active plan detected: <plan-name>
+
+- Phase: [e.g., "Implementation — 3 of 8 tasks complete"]
+- Last completed: Task 3 — [task name]
+- Blockers: [none / list]
+- Error patterns: [none / brief summary]
+- Next up: Task 4 — [task name]
+```
+
+### Step 4: Confirm with User
+
+Ask: **"Ready to continue from Task N, or review the plan first?"**
+
+- If **continue**: Resume execution using the appropriate skill (subagent-driven-development or executing-plans)
+- If **review**: Show the full plan with progress overlay (checked/unchecked tasks)
+
+## Important Notes
+
+- Always re-read findings before resuming — context from earlier tasks may have changed
+- Check the Error Log for patterns that affect the next task
+- If the Decisions Log has entries, the plan may have deviated — review decisions before assuming the plan text is current

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -82,6 +82,21 @@ digraph process {
 }
 ```
 
+## Persistent Planning Integration
+
+Before dispatching EACH implementer subagent:
+1. Read `*-findings.md` for the active plan
+2. If findings > 200 lines, use only the Summary section
+3. Include findings content in subagent prompt under `## Context from Previous Tasks`
+4. Check Error Log for failures relevant to this task's domain
+
+After EACH task completes (all reviews pass):
+1. Update `*-progress.md`: check off task with timestamp
+2. Append any new findings from implementer's report to `*-findings.md`
+3. Record review results in progress.md Review Results table
+4. Every 2 tasks: re-read findings and assess cross-cutting concerns
+5. If plan change needed: record decision in findings Decisions Log (do NOT edit the plan)
+
 ## Prompt Templates
 
 - `./implementer-prompt.md` - Dispatch implementer subagent

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -15,6 +15,17 @@ Task tool (superpowers:code-reviewer):
   BASE_SHA: [commit before task]
   HEAD_SHA: [current commit]
   DESCRIPTION: [task summary]
+
+  ## Implementation Context
+
+  <ERROR_HISTORY>
+  {ORCHESTRATOR_PASTES_ERROR_LOG_HERE}
+  </ERROR_HISTORY>
+
+  If the error log shows repeated failures with a standard approach,
+  and the implementer chose an alternative, evaluate the alternative
+  on its merits. A working non-standard approach that avoids a known
+  failure is preferable to a "clean" approach that doesn't work.
 ```
 
 **Code reviewer returns:** Strengths, Issues (Critical/Important/Minor), Assessment

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -16,6 +16,17 @@ Task tool (general-purpose):
 
     [Scene-setting: where this fits, dependencies, architectural context]
 
+    ## Context from Previous Tasks
+
+    <FINDINGS>
+    {ORCHESTRATOR_PASTES_FINDINGS_CONTENT_HERE}
+    </FINDINGS>
+
+    Use this context to:
+    - Avoid approaches that already failed (see Error Log)
+    - Reuse discovered resources and patterns
+    - Respect decisions that deviated from the original plan
+
     ## Before You Begin
 
     If you have questions about:
@@ -67,6 +78,18 @@ Task tool (general-purpose):
 
     If you find issues during self-review, fix them now before reporting.
 
+    ## Reporting New Discoveries
+
+    In your completion report, include a section:
+
+    ### Discoveries
+    - Technical insights: [any architecture/API/codebase discoveries]
+    - Useful files: [paths to files future tasks might need]
+    - Gotchas: [anything surprising or non-obvious]
+    - Failed approaches: [what you tried that didn't work and why]
+
+    The orchestrator will merge these into the shared findings file.
+
     ## Report Format
 
     When done, report:
@@ -74,5 +97,6 @@ Task tool (general-purpose):
     - What you tested and test results
     - Files changed
     - Self-review findings (if any)
+    - Discoveries (see above)
     - Any issues or concerns
 ```

--- a/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -53,6 +53,16 @@ Task tool (general-purpose):
     - Did they solve the wrong problem?
     - Did they implement the right feature but wrong way?
 
+    ## Decisions Log Context
+
+    <DECISIONS>
+    {ORCHESTRATOR_PASTES_DECISIONS_LOG_HERE}
+    </DECISIONS>
+
+    If the Decisions Log records an intentional deviation from the plan
+    (with rationale), that is NOT a spec violation. Evaluate the deviation
+    against the recorded rationale, not against the original plan text.
+
     **Verify by reading code, not by trusting report.**
 
     Report:

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -44,6 +44,21 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 ---
 ```
 
+## Companion Files (Persistent Planning)
+
+After writing the plan, generate two companion files using @persistent-planning templates:
+
+1. `docs/plans/YYYY-MM-DD-<feature>-findings.md`
+   - Copy findings-template.md
+   - Fill `{FEATURE_NAME}` with the feature name
+
+2. `docs/plans/YYYY-MM-DD-<feature>-progress.md`
+   - Copy progress-template.md
+   - Fill `{FEATURE_NAME}` and `{DATE}`
+   - Pre-populate Task Status with all tasks from plan (all `- [ ]`)
+
+Confirm all three files exist before offering execution options.
+
 ## Task Structure
 
 ````markdown


### PR DESCRIPTION
## Summary
- Adds new `persistent-planning` skill with a 3-file pattern (plan + findings + progress) that gives the orchestrator and subagents shared, file-based memory across tasks and sessions
- Modifies `writing-plans`, `subagent-driven-development`, `executing-plans` skills and all three subagent prompt templates to integrate findings context, decisions log awareness, and error history
- Adds active plan detection to `session-start.sh` hook for automatic recovery after `/clear`

## Test plan
- [ ] Verify `persistent-planning` skill loads (visible in skill list)
- [ ] Invoke `writing-plans` and confirm all 3 companion files are generated in `docs/plans/`
- [ ] Execute a multi-task plan with `subagent-driven-development` and verify findings accumulate across tasks
- [ ] Verify progress.md updates after each task completion
- [ ] Run `/clear` and restart — verify session recovery detects active plan
- [ ] Verify spec-reviewer respects decisions log (intentional deviations not flagged)
- [ ] Verify code-quality-reviewer considers error history when evaluating alternative approaches
- [ ] Verify 3-Strike error protocol stops execution after 3rd failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Persistent planning system tracks progress and findings across sessions
  * Session recovery restores interrupted work with state details
  * Enhanced planning integration within task execution workflows

* **Documentation**
  * New persistent planning protocol and workflow documentation
  * Companion file structure for tracking findings and progress
  * Updated subagent integration guides with context preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->