### PR TITLE
docs(writing-skills): add character-safety guidance for inline exclamation parsing

### DIFF
--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -344,6 +344,22 @@ Choose most relevant language:
 
 You're good at porting - one great example is enough.
 
+## Character Safety Gotcha (Claude Code parser bug)
+
+**Never put exclamation marks inside single-backtick inline code spans.**
+
+Claude Code can mis-parse those spans as shell operators and reject the skill at load time with a bash permission-check error.
+
+Workarounds:
+- Spell operators out in prose (`exclamation-equals`, `exclamation-tilde`) instead of writing symbols inline
+- Put exact syntax in fenced code blocks when needed
+- Avoid placing exclamation marks directly next to backticks, even in examples
+
+References:
+- https://github.com/anthropics/claude-code/issues/13655
+- https://github.com/anthropics/claude-code/issues/12762
+- https://github.com/anthropics/claude-code/issues/12781
+
 ## File Organization
 
 ### Self-Contained Skill


### PR DESCRIPTION
## Summary
- add a new "Character Safety Gotcha" section to `skills/writing-skills/SKILL.md`
- document that exclamation marks inside single-backtick inline code spans can break skill loading in Claude Code
- add practical workarounds and links to upstream bug reports

## Verification
- `bash tests/opencode/test-skills-core.sh`
- inline safety check: no single-backtick inline code spans in `skills/writing-skills/SKILL.md` contain exclamation marks

Closes #451
