### PR TITLE
writing-plans: add output budget guardrails to avoid token overflow

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -26,6 +26,16 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 - "Run the tests and make sure they pass" - step
 - "Commit" - step
 
+## Output Budget Guardrails
+
+To avoid oversized responses and token overflows:
+
+- Keep plans concise: target **~120 lines max** (excluding blank lines/code fences)
+- Cap at **10 tasks per response**
+- If work is larger, split into phases and only output **Phase 1**
+- Prefer short, high-signal snippets (5-15 lines) instead of full-file dumps
+- For repetitive tasks, provide one concrete example then reference the same pattern for remaining tasks
+
 ## Plan Document Header
 
 **Every plan MUST start with this header:**
@@ -89,7 +99,7 @@ git commit -m "feat: add specific feature"
 
 ## Remember
 - Exact file paths always
-- Complete code in plan (not "add validation")
+- Include concrete snippets and commands, but avoid full-file dumps unless truly necessary
 - Exact commands with expected output
 - Reference relevant skills with @ syntax
 - DRY, YAGNI, TDD, frequent commits


### PR DESCRIPTION
## Summary\n- add an `Output Budget Guardrails` section to the `writing-plans` skill\n- cap generated plans to a concise size (task count + line budget)\n- instruct phased planning for large scopes and avoid full-file dumps\n\n## Why\nIssue #227 reports `write-plan` responses frequently exceeding Claude Code output limits. These guardrails keep plans actionable while reducing oversized responses.\n\n## Validation\n- ran markdown sanity check for `skills/writing-plans/SKILL.md` front matter and section presence\n- ran `git diff --check`\n\nCloses #227