### PR TITLE
fix(brainstorming): ensure worktree setup happens before writing plan

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -28,7 +28,8 @@ You MUST create a task for each of these items and complete them in order:
 3. **Propose 2-3 approaches** — with trade-offs and your recommendation
 4. **Present design** — in sections scaled to their complexity, get user approval after each section
 5. **Write design doc** — save to `docs/plans/YYYY-MM-DD-<topic>-design.md` and commit
-6. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+6. **Create implementation worktree** — invoke using-git-worktrees to set up an isolated branch/worktree
+7. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -40,6 +41,7 @@ digraph brainstorming {
     "Present design sections" [shape=box];
     "User approves design?" [shape=diamond];
     "Write design doc" [shape=box];
+    "Invoke using-git-worktrees" [shape=box];
     "Invoke writing-plans skill" [shape=doublecircle];
 
     "Explore project context" -> "Ask clarifying questions";
@@ -48,11 +50,12 @@ digraph brainstorming {
     "Present design sections" -> "User approves design?";
     "User approves design?" -> "Present design sections" [label="no, revise"];
     "User approves design?" -> "Write design doc" [label="yes"];
-    "Write design doc" -> "Invoke writing-plans skill";
+    "Write design doc" -> "Invoke using-git-worktrees";
+    "Invoke using-git-worktrees" -> "Invoke writing-plans skill";
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skills you invoke after brainstorming are using-git-worktrees and then writing-plans (in that order).
 
 ## The Process
 
@@ -83,8 +86,9 @@ digraph brainstorming {
 - Commit the design document to git
 
 **Implementation:**
-- Invoke the writing-plans skill to create a detailed implementation plan
-- Do NOT invoke any other skill. writing-plans is the next step.
+- Invoke using-git-worktrees to set up an isolated branch/worktree for execution
+- Then invoke the writing-plans skill to create a detailed implementation plan
+- Do NOT invoke any other implementation skill before writing-plans.
 
 ## Key Principles
 


### PR DESCRIPTION
## Summary
- restore a dedicated `using-git-worktrees` step in `skills/brainstorming/SKILL.md` between design-doc commit and writing-plans
- update the process-flow diagram to enforce that ordering
- clarify post-design guidance so only `using-git-worktrees` then `writing-plans` are allowed

## Validation
- `bash tests/opencode/test-skills-core.sh`

Closes #574
