### PR TITLE
Add missing post-action verification to two skills

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -164,11 +164,21 @@ Agent 3 → Fix tool-approval-race-conditions.test.ts
 
 ## Verification
 
-After agents return:
+After agents return, complete ALL steps before reporting done:
+
 1. **Review each summary** - Understand what changed
 2. **Check for conflicts** - Did agents edit same code?
-3. **Run full suite** - Verify all fixes work together
+3. **Run full suite** - This is a hard gate, not optional
+
+```bash
+npm test / cargo test / pytest / go test ./...
+```
+
+**If suite fails:** Stop. Do not report completion. Fix conflicts or re-dispatch the failing domain.
+
 4. **Spot check** - Agents can make systematic errors
+
+**Never report integration complete without step 3 output in hand.**
 
 ## Real-World Impact
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -92,6 +92,9 @@ Then: Cleanup worktree (Step 5)
 # Push branch
 git push -u origin <feature-branch>
 
+# Verify push succeeded
+git log origin/<feature-branch> -1 --oneline
+
 # Create PR
 gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Summary
@@ -101,6 +104,9 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 - [ ] <verification steps>
 EOF
 )"
+
+# Confirm PR was created
+gh pr view --json url,title,state
 ```
 
 Then: Cleanup worktree (Step 5)
@@ -183,12 +189,14 @@ git worktree remove <worktree-path>
 - Merge without verifying tests on result
 - Delete work without confirmation
 - Force-push without explicit request
+- Assume push/PR succeeded without checking
 
 **Always:**
 - Verify tests before offering options
 - Present exactly 4 options
 - Get typed confirmation for Option 4
 - Clean up worktree for Options 1 & 4 only
+- Confirm PR was created with `gh pr view` after Option 2
 
 ## Integration
 


### PR DESCRIPTION
While working through the workflow, I noticed two skills that complete irreversible or hard-to-reverse actions without confirming the outcome.

## finishing-a-development-branch — Option 2

After `git push` and `gh pr create`, the skill moves straight to worktree cleanup with no confirmation that either operation succeeded. A failed push (e.g. rejected by remote) or a malformed `gh pr create` call would go unnoticed.

Added two verification steps after the push/create sequence:
- `git log origin/<branch> -1 --oneline` — confirms the push landed
- `gh pr view --json url,title,state` — confirms the PR was created

Also added to Red Flags: "Assume push/PR succeeded without checking" and to Always: "Confirm PR was created with `gh pr view` after Option 2".

## dispatching-parallel-agents — Integration verification

The Verification section listed "Run full suite" as bullet point 3 of 4, at the same visual weight as "Spot check". Nothing indicated it was a blocking condition — an agent could read past it and report completion after just reviewing summaries.

Made the requirement unambiguous: added a bash block showing the command, and an explicit stop condition if the suite fails. Added "Never report integration complete without step 3 output in hand."

Both changes are minimal and follow the existing style of the skills.