### PR TITLE
fix(hooks): emit session-start context only once per platform

### DIFF
--- a/hooks/session-start
+++ b/hooks/session-start
@@ -35,17 +35,27 @@ warning_escaped=$(escape_for_json "$warning_message")
 session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
-# Keep both shapes for compatibility:
-# - Cursor hooks expect additional_context.
-# - Claude hooks expect hookSpecificOutput.additionalContext.
-cat <<EOF
+# Cursor hooks expect additional_context.
+# Claude Code hooks expect hookSpecificOutput.additionalContext.
+# Claude Code reads BOTH fields without deduplication, so we must only
+# emit the field consumed by the current platform to avoid double injection.
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  # Claude Code sets CLAUDE_PLUGIN_ROOT — emit only hookSpecificOutput
+  cat <<EOF
 {
-  "additional_context": "${session_context}",
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
     "additionalContext": "${session_context}"
   }
 }
 EOF
+else
+  # Other platforms (Cursor, etc.) — emit only additional_context
+  cat <<EOF
+{
+  "additional_context": "${session_context}"
+}
+EOF
+fi
 
 exit 0


### PR DESCRIPTION
## Summary

- Fixes the session-start hook to avoid emitting superpowers context in both `additional_context` and `hookSpecificOutput.additionalContext`
- Claude Code reads both fields without deduplication, causing the full prompt to be injected twice into every session, wasting context window tokens
- The fix detects the runtime via `CLAUDE_PLUGIN_ROOT` (set by Claude Code) and conditionally emits only the field consumed by the current platform
- Cursor and other platforms that read `additional_context` continue to work via the else branch

Fixes #648

This contribution was developed with AI assistance (Claude Code).