### PR TITLE
Fix sessionStart hook for Cursor

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -14,5 +14,5 @@
   "skills": "./skills/",
   "agents": "./agents/",
   "commands": "./commands/",
-  "hooks": "./hooks/hooks.json"
+  "hooks": "./hooks/hooks-cursor.json"
 }

--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "./hooks/session-start.sh"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Problem

The superpowers plugin's `sessionStart` hook doesn't fire in Cursor. The current `hooks.json` uses the Claude Code hooks format (`SessionStart`, `matcher`, nested `hooks` array), which Cursor doesn't recognize. Cursor expects a different schema — `sessionStart` (camelCase) with a flat `command` field.

## Changes

- Add `hooks/hooks-cursor.json` using Cursor's hooks format
- Update `plugin.json` to reference the new Cursor-compatible hooks file
- Existing `hooks.json` is unchanged for Claude Code compatibility