### PR TITLE
fix: brainstorming skill should use AskUserQuestion tool

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -60,6 +60,7 @@ digraph brainstorming {
 - Check out the current project state first (files, docs, recent commits)
 - Ask questions one at a time to refine the idea
 - Prefer multiple choice questions when possible, but open-ended is fine too
+- ALWAYS use the AskUserQuestion tool for multiple choice questions — never present options as lettered text lists in chat
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
 - Focus on understanding: purpose, constraints, success criteria
 
@@ -89,7 +90,7 @@ digraph brainstorming {
 ## Key Principles
 
 - **One question at a time** - Don't overwhelm with multiple questions
-- **Multiple choice preferred** - Easier to answer than open-ended when possible
+- **Multiple choice preferred** - Always use the AskUserQuestion tool, never inline lettered lists
 - **YAGNI ruthlessly** - Remove unnecessary features from all designs
 - **Explore alternatives** - Always propose 2-3 approaches before settling
 - **Incremental validation** - Present design, get approval before moving on


### PR DESCRIPTION
## Summary

- The brainstorming skill says "prefer multiple choice questions" but never tells the model to use the `AskUserQuestion` tool
- This causes the model to present options as lettered text lists (A, B, C, D) in chat instead of using the native interactive arrow-key picker
- Added explicit instructions to always use `AskUserQuestion` for multiple choice questions

## Changes

Two lines in `skills/brainstorming/SKILL.md`:
1. Added "ALWAYS use the AskUserQuestion tool for multiple choice questions" in the process section
2. Updated the "Multiple choice preferred" key principle to reference the tool

## Test plan

- [ ] Enable superpowers plugin
- [ ] Start a task that triggers brainstorming
- [ ] Verify options appear as interactive arrow-key picker, not lettered text

Related issue: https://github.com/anthropics/claude-code/issues/32474