### PR TITLE
Feat/support kiro

### DIFF
--- a/.kiro/README.md
+++ b/.kiro/README.md
@@ -1,0 +1,34 @@
+# Superpowers Kiro Configuration
+
+This project uses Kiro for AI-assisted development with Superpowers skills.
+
+## Quick Start
+
+1. Use `/using-superpowers` to learn about available skills
+2. Use `/brainstorming` before starting any creative work
+3. Use `/writing-plans` to create implementation plans
+4. Use `/executing-plans` to implement plan tasks
+
+## Directory Structure
+
+```
+.kiro/
+├── README.md           # This file
+└── steering/           # Kiro steering commands
+    ├── README.md       # Command reference
+    └── sp-*.md         # Individual skill steerings
+```
+
+## Superpowers Skills
+
+All skills are prefixed with `sp-` to avoid conflicts:
+
+- **Development Workflow**: `brainstorming`, `writing-plans`, `executing-plans`, `subagent-driven-development`
+- **Code Quality**: `test-driven-development`, `systematic-debugging`, `requesting-code-review`, `receiving-code-review`, `verification-before-completion`
+- **Git Operations**: `using-git-worktrees`, `finishing-a-development-branch`
+- **Advanced**: `dispatching-parallel-agents`, `writing-skills`
+
+## Skill Location
+
+The actual skill files are located in:
+- `skills/<skill-name>/SKILL.md`

--- a/.kiro/README.md
+++ b/.kiro/README.md
@@ -21,12 +21,12 @@ This project uses Kiro for AI-assisted development with Superpowers skills.
 
 ## Superpowers Skills
 
-All skills are prefixed with `sp-` to avoid conflicts:
+All skills are prefixed with `sp-` to avoid conflicts (the list below omits the prefix for brevity; actual command/file names include it):
 
-- **Development Workflow**: `brainstorming`, `writing-plans`, `executing-plans`, `subagent-driven-development`
-- **Code Quality**: `test-driven-development`, `systematic-debugging`, `requesting-code-review`, `receiving-code-review`, `verification-before-completion`
-- **Git Operations**: `using-git-worktrees`, `finishing-a-development-branch`
-- **Advanced**: `dispatching-parallel-agents`, `writing-skills`
+- **Development Workflow**: `sp-brainstorming`, `sp-writing-plans`, `sp-executing-plans`, `sp-subagent-driven-development`
+- **Code Quality**: `sp-test-driven-development`, `sp-systematic-debugging`, `sp-requesting-code-review`, `sp-receiving-code-review`, `sp-verification-before-completion`
+- **Git Operations**: `sp-using-git-worktrees`, `sp-finishing-a-development-branch`
+- **Advanced**: `sp-dispatching-parallel-agents`, `sp-writing-skills`
 
 ## Skill Location
 

--- a/.kiro/steering/README.md
+++ b/.kiro/steering/README.md
@@ -1,0 +1,28 @@
+# Superpowers Kiro Steering
+
+This directory contains Kiro steering files for all Superpowers skills.
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `brainstorming` | Explore requirements and design before implementation |
+| `dispatching-parallel-agents` | Dispatch parallel subagents for independent tasks |
+| `executing-plans` | Execute implementation plans task-by-task |
+| `finishing-a-development-branch` | Guide completion of development work |
+| `receiving-code-review` | Handle code review feedback with technical rigor |
+| `requesting-code-review` | Request code review for completed work |
+| `subagent-driven-development` | Execute implementation with subagent per task |
+| `systematic-debugging` | Debug issues with systematic methodology |
+| `test-driven-development` | Implement features using TDD workflow |
+| `using-git-worktrees` | Create isolated git worktrees |
+| `using-superpowers` | Introduction to using superpowers skills |
+| `verification-before-completion` | Verify work before claiming completion |
+| `writing-plans` | Create comprehensive implementation plans |
+| `writing-skills` | Create or edit superpowers skills |
+
+## Usage
+
+In Kiro chat, type `/` followed by the command name to activate the skill.
+
+Example: `/brainstorming` or `/writing-plans`

--- a/.kiro/steering/sp-brainstorming.md
+++ b/.kiro/steering/sp-brainstorming.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# brainstorming
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/brainstorming/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-dispatching-parallel-agents.md
+++ b/.kiro/steering/sp-dispatching-parallel-agents.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# dispatching-parallel-agents
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/dispatching-parallel-agents/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-executing-plans.md
+++ b/.kiro/steering/sp-executing-plans.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# executing-plans
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/executing-plans/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-finishing-a-development-branch.md
+++ b/.kiro/steering/sp-finishing-a-development-branch.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# finishing-a-development-branch
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/finishing-a-development-branch/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-receiving-code-review.md
+++ b/.kiro/steering/sp-receiving-code-review.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# receiving-code-review
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/receiving-code-review/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-requesting-code-review.md
+++ b/.kiro/steering/sp-requesting-code-review.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# requesting-code-review
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/requesting-code-review/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-subagent-driven-development.md
+++ b/.kiro/steering/sp-subagent-driven-development.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# subagent-driven-development
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/subagent-driven-development/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-systematic-debugging.md
+++ b/.kiro/steering/sp-systematic-debugging.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# systematic-debugging
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/systematic-debugging/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-test-driven-development.md
+++ b/.kiro/steering/sp-test-driven-development.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# test-driven-development
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/test-driven-development/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-using-git-worktrees.md
+++ b/.kiro/steering/sp-using-git-worktrees.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# using-git-worktrees
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/using-git-worktrees/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-using-superpowers.md
+++ b/.kiro/steering/sp-using-superpowers.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# using-superpowers
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/using-superpowers/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-verification-before-completion.md
+++ b/.kiro/steering/sp-verification-before-completion.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# verification-before-completion
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/verification-before-completion/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-writing-plans.md
+++ b/.kiro/steering/sp-writing-plans.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# writing-plans
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/writing-plans/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>

--- a/.kiro/steering/sp-writing-skills.md
+++ b/.kiro/steering/sp-writing-skills.md
@@ -1,0 +1,13 @@
+---
+inclusion: manual
+---
+
+# writing-skills
+
+IT IS CRITICAL THAT YOU FOLLOW THESE STEPS:
+
+<steps CRITICAL="TRUE">
+1. LOAD the FULL skill file at: #[[file:skills/writing-skills/SKILL.md]]
+2. READ its entire contents - this contains the complete skill definition
+3. FOLLOW every instruction in the skill exactly as specified
+</steps>


### PR DESCRIPTION
## Summary

Add Kiro steering files for all Superpowers skills to enable AI-assisted development workflow in Kiro IDE.

## Changes

- Create `.kiro/steering/` directory with 14 skill steerings
- Add pattern steering files referencing `skills/<name>/SKILL.md`
- Include documentation (README.md index and root config)

## Files Added

- 14 `sp-*.md` steering files (brainstorming, executing-plans, etc.)
- `.kiro/steering/README.md` (command reference)
- `.kiro/README.md` (root configuration)

All steering files use `inclusion: manual` frontmatter and follow the kiro steering pattern.
