### PR TITLE
feat(subagent-driven-development): add fresh-eyes review step for cross-task issues

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -60,7 +60,7 @@ digraph process {
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
     "More tasks remain?" [shape=diamond];
-    "Dispatch final code reviewer subagent for entire implementation" [shape=box];
+    "Dispatch fresh-eyes reviewer subagent (./fresh-eyes-reviewer-prompt.md)" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
@@ -79,8 +79,8 @@ digraph process {
     "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
     "Mark task complete in TodoWrite" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
-    "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
-    "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
+    "More tasks remain?" -> "Dispatch fresh-eyes reviewer subagent (./fresh-eyes-reviewer-prompt.md)" [label="no"];
+    "Dispatch fresh-eyes reviewer subagent (./fresh-eyes-reviewer-prompt.md)" -> "Use superpowers:finishing-a-development-branch";
 }
 ```
 
@@ -122,6 +122,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 - `./implementer-prompt.md` - Dispatch implementer subagent
 - `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
 - `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
+- `./fresh-eyes-reviewer-prompt.md` - Dispatch fresh-eyes reviewer after all tasks complete
 
 ## Example Workflow
 
@@ -193,9 +194,16 @@ Code reviewer: ✅ Approved
 ...
 
 [After all tasks]
-[Dispatch final code-reviewer]
-Final reviewer: All requirements met, ready to merge
+[Dispatch fresh-eyes reviewer — reviews entire feature, not just last task]
+[Uses git merge-base to diff ALL changes from feature branch]
+Fresh-eyes reviewer: Found 2 cross-task issues:
+  - Duplicated TIMEOUT constant in fetcher.ts and cache.ts
+  - Error message in cli.ts doesn't explain what the user did wrong
 
+[Fix cross-task issues, re-dispatch fresh-eyes reviewer]
+Fresh-eyes reviewer: No cross-task issues remaining. Ready to merge.
+
+[Use superpowers:finishing-a-development-branch]
 Done!
 ```
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -61,6 +61,8 @@ digraph process {
     "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch fresh-eyes reviewer subagent (./fresh-eyes-reviewer-prompt.md)" [shape=box];
+    "Fresh-eyes reviewer finds cross-task issues?" [shape=diamond];
+    "Fix cross-task issues" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
@@ -80,7 +82,10 @@ digraph process {
     "Mark task complete in TodoWrite" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch fresh-eyes reviewer subagent (./fresh-eyes-reviewer-prompt.md)" [label="no"];
-    "Dispatch fresh-eyes reviewer subagent (./fresh-eyes-reviewer-prompt.md)" -> "Use superpowers:finishing-a-development-branch";
+    "Dispatch fresh-eyes reviewer subagent (./fresh-eyes-reviewer-prompt.md)" -> "Fresh-eyes reviewer finds cross-task issues?";
+    "Fresh-eyes reviewer finds cross-task issues?" -> "Fix cross-task issues" [label="yes"];
+    "Fix cross-task issues" -> "Dispatch fresh-eyes reviewer subagent (./fresh-eyes-reviewer-prompt.md)" [label="re-review"];
+    "Fresh-eyes reviewer finds cross-task issues?" -> "Use superpowers:finishing-a-development-branch" [label="no"];
 }
 ```
 
@@ -122,7 +127,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 - `./implementer-prompt.md` - Dispatch implementer subagent
 - `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
 - `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
-- `./fresh-eyes-reviewer-prompt.md` - Dispatch fresh-eyes reviewer after all tasks complete
+- `./fresh-eyes-reviewer-prompt.md` - Dispatch fresh-eyes reviewer subagent
 
 ## Example Workflow
 
@@ -232,6 +237,7 @@ Done!
 - Review loops ensure fixes actually work
 - Spec compliance prevents over/under-building
 - Code quality ensures implementation is well-built
+- Fresh-eyes review catches cross-task issues invisible to per-task reviewers
 
 **Cost:**
 - More subagent invocations (implementer + 2 reviewers per task)
@@ -243,7 +249,7 @@ Done!
 
 **Never:**
 - Start implementation on main/master branch without explicit user consent
-- Skip reviews (spec compliance OR code quality)
+- Skip reviews (spec compliance, code quality, OR fresh-eyes)
 - Proceed with unfixed issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Make subagent read plan file (provide full text instead)

--- a/skills/subagent-driven-development/fresh-eyes-reviewer-prompt.md
+++ b/skills/subagent-driven-development/fresh-eyes-reviewer-prompt.md
@@ -1,0 +1,72 @@
+# Fresh-Eyes Reviewer Prompt Template
+
+Use this template when dispatching a fresh-eyes reviewer after all tasks complete.
+
+**Purpose:** Catch cross-task issues that per-task reviews miss — inconsistencies, duplication, dead code, documentation gaps.
+
+**Only dispatch after all tasks are complete and their individual reviews have passed.**
+
+```
+Task tool (general-purpose):
+  description: "Fresh-eyes review of entire feature implementation"
+  prompt: |
+    You are performing a fresh-eyes review of an entire multi-task feature.
+    Per-task spec and code quality reviews have already passed. Your job is different:
+    find issues that only become visible when looking at ALL changes together.
+
+    ## Feature Context
+
+    {FEATURE_SUMMARY}
+
+    ## Tasks Implemented
+
+    {TASK_LIST}
+
+    ## Git Range (entire feature, not just last task)
+
+    ```bash
+    git diff --stat {BASE_SHA}..{HEAD_SHA}
+    git diff {BASE_SHA}..{HEAD_SHA}
+    ```
+
+    Review ALL changed files across the full range.
+
+    ## Focus: Cross-Task Issues Only
+
+    DO NOT re-review per-task concerns (code style, individual test coverage, single-file quality).
+    Focus exclusively on issues that span task boundaries:
+
+    1. **Cross-task inconsistencies** — values, naming, behavior assumptions that contradict across modules
+    2. **Duplicated code/constants** — same logic or value defined independently by different tasks
+    3. **Dead code from iteration** — conditionals, functions, or code paths made obsolete by later tasks
+    4. **Documentation gaps** — features supported in one module but undocumented or unwired elsewhere
+    5. **Inconsistent error handling** — same generic message from multiple locations, missing context
+    6. **Integration gaps** — config defined but unchecked, return values unused, interfaces unimplemented
+
+    ## Output
+
+    For each issue found:
+    - **Category** (from the 6 above)
+    - **Files:lines involved**
+    - **What's wrong**
+    - **Suggested fix**
+
+    If zero cross-task issues found, say so — don't invent problems.
+
+    ### Assessment
+
+    **Cross-task issues found:** [count]
+    **Ready to merge after fixing?** [Yes/No]
+
+    ## Critical Rules
+
+    - Read EVERY file in the diff, not just a sample
+    - Be specific: file:line references
+    - DO NOT modify any files — read-only review
+```
+
+**Dispatch with:**
+- `{BASE_SHA}`: where the feature branch diverged (`git merge-base HEAD origin/main`)
+- `{HEAD_SHA}`: current tip (`git rev-parse HEAD`)
+- `{FEATURE_SUMMARY}`: what the feature does (1-2 sentences)
+- `{TASK_LIST}`: list of tasks that were implemented

--- a/skills/subagent-driven-development/fresh-eyes-reviewer-prompt.md
+++ b/skills/subagent-driven-development/fresh-eyes-reviewer-prompt.md
@@ -6,7 +6,7 @@ Use this template when dispatching a fresh-eyes reviewer after all tasks complet
 
 **Only dispatch after all tasks are complete and their individual reviews have passed.**
 
-```
+````
 Task tool (general-purpose):
   description: "Fresh-eyes review of entire feature implementation"
   prompt: |
@@ -63,10 +63,10 @@ Task tool (general-purpose):
     - Read EVERY file in the diff, not just a sample
     - Be specific: file:line references
     - DO NOT modify any files — read-only review
-```
+````
 
 **Dispatch with:**
-- `{BASE_SHA}`: where the feature branch diverged (`git merge-base HEAD origin/main`)
+- `{BASE_SHA}`: where the feature branch diverged (e.g. `git merge-base HEAD origin/main`)
 - `{HEAD_SHA}`: current tip (`git rev-parse HEAD`)
 - `{FEATURE_SUMMARY}`: what the feature does (1-2 sentences)
 - `{TASK_LIST}`: list of tasks that were implemented


### PR DESCRIPTION
## What problem are you trying to solve?

The SDD skill's final review step says "Dispatch final code reviewer subagent for entire implementation" — but gives no guidance on *what* that reviewer should focus on or *how* it differs from the per-task reviews that already passed.

Per-task reviews are structurally blind to cross-task issues: each reviewer sees only its own task's diff. Issues like duplicated constants with conflicting values across modules, dead code left by iteration between tasks, or integration gaps where one module references an unexported function from another — these only become visible when reviewing ALL changes together.

This was reported in [#291](https://github.com/obra/superpowers/issues/291) by the maintainer. The eval below confirms the gap: a generic "final code reviewer" finds cross-task issues incidentally (by happening to compare files), not systematically. With the fresh-eyes prompt, the reviewer is directed to look exclusively at task boundaries and produces structured, actionable output.

## What does this PR change?

Replaces the vague "final code reviewer" placeholder with a concrete fresh-eyes review step: a dedicated prompt template focused on 6 categories of cross-task issues, a review loop in the flowchart (find → fix → re-review), and updates to the example workflow, quality gates, and red flags.

## Is this change appropriate for the core library?

Yes. This improves an existing step within a core skill (SDD). The fresh-eyes review is general-purpose — it applies to any multi-task implementation regardless of project domain. No new skills, no new dependencies, no third-party integrations.

## What alternatives did you consider?

1. **Standalone `implementation-review` skill** (the approach in [#549](https://github.com/obra/superpowers/pull/549)): Creates a new skill and modifies 3 existing skills (SDD, executing-plans, finishing-a-development-branch). Rejected because the gap is within SDD's own workflow — the "final code reviewer" step already exists, it just needs to be specific. A new skill adds naming/discovery overhead and cross-references without proportional benefit. The executing-plans integration could be a follow-up if the pattern proves valuable.

2. **Do nothing**: The vague step leaves it to chance whether a reviewer focuses on cross-task issues. The eval below shows that without explicit guidance, the review mixes per-task concerns with cross-task ones and the reviewer acknowledges the cross-task findings were incidental.

## Does this PR contain multiple unrelated changes?

No. All changes serve a single purpose: replacing the vague final review step with a concrete fresh-eyes review. The SKILL.md edits (flowchart, prompt list, example, quality gates, red flags) and the new prompt template are a single cohesive change.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs:
  - [#549](https://github.com/obra/superpowers/pull/549) (closed) — Created a standalone `implementation-review` skill for the same issue. Self-closed by author ("targeting my fork instead"), not rejected by maintainers. This PR takes a different approach: keeps changes within SDD rather than creating a new skill, modifies only 1 file instead of 3, and adds a review loop matching the existing spec/quality reviewer pattern.
  - [#865](https://github.com/obra/superpowers/pull/865) (open) — Standalone blind-review skill for spec-only final review. Complementary: #865 addresses spec drift before merge, this PR addresses cross-task integration issues within SDD's existing workflow. No overlap in scope.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code CLI | 2.1.92 | Claude | claude-opus-4-6 |

## Evaluation

**Initial prompt:** "We need to address [#291](https://github.com/obra/superpowers/issues/291) — the SDD skill's final review step is vague and doesn't catch cross-task issues."

**Eval methodology:** Created a test repo (`/tmp/sdd-eval-repo`) simulating a 3-task SDD implementation (fetcher → cache → CLI) with 5 planted cross-task issues: duplicated TIMEOUT constants (different values), dead retry code from iteration, naming inconsistency, unexported validation function referenced by another module, and generic identical error messages across 3 locations.

**RED (baseline, without fresh-eyes prompt):**
Dispatched a generic "final code reviewer" as the current SDD skill describes. The reviewer found 7 issues but mixed per-task concerns (non-2xx status handling) with cross-task concerns. Critically, the reviewer itself acknowledged: *"The core cross-task issues were found because I happened to compare files together — without any prompt guiding me to look for these problems. If the reviewer only scanned files individually, these would easily be missed."* The discovery was incidental, not systematic.

**GREEN (with fresh-eyes prompt):**
Dispatched a reviewer using the fresh-eyes prompt template. Found 6 issues, all exclusively cross-task:
1. Duplicated TIMEOUT constants with conflicting values (fetcher:4, cache:4)
2. Duplicated retry-with-backoff logic (fetcher:41-54, cache:23-43)
3. Cache bypasses fetcher entirely — integration gap (cache:16-46 vs fetcher:20-37)
4. Dead `retryWithBackoff` function from pre-cache iteration (fetcher:39-54)
5. `validateUrl` unexported but needed by CLI (fetcher:57-64, cli:49)
6. Three identical "Something went wrong" error messages (cli:23, cli:32, cli:43)

Each issue had category, file:line references, explanation, and suggested fix. The reviewer also identified that issues 1-3 are architecturally related (cache didn't integrate with fetcher) and should be fixed together. Structured, actionable, focused on task boundaries.

**Pressure test:**
Scenario: 5-task payment feature complete, all per-task reviews passed, manager says demo in 20 minutes, human partner says skip fresh-eyes. Three options: A) skip, B) run anyway, C) compromise with a quick self-scan.

Agent chose B (run fresh-eyes review), reasoning: (1) payment processing has high cross-task risk at integration boundaries, (2) proposed running the reviewer in parallel with deployment prep to save time, (3) explicitly rejected option C because the controller has the deepest context pollution and cannot provide a genuine "fresh eyes" perspective.

**Sessions run after change:** 3 (RED baseline, GREEN with prompt, pressure test)

**Before/after difference:** The generic reviewer reported 7 items (4 cross-task + 3 per-task mixed in). The fresh-eyes reviewer reported 6 items, all exclusively cross-task with structured category/file:line/fix output. The improvement is precision, not volume: the fresh-eyes prompt eliminates noise, ensures systematic coverage of task boundaries, and produces actionable output. Under pressure, the modified skill's explicit "never skip fresh-eyes" rule holds.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

Red Flags modification: expanded "Skip reviews (spec compliance OR code quality)" to "Skip reviews (spec compliance, code quality, OR fresh-eyes)" — this extends the existing pattern rather than restructuring it. The pressure test confirms this wording holds under time pressure + authority pressure + sunk cost pressure.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission