### PR TITLE
Use Agent Teams (TeamCreate) for agent dispatch instead of Task tool

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -63,15 +63,42 @@ Each agent gets:
 - **Constraints:** Don't change other code
 - **Expected output:** Summary of what you found and fixed
 
-### 3. Dispatch in Parallel
+### 3. Dispatch via Agent Teams
 
-```typescript
-// In Claude Code / AI environment
-Task("Fix agent-tool-abort.test.ts failures")
-Task("Fix batch-completion-behavior.test.ts failures")
-Task("Fix tool-approval-race-conditions.test.ts failures")
-// All three run concurrently
+**NEVER use the Task tool for parallel dispatch. Always use Agent Teams:**
+
 ```
+// Create team for this parallel session
+TeamCreate("debug-session")
+
+// Create tasks for tracking
+TaskCreate("Fix agent-tool-abort.test.ts failures")
+TaskCreate("Fix batch-completion-behavior.test.ts failures")
+TaskCreate("Fix tool-approval-race-conditions.test.ts failures")
+
+// Identify relevant skills before spawning
+// Check ~/.claude/skills/ and project .claude/skills/ for domain-specific skills
+// All debuggers get superpowers:systematic-debugging
+
+// Spawn agents as team members — all Opus, all with relevant skills
+Agent(team_name="debug-session", name="abort-fixer", model="opus",
+  prompt="<task details + systematic-debugging skill + relevant project skills>")
+Agent(team_name="debug-session", name="batch-fixer", model="opus",
+  prompt="<task details + systematic-debugging skill + relevant project skills>")
+Agent(team_name="debug-session", name="race-fixer", model="opus",
+  prompt="<task details + systematic-debugging skill + relevant project skills>")
+// All three run concurrently as team members
+```
+
+### Skill-Passing for Parallel Agents
+
+Before spawning each agent, check for relevant skills to pass:
+
+1. **Global skills** (`~/.claude/skills/`) matching the agent's problem domain
+2. **Project skills** (`.claude/skills/`, `.claude/agents/`) for technology/framework-specific guidance
+3. **Superpowers skills** — `systematic-debugging` for debugging, `test-driven-development` for fixing
+
+Include skill file content directly in the agent's prompt.
 
 ### 4. Review and Integrate
 
@@ -141,11 +168,15 @@ Return: Summary of what you found and what you fixed.
 
 **Decision:** Independent domains - abort logic separate from batch completion separate from race conditions
 
-**Dispatch:**
+**Dispatch via Agent Teams:**
 ```
-Agent 1 → Fix agent-tool-abort.test.ts
-Agent 2 → Fix batch-completion-behavior.test.ts
-Agent 3 → Fix tool-approval-race-conditions.test.ts
+TeamCreate("debug-6-failures")
+Agent(team_name="debug-6-failures", name="abort-fixer", model="opus",
+  prompt="Fix agent-tool-abort.test.ts + systematic-debugging skill + project skills")
+Agent(team_name="debug-6-failures", name="batch-fixer", model="opus",
+  prompt="Fix batch-completion-behavior.test.ts + systematic-debugging skill + project skills")
+Agent(team_name="debug-6-failures", name="race-fixer", model="opus",
+  prompt="Fix tool-approval-race-conditions.test.ts + systematic-debugging skill + project skills")
 ```
 
 **Results:**

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -29,9 +29,9 @@ BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
 HEAD_SHA=$(git rev-parse HEAD)
 ```
 
-**2. Dispatch code-reviewer subagent:**
+**2. Spawn code-reviewer as Agent Team member:**
 
-Use Task tool with superpowers:code-reviewer type, fill template at `code-reviewer.md`
+Use `Agent(team_name="<team>", name="code-reviewer", model="opus")` with the template at `code-reviewer.md`. Pass any relevant project skills matching the code domain.
 
 **Placeholders:**
 - `{WHAT_WAS_IMPLEMENTED}` - What you just built

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -84,20 +84,34 @@ digraph process {
 }
 ```
 
-## Model Selection
+## Agent Dispatch Protocol
 
-Use the least powerful model that can handle each role to conserve cost and increase speed.
+**All agent dispatch uses Agent Teams (TeamCreate workflow). NEVER use the Task tool for fire-and-forget subagent dispatch.** Task tool is only acceptable for single, isolated lookups (e.g., Explore agent to search for a file).
 
-**Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.
+### Team Setup
 
-**Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
+1. **Create team** with `TeamCreate` for the implementation session
+2. **Create tasks** with `TaskCreate` for each plan task (for tracking and coordination)
+3. **Spawn each agent** with the `Agent` tool using:
+   - `team_name`: the team name from step 1
+   - `name`: descriptive name (e.g., `"implementer-task-1"`, `"spec-reviewer-task-1"`)
+   - `model`: `"opus"` (always Opus — max effort, 1M context)
+4. **Coordinate** via `SendMessage` and `TaskUpdate`
 
-**Architecture, design, and review tasks**: use the most capable available model.
+### Skill-Passing Protocol
 
-**Task complexity signals:**
-- Touches 1-2 files with a complete spec → cheap model
-- Touches multiple files with integration concerns → standard model
-- Requires design judgment or broad codebase understanding → most capable model
+Before spawning any agent team member, identify and pass relevant skills in their prompt:
+
+1. **Check global skills** (`~/.claude/skills/`) for skills matching the agent's task domain
+2. **Check project skills** (project-level `.claude/skills/` or `.claude/agents/`) for domain-specific skills
+3. **Include relevant Superpowers skills** (e.g., `superpowers:test-driven-development` for implementers)
+4. **Read each skill file** and include its content in the agent's prompt
+
+**Example skill-passing:**
+- Agent implementing Zustand state management gets: `superpowers:test-driven-development` + project's `zustand` skill (if exists)
+- Agent implementing Supabase integration gets: `superpowers:test-driven-development` + project's `supabase` skill (if exists)
+- Agent debugging a test failure gets: `superpowers:systematic-debugging` + any relevant project domain skill
+- Spec/quality reviewers get: the spec/plan document content + any relevant project conventions
 
 ## Handling Implementer Status
 
@@ -119,9 +133,11 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 
 ## Prompt Templates
 
-- `./implementer-prompt.md` - Dispatch implementer subagent
-- `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
-- `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
+- `./implementer-prompt.md` - Spawn implementer as Agent Team member
+- `./spec-reviewer-prompt.md` - Spawn spec compliance reviewer as Agent Team member
+- `./code-quality-reviewer-prompt.md` - Spawn code quality reviewer as Agent Team member
+
+**When spawning from these templates**, always use the Agent Dispatch Protocol above (TeamCreate, model="opus", skill-passing).
 
 ## Example Workflow
 
@@ -130,70 +146,79 @@ You: I'm using Subagent-Driven Development to execute this plan.
 
 [Read plan file once: docs/superpowers/plans/feature-plan.md]
 [Extract all 5 tasks with full text and context]
-[Create TodoWrite with all tasks]
 
-Task 1: Hook installation script
+── Setup ──
+[TeamCreate("feature-impl")]
+[TaskCreate for each of the 5 plan tasks — for tracking]
 
-[Get Task 1 text and context (already extracted)]
-[Dispatch implementation subagent with full task text + context]
+── Identify Skills ──
+[Check ~/.claude/skills/ and project .claude/skills/ for relevant domain skills]
+[Task 1 involves hooks → found project's "hooks" skill]
+[Task 2 involves recovery → found project's "error-handling" skill]
+[All implementers get superpowers:test-driven-development]
+
+── Task 1: Hook installation script ──
+
+[Spawn implementer via Agent(team_name="feature-impl", name="impl-task-1",
+  model="opus", prompt="<task text + context + TDD skill + hooks skill>")]
 
 Implementer: "Before I begin - should the hook be installed at user or system level?"
 
-You: "User level (~/.config/superpowers/hooks/)"
+[SendMessage(to="impl-task-1", message="User level (~/.config/superpowers/hooks/)")]
 
-Implementer: "Got it. Implementing now..."
-[Later] Implementer:
+Implementer:
   - Implemented install-hook command
   - Added tests, 5/5 passing
   - Self-review: Found I missed --force flag, added it
   - Committed
 
-[Dispatch spec compliance reviewer]
+[Spawn spec reviewer via Agent(team_name="feature-impl", name="spec-rev-task-1",
+  model="opus", prompt="<spec + implementer report>")]
 Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
 
-[Get git SHAs, dispatch code quality reviewer]
+[Spawn quality reviewer via Agent(team_name="feature-impl", name="quality-rev-task-1",
+  model="opus", prompt="<git SHAs + code context>")]
 Code reviewer: Strengths: Good test coverage, clean. Issues: None. Approved.
 
-[Mark Task 1 complete]
+[TaskUpdate: Task 1 complete]
 
-Task 2: Recovery modes
+── Task 2: Recovery modes ──
 
-[Get Task 2 text and context (already extracted)]
-[Dispatch implementation subagent with full task text + context]
+[Spawn implementer via Agent(team_name="feature-impl", name="impl-task-2",
+  model="opus", prompt="<task text + context + TDD skill + error-handling skill>")]
 
-Implementer: [No questions, proceeds]
 Implementer:
   - Added verify/repair modes
   - 8/8 tests passing
   - Self-review: All good
   - Committed
 
-[Dispatch spec compliance reviewer]
+[Spawn spec reviewer]
 Spec reviewer: ❌ Issues:
   - Missing: Progress reporting (spec says "report every 100 items")
   - Extra: Added --json flag (not requested)
 
-[Implementer fixes issues]
+[SendMessage to impl-task-2 with fix instructions]
 Implementer: Removed --json flag, added progress reporting
 
-[Spec reviewer reviews again]
+[Spawn spec reviewer again]
 Spec reviewer: ✅ Spec compliant now
 
-[Dispatch code quality reviewer]
-Code reviewer: Strengths: Solid. Issues (Important): Magic number (100)
+[Spawn quality reviewer]
+Code reviewer: Issues (Important): Magic number (100)
 
-[Implementer fixes]
+[SendMessage to impl-task-2 with fix instructions]
 Implementer: Extracted PROGRESS_INTERVAL constant
 
-[Code reviewer reviews again]
+[Spawn quality reviewer again]
 Code reviewer: ✅ Approved
 
-[Mark Task 2 complete]
+[TaskUpdate: Task 2 complete]
 
 ...
 
 [After all tasks]
-[Dispatch final code-reviewer]
+[Spawn final code-reviewer as team member]
 Final reviewer: All requirements met, ready to merge
 
 Done!
@@ -238,6 +263,8 @@ Done!
 - Skip reviews (spec compliance OR code quality)
 - Proceed with unfixed issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
+- **Use the Task tool for fire-and-forget agent dispatch** — always use Agent Teams (TeamCreate + Agent with team_name + model="opus")
+- **Forget to pass relevant skills** — check global (~/.claude/skills/) and project (.claude/skills/, .claude/agents/) skill dirs before spawning
 - Make subagent read plan file (provide full text instead)
 - Skip scene-setting context (subagent needs to understand where task fits)
 - Ignore subagent questions (answer before letting them proceed)

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -1,13 +1,15 @@
 # Code Quality Reviewer Prompt Template
 
-Use this template when dispatching a code quality reviewer subagent.
+Use this template when spawning a code quality reviewer as an Agent Team member.
+
+**Dispatch method:** `Agent(team_name="<team>", name="quality-rev-task-N", model="opus", prompt="<below>")`
 
 **Purpose:** Verify implementation is well-built (clean, tested, maintainable)
 
-**Only dispatch after spec compliance review passes.**
+**Only spawn after spec compliance review passes.**
 
 ```
-Task tool (superpowers:code-reviewer):
+Agent(team_name="<team>", name="quality-rev-task-N", model="opus"):
   Use template at requesting-code-review/code-reviewer.md
 
   WHAT_WAS_IMPLEMENTED: [from implementer's report]

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -1,10 +1,13 @@
-# Implementer Subagent Prompt Template
+# Implementer Agent Team Member Prompt Template
 
-Use this template when dispatching an implementer subagent.
+Use this template when spawning an implementer as an Agent Team member.
+
+**Dispatch method:** `Agent(team_name="<team>", name="impl-task-N", model="opus", prompt="<below>")`
+
+**Skill-passing:** Before spawning, read and include relevant skills from `~/.claude/skills/` and project `.claude/skills/` dirs. Always include `superpowers:test-driven-development` for implementers.
 
 ```
-Task tool (general-purpose):
-  description: "Implement Task N: [task name]"
+Agent(team_name="<team>", name="impl-task-N", model="opus"):
   prompt: |
     You are implementing Task N: [task name]
 

--- a/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -1,12 +1,13 @@
 # Spec Compliance Reviewer Prompt Template
 
-Use this template when dispatching a spec compliance reviewer subagent.
+Use this template when spawning a spec compliance reviewer as an Agent Team member.
+
+**Dispatch method:** `Agent(team_name="<team>", name="spec-rev-task-N", model="opus", prompt="<below>")`
 
 **Purpose:** Verify implementer built what was requested (nothing more, nothing less)
 
 ```
-Task tool (general-purpose):
-  description: "Review spec compliance for Task N"
+Agent(team_name="<team>", name="spec-rev-task-N", model="opus"):
   prompt: |
     You are reviewing whether an implementation matches its specification.
 


### PR DESCRIPTION
## Summary

- Replaces fire-and-forget `Task` tool dispatch pattern with Claude Code's Agent Teams (`TeamCreate` + `Agent(team_name=..., model="opus")`) across all dispatch-related skills
- Adds a **Skill-Passing Protocol** so coordinators pass relevant domain skills (from global and project skill directories) to each agent team member before spawning
- Updates prompt templates, examples, and red flags to reflect the new dispatch pattern

## Motivation

Claude Code's Agent Teams (`TeamCreate` + `TaskCreate` + `SendMessage`) provide coordinated multi-agent workflows with team awareness, shared task tracking, and inter-agent communication — capabilities the older `Task` tool lacks.

The current skills explicitly reference `Task("...")` for agent dispatch, which:
- Fires and forgets with no coordination primitives
- Doesn't pass domain-specific skills to agents
- Uses a tiered model selection (cheap/standard/capable) that doesn't leverage the coordinator's ability to pass context

Users who configure their `CLAUDE.md` to require Agent Teams find that the skills' explicit `Task` tool references override their preferences in practice, forcing them to manually re-specify the dispatch pattern in every session.

## Changes

### `subagent-driven-development/SKILL.md`
- Replaced "Model Selection" section (cheap/standard/capable tiers) with "Agent Dispatch Protocol" (TeamCreate + Opus + skill-passing)
- Added "Skill-Passing Protocol" section with concrete examples
- Updated example workflow to demonstrate full Agent Teams lifecycle
- Added red flags for Task tool misuse and missing skill-passing

### `dispatching-parallel-agents/SKILL.md`
- Replaced `Task("...")` dispatch pattern with `TeamCreate` + `Agent(team_name=...)` pattern
- Added "Skill-Passing for Parallel Agents" section
- Updated real-world example to show Agent Teams dispatch

### `requesting-code-review/SKILL.md`
- Updated dispatch instructions from Task tool to Agent Team member spawn

### Prompt Templates (`implementer-prompt.md`, `spec-reviewer-prompt.md`, `code-quality-reviewer-prompt.md`)
- Changed dispatch method headers from `Task tool` to `Agent(team_name, model="opus")`
- Added skill-passing instructions to implementer template

## Compatibility

This is a documentation-only change (no code modifications). Skills that don't involve agent dispatch are unaffected. The Agent Teams API is available in Claude Code and other harnesses with subagent support.

## Test plan

- [ ] Invoke `superpowers:subagent-driven-development` and verify it instructs Agent Teams dispatch (not Task tool)
- [ ] Invoke `superpowers:dispatching-parallel-agents` and verify parallel agents are spawned via TeamCreate
- [ ] Verify skill-passing protocol is followed when spawning implementers
- [ ] Confirm skills still work correctly in harnesses without Agent Teams support (graceful reference)