### PR TITLE
fix(writing-plans): avoid invalid placeholder chars in plan filenames

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -15,7 +15,12 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill).
 
-**Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
+**Save plans to:** `docs/plans/YYYY-MM-DD-feature-name.md`
+
+Filename rules (to avoid tool/path errors across macOS/Linux/Windows):
+- Replace `feature-name` with a real lowercase slug (e.g., `oauth-login`, `invoice-export`)
+- Use only: `a-z`, `0-9`, and hyphens (`-`)
+- Never leave placeholder characters like `<` `>` in the actual filename
 
 ## Bite-Sized Task Granularity
 


### PR DESCRIPTION
## Summary
- change the writing-plans save-path example to a real cross-platform filename pattern (docs/plans/YYYY-MM-DD-feature-name.md)
- add explicit filename slug rules (a-z, 0-9, hyphen)
- call out that placeholder characters like < and > must never appear in the actual filename

This targets intermittent "invalid argument passed to tool" failures when /superpowers:write-plan tries to save a plan using literal placeholder characters.

Closes #408