### PR TITLE
fix(skills): restore worktree step in brainstorming workflow

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -29,7 +29,8 @@ You MUST create a task for each of these items and complete them in order:
 6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+9. **Set up worktree** — invoke using-git-worktrees to create isolated implementation workspace
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -45,6 +46,7 @@ digraph brainstorming {
     "Write design doc" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
     "User reviews spec?" [shape=diamond];
+    "Set up worktree\n(using-git-worktrees)" [shape=box];
     "Invoke writing-plans skill" [shape=doublecircle];
 
     "Explore project context" -> "Visual questions ahead?";
@@ -59,11 +61,12 @@ digraph brainstorming {
     "Write design doc" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "User reviews spec?";
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
-    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+    "User reviews spec?" -> "Set up worktree\n(using-git-worktrees)" [label="approved"];
+    "Set up worktree\n(using-git-worktrees)" -> "Invoke writing-plans skill";
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skills you invoke after brainstorming are using-git-worktrees (for workspace isolation) then writing-plans.
 
 ## The Process
 
@@ -130,10 +133,15 @@ After the spec review loop passes, ask the user to review the written spec befor
 
 Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
 
+**Workspace isolation:**
+
+- Invoke using-git-worktrees to create an isolated worktree for implementation
+- This ensures implementation work doesn't affect the main working tree
+
 **Implementation:**
 
 - Invoke the writing-plans skill to create a detailed implementation plan
-- Do NOT invoke any other skill. writing-plans is the next step.
+- Do NOT invoke any implementation skill (frontend-design, mcp-builder, etc.). writing-plans is the next step after workspace isolation.
 
 ## Key Principles
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -209,7 +209,7 @@ Ready to implement auth feature
 ## Integration
 
 **Called by:**
-- **brainstorming** (Phase 4) - REQUIRED when design is approved and implementation follows
+- **brainstorming** (Step 9) - REQUIRED after user approves spec, before invoking writing-plans
 - **subagent-driven-development** - REQUIRED before executing any tasks
 - **executing-plans** - REQUIRED before executing any tasks
 - Any skill needing isolated workspace


### PR DESCRIPTION
## Summary

- Restore the `using-git-worktrees` invocation lost during brainstorming skill
  simplification (8e38ab8, 7f2ee61) and still missing after the v5.0.0 rework
- Fix stale "Phase 4" cross-reference in `using-git-worktrees` Integration section
- Align actual workflow with `writing-plans` expectation that brainstorming
  creates a worktree (line 16)

## Problem

`brainstorming` never invokes `using-git-worktrees`, despite `writing-plans`
expecting it (line 16: *"This should be run in a dedicated worktree (created by
brainstorming skill)."*) and `using-git-worktrees` documenting it (line 212:
*"Called by: brainstorming (Phase 4)"*).

In practice, after brainstorming completes, `writing-plans` runs directly in
the main working tree — no workspace isolation occurs.

## Changes

**`skills/brainstorming/SKILL.md`** (4 edits):
- **Checklist:** insert step 7 *Set up worktree* between *Write design doc*
  and *Transition to implementation*
- **Process flow diagram:** add worktree node with correct edges
- **Terminal state note:** expand skill whitelist to include
  `using-git-worktrees`
- **After the Design:** add *Workspace isolation* section between Spec Review
  Loop and Implementation; adjust Implementation prohibition from
  "any other skill" to "any implementation skill (frontend-design,
  mcp-builder, etc.)" so `using-git-worktrees` is not blocked

**`skills/using-git-worktrees/SKILL.md`** (1 edit):
- **Integration:** fix stale "Phase 4" cross-reference → "Step 7"

## Context

This is a re-implementation of #483 against the v5.0.0 codebase. The original
PR was closed as stale after v5.0.0 substantially reworked the brainstorming
skill (Visual Companion, Scope Assessment, Spec Review Loop). The core intent
is the same — restore the missing worktree step — but adapted to v5.0.0's
expanded checklist (step 7 instead of 6) and refined prohibition wording. All
v5.0.0 features are unaffected.

Related: #483 (original PR, closed as stale)
Closes #574
Ref #186

## Test Plan

- [ ] Invoke brainstorming skill and verify worktree step appears in task
      checklist as step 7
- [ ] After design approval, verify `using-git-worktrees` is invoked before
      `writing-plans`
- [ ] Verify `using-git-worktrees` Integration section references "Step 7"
- [ ] Confirm v5.0.0 features (Visual Companion, Spec Review Loop) still
      work normally