### PR TITLE
fix(hooks): use cmd-compatible quoting for SessionStart run-hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
             "async": false
           }
         ]


### PR DESCRIPTION
## Summary
- replace the single-quoted SessionStart hook command with escaped double quotes in `hooks/hooks.json`
- preserve spaces in `CLAUDE_PLUGIN_ROOT` paths while remaining compatible with Windows `cmd.exe`

## Validation
- `python3 -m json.tool hooks/hooks.json`

Closes #529
