### PR TITLE
fix: handle symlinked skill directories in findSkillsInDir

### DIFF
--- a/lib/skills-core.js
+++ b/lib/skills-core.js
@@ -61,40 +61,55 @@ function extractFrontmatter(filePath) {
  */
 function findSkillsInDir(dir, sourceType, maxDepth = 3) {
     const skills = [];
+    const activePaths = new Set();
 
     if (!fs.existsSync(dir)) return skills;
 
     function recurse(currentDir, depth) {
         if (depth > maxDepth) return;
 
-        const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+        let realCurrentDir;
+        try {
+            realCurrentDir = fs.realpathSync(currentDir);
+        } catch {
+            return;
+        }
 
-        for (const entry of entries) {
-            const fullPath = path.join(currentDir, entry.name);
+        if (activePaths.has(realCurrentDir)) return;
+        activePaths.add(realCurrentDir);
 
-            // Handle both real directories and symlinks to directories
-            const isDir = entry.isDirectory();
-            const isSymlinkDir = entry.isSymbolicLink() && (() => {
-                try { return fs.statSync(fullPath).isDirectory(); } catch { return false; }
-            })();
+        try {
+            const entries = fs.readdirSync(currentDir, { withFileTypes: true });
 
-            if (isDir || isSymlinkDir) {
-                // Check for SKILL.md in this directory
-                const skillFile = path.join(fullPath, 'SKILL.md');
-                if (fs.existsSync(skillFile)) {
-                    const { name, description } = extractFrontmatter(skillFile);
-                    skills.push({
-                        path: fullPath,
-                        skillFile: skillFile,
-                        name: name || entry.name,
-                        description: description || '',
-                        sourceType: sourceType
-                    });
+            for (const entry of entries) {
+                const fullPath = path.join(currentDir, entry.name);
+
+                // Handle both real directories and symlinks to directories
+                const isDir = entry.isDirectory();
+                const isSymlinkDir = entry.isSymbolicLink() && (() => {
+                    try { return fs.statSync(fullPath).isDirectory(); } catch { return false; }
+                })();
+
+                if (isDir || isSymlinkDir) {
+                    // Check for SKILL.md in this directory
+                    const skillFile = path.join(fullPath, 'SKILL.md');
+                    if (fs.existsSync(skillFile)) {
+                        const { name, description } = extractFrontmatter(skillFile);
+                        skills.push({
+                            path: fullPath,
+                            skillFile: skillFile,
+                            name: name || entry.name,
+                            description: description || '',
+                            sourceType: sourceType
+                        });
+                    }
+
+                    // Recurse into subdirectories
+                    recurse(fullPath, depth + 1);
                 }
-
-                // Recurse into subdirectories
-                recurse(fullPath, depth + 1);
             }
+        } finally {
+            activePaths.delete(realCurrentDir);
         }
     }
 

--- a/tests/opencode/test-skills-core.sh
+++ b/tests/opencode/test-skills-core.sh
@@ -198,26 +198,39 @@ function extractFrontmatter(filePath) {
 
 function findSkillsInDir(dir, sourceType, maxDepth = 3) {
     const skills = [];
+    const activePaths = new Set();
     if (!fs.existsSync(dir)) return skills;
     function recurse(currentDir, depth) {
         if (depth > maxDepth) return;
-        const entries = fs.readdirSync(currentDir, { withFileTypes: true });
-        for (const entry of entries) {
-            const fullPath = path.join(currentDir, entry.name);
-            if (entry.isDirectory()) {
-                const skillFile = path.join(fullPath, 'SKILL.md');
-                if (fs.existsSync(skillFile)) {
-                    const { name, description } = extractFrontmatter(skillFile);
-                    skills.push({
-                        path: fullPath,
-                        skillFile: skillFile,
-                        name: name || entry.name,
-                        description: description || '',
-                        sourceType: sourceType
-                    });
+        let realCurrentDir;
+        try { realCurrentDir = fs.realpathSync(currentDir); } catch { return; }
+        if (activePaths.has(realCurrentDir)) return;
+        activePaths.add(realCurrentDir);
+        try {
+            const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+            for (const entry of entries) {
+                const fullPath = path.join(currentDir, entry.name);
+                const isDir = entry.isDirectory();
+                const isSymlinkDir = entry.isSymbolicLink() && (() => {
+                    try { return fs.statSync(fullPath).isDirectory(); } catch { return false; }
+                })();
+                if (isDir || isSymlinkDir) {
+                    const skillFile = path.join(fullPath, 'SKILL.md');
+                    if (fs.existsSync(skillFile)) {
+                        const { name, description } = extractFrontmatter(skillFile);
+                        skills.push({
+                            path: fullPath,
+                            skillFile: skillFile,
+                            name: name || entry.name,
+                            description: description || '',
+                            sourceType: sourceType
+                        });
+                    }
+                    recurse(fullPath, depth + 1);
                 }
-                recurse(fullPath, depth + 1);
             }
+        } finally {
+            activePaths.delete(realCurrentDir);
         }
     }
     recurse(dir, 0);
@@ -310,30 +323,39 @@ function extractFrontmatter(filePath) {
 
 function findSkillsInDir(dir, sourceType, maxDepth = 3) {
     const skills = [];
+    const activePaths = new Set();
     if (!fs.existsSync(dir)) return skills;
     function recurse(currentDir, depth) {
         if (depth > maxDepth) return;
-        const entries = fs.readdirSync(currentDir, { withFileTypes: true });
-        for (const entry of entries) {
-            const fullPath = path.join(currentDir, entry.name);
-            const isDir = entry.isDirectory();
-            const isSymlinkDir = entry.isSymbolicLink() && (() => {
-                try { return fs.statSync(fullPath).isDirectory(); } catch { return false; }
-            })();
-            if (isDir || isSymlinkDir) {
-                const skillFile = path.join(fullPath, 'SKILL.md');
-                if (fs.existsSync(skillFile)) {
-                    const { name, description } = extractFrontmatter(skillFile);
-                    skills.push({
-                        path: fullPath,
-                        skillFile: skillFile,
-                        name: name || entry.name,
-                        description: description || '',
-                        sourceType: sourceType
-                    });
+        let realCurrentDir;
+        try { realCurrentDir = fs.realpathSync(currentDir); } catch { return; }
+        if (activePaths.has(realCurrentDir)) return;
+        activePaths.add(realCurrentDir);
+        try {
+            const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+            for (const entry of entries) {
+                const fullPath = path.join(currentDir, entry.name);
+                const isDir = entry.isDirectory();
+                const isSymlinkDir = entry.isSymbolicLink() && (() => {
+                    try { return fs.statSync(fullPath).isDirectory(); } catch { return false; }
+                })();
+                if (isDir || isSymlinkDir) {
+                    const skillFile = path.join(fullPath, 'SKILL.md');
+                    if (fs.existsSync(skillFile)) {
+                        const { name, description } = extractFrontmatter(skillFile);
+                        skills.push({
+                            path: fullPath,
+                            skillFile: skillFile,
+                            name: name || entry.name,
+                            description: description || '',
+                            sourceType: sourceType
+                        });
+                    }
+                    recurse(fullPath, depth + 1);
                 }
-                recurse(fullPath, depth + 1);
             }
+        } finally {
+            activePaths.delete(realCurrentDir);
         }
     }
     recurse(dir, 0);
@@ -372,6 +394,110 @@ fi
 
 # The broken symlink should not cause a crash - if we got here, it didn't
 echo "  [PASS] Broken symlink did not cause a crash"
+
+# Test 3c: Test findSkillsInDir handles symlink cycles
+echo ""
+echo "Test 3c: Testing findSkillsInDir with symlink cycle..."
+
+# Create a directory with a symlink pointing back to its parent (cycle)
+mkdir -p "$TEST_HOME/cycle-test-dir/real-skill"
+cat > "$TEST_HOME/cycle-test-dir/real-skill/SKILL.md" <<'SKILL_EOF'
+---
+name: cycle-skill
+description: Skill in a directory with a symlink cycle
+---
+# Cycle Skill
+SKILL_EOF
+
+# Create a symlink cycle: cycle-test-dir/loop -> cycle-test-dir
+ln -s "$TEST_HOME/cycle-test-dir" "$TEST_HOME/cycle-test-dir/loop"
+
+result=$(node -e "
+const fs = require('fs');
+const path = require('path');
+
+function extractFrontmatter(filePath) {
+    try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const lines = content.split('\n');
+        let inFrontmatter = false;
+        let name = '';
+        let description = '';
+        for (const line of lines) {
+            if (line.trim() === '---') {
+                if (inFrontmatter) break;
+                inFrontmatter = true;
+                continue;
+            }
+            if (inFrontmatter) {
+                const match = line.match(/^(\w+):\s*(.*)$/);
+                if (match) {
+                    const [, key, value] = match;
+                    if (key === 'name') name = value.trim();
+                    if (key === 'description') description = value.trim();
+                }
+            }
+        }
+        return { name, description };
+    } catch (error) {
+        return { name: '', description: '' };
+    }
+}
+
+function findSkillsInDir(dir, sourceType, maxDepth = 3) {
+    const skills = [];
+    const activePaths = new Set();
+    if (!fs.existsSync(dir)) return skills;
+    function recurse(currentDir, depth) {
+        if (depth > maxDepth) return;
+        let realCurrentDir;
+        try { realCurrentDir = fs.realpathSync(currentDir); } catch { return; }
+        if (activePaths.has(realCurrentDir)) return;
+        activePaths.add(realCurrentDir);
+        try {
+            const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+            for (const entry of entries) {
+                const fullPath = path.join(currentDir, entry.name);
+                const isDir = entry.isDirectory();
+                const isSymlinkDir = entry.isSymbolicLink() && (() => {
+                    try { return fs.statSync(fullPath).isDirectory(); } catch { return false; }
+                })();
+                if (isDir || isSymlinkDir) {
+                    const skillFile = path.join(fullPath, 'SKILL.md');
+                    if (fs.existsSync(skillFile)) {
+                        const { name, description } = extractFrontmatter(skillFile);
+                        skills.push({
+                            path: fullPath,
+                            skillFile: skillFile,
+                            name: name || entry.name,
+                            description: description || '',
+                            sourceType: sourceType
+                        });
+                    }
+                    recurse(fullPath, depth + 1);
+                }
+            }
+        } finally {
+            activePaths.delete(realCurrentDir);
+        }
+    }
+    recurse(dir, 0);
+    return skills;
+}
+
+const skills = findSkillsInDir('$TEST_HOME/cycle-test-dir', 'test', 3);
+console.log(JSON.stringify(skills, null, 2));
+" 2>&1)
+
+cycle_count=$(echo "$result" | grep -c '"name":' || echo "0")
+
+if [ "$cycle_count" -eq 1 ]; then
+    echo "  [PASS] findSkillsInDir found skill exactly once despite symlink cycle (found $cycle_count)"
+else
+    echo "  [FAIL] findSkillsInDir should find skill exactly once with symlink cycle (found $cycle_count)"
+    echo "  Result: $result"
+    exit 1
+fi
 
 # Test 4: Test resolveSkillPath function
 echo ""


### PR DESCRIPTION
## Summary

- `Dirent.isDirectory()` returns `false` for symlinks to directories on Node.js v24, causing `findSkillsInDir` to skip symlinked skill directories entirely
- Added `isSymbolicLink()` check with `statSync` verification so symlinked skills are properly discovered
- Broken symlinks are handled gracefully via try/catch

Fixes #624

## Context

Symlinked skills are a common pattern — tools like `camp skills link` create per-bundle symlinks from project skill directories into `.claude/skills/`. Without this fix, all symlinked skills fail during session init with:

```
Error: InputValidationError: Skill failed due to the following issue:
The required parameter `skill` is missing
```

## Test plan

- [x] Verify symlinked skill directories are discovered by `findSkillsInDir`
- [x] Verify regular (non-symlinked) skill directories still work
- [x] Verify broken symlinks don't cause crashes