### PR TITLE
Remove deprecated slash commands (brainstorm, execute-plan, write-plan)

### DIFF
--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:brainstorming skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers brainstorming" skill instead.

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:executing-plans skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers executing-plans" skill instead.

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:writing-plans skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers writing-plans" skill instead.


### PR DESCRIPTION
## Summary

Remove deprecated command files (brainstorm.md, execute-plan.md, write-plan.md) that only displayed deprecation messages pointing users to use the new skill names instead.

These commands were replaced by the new skill names (brainstorming, executing-plans, writing-plans) in superpowers 5.0.0.

## Changes

- Removed `commands/brainstorm.md`
- Removed `commands/execute-plan.md`
- Removed `commands/write-plan.md`

## Fixes

Fixes #669