### PR TITLE
fix: prevent path traversal in resolveSkillPath

### DIFF
--- a/lib/skills-core.js
+++ b/lib/skills-core.js
@@ -110,9 +110,19 @@ function resolveSkillPath(skillName, superpowersDir, personalDir) {
     const forceSuperpowers = skillName.startsWith('superpowers:');
     const actualSkillName = forceSuperpowers ? skillName.replace(/^superpowers:/, '') : skillName;
 
+    // Reject skill names containing path traversal sequences
+    if (actualSkillName.includes('..') || path.isAbsolute(actualSkillName)) {
+        return null;
+    }
+
     // Try personal skills first (unless explicitly superpowers:)
     if (!forceSuperpowers && personalDir) {
-        const personalPath = path.join(personalDir, actualSkillName);
+        const personalPath = path.resolve(personalDir, actualSkillName);
+        // Ensure resolved path stays within personalDir
+        if (!personalPath.startsWith(path.resolve(personalDir) + path.sep) &&
+            personalPath !== path.resolve(personalDir)) {
+            return null;
+        }
         const personalSkillFile = path.join(personalPath, 'SKILL.md');
         if (fs.existsSync(personalSkillFile)) {
             return {
@@ -125,7 +135,12 @@ function resolveSkillPath(skillName, superpowersDir, personalDir) {
 
     // Try superpowers skills
     if (superpowersDir) {
-        const superpowersPath = path.join(superpowersDir, actualSkillName);
+        const superpowersPath = path.resolve(superpowersDir, actualSkillName);
+        // Ensure resolved path stays within superpowersDir
+        if (!superpowersPath.startsWith(path.resolve(superpowersDir) + path.sep) &&
+            superpowersPath !== path.resolve(superpowersDir)) {
+            return null;
+        }
         const superpowersSkillFile = path.join(superpowersPath, 'SKILL.md');
         if (fs.existsSync(superpowersSkillFile)) {
             return {


### PR DESCRIPTION
## Summary

Prevent directory traversal attacks in `resolveSkillPath()` by validating that skill names don't contain path traversal sequences and that resolved paths stay within expected directories.

## Problem

`resolveSkillPath()` in `lib/skills-core.js` accepts a `skillName` parameter and uses it directly in `path.join()` to construct file paths. A malicious skill name like `../../etc/shadow` would resolve outside the intended skills directory.

## Fix

1. **Reject traversal patterns early**: Return `null` if `actualSkillName` contains `..` or is an absolute path
2. **Validate resolved paths**: Use `path.resolve()` + `startsWith()` to verify the resolved path remains within the expected personal or superpowers skills directory
3. **Defense in depth**: Both checks are applied, so even if one is bypassed, the other catches it

## Impact

- No behavior change for legitimate skill names (e.g., `brainstorming`, `superpowers:code-review`)
- Skill names with path traversal attempts now return `null` instead of potentially reading from outside the skills directory
