### PR TITLE
Use portable shebang in all shell scripts

### DIFF
--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Start the brainstorm server and output connection info
 # Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--foreground] [--background]
 #

--- a/skills/brainstorming/scripts/stop-server.sh
+++ b/skills/brainstorming/scripts/stop-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Stop the brainstorm server and clean up
 # Usage: stop-server.sh <screen_dir>
 #

--- a/tests/explicit-skill-requests/run-all.sh
+++ b/tests/explicit-skill-requests/run-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run all explicit skill request tests
 # Usage: ./run-all.sh
 

--- a/tests/explicit-skill-requests/run-claude-describes-sdd.sh
+++ b/tests/explicit-skill-requests/run-claude-describes-sdd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test where Claude explicitly describes subagent-driven-development before user requests it
 # This mimics the original failure scenario
 

--- a/tests/explicit-skill-requests/run-extended-multiturn-test.sh
+++ b/tests/explicit-skill-requests/run-extended-multiturn-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Extended multi-turn test with more conversation history
 # This tries to reproduce the failure by building more context
 

--- a/tests/explicit-skill-requests/run-haiku-test.sh
+++ b/tests/explicit-skill-requests/run-haiku-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test with haiku model and user's CLAUDE.md
 # This tests whether a cheaper/faster model fails more easily
 

--- a/tests/explicit-skill-requests/run-multiturn-test.sh
+++ b/tests/explicit-skill-requests/run-multiturn-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test explicit skill requests in multi-turn conversations
 # Usage: ./run-multiturn-test.sh
 #

--- a/tests/explicit-skill-requests/run-test.sh
+++ b/tests/explicit-skill-requests/run-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test explicit skill requests (user names a skill directly)
 # Usage: ./run-test.sh <skill-name> <prompt-file>
 #

--- a/tests/skill-triggering/run-all.sh
+++ b/tests/skill-triggering/run-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run all skill triggering tests
 # Usage: ./run-all.sh
 

--- a/tests/skill-triggering/run-test.sh
+++ b/tests/skill-triggering/run-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test skill triggering with naive prompts
 # Usage: ./run-test.sh <skill-name> <prompt-file>
 #

--- a/tests/subagent-driven-dev/go-fractals/scaffold.sh
+++ b/tests/subagent-driven-dev/go-fractals/scaffold.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Scaffold the Go Fractals test project
 # Usage: ./scaffold.sh /path/to/target/directory
 

--- a/tests/subagent-driven-dev/run-test.sh
+++ b/tests/subagent-driven-dev/run-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run a subagent-driven-development test
 # Usage: ./run-test.sh <test-name> [--plugin-dir <path>]
 #

--- a/tests/subagent-driven-dev/svelte-todo/scaffold.sh
+++ b/tests/subagent-driven-dev/svelte-todo/scaffold.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Scaffold the Svelte Todo test project
 # Usage: ./scaffold.sh /path/to/target/directory
 


### PR DESCRIPTION
## Summary
- Replace `#!/bin/bash` with `#!/usr/bin/env bash` in all 13 shell scripts
- `#!/bin/bash` assumes bash lives at `/bin/bash`, which isn't true on NixOS, FreeBSD, or macOS with Homebrew
- `#!/usr/bin/env bash` is the portable, POSIX-friendly alternative

## Files changed
- `skills/brainstorming/scripts/start-server.sh`
- `skills/brainstorming/scripts/stop-server.sh`
- `tests/explicit-skill-requests/run-*.sh` (6 files)
- `tests/skill-triggering/run-*.sh` (2 files)
- `tests/subagent-driven-dev/run-test.sh`
- `tests/subagent-driven-dev/*/scaffold.sh` (2 files)

## Test plan
- [ ] Verify scripts remain executable on Linux
- [ ] No functional changes — only the shebang line is modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)