### PR TITLE
fix(hooks): remove single quotes from command paths for Windows compatibility

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
             "async": false
           }
         ]


### PR DESCRIPTION
## Summary

- Replaces single quotes with double quotes in hook command paths in `hooks/hooks.json`
- On Windows, `cmd.exe` interprets `'C:` as the command name instead of recognizing single quotes as path delimiters
- Double quotes are used (not bare paths) to handle spaces in paths like `C:\Program Files\...`
- The fix works on both Windows (`cmd.exe`) and Unix (`bash`)

Fixes #644

This contribution was developed with AI assistance (Claude Code).