### PR TITLE
fix(writing-skills): replace @ reference with markdown link

### DIFF
--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -553,7 +553,7 @@ Run same scenarios WITH skill. Agent should now comply.
 
 Agent found new rationalization? Add explicit counter. Re-test until bulletproof.
 
-**Testing methodology:** See @testing-skills-with-subagents.md for the complete testing methodology:
+**Testing methodology:** See [testing-skills-with-subagents.md](testing-skills-with-subagents.md) for the complete testing methodology:
 - How to write pressure scenarios
 - Pressure types (time, sunk cost, authority, exhaustion)
 - Plugging holes systematically


### PR DESCRIPTION
## Summary
- replace `@testing-skills-with-subagents.md` with a standard markdown link in `skills/writing-skills/SKILL.md`
- keep the guidance consistent with earlier advice in the same skill to avoid force-loading via `@` references

Fixes #280

## Validation
- ran a local markdown link check for `skills/writing-skills/SKILL.md` to confirm the linked file resolves (`links_checked=1 missing=0`)
