### PR TITLE
fix(install): remove deprecated slash command aliases from fresh installs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,12 @@
 # Superpowers Release Notes
 
+## v5.0.3 (unreleased)
+
+### Slash Command Cleanup
+
+- Removed deprecated slash command redirects (`/superpowers:brainstorm`, `/superpowers:write-plan`, `/superpowers:execute-plan`) from fresh installs.
+- New installs now only surface current skill names, reducing autocomplete clutter and confusion.
+
 ## v5.0.2 (2026-03-11)
 
 ### Zero-Dependency Brainstorm Server

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:brainstorming skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers brainstorming" skill instead.

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:executing-plans skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers executing-plans" skill instead.

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -1,5 +1,0 @@
----
-description: "Deprecated - use the superpowers:writing-plans skill instead"
----
-
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers writing-plans" skill instead.


### PR DESCRIPTION
Fixes #756

## Problem
Fresh installs currently surface deprecated slash aliases (`/superpowers:brainstorm`, `/superpowers:write-plan`, `/superpowers:execute-plan`) in autocomplete, which is confusing for new users that never used legacy command names.

## Changes
- Removed deprecated command redirect files:
  - `commands/brainstorm.md`
  - `commands/write-plan.md`
  - `commands/execute-plan.md`
- Added release note entry documenting the cleanup for fresh installs.

## Result
New installs only show current skills/commands, reducing namespace clutter and onboarding confusion.