### PR TITLE
fix: complete the TDD cycle in plan generation and execution

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -38,11 +38,14 @@ After all tasks complete and verified:
 
 ## When to Stop and Ask for Help
 
-**STOP executing immediately when:**
-- Hit a blocker (missing dependency, test fails, instruction unclear)
+**First: follow the step's own guidance.** Plan steps often include instructions for handling expected failures (e.g., "if test passes, fix the test" or "if other tests break, fix now"). Follow that guidance and iterate — this is normal execution, not a blocker.
+
+**STOP executing only when:**
+- Hit an external blocker (missing dependency, service down, environment issue)
+- Plan instruction is ambiguous or contradictory
+- A step fails for reasons unrelated to the current task
+- You've followed the step's failure guidance 3 times without progress
 - Plan has critical gaps preventing starting
-- You don't understand an instruction
-- Verification fails repeatedly
 
 **Ask for clarification rather than guessing.**
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -36,10 +36,12 @@ This structure informs the task decomposition. Each task should produce self-con
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**
-- "Write the failing test" - step
-- "Run it to make sure it fails" - step
-- "Implement the minimal code to make the test pass" - step
-- "Run the tests and make sure they pass" - step
+- "Write the failing test" - step (RED)
+- "Run it to make sure it fails" - step (verify RED)
+- "Implement the minimal code to make the test pass" - step (GREEN)
+- "Run all tests and make sure they pass" - step (verify GREEN)
+- "Refactor — clean up while tests stay green" - step (REFACTOR)
+- "Run all tests to confirm still green" - step (verify REFACTOR)
 - "Commit" - step
 
 ## Plan Document Header
@@ -70,7 +72,7 @@ This structure informs the task decomposition. Each task should produce self-con
 - Modify: `exact/path/to/existing.py:123-145`
 - Test: `tests/exact/path/to/test.py`
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing test** (RED)
 
 ```python
 def test_specific_behavior():
@@ -78,24 +80,39 @@ def test_specific_behavior():
     assert result == expected
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run test to verify it fails** (verify RED)
 
 Run: `pytest tests/path/test.py::test_name -v`
 Expected: FAIL with "function not defined"
+If test passes → you're testing existing behavior, fix the test.
+If test errors (not fails) → fix the error, re-run until it fails correctly.
 
-- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 3: Write minimal implementation** (GREEN)
 
 ```python
 def function(input):
     return expected
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Run ALL tests to verify they pass** (verify GREEN)
 
-Run: `pytest tests/path/test.py::test_name -v`
-Expected: PASS
+Run: `pytest -v` (or project test command)
+Expected: ALL tests PASS — not just the new one.
+If new test fails → fix implementation, not the test.
+If other tests fail → fix now before proceeding.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Refactor** (REFACTOR)
+
+Clean up while tests stay green: remove duplication, improve names, extract helpers.
+Don't add new behavior — only restructure.
+Skip this step if implementation is already clean.
+
+- [ ] **Step 6: Run ALL tests to confirm still green** (verify REFACTOR)
+
+Run: `pytest -v` (or project test command)
+Expected: ALL tests still PASS after refactoring.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 git add tests/path/test.py src/path/file.py


### PR DESCRIPTION
## Summary

The `writing-plans` task template and `executing-plans` STOP condition have gaps that break the RED-GREEN-REFACTOR cycle during plan execution:

- **writing-plans** generates a 5-step task template that skips REFACTOR entirely (RED → verify RED → GREEN → verify GREEN → commit). It also only runs the specific new test in verification, not the full suite — so regressions go undetected.
- **executing-plans** lists "test fails" as a STOP condition, which directly conflicts with TDD's RED phase where a failing test is *expected*. An executor following this skill will bail on normal TDD iteration.

### Changes

**`skills/writing-plans/SKILL.md`** — 5-step → 7-step task template:
1. Step labels now match TDD phases: (RED), (verify RED), (GREEN), (verify GREEN), (REFACTOR), (verify REFACTOR), commit
2. Verify steps run the full test suite (`pytest -v`), not just the new test
3. Each verify step includes error handling guidance (what to do if the test passes when it shouldn't, if other tests break, etc.)
4. REFACTOR step includes "skip if already clean" to avoid busywork
5. Bite-Sized Task Granularity summary updated to match

**`skills/executing-plans/SKILL.md`** — narrowed STOP condition:
1. Added "First: follow the step's own guidance" preamble — expected failures that the plan tells you how to handle are iteration, not blockers
2. Changed "STOP immediately" → "STOP only when" with refined list: external blockers, ambiguous instructions, unrelated failures, or 3 failed attempts after following the step's guidance
3. This change is methodology-agnostic — it works for TDD plans, migration plans, or any plan with inline error handling

## Test plan

- [ ] Generate a plan using `writing-plans` — verify tasks have 7 steps with RED/GREEN/REFACTOR labels
- [ ] Execute a plan using `executing-plans` — verify executor iterates on expected test failures instead of stopping
- [ ] Execute a plan with a genuine blocker — verify executor still stops and asks for help

🤖 Generated with [Claude Code](https://claude.com/claude-code)