### PR TITLE
fix: use double quotes for CLAUDE_PLUGIN_ROOT in SessionStart hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
             "async": false
           }
         ]


### PR DESCRIPTION
## Problem

The `SessionStart` hook in `hooks/hooks.json` fails on Linux with:

```
bash: line 1: /hooks/run-hook.cmd: No such file or directory
```

The hook command uses single quotes around `${CLAUDE_PLUGIN_ROOT}`:

```json
"command": '${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start"
```

Single quotes prevent shell variable expansion, so `CLAUDE_PLUGIN_ROOT` is empty and the shell tries to execute `/hooks/run-hook.cmd` (absolute path from root).

Reported in #577.

## Solution

Use escaped double quotes instead of single quotes:

```json
"command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start"
```

Double quotes allow `${CLAUDE_PLUGIN_ROOT}` to expand while still properly quoting paths with spaces.

## Changes

- `hooks/hooks.json`: 1 character change (single → double quotes)

## Testing

- Verified variable expansion works with double quotes on Linux bash
- No impact on macOS/Windows (double quotes work universally)

Closes #577