### PR TITLE
fix: auto-foreground on Windows/Git Bash where nohup reaps background processes

### DIFF
--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -64,6 +64,17 @@ if [[ -n "${CODEX_CI:-}" && "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "t
   FOREGROUND="true"
 fi
 
+# Windows/Git Bash reaps nohup background processes. Auto-foreground when detected.
+if [[ "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "true" ]]; then
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|mingw*) FOREGROUND="true" ;;
+  esac
+  # Git Bash sets MSYSTEM (MINGW64, MINGW32, MSYS)
+  if [[ -n "${MSYSTEM:-}" ]]; then
+    FOREGROUND="true"
+  fi
+fi
+
 # Generate unique session directory
 SESSION_ID="$$-$(date +%s)"
 
@@ -91,9 +102,14 @@ cd "$SCRIPT_DIR"
 # Resolve the harness PID (grandparent of this script).
 # $PPID is the ephemeral shell the harness spawned to run us — it dies
 # when this script exits. The harness itself is $PPID's parent.
-OWNER_PID="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')"
-if [[ -z "$OWNER_PID" || "$OWNER_PID" == "1" ]]; then
+# Skip ps-based resolution on Windows where MSYS2 ps doesn't support -o ppid=.
+if [[ -n "${MSYSTEM:-}" ]] || [[ "${OSTYPE:-}" == msys* ]] || [[ "${OSTYPE:-}" == cygwin* ]]; then
   OWNER_PID="$PPID"
+else
+  OWNER_PID="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')"
+  if [[ -z "$OWNER_PID" || "$OWNER_PID" == "1" ]]; then
+    OWNER_PID="$PPID"
+  fi
 fi
 
 # Foreground mode for environments that reap detached/background processes.

--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -61,6 +61,14 @@ scripts/start-server.sh --project-dir /path/to/project
 scripts/start-server.sh --project-dir /path/to/project
 ```
 
+**Windows (Git Bash / Claude Code on Windows):**
+```bash
+# Windows/Git Bash reaps nohup background processes. The script auto-detects
+# this via OSTYPE/MSYSTEM and switches to foreground mode automatically.
+# No extra flags needed.
+scripts/start-server.sh --project-dir /path/to/project
+```
+
 **Gemini CLI:**
 ```bash
 # Use --foreground and set is_background: true on your shell tool call


### PR DESCRIPTION
## Problem

`start-server.sh` fails silently on Windows 10/11 with Git Bash (issue #737).
The server process is launched but reaped immediately by the Windows process
model before it can write any output. Symptoms:
- `.server.log` — 0 bytes
- `.server.pid` — written (PID was assigned)
- `.server-info` — missing (server never reached startup)
- Error after 5s: `"Server failed to start within 5 seconds"`

The `--foreground` flag works as a manual workaround, but agents running on
Windows have no way to know they need it.

## Fix

Detect Windows/Git Bash via `OSTYPE` (`msys*`, `cygwin*`, `mingw*`) and `MSYSTEM`
(set by all Git Bash variants: `MINGW64`, `MINGW32`, `MSYS`) and auto-switch to
foreground mode — the same pattern already used for Codex CI detection on line 63.

Also skip the `ps -o ppid=` grandparent-PID resolution on Windows, where MSYS2's
minimal `ps` doesn't support the `-o` flag. Fall back directly to `$PPID`.

Update `visual-companion.md` to document the Windows behavior in the
"Launching the server by platform" section.

## Test plan
- [ ] macOS/Linux: default background mode still works (`OSTYPE` is `darwin*`/`linux*`)
- [ ] Windows Git Bash: server starts in auto-foreground mode
- [ ] `--foreground` flag still works on all platforms
- [ ] `--background` flag overrides auto-detection (`FORCE_BACKGROUND` check preserved)
- [ ] Codex CI auto-foreground unaffected (checked before Windows block)

Fixes #737