### PR TITLE
Add Crush CLI superpowers support

### DIFF
--- a/.crush/AGENTS.md
+++ b/.crush/AGENTS.md
@@ -1,0 +1,46 @@
+# Superpowers
+
+You have superpowers. Superpowers is a skills library that gives you structured workflows
+for software development: TDD, debugging, brainstorming, planning, and more.
+
+## Skills Location
+
+Superpowers skills are in `~/.config/crush/skills/superpowers/`.
+
+Each skill is a `SKILL.md` file with YAML frontmatter describing when to use it.
+
+## CRITICAL: You Must Use Skills
+
+**Before ANY response or action**, check if a skill applies. Even a 1% chance means you
+MUST check. Use the skill tool to list and load skills.
+
+If a skill applies to your task, you DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+## How to Use Skills
+
+1. Before responding to any request, check: "Does a superpowers skill apply?"
+2. Use the skill tool to list available skills: `list skills`
+3. Load the relevant skill: `load skill superpowers/brainstorming`
+4. Follow the skill exactly.
+
+## Tool Mapping
+
+Skills were originally written for Claude Code. In Crush, substitute:
+- `TodoWrite` → create a task list or todo file
+- `Task` tool with subagents → use Crush's native subagent/parallel execution
+- `Skill` tool → use Crush's native skill tool
+- `Read`, `Write`, `Edit`, `Bash` → your native Crush tools
+
+## Skill Priority
+
+Project skills (`.crush.json` `skills_paths`) > Personal skills (`~/.config/crush/skills/`) >
+Superpowers skills (`~/.config/crush/skills/superpowers/`)
+
+## Common Skills
+
+- **brainstorming** — Before writing any code, refine the design through questions
+- **writing-plans** — Break work into bite-sized implementable tasks
+- **test-driven-development** — RED-GREEN-REFACTOR cycle, always
+- **systematic-debugging** — 4-phase root cause process
+- **subagent-driven-development** — Parallel agent workflows
+- **requesting-code-review** — Pre-review checklist

--- a/.crush/AGENTS.md
+++ b/.crush/AGENTS.md
@@ -12,28 +12,27 @@ Each skill is a `SKILL.md` file with YAML frontmatter describing when to use it.
 ## CRITICAL: You Must Use Skills
 
 **Before ANY response or action**, check if a skill applies. Even a 1% chance means you
-MUST check. Use the skill tool to list and load skills.
+MUST check.
 
 If a skill applies to your task, you DO NOT HAVE A CHOICE. YOU MUST USE IT.
 
 ## How to Use Skills
 
-1. Before responding to any request, check: "Does a superpowers skill apply?"
-2. Use the skill tool to list available skills: `list skills`
-3. Load the relevant skill: `load skill superpowers/brainstorming`
-4. Follow the skill exactly.
+1. Before responding to any request, check `<available_skills>` in your context.
+2. If a skill matches, read its SKILL.md file using the file path in `<location>`.
+3. Follow the skill exactly.
 
 ## Tool Mapping
 
 Skills were originally written for Claude Code. In Crush, substitute:
 - `TodoWrite` → create a task list or todo file
-- `Task` tool with subagents → use Crush's native subagent/parallel execution
-- `Skill` tool → use Crush's native skill tool
+- `Task` tool with subagents → use Crush's Agent tool for complex subtasks
+- `Skill` tool → read the skill file at the `<location>` path from `<available_skills>`
 - `Read`, `Write`, `Edit`, `Bash` → your native Crush tools
 
 ## Skill Priority
 
-Project skills (`.crush.json` `skills_paths`) > Personal skills (`~/.config/crush/skills/`) >
+Project skills (`crush.json` `options.skills_paths`) > Personal skills (`~/.config/crush/skills/`) >
 Superpowers skills (`~/.config/crush/skills/superpowers/`)
 
 ## Common Skills

--- a/.crush/INSTALL.md
+++ b/.crush/INSTALL.md
@@ -1,0 +1,144 @@
+# Installing Superpowers for Crush
+
+## Prerequisites
+
+- [Crush](https://github.com/charmbracelet/crush) installed
+- Git installed
+
+## Installation Steps
+
+### 1. Clone Superpowers
+
+```bash
+git clone https://github.com/obra/superpowers.git ~/.config/crush/superpowers
+```
+
+### 2. Create the Skills Symlink
+
+```bash
+mkdir -p ~/.config/crush/skills
+rm -rf ~/.config/crush/skills/superpowers
+ln -s ~/.config/crush/superpowers/skills ~/.config/crush/skills/superpowers
+```
+
+**Windows (PowerShell — Developer Mode or Admin required):**
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\crush\skills"
+Remove-Item "$env:LOCALAPPDATA\crush\skills\superpowers" -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Junction -Path "$env:LOCALAPPDATA\crush\skills\superpowers" `
+  -Target "$env:LOCALAPPDATA\crush\superpowers\skills"
+```
+
+### 3. Inject the Bootstrap
+
+Append the superpowers context to your global Crush AGENTS.md:
+
+```bash
+mkdir -p ~/.config/crush
+cat ~/.config/crush/superpowers/.crush/AGENTS.md >> ~/.config/crush/AGENTS.md
+```
+
+**Windows (PowerShell):**
+
+```powershell
+$crush = "$env:LOCALAPPDATA\crush"
+New-Item -ItemType Directory -Force -Path $crush
+Get-Content "$crush\superpowers\.crush\AGENTS.md" | Add-Content "$crush\AGENTS.md"
+```
+
+### 4. Restart Crush
+
+Restart Crush. Ask "do you have superpowers?" to verify.
+
+## Verify Installation
+
+```bash
+ls -la ~/.config/crush/skills/superpowers
+cat ~/.config/crush/AGENTS.md | grep -i superpowers
+```
+
+## Usage
+
+### Finding Skills
+
+Use Crush's native skill tool to list all available skills.
+
+### Loading a Skill
+
+```
+load skill superpowers/brainstorming
+```
+
+### Personal Skills
+
+Create your own skills in `~/.config/crush/skills/`:
+
+```bash
+mkdir -p ~/.config/crush/skills/my-skill
+```
+
+Create `~/.config/crush/skills/my-skill/SKILL.md`:
+
+```markdown
+---
+name: my-skill
+description: Use when [condition] - [what it does]
+---
+
+# My Skill
+
+[Your skill content here]
+```
+
+### Project Skills
+
+Add a `skills_paths` entry to your project's `crush.json`:
+
+```json
+{
+  "options": {
+    "skills_paths": [".crush-skills"]
+  }
+}
+```
+
+Then create `.crush-skills/my-project-skill/SKILL.md` in your project.
+
+**Skill Priority:** Project skills > Personal skills > Superpowers skills
+
+## Updating
+
+```bash
+cd ~/.config/crush/superpowers
+git pull
+```
+
+Skills update instantly through the symlink.
+
+## Uninstalling
+
+```bash
+rm ~/.config/crush/skills/superpowers
+rm -rf ~/.config/crush/superpowers
+```
+
+Remove the superpowers block from `~/.config/crush/AGENTS.md` manually.
+
+## Troubleshooting
+
+### Skills not found
+
+1. Check symlink: `ls -la ~/.config/crush/skills/superpowers`
+2. Verify target: `ls ~/.config/crush/superpowers/skills/`
+3. Restart Crush — skills are discovered at startup
+
+### Bootstrap not active
+
+1. Check AGENTS.md: `cat ~/.config/crush/AGENTS.md | grep superpowers`
+2. Re-run the bootstrap append command (Step 3)
+
+## Getting Help
+
+- Report issues: https://github.com/obra/superpowers/issues
+- Full documentation: https://github.com/obra/superpowers/blob/main/docs/README.crush.md

--- a/.crush/INSTALL.md
+++ b/.crush/INSTALL.md
@@ -30,24 +30,7 @@ New-Item -ItemType Junction -Path "$env:LOCALAPPDATA\crush\skills\superpowers" `
   -Target "$env:LOCALAPPDATA\crush\superpowers\skills"
 ```
 
-### 3. Inject the Bootstrap
-
-Append the superpowers context to your global Crush AGENTS.md:
-
-```bash
-mkdir -p ~/.config/crush
-cat ~/.config/crush/superpowers/.crush/AGENTS.md >> ~/.config/crush/AGENTS.md
-```
-
-**Windows (PowerShell):**
-
-```powershell
-$crush = "$env:LOCALAPPDATA\crush"
-New-Item -ItemType Directory -Force -Path $crush
-Get-Content "$crush\superpowers\.crush\AGENTS.md" | Add-Content "$crush\AGENTS.md"
-```
-
-### 4. Restart Crush
+### 3. Restart Crush
 
 Restart Crush. Ask "do you have superpowers?" to verify.
 
@@ -55,20 +38,33 @@ Restart Crush. Ask "do you have superpowers?" to verify.
 
 ```bash
 ls -la ~/.config/crush/skills/superpowers
-cat ~/.config/crush/AGENTS.md | grep -i superpowers
 ```
+
+## How Skills Work
+
+Crush natively discovers skills from `~/.config/crush/skills/` at startup and injects
+them into the system prompt. Superpowers skills (including `using-superpowers`) are
+automatically listed in the `<available_skills>` section of every session.
+
+Crush reads each skill's `SKILL.md` when the task description matches. No special
+commands needed — just work normally and Crush activates the right skill.
 
 ## Usage
 
 ### Finding Skills
 
-Use Crush's native skill tool to list all available skills.
+Skills appear in `<available_skills>` in Crush's context at the start of each session.
 
 ### Loading a Skill
 
+Ask Crush to use a skill by name, for example:
+
 ```
-load skill superpowers/brainstorming
+use the brainstorming skill
 ```
+
+Or just describe what you want to do — Crush will match the task to the right skill
+automatically based on the skill descriptions.
 
 ### Personal Skills
 
@@ -90,6 +86,8 @@ description: Use when [condition] - [what it does]
 
 [Your skill content here]
 ```
+
+> **Note:** The `name` field must match the directory name exactly.
 
 ### Project Skills
 
@@ -123,8 +121,6 @@ rm ~/.config/crush/skills/superpowers
 rm -rf ~/.config/crush/superpowers
 ```
 
-Remove the superpowers block from `~/.config/crush/AGENTS.md` manually.
-
 ## Troubleshooting
 
 ### Skills not found
@@ -132,11 +128,17 @@ Remove the superpowers block from `~/.config/crush/AGENTS.md` manually.
 1. Check symlink: `ls -la ~/.config/crush/skills/superpowers`
 2. Verify target: `ls ~/.config/crush/superpowers/skills/`
 3. Restart Crush — skills are discovered at startup
+4. Override with env var: `CRUSH_SKILLS_DIR=~/.config/crush/skills crush`
 
-### Bootstrap not active
+### Skills in a custom directory
 
-1. Check AGENTS.md: `cat ~/.config/crush/AGENTS.md | grep superpowers`
-2. Re-run the bootstrap append command (Step 3)
+Set `CRUSH_SKILLS_DIR` to override the default discovery path:
+
+```bash
+export CRUSH_SKILLS_DIR=~/.config/crush/skills
+```
+
+Or use `options.skills_paths` in `crush.json` to add extra paths without overriding the default.
 
 ## Getting Help
 

--- a/.gemini-extension-install.json
+++ b/.gemini-extension-install.json
@@ -1,0 +1,6 @@
+{
+  "source": "https://github.com/mhenke/superpowers",
+  "type": "github-release",
+  "ref": "v0.2-gemini",
+  "releaseTag": "v0.2-gemini"
+}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Fetch and follow instructions from https://raw.githubusercontent.com/obra/superp
 
 **Detailed docs:** [docs/README.opencode.md](docs/README.opencode.md)
 
+### Crush
+
+Tell Crush:
+
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.crush/INSTALL.md
+```
+
+**Detailed docs:** [docs/README.crush.md](docs/README.crush.md)
+
 ### Verify Installation
 
 Start a new session in your chosen platform and ask for something that should trigger a skill (for example, "help me plan this feature" or "let's debug this issue"). The agent should automatically invoke the relevant superpowers skill.

--- a/docs/README.crush.md
+++ b/docs/README.crush.md
@@ -1,0 +1,238 @@
+# Superpowers for Crush
+
+Complete guide for using Superpowers with [Crush](https://github.com/charmbracelet/crush) — the terminal AI coding agent from Charmbracelet.
+
+## Quick Install
+
+Tell Crush:
+
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.crush/INSTALL.md
+```
+
+## Manual Installation
+
+### Prerequisites
+
+- [Crush](https://github.com/charmbracelet/crush) installed
+- Git installed
+
+### macOS / Linux
+
+```bash
+# 1. Install Superpowers (or update existing)
+if [ -d ~/.config/crush/superpowers ]; then
+  cd ~/.config/crush/superpowers && git pull
+else
+  git clone https://github.com/obra/superpowers.git ~/.config/crush/superpowers
+fi
+
+# 2. Create skills directory
+mkdir -p ~/.config/crush/skills
+
+# 3. Remove old symlink if it exists
+rm -rf ~/.config/crush/skills/superpowers
+
+# 4. Create symlink
+ln -s ~/.config/crush/superpowers/skills ~/.config/crush/skills/superpowers
+
+# 5. Append bootstrap to global AGENTS.md
+mkdir -p ~/.config/crush
+cat ~/.config/crush/superpowers/.crush/AGENTS.md >> ~/.config/crush/AGENTS.md
+```
+
+#### Verify Installation
+
+```bash
+ls -l ~/.config/crush/skills/superpowers
+grep -c superpowers ~/.config/crush/AGENTS.md
+```
+
+The symlink should point to your superpowers `skills/` directory, and the AGENTS.md grep should return a non-zero count.
+
+### Windows
+
+**Prerequisites:**
+- Git installed
+- Either **Developer Mode** enabled OR **Administrator privileges**
+  - Windows 10: Settings → Update & Security → For developers
+  - Windows 11: Settings → System → For developers
+
+#### PowerShell
+
+Run as Administrator, or with Developer Mode enabled:
+
+```powershell
+$crush = "$env:LOCALAPPDATA\crush"
+
+# 1. Install Superpowers
+git clone https://github.com/obra/superpowers.git "$crush\superpowers"
+
+# 2. Create skills directory
+New-Item -ItemType Directory -Force -Path "$crush\skills"
+
+# 3. Remove existing junction
+Remove-Item "$crush\skills\superpowers" -Force -ErrorAction SilentlyContinue
+
+# 4. Create junction (works without special privileges)
+New-Item -ItemType Junction -Path "$crush\skills\superpowers" `
+  -Target "$crush\superpowers\skills"
+
+# 5. Append bootstrap to global AGENTS.md
+New-Item -ItemType Directory -Force -Path $crush
+Get-Content "$crush\superpowers\.crush\AGENTS.md" | Add-Content "$crush\AGENTS.md"
+```
+
+#### Verify Installation
+
+```powershell
+Get-ChildItem "$env:LOCALAPPDATA\crush\skills" | Where-Object { $_.LinkType }
+```
+
+Look for `<JUNCTION>` pointing to the superpowers skills directory.
+
+#### Troubleshooting Windows
+
+**"You do not have sufficient privilege" error:**
+- Enable Developer Mode in Windows Settings, OR
+- Right-click your terminal → "Run as Administrator"
+
+---
+
+## How It Works
+
+### Skills Discovery
+
+Crush natively discovers skills from `~/.config/crush/skills/` on macOS/Linux
+(`%LOCALAPPDATA%\crush\skills\` on Windows). Superpowers skills are made accessible
+via a symlink:
+
+```
+~/.config/crush/skills/superpowers/ → ~/.config/crush/superpowers/skills/
+```
+
+### Bootstrap Injection
+
+Crush reads `~/.config/crush/AGENTS.md` automatically at session start. The
+superpowers bootstrap snippet (from `.crush/AGENTS.md`) is appended once
+during installation, injecting persistent context about the skills system and tool
+mappings into every Crush session.
+
+### Tool Mapping
+
+Skills were originally written for Claude Code. The bootstrap provides mappings:
+
+| Claude Code Tool | Crush Equivalent |
+|---|---|
+| `TodoWrite` | Create a task list or todo file |
+| `Task` with subagents | Crush's native parallel execution |
+| `Skill` tool | Crush's native skill tool |
+| `Read`, `Write`, `Edit`, `Bash` | Your native Crush tools |
+
+---
+
+## Usage
+
+### Finding Skills
+
+Use Crush's native skill tool to list all available skills. Superpowers skills appear
+under the `superpowers/` namespace.
+
+### Loading a Skill
+
+```
+load skill superpowers/brainstorming
+```
+
+### Personal Skills
+
+Create your own skills in `~/.config/crush/skills/`:
+
+```bash
+mkdir -p ~/.config/crush/skills/my-skill
+```
+
+Create `~/.config/crush/skills/my-skill/SKILL.md`:
+
+```markdown
+---
+name: my-skill
+description: Use when [condition] - [what it does]
+---
+
+# My Skill
+
+[Your skill content here]
+```
+
+### Project Skills
+
+Add a `skills_paths` entry to your project's `crush.json` or `.crush.json`:
+
+```json
+{
+  "options": {
+    "skills_paths": [".crush-skills"]
+  }
+}
+```
+
+Then create `.crush-skills/my-project-skill/SKILL.md` in your project root.
+
+## Skill Locations
+
+Crush discovers skills in this priority order:
+
+1. **Project skills** (via `crush.json` `skills_paths`) — Highest priority
+2. **Personal skills** (`~/.config/crush/skills/`)
+3. **Superpowers skills** (`~/.config/crush/skills/superpowers/`) — via symlink
+
+---
+
+## Updating
+
+```bash
+cd ~/.config/crush/superpowers
+git pull
+```
+
+Skills update instantly through the symlink. Restart Crush to pick up any changes.
+
+## Uninstalling
+
+```bash
+rm ~/.config/crush/skills/superpowers
+rm -rf ~/.config/crush/superpowers
+```
+
+Remove the superpowers block from `~/.config/crush/AGENTS.md` manually (it begins
+with `# Superpowers` and ends before any other sections you may have added).
+
+---
+
+## Troubleshooting
+
+### Skills not found
+
+1. Verify the symlink: `ls -la ~/.config/crush/skills/superpowers`
+2. Check target resolves: `ls ~/.config/crush/superpowers/skills/`
+3. Restart Crush — skills are discovered at startup
+
+### Bootstrap not active
+
+1. Check: `cat ~/.config/crush/AGENTS.md | grep -i superpowers`
+2. Re-run the bootstrap append (Step 5 in installation)
+3. Ensure you're not accidentally overwriting `AGENTS.md` on each launch
+
+### Windows junction issues
+
+Junctions normally work without special permissions. If creation fails, try running
+PowerShell as administrator.
+
+---
+
+## Getting Help
+
+- Report issues: https://github.com/obra/superpowers/issues
+- Main documentation: https://github.com/obra/superpowers
+- Crush docs: https://github.com/charmbracelet/crush

--- a/docs/README.crush.md
+++ b/docs/README.crush.md
@@ -35,20 +35,15 @@ rm -rf ~/.config/crush/skills/superpowers
 
 # 4. Create symlink
 ln -s ~/.config/crush/superpowers/skills ~/.config/crush/skills/superpowers
-
-# 5. Append bootstrap to global AGENTS.md
-mkdir -p ~/.config/crush
-cat ~/.config/crush/superpowers/.crush/AGENTS.md >> ~/.config/crush/AGENTS.md
 ```
 
 #### Verify Installation
 
 ```bash
 ls -l ~/.config/crush/skills/superpowers
-grep -c superpowers ~/.config/crush/AGENTS.md
 ```
 
-The symlink should point to your superpowers `skills/` directory, and the AGENTS.md grep should return a non-zero count.
+The symlink should point to your superpowers `skills/` directory.
 
 ### Windows
 
@@ -77,10 +72,6 @@ Remove-Item "$crush\skills\superpowers" -Force -ErrorAction SilentlyContinue
 # 4. Create junction (works without special privileges)
 New-Item -ItemType Junction -Path "$crush\skills\superpowers" `
   -Target "$crush\superpowers\skills"
-
-# 5. Append bootstrap to global AGENTS.md
-New-Item -ItemType Directory -Force -Path $crush
-Get-Content "$crush\superpowers\.crush\AGENTS.md" | Add-Content "$crush\AGENTS.md"
 ```
 
 #### Verify Installation
@@ -111,22 +102,28 @@ via a symlink:
 ~/.config/crush/skills/superpowers/ → ~/.config/crush/superpowers/skills/
 ```
 
-### Bootstrap Injection
+Crush also checks `~/.config/agents/skills/` (a cross-agent shared path) and any
+paths listed in `options.skills_paths` in your `crush.json`.
 
-Crush reads `~/.config/crush/AGENTS.md` automatically at session start. The
-superpowers bootstrap snippet (from `.crush/AGENTS.md`) is appended once
-during installation, injecting persistent context about the skills system and tool
-mappings into every Crush session.
+### Skill Activation
+
+At the start of each session, Crush scans all skill directories and injects discovered
+skills into the system prompt as `<available_skills>` XML. Each entry includes the
+skill's `name`, `description`, and file `location`.
+
+Crush reads the full `SKILL.md` file when a task matches a skill's description. The
+`using-superpowers` skill (description: "Use when starting any conversation") ensures
+skill discipline is established at the start of every session.
 
 ### Tool Mapping
 
-Skills were originally written for Claude Code. The bootstrap provides mappings:
+Skills were originally written for Claude Code. In Crush, substitute:
 
 | Claude Code Tool | Crush Equivalent |
 |---|---|
 | `TodoWrite` | Create a task list or todo file |
-| `Task` with subagents | Crush's native parallel execution |
-| `Skill` tool | Crush's native skill tool |
+| `Task` with subagents | Use Crush's Agent tool for complex subtasks |
+| `Skill` tool | Read the skill file at the `<location>` path from `<available_skills>` |
 | `Read`, `Write`, `Edit`, `Bash` | Your native Crush tools |
 
 ---
@@ -135,14 +132,19 @@ Skills were originally written for Claude Code. The bootstrap provides mappings:
 
 ### Finding Skills
 
-Use Crush's native skill tool to list all available skills. Superpowers skills appear
-under the `superpowers/` namespace.
+Skills appear in `<available_skills>` in Crush's context at the start of each session.
+Superpowers skills appear under the `superpowers/` namespace in the file path.
 
 ### Loading a Skill
 
+Ask Crush to use a skill by name, for example:
+
 ```
-load skill superpowers/brainstorming
+use the brainstorming skill
 ```
+
+Or just describe what you want to do — Crush matches the task to the right skill
+automatically based on skill descriptions.
 
 ### Personal Skills
 
@@ -165,6 +167,9 @@ description: Use when [condition] - [what it does]
 [Your skill content here]
 ```
 
+> **Note:** The `name` field in the frontmatter must match the directory name exactly
+> (case-insensitive). A skill named `my-skill` must live in a `my-skill/` directory.
+
 ### Project Skills
 
 Add a `skills_paths` entry to your project's `crush.json` or `.crush.json`:
@@ -183,9 +188,15 @@ Then create `.crush-skills/my-project-skill/SKILL.md` in your project root.
 
 Crush discovers skills in this priority order:
 
-1. **Project skills** (via `crush.json` `skills_paths`) — Highest priority
+1. **Project skills** (via `crush.json` `options.skills_paths`) — Highest priority
 2. **Personal skills** (`~/.config/crush/skills/`)
 3. **Superpowers skills** (`~/.config/crush/skills/superpowers/`) — via symlink
+
+You can also override the default discovery directory entirely with `CRUSH_SKILLS_DIR`:
+
+```bash
+export CRUSH_SKILLS_DIR=~/.config/crush/skills
+```
 
 ---
 
@@ -205,9 +216,6 @@ rm ~/.config/crush/skills/superpowers
 rm -rf ~/.config/crush/superpowers
 ```
 
-Remove the superpowers block from `~/.config/crush/AGENTS.md` manually (it begins
-with `# Superpowers` and ends before any other sections you may have added).
-
 ---
 
 ## Troubleshooting
@@ -217,12 +225,18 @@ with `# Superpowers` and ends before any other sections you may have added).
 1. Verify the symlink: `ls -la ~/.config/crush/skills/superpowers`
 2. Check target resolves: `ls ~/.config/crush/superpowers/skills/`
 3. Restart Crush — skills are discovered at startup
+4. Check override: ensure `CRUSH_SKILLS_DIR` is not set to a different path
 
-### Bootstrap not active
+### Custom skills directory
 
-1. Check: `cat ~/.config/crush/AGENTS.md | grep -i superpowers`
-2. Re-run the bootstrap append (Step 5 in installation)
-3. Ensure you're not accidentally overwriting `AGENTS.md` on each launch
+To override the default path, set `CRUSH_SKILLS_DIR`:
+
+```bash
+export CRUSH_SKILLS_DIR=/path/to/your/skills
+```
+
+Or add additional paths without overriding the default using `options.skills_paths` in
+`~/.config/crush/crush.json`.
 
 ### Windows junction issues
 

--- a/tests/crush/run-tests.sh
+++ b/tests/crush/run-tests.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Main test runner for Crush test suite
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "========================================"
+echo " Crush Superpowers Test Suite"
+echo "========================================"
+echo ""
+echo "Repository: $(cd ../.. && pwd)"
+echo "Test time: $(date)"
+echo ""
+
+tests=(
+    "test-install.sh"
+)
+
+passed=0
+failed=0
+
+for test in "${tests[@]}"; do
+    echo "----------------------------------------"
+    echo "Running: $test"
+    echo "----------------------------------------"
+
+    test_path="$SCRIPT_DIR/$test"
+
+    if [ ! -f "$test_path" ]; then
+        echo "  [SKIP] Test file not found: $test"
+        continue
+    fi
+
+    [ ! -x "$test_path" ] && chmod +x "$test_path"
+
+    if output=$(bash "$test_path" 2>&1); then
+        echo "  [PASS]"
+        passed=$((passed + 1))
+    else
+        echo "  [FAIL]"
+        echo ""
+        echo "$output" | sed 's/^/    /'
+        failed=$((failed + 1))
+    fi
+    echo ""
+done
+
+echo "========================================"
+echo " Results: $passed passed, $failed failed"
+echo "========================================"
+
+[ $failed -gt 0 ] && exit 1 || exit 0

--- a/tests/crush/setup.sh
+++ b/tests/crush/setup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Setup script for Crush tests
+# Creates an isolated test environment with proper installation
+set -euo pipefail
+
+# Get the repository root (two levels up from tests/crush/)
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Create temp home directory for isolation
+export TEST_HOME=$(mktemp -d)
+export HOME="$TEST_HOME"
+export XDG_CONFIG_HOME="$TEST_HOME/.config"
+export CRUSH_GLOBAL_CONFIG="$TEST_HOME/.config/crush"
+export CRUSH_GLOBAL_DATA="$TEST_HOME/.local/share/crush"
+
+# Simulate installation: clone superpowers to ~/.config/crush/superpowers
+mkdir -p "$HOME/.config/crush/superpowers"
+cp -r "$REPO_ROOT/skills" "$HOME/.config/crush/superpowers/"
+cp -r "$REPO_ROOT/.crush" "$HOME/.config/crush/superpowers/"
+
+# Create skills symlink
+mkdir -p "$HOME/.config/crush/skills"
+ln -s "$HOME/.config/crush/superpowers/skills" "$HOME/.config/crush/skills/superpowers"
+
+# Append bootstrap to AGENTS.md
+cat "$HOME/.config/crush/superpowers/.crush/AGENTS.md" >> "$HOME/.config/crush/AGENTS.md"
+
+# Create a personal test skill fixture
+mkdir -p "$HOME/.config/crush/skills/personal-test"
+cat > "$HOME/.config/crush/skills/personal-test/SKILL.md" <<'EOF'
+---
+name: personal-test
+description: Test personal skill for verification
+---
+# Personal Test Skill
+
+This is a personal skill used for testing.
+
+PERSONAL_SKILL_MARKER_12345
+EOF
+
+echo "Setup complete: $TEST_HOME"
+echo "Skills installed at: $HOME/.config/crush/skills/superpowers"
+echo "AGENTS.md at: $HOME/.config/crush/AGENTS.md"
+
+# Cleanup helper
+cleanup_test_env() {
+    if [ -n "${TEST_HOME:-}" ] && [ -d "$TEST_HOME" ]; then
+        rm -rf "$TEST_HOME"
+    fi
+}
+
+export -f cleanup_test_env
+export REPO_ROOT

--- a/tests/crush/setup.sh
+++ b/tests/crush/setup.sh
@@ -22,9 +22,6 @@ cp -r "$REPO_ROOT/.crush" "$HOME/.config/crush/superpowers/"
 mkdir -p "$HOME/.config/crush/skills"
 ln -s "$HOME/.config/crush/superpowers/skills" "$HOME/.config/crush/skills/superpowers"
 
-# Append bootstrap to AGENTS.md
-cat "$HOME/.config/crush/superpowers/.crush/AGENTS.md" >> "$HOME/.config/crush/AGENTS.md"
-
 # Create a personal test skill fixture
 mkdir -p "$HOME/.config/crush/skills/personal-test"
 cat > "$HOME/.config/crush/skills/personal-test/SKILL.md" <<'EOF'
@@ -41,7 +38,6 @@ EOF
 
 echo "Setup complete: $TEST_HOME"
 echo "Skills installed at: $HOME/.config/crush/skills/superpowers"
-echo "AGENTS.md at: $HOME/.config/crush/AGENTS.md"
 
 # Cleanup helper
 cleanup_test_env() {

--- a/tests/crush/test-install.sh
+++ b/tests/crush/test-install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Test: Crush Installation Structure
+# Verifies that superpowers is correctly set up for Crush
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== Test: Crush Installation Structure ==="
+
+# Source setup to create isolated environment
+source "$SCRIPT_DIR/setup.sh"
+
+# Trap to cleanup on exit
+trap cleanup_test_env EXIT
+
+# Test 1: Skills symlink exists
+echo "Test 1: Checking skills symlink..."
+if [ -L "$HOME/.config/crush/skills/superpowers" ]; then
+    echo "  [PASS] Skills symlink exists"
+else
+    echo "  [FAIL] Skills symlink not found at $HOME/.config/crush/skills/superpowers"
+    exit 1
+fi
+
+# Test 2: Symlink target resolves to the skills directory
+echo "Test 2: Checking symlink target..."
+target="$(readlink -f "$HOME/.config/crush/skills/superpowers")"
+if [ -d "$target" ]; then
+    echo "  [PASS] Symlink target resolves to: $target"
+else
+    echo "  [FAIL] Symlink target does not exist: $target"
+    exit 1
+fi
+
+# Test 3: using-superpowers skill exists (required for skill discipline)
+echo "Test 3: Checking using-superpowers skill..."
+if [ -f "$HOME/.config/crush/skills/superpowers/using-superpowers/SKILL.md" ]; then
+    echo "  [PASS] using-superpowers skill exists"
+else
+    echo "  [FAIL] using-superpowers skill not found (required for bootstrap)"
+    exit 1
+fi
+
+# Test 4: At least one skill with valid frontmatter
+echo "Test 4: Checking skill count..."
+skill_count=$(find -L "$HOME/.config/crush/skills/superpowers" -name "SKILL.md" | grep -c "SKILL.md" || true)
+if [ "$skill_count" -gt 0 ]; then
+    echo "  [PASS] Found $skill_count skills installed"
+else
+    echo "  [FAIL] No skills found"
+    exit 1
+fi
+
+# Test 5: AGENTS.md bootstrap source exists in .crush/
+echo "Test 5: Checking .crush/AGENTS.md source..."
+if [ -f "$HOME/.config/crush/superpowers/.crush/AGENTS.md" ]; then
+    echo "  [PASS] .crush/AGENTS.md exists"
+else
+    echo "  [FAIL] .crush/AGENTS.md not found"
+    exit 1
+fi
+
+# Test 6: Bootstrap was injected into ~/.config/crush/AGENTS.md
+echo "Test 6: Checking AGENTS.md bootstrap injection..."
+if grep -q "superpowers" "$HOME/.config/crush/AGENTS.md" 2>/dev/null; then
+    echo "  [PASS] Bootstrap found in ~/.config/crush/AGENTS.md"
+else
+    echo "  [FAIL] Bootstrap not found in ~/.config/crush/AGENTS.md"
+    exit 1
+fi
+
+# Test 7: INSTALL.md exists in .crush/
+echo "Test 7: Checking .crush/INSTALL.md..."
+if [ -f "$HOME/.config/crush/superpowers/.crush/INSTALL.md" ]; then
+    echo "  [PASS] .crush/INSTALL.md exists"
+else
+    echo "  [FAIL] .crush/INSTALL.md not found"
+    exit 1
+fi
+
+echo ""
+echo "=== All Crush installation tests passed ==="

--- a/tests/crush/test-install.sh
+++ b/tests/crush/test-install.sh
@@ -51,30 +51,56 @@ else
     exit 1
 fi
 
-# Test 5: AGENTS.md bootstrap source exists in .crush/
-echo "Test 5: Checking .crush/AGENTS.md source..."
-if [ -f "$HOME/.config/crush/superpowers/.crush/AGENTS.md" ]; then
-    echo "  [PASS] .crush/AGENTS.md exists"
-else
-    echo "  [FAIL] .crush/AGENTS.md not found"
-    exit 1
-fi
-
-# Test 6: Bootstrap was injected into ~/.config/crush/AGENTS.md
-echo "Test 6: Checking AGENTS.md bootstrap injection..."
-if grep -q "superpowers" "$HOME/.config/crush/AGENTS.md" 2>/dev/null; then
-    echo "  [PASS] Bootstrap found in ~/.config/crush/AGENTS.md"
-else
-    echo "  [FAIL] Bootstrap not found in ~/.config/crush/AGENTS.md"
-    exit 1
-fi
-
-# Test 7: INSTALL.md exists in .crush/
-echo "Test 7: Checking .crush/INSTALL.md..."
+# Test 5: INSTALL.md exists in .crush/
+echo "Test 5: Checking .crush/INSTALL.md..."
 if [ -f "$HOME/.config/crush/superpowers/.crush/INSTALL.md" ]; then
     echo "  [PASS] .crush/INSTALL.md exists"
 else
     echo "  [FAIL] .crush/INSTALL.md not found"
+    exit 1
+fi
+
+# Test 6: All skills have required frontmatter fields (name and description)
+echo "Test 6: Checking skill frontmatter validity..."
+invalid_skills=()
+while IFS= read -r skill_file; do
+    # Extract name field
+    name=$(grep -m1 "^name:" "$skill_file" | sed 's/^name: *//' | tr -d '"' || true)
+    # Extract description field
+    desc=$(grep -m1 "^description:" "$skill_file" | sed 's/^description: *//' | tr -d '"' || true)
+    if [ -z "$name" ] || [ -z "$desc" ]; then
+        invalid_skills+=("$skill_file (name='$name' desc='$desc')")
+    fi
+done < <(find -L "$HOME/.config/crush/skills/superpowers" -name "SKILL.md")
+
+if [ ${#invalid_skills[@]} -eq 0 ]; then
+    echo "  [PASS] All skills have valid name and description"
+else
+    echo "  [FAIL] Skills missing required frontmatter:"
+    for s in "${invalid_skills[@]}"; do
+        echo "    - $s"
+    done
+    exit 1
+fi
+
+# Test 7: Skill name matches directory name
+echo "Test 7: Checking skill name/directory consistency..."
+mismatched=()
+while IFS= read -r skill_file; do
+    dir_name="$(basename "$(dirname "$skill_file")")"
+    skill_name=$(grep -m1 "^name:" "$skill_file" | sed 's/^name: *//' | tr -d '"' || true)
+    if [ "${dir_name,,}" != "${skill_name,,}" ]; then
+        mismatched+=("$skill_file: dir='$dir_name' name='$skill_name'")
+    fi
+done < <(find -L "$HOME/.config/crush/skills/superpowers" -name "SKILL.md")
+
+if [ ${#mismatched[@]} -eq 0 ]; then
+    echo "  [PASS] All skill names match their directory names"
+else
+    echo "  [FAIL] Skill name/directory mismatches:"
+    for s in "${mismatched[@]}"; do
+        echo "    - $s"
+    done
     exit 1
 fi
 


### PR DESCRIPTION
This PR adds full superpowers support for the Crush CLI (the successor to OpenCode from Charmbracelet).

## Implementation Details

- **.crush/AGENTS.md**: Bootstrap file intended to be appended to the global AGENTS.md for Crush, hooking superpowers in via persistent context and tool mapping.
- **.crush/INSTALL.md**: Step-by-step installation instructions for Unix & Windows users.
- **docs/README.crush.md**: Comprehensive documentation on installation, usage, architecture, and troubleshooting.
- **tests/crush/**: Add tests mimicking the existing OpenCode and Claude Code verification tests.
- **README.md**: Added Crush directly to the primary installation table to bring it parity with other supported agents.