### PR TITLE
docs: add Community Extensions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ Skills update automatically when you update the plugin:
 /plugin update superpowers
 ```
 
+## Community Extensions
+
+Projects built on top of Superpowers:
+
+| Extension | What It Adds |
+|-----------|-------------|
+| [Autonomous Coding Toolkit](https://github.com/parthalon025/autonomous-coding-toolkit) | Headless batch execution, quality gates between every batch, 79 community lessons, Multi-Armed Bandit routing, fresh context per batch |
+
+*Built something on Superpowers? Open a PR to add it here.*
+
 ## License
 
 MIT License - see LICENSE file for details


### PR DESCRIPTION
## Summary

Adds a **Community Extensions** table to the README for projects built on top of Superpowers. This gives the ecosystem a natural discovery point and encourages others to contribute their extensions.

Starting entry: [Autonomous Coding Toolkit](https://github.com/parthalon025/autonomous-coding-toolkit) — extends the Superpowers skill chain with:
- **Headless batch execution** (`scripts/run-plan.sh`) — `claude -p` per batch, fully autonomous
- **Quality gates** between every batch (lesson check + ast-grep + tests + memory + test count regression)
- **79 community lessons** across 6 failure clusters, learned from production bugs
- **Multi-Armed Bandit routing** — competing execution strategies via Thompson Sampling
- **Fresh 200k context per batch** — prevents context degradation on long tasks

The table includes an open invitation for others to add their extensions via PR.

## Why This Belongs in the README

Superpowers has 60K+ stars and 4,500+ forks — the community is clearly building on top of it. A lightweight extensions table makes those projects discoverable without adding maintenance burden.

## Changes
- `README.md` — added "Community Extensions" section between "Updating" and "License"