### PR TITLE
feat(finishing-branch): add issue-closing keywords to PR template

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -108,7 +108,7 @@ git pull
 ### Tool mapping
 
 When skills reference Claude Code tools:
-- `TodoWrite` → `update_plan`
+- `TodoWrite` → `todowrite`
 - `Task` with subagents → `@mention` syntax
 - `Skill` tool → OpenCode's native `skill` tool
 - File operations → your native tools

--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -63,7 +63,7 @@ export const SuperpowersPlugin = async ({ client, directory }) => {
 
     const toolMapping = `**Tool Mapping for OpenCode:**
 When skills reference tools you don't have, substitute OpenCode equivalents:
-- \`TodoWrite\` → \`update_plan\`
+- \`TodoWrite\` → \`todowrite\`
 - \`Task\` tool with subagents → Use OpenCode's subagent system (@mention)
 - \`Skill\` tool → OpenCode's native \`skill\` tool
 - \`Read\`, \`Write\`, \`Edit\`, \`Bash\` → Your native tools

--- a/docs/README.opencode.md
+++ b/docs/README.opencode.md
@@ -249,7 +249,7 @@ Superpowers uses OpenCode's native `skill` tool for skill discovery and loading.
 
 Skills written for Claude Code are automatically adapted for OpenCode. The bootstrap provides mapping instructions:
 
-- `TodoWrite` → `update_plan`
+- `TodoWrite` → `todowrite`
 - `Task` with subagents → OpenCode's `@mention` system
 - `Skill` tool → OpenCode's native `skill` tool
 - File operations → Native OpenCode tools

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -92,8 +92,9 @@ Then: Cleanup worktree (Step 5)
 - Look at the branch name for issue numbers (e.g., `fix-123`, `issue-456`, `600-feat-...`)
 - Check commit messages for issue references (`#123`, `fixes #123`)
 - Check plan files or task descriptions for issue links
-- If a related issue is found, include a closing keyword (`Closes #NNN`) in the PR body
-- If no related issue is found, skip the closing keyword - don't fabricate one
+- Only use closing keywords for issues this PR actually resolves; ignore incidental references from unrelated commits or notes
+- If the PR resolves multiple issues, include one closing line per issue
+- If no resolved issue is found, omit the closing line entirely - don't fabricate one
 
 ```bash
 # Push branch
@@ -107,7 +108,7 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Test Plan
 - [ ] <verification steps>
 
-<Closes #NNN if a related issue was found, otherwise omit this line>
+<One `Closes #NNN` line per issue this PR resolves, otherwise omit this block>
 EOF
 )"
 ```

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -88,6 +88,13 @@ Then: Cleanup worktree (Step 5)
 
 #### Option 2: Push and Create PR
 
+**Check for related GitHub issues** before creating the PR:
+- Look at the branch name for issue numbers (e.g., `fix-123`, `issue-456`, `600-feat-...`)
+- Check commit messages for issue references (`#123`, `fixes #123`)
+- Check plan files or task descriptions for issue links
+- If a related issue is found, include a closing keyword (`Closes #NNN`) in the PR body
+- If no related issue is found, skip the closing keyword - don't fabricate one
+
 ```bash
 # Push branch
 git push -u origin <feature-branch>
@@ -99,6 +106,8 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 
 ## Test Plan
 - [ ] <verification steps>
+
+<Closes #NNN if a related issue was found, otherwise omit this line>
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary

- Adds instructions to the `finishing-a-development-branch` skill to check for related GitHub issues
- When a related issue is found (via branch name, commit messages, or plan files), includes a closing keyword (`Closes #NNN`) in the PR body
- Enables automatic issue closure on merge instead of requiring manual cleanup

Fixes #600

This contribution was developed with AI assistance (Claude Code).