### PR TITLE
fix(docs): replace deprecated `collab` flag with `multi_agent` for Codex docs

### DIFF
--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -32,10 +32,10 @@ Fetch and follow instructions from https://raw.githubusercontent.com/obra/superp
 
 3. Restart Codex.
 
-4. **For subagent skills** (optional): Skills like `dispatching-parallel-agents` and `subagent-driven-development` require Codex's collab feature. Add to your Codex config:
+4. **For subagent skills** (optional): Skills like `dispatching-parallel-agents` and `subagent-driven-development` require Codex's multi-agent feature. Add to your Codex config:
    ```toml
    [features]
-   collab = true
+   multi_agent = true
    ```
 
 ### Windows

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -13,13 +13,13 @@ Skills use Claude Code tool names. When you encounter these in a skill, use your
 | `Read`, `Write`, `Edit` (files) | Use your native file tools |
 | `Bash` (run commands) | Use your native shell tools |
 
-## Subagent dispatch requires collab
+## Subagent dispatch requires multi-agent support
 
 Add to your Codex config (`~/.codex/config.toml`):
 
 ```toml
 [features]
-collab = true
+multi_agent = true
 ```
 
 This enables `spawn_agent`, `wait`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`.


### PR DESCRIPTION
This PR updates the Codex related docs to replace the deprecated `collab` feature flag with `multi_agent`.

## Motivation and Context
Codex now warns that `collab` is deprecated and directs users to `[features].multi_agent` instead. Superpowers still documented `collab`, which caused avoidable warnings and stale setup guidance. This change updates the docs to replace the deprecated `collab` flag with the `multi_agent` flag.

> ⚠ `collab` is deprecated. Use `[features].multi_agent` instead.
  Enable it with `--enable multi_agent` or `[features].multi_agent` in config.toml. See https://developers.openai.com/codex/config-basic#feature-flags for details.

## How Has This Been Tested?
Searching the repo for `collab` and confirming active Codex-facing docs no longer use it, replaced with `multi_agent`.

## Breaking Changes
**No essentially**. This only updates the Codex setup documentation to reflect the current Codex configuration flag, from the deprecated `collab` to `multi_agent`. **However, users on older Codex versions may be unable to enable the multi-agent feature**, as they need to use the old `collab` flag for it to work, but this should be okay once they update to a newer version.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The documentation now targets current Codex behavior. Codex renamed `collab` feature flag key to `multi_agent` in 
 https://github.com/openai/codex/pull/11918
