### PR TITLE
Add tool usage rules to implementer prompt: dedicated file tools over bash

### DIFF
--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -38,6 +38,22 @@ Task tool (general-purpose):
 
     Work from: [directory]
 
+    ## Tool Usage
+
+    **IMPORTANT: Use dedicated Claude Code tools for file operations — never bash commands.**
+
+    | Operation | Use this | NOT this |
+    |-----------|----------|----------|
+    | Read files | `Read` tool | `cat`, `head`, `tail`, `sed` |
+    | Create files | `Write` tool | `echo >`, `cat <<EOF` |
+    | Edit files | `Edit` tool | `sed`, `awk`, `perl -i` |
+    | Find files | `Glob` tool | `find`, `ls` |
+    | Search content | `Grep` tool | `grep`, `rg` |
+    | Everything else | `Bash` tool | — |
+
+    Reserve `Bash` exclusively for running tests, git commands, package managers, and other system/terminal operations.
+    Using bash to modify files produces invisible changes that can't be reviewed and silently break files.
+
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.
 


### PR DESCRIPTION
## Problem

Sub-agents dispatched by `subagent-driven-development` were using `sed`, `cat`, `awk` etc. to modify files. This:
- Makes file changes invisible to the user (no diff review)
- Silently corrupts files when patterns don't match
- Bypasses Claude Code's permission model for file edits

## Fix

Added a **Tool Usage** section to `implementer-prompt.md` with an explicit table showing:
- Read/Write/Edit/Glob/Grep for file operations
- Bash reserved for tests, git, package managers, system commands only

The guidance mirrors the existing Claude Code system instructions but makes it explicit for sub-agents that don't inherit that context.

## Test

Dispatch an implementer subagent with a file-modification task — it should use `Edit`/`Write` tools instead of `sed`/`cat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)