### PR TITLE
feat(brainstorming): add scale/volume as required discovery question

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -19,6 +19,7 @@ Start by understanding the current project context, then ask questions one at a 
 - Prefer multiple choice questions when possible, but open-ended is fine too
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
 - Focus on understanding: purpose, constraints, success criteria
+- **Always ask about scale** - Expected volume (transactions/sec, records, users, messages, requests) is a critical architectural driver. The answer fundamentally shapes storage, architecture, queueing, and cost decisions. Ask early.
 
 **Exploring approaches:**
 - Propose 2-3 different approaches with trade-offs


### PR DESCRIPTION
## Summary

- Adds **scale/volume** as an explicit required question during the brainstorming skill's "Understanding the idea" phase
- Expected volume (transactions/sec, records, users, messages, requests) is a critical architectural driver that fundamentally shapes storage, architecture, queueing, and cost decisions
- Without this question, designs risk being over- or under-engineered for their actual load

## Change

One line added to the "Understanding the idea" checklist in `brainstorming/SKILL.md`:

```
- **Always ask about scale** - Expected volume (transactions/sec, records, users, messages, requests) is a critical architectural driver. The answer fundamentally shapes storage, architecture, queueing, and cost decisions. Ask early.
```

## Testing Evidence (RED-GREEN)

Following the project's TDD-for-skills methodology (technique skill — application test):

### RED (baseline without change)
**Scenario:** "Build an event ticketing service where organizers create events and customers purchase/redeem tickets via web or mobile."

**Result:** Agent asked 5 questions focused on purpose, constraints, success criteria, user profiles, and channel support. Volume/scale was never asked directly — it appeared only as a buried sub-option within the constraints question.

### GREEN (with change)
**Same scenario, same agent.**

**Result:** Agent asked about volume as question #2: "How many ticket purchases/redemptions per second at peak, and roughly how many active tickets in the system at any given time?" This shaped downstream questions — the agent then asked about consistency vs speed tradeoffs, which only makes sense once scale is known.

### Conclusion
The one-line addition causes the agent to treat scale as a first-class architectural discovery question rather than an afterthought. The test confirms the agent applies the technique correctly when instructed.