### PR TITLE
fix: add hard gates to prevent review skipping in subagent-driven-development

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -14,6 +14,7 @@ DO NOT mark any task complete without dispatching BOTH reviewer subagents.
 This is non-negotiable. No exceptions. No "going faster."
 
 For EVERY task, you MUST dispatch:
+
 1. Spec compliance reviewer subagent (./spec-reviewer-prompt.md)
 2. Code quality reviewer subagent (./code-quality-reviewer-prompt.md)
 
@@ -42,6 +43,7 @@ digraph when_to_use {
 ```
 
 **vs. Executing Plans (parallel session):**
+
 - Same session (no context switch)
 - Fresh subagent per task (no context pollution)
 - Two-stage review after each task: spec compliance first, then code quality
@@ -98,7 +100,7 @@ digraph process {
 
 Before marking ANY task complete, verify ALL of these are true:
 
-```
+```text
 □ Implementer subagent dispatched and completed
 □ Spec reviewer subagent dispatched → result was ✅
 □ Code quality reviewer subagent dispatched → result was ✅
@@ -113,16 +115,16 @@ Before marking ANY task complete, verify ALL of these are true:
 
 These thoughts mean STOP — you are about to skip a required review:
 
-| Thought | Reality |
-|---------|---------|
-| "I'll skip reviews to go faster" | Skipping reviews = rework later = slower |
-| "This task was simple, doesn't need review" | ALL tasks get reviewed. No exceptions. |
-| "Context is getting long, let me streamline" | Reviews are not optional streamlining |
-| "I already reviewed it mentally" | Mental review ≠ dispatched reviewer subagent |
-| "Just for the last few tasks" | ESPECIALLY the last tasks need reviews |
+| Thought                                      | Reality                                         |
+| -------------------------------------------- | ----------------------------------------------- |
+| "I'll skip reviews to go faster"             | Skipping reviews = rework later = slower        |
+| "This task was simple, doesn't need review"  | ALL tasks get reviewed. No exceptions.          |
+| "Context is getting long, let me streamline" | Reviews are not optional streamlining           |
+| "I already reviewed it mentally"             | Mental review ≠ dispatched reviewer subagent    |
+| "Just for the last few tasks"                | ESPECIALLY the last tasks need reviews          |
 | "The implementer's self-review was thorough" | Self-review does not replace reviewer subagents |
-| "I'll review them all at the end" | Per-task review catches issues early |
-| "Almost done, let me just finish up" | "Almost done" is when corners get cut most |
+| "I'll review them all at the end"            | Per-task review catches issues early            |
+| "Almost done, let me just finish up"         | "Almost done" is when corners get cut most      |
 
 ## Prompt Templates
 
@@ -209,23 +211,27 @@ Done!
 ## Advantages
 
 **vs. Manual execution:**
+
 - Subagents follow TDD naturally
 - Fresh context per task (no confusion)
 - Parallel-safe (subagents don't interfere)
 - Subagent can ask questions (before AND during work)
 
 **vs. Executing Plans:**
+
 - Same session (no handoff)
 - Continuous progress (no waiting)
 - Review checkpoints automatic
 
 **Efficiency gains:**
+
 - No file reading overhead (controller provides full text)
 - Controller curates exactly what context is needed
 - Subagent gets complete information upfront
 - Questions surfaced before work begins (not after)
 
 **Quality gates:**
+
 - Self-review catches issues before handoff
 - Two-stage review: spec compliance, then code quality
 - Review loops ensure fixes actually work
@@ -233,6 +239,7 @@ Done!
 - Code quality ensures implementation is well-built
 
 **Cost:**
+
 - More subagent invocations (implementer + 2 reviewers per task)
 - Controller does more prep work (extracting all tasks upfront)
 - Review loops add iterations
@@ -241,6 +248,7 @@ Done!
 ## Red Flags
 
 **Never:**
+
 - Start implementation on main/master branch without explicit user consent
 - **NEVER skip reviews (spec compliance OR code quality) — this is the #1 failure mode of this workflow**
 - Proceed with unfixed issues
@@ -255,30 +263,36 @@ Done!
 - Move to next task while either review has open issues
 
 **If subagent asks questions:**
+
 - Answer clearly and completely
 - Provide additional context if needed
 - Don't rush them into implementation
 
 **If reviewer finds issues:**
+
 - Implementer (same subagent) fixes them
 - Reviewer reviews again
 - Repeat until approved
 - Don't skip the re-review
 
 **If subagent fails task:**
+
 - Dispatch fix subagent with specific instructions
 - Don't try to fix manually (context pollution)
 
 ## Integration
 
 **Required workflow skills:**
+
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
 - **superpowers:requesting-code-review** - Code review template for reviewer subagents
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks
 
 **Subagents should use:**
+
 - **superpowers:test-driven-development** - Subagents follow TDD for each task
 
 **Alternative workflow:**
+
 - **superpowers:executing-plans** - Use for parallel session instead of same-session execution

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -9,6 +9,18 @@ Execute plan by dispatching fresh subagent per task, with two-stage review after
 
 **Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration
 
+<HARD-GATE>
+DO NOT mark any task complete without dispatching BOTH reviewer subagents.
+This is non-negotiable. No exceptions. No "going faster."
+
+For EVERY task, you MUST dispatch:
+1. Spec compliance reviewer subagent (./spec-reviewer-prompt.md)
+2. Code quality reviewer subagent (./code-quality-reviewer-prompt.md)
+
+If you skip either review, you are violating this skill. Period.
+Skipping reviews is the #1 failure mode of this workflow. Do not rationalize it.
+</HARD-GATE>
+
 ## When to Use
 
 ```dot
@@ -81,6 +93,36 @@ digraph process {
     "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
 }
 ```
+
+## Completion Gate (Mandatory Per Task)
+
+Before marking ANY task complete, verify ALL of these are true:
+
+```
+□ Implementer subagent dispatched and completed
+□ Spec reviewer subagent dispatched → result was ✅
+□ Code quality reviewer subagent dispatched → result was ✅
+□ Any issues found by reviewers were fixed AND re-reviewed
+```
+
+**If ANY box is unchecked → DO NOT mark task complete.**
+**"Going faster" by skipping reviews = going slower (rework later).**
+**This gate applies to every task. No exceptions. ESPECIALLY the last tasks.**
+
+## Rationalization Prevention
+
+These thoughts mean STOP — you are about to skip a required review:
+
+| Thought | Reality |
+|---------|---------|
+| "I'll skip reviews to go faster" | Skipping reviews = rework later = slower |
+| "This task was simple, doesn't need review" | ALL tasks get reviewed. No exceptions. |
+| "Context is getting long, let me streamline" | Reviews are not optional streamlining |
+| "I already reviewed it mentally" | Mental review ≠ dispatched reviewer subagent |
+| "Just for the last few tasks" | ESPECIALLY the last tasks need reviews |
+| "The implementer's self-review was thorough" | Self-review does not replace reviewer subagents |
+| "I'll review them all at the end" | Per-task review catches issues early |
+| "Almost done, let me just finish up" | "Almost done" is when corners get cut most |
 
 ## Prompt Templates
 
@@ -200,7 +242,7 @@ Done!
 
 **Never:**
 - Start implementation on main/master branch without explicit user consent
-- Skip reviews (spec compliance OR code quality)
+- **NEVER skip reviews (spec compliance OR code quality) — this is the #1 failure mode of this workflow**
 - Proceed with unfixed issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Make subagent read plan file (provide full text instead)

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -105,6 +105,7 @@ Before marking ANY task complete, verify ALL of these are true:
 □ Spec reviewer subagent dispatched → result was ✅
 □ Code quality reviewer subagent dispatched → result was ✅
 □ Any issues found by reviewers were fixed AND re-reviewed
+□ If any post-review fix changed behavior or scope, spec reviewer re-approved the final state
 ```
 
 **If ANY box is unchecked → DO NOT mark task complete.**


### PR DESCRIPTION
This adds structural guards: a <HARD-GATE> block at the top, a mandatory completion gate checklist, and a rationalization prevention table targeting observed failure modes.

## Motivation and Context
Claude frequently skips spec compliance and code quality reviews under context pressure, rationalizing it as "going faster." Fixes #528

## How Has This Been Tested?
Tested different long-running task with different a few different changes to the prompts. Another change I tried was [this](https://github.com/philippevezina/superpowers/pull/1/changes) but it did not give good results. So far these changes have proven to enforce the reviews pretty well.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed