### PR TITLE
fix(hooks): remove single quotes from command path for Windows compatibility

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd' session-start",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd session-start",
             "async": false
           }
         ]


### PR DESCRIPTION
On Windows, cmd.exe does not recognize single quotes as path delimiters. This causes the SessionStart hook to fail. Remove single quotes from the command path in hooks.json. This works on both Windows (cmd.exe) and Unix (bash). Fixes #644