### PR TITLE
Fix session-start hang on bash 5.3+

### DIFF
--- a/hooks/session-start
+++ b/hooks/session-start
@@ -38,14 +38,10 @@ session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the 
 # Keep both shapes for compatibility:
 # - Cursor hooks expect additional_context.
 # - Claude hooks expect hookSpecificOutput.additionalContext.
-cat <<EOF
-{
-  "additional_context": "${session_context}",
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "${session_context}"
-  }
-}
-EOF
+#
+# Uses printf instead of heredoc (cat <<EOF) to work around a bash 5.3+
+# bug where heredoc variable expansion hangs when content exceeds ~512 bytes.
+# See: https://github.com/obra/superpowers/issues/571
+printf '{\n  "additional_context": "%s",\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context" "$session_context"
 
 exit 0


### PR DESCRIPTION
## Summary

- Replaces `cat <<EOF` heredoc with `printf` in `hooks/session-start` to fix a hang caused by a bash 5.3 regression where heredoc variable expansion blocks when content exceeds ~512 bytes
- The `session_context` variable is ~4,500 bytes, well above this threshold
- Users with Homebrew bash 5.3+ on macOS hit this because `#!/usr/bin/env bash` resolves to the newer version; the system `/bin/bash` (3.2) is unaffected

## Minimal reproducer (bash 5.3)

```bash
# Hangs:
/opt/homebrew/bin/bash -c 's=$(printf "%0.s=" {1..520}); cat <<EOF
${s}
EOF'

# Works:
/opt/homebrew/bin/bash -c 's=$(printf "%0.s=" {1..520}); printf "%s\n" "$s"'
```

## Test plan

- [x] Verified fix works on bash 5.3.9 (Homebrew) — no hang, completes instantly
- [x] Verified fix works on bash 3.2.57 (macOS system) — no regression
- [x] Verified output is valid JSON with correct structure (`additional_context` + `hookSpecificOutput`)

Fixes #571