### PR TITLE
Remove deprecated command files

### DIFF
--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:brainstorming skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers brainstorming" skill instead.

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:executing-plans skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers executing-plans" skill instead.

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:writing-plans skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers writing-plans" skill instead.


### PR DESCRIPTION
## Summary

- Remove 3 deprecated command files that have been replaced by their corresponding skills
- `commands/brainstorm.md` → replaced by `brainstorming` skill
- `commands/write-plan.md` → replaced by `writing-plans` skill  
- `commands/execute-plan.md` → replaced by `executing-plans` skill

## Context

These command files only contained deprecation notices directing users to use the skill equivalents instead. Since the skills are fully functional and these commands serve no purpose beyond showing a deprecation message, they can be safely removed.

## Changes

- Deleted `commands/brainstorm.md`
- Deleted `commands/write-plan.md`
- Deleted `commands/execute-plan.md`