### PR TITLE
Fix SessionStart hook variable expansion on Linux

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd session-start",
             "async": false
           }
         ]


### PR DESCRIPTION
Fixes issue #577. The hook command used single quotes around CLAUDE_PLUGIN_ROOT which prevented shell variable expansion on Linux. This caused the hook to fail with No such file or directory error.

Changed from single quotes to no quotes since the JSON string already provides proper quoting. The shell will now correctly expand the CLAUDE_PLUGIN_ROOT environment variable.