### PR TITLE
fix(subagent-dev): add post-commit verification for untracked files

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
             "async": false
           }
         ]

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -88,6 +88,13 @@ Then: Cleanup worktree (Step 5)
 
 #### Option 2: Push and Create PR
 
+**Check for related GitHub issues** before creating the PR:
+- Look at the branch name for issue numbers (e.g., `fix-123`, `issue-456`, `600-feat-...`)
+- Check commit messages for issue references (`#123`, `fixes #123`)
+- Check plan files or task descriptions for issue links
+- If a related issue is found, include a closing keyword (`Closes #NNN`) in the PR body
+- If no related issue is found, skip the closing keyword - don't fabricate one
+
 ```bash
 # Push branch
 git push -u origin <feature-branch>
@@ -99,6 +106,8 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 
 ## Test Plan
 - [ ] <verification steps>
+
+<Closes #NNN if a related issue was found, otherwise omit this line>
 EOF
 )"
 ```

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -53,6 +53,7 @@ digraph process {
         "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
         "Code quality reviewer subagent approves?" [shape=diamond];
         "Implementer subagent fixes quality issues" [shape=box];
+        "Controller: verify no untracked files (git status)" [shape=box];
         "Mark task complete in TodoWrite" [shape=box];
     }
 
@@ -74,7 +75,8 @@ digraph process {
     "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
     "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
     "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
-    "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
+    "Code quality reviewer subagent approves?" -> "Controller: verify no untracked files (git status)" [label="yes"];
+    "Controller: verify no untracked files (git status)" -> "Mark task complete in TodoWrite";
     "Mark task complete in TodoWrite" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
@@ -119,6 +121,8 @@ Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
 [Get git SHAs, dispatch code quality reviewer]
 Code reviewer: Strengths: Good test coverage, clean. Issues: None. Approved.
 
+[Controller: git status check - no untracked files, clean]
+
 [Mark Task 1 complete]
 
 Task 2: Recovery modes
@@ -152,6 +156,9 @@ Implementer: Extracted PROGRESS_INTERVAL constant
 
 [Code reviewer reviews again]
 Code reviewer: ✅ Approved
+
+[Controller: git status check - found untracked test fixture file]
+[Dispatch implementer to stage and amend]
 
 [Mark Task 2 complete]
 
@@ -189,6 +196,7 @@ Done!
 - Review loops ensure fixes actually work
 - Spec compliance prevents over/under-building
 - Code quality ensures implementation is well-built
+- Post-commit verification catches untracked files
 
 **Cost:**
 - More subagent invocations (implementer + 2 reviewers per task)
@@ -222,6 +230,11 @@ Done!
 - Reviewer reviews again
 - Repeat until approved
 - Don't skip the re-review
+
+**After each subagent completes (controller-side check):**
+- Run `git status` to check for untracked files before marking the task complete
+- If untracked files exist that belong to the task, dispatch the implementer subagent to stage and amend
+- This catches cases where the subagent committed without `git add`-ing new files
 
 **If subagent fails task:**
 - Dispatch fix subagent with specific instructions

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -46,7 +46,7 @@ Task tool (general-purpose):
 
     Verify the committed state is complete:
     1. Run `git status` - check for untracked files that should have been committed
-    2. Especially check for new files you created - `git add` only stages tracked files by default
+    2. Especially check for new files you created - `git commit -a` only commits tracked files, so new files need explicit `git add`
     3. If you find untracked files that belong to your work, stage them and amend the commit
     4. Run `git diff HEAD` to confirm nothing is left uncommitted
 

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -33,13 +33,22 @@ Task tool (general-purpose):
     2. Write tests (following TDD if task says to)
     3. Verify implementation works
     4. Commit your work
-    5. Self-review (see below)
-    6. Report back
+    5. Verify committed state (see below)
+    6. Self-review (see below)
+    7. Report back
 
     Work from: [directory]
 
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.
+
+    ## After Committing
+
+    Verify the committed state is complete:
+    1. Run `git status` - check for untracked files that should have been committed
+    2. Especially check for new files you created - `git add` only stages tracked files by default
+    3. If you find untracked files that belong to your work, stage them and amend the commit
+    4. Run `git diff HEAD` to confirm nothing is left uncommitted
 
     ## Before Reporting Back: Self-Review
 


### PR DESCRIPTION
## Summary

- Adds a post-commit verification step to the subagent-driven-development skill
- After each commit, the implementer checks `git status` for untracked files that should have been committed
- Adds a controller-side safety net to flag untracked files before moving to the next task
- Prevents silent failures where the committed state diverges from the working tree

Fixes #633

This contribution was developed with AI assistance (Claude Code).