### PR TITLE
feat: prefer AskUserQuestion for structured user input on Claude Code

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -37,6 +37,10 @@ If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "alw
 
 Skills use Claude Code tool names. Non-CC platforms: see `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
 
+## Structured User Input
+
+When a skill pauses for user input — confirming a design, choosing between approaches, answering clarifying questions — prefer the `AskUserQuestion` tool if available. It provides a structured UI with selectable options, making questions visually distinct from output and reducing ambiguity. Fall back to plain text on platforms that don't support it.
+
 # Using Skills
 
 ## The Rule


### PR DESCRIPTION
## Summary
- Adds guidance to `using-superpowers` skill to prefer `AskUserQuestion` tool when available for structured user input
- Falls back to plain text on platforms without it (Codex, Gemini, Cursor, etc.)
- One-line change in the central skill that governs all others — no per-skill modifications needed

## Motivation
Skills like brainstorming and writing-plans frequently pause for user input. Claude Code has a dedicated `AskUserQuestion` tool with structured UI (selectable options, multi-select, headers) that makes questions visually distinct and reduces ambiguity. Currently all skills use plain text, which is the right cross-platform default but misses the better UX on Claude Code.

Closes #745

## Test plan
- [ ] Claude Code sessions use `AskUserQuestion` for skill checkpoints (brainstorming clarifications, plan confirmations)
- [ ] Non-Claude-Code platforms (Gemini, Codex) continue working with text-based questions
- [ ] No breaking changes to existing skill behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)