### PR TITLE
fix(brainstorming): auto-open visual companion URL on WSL2/macOS/Linux

### DIFF
--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -16,6 +16,40 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+is_wsl() {
+  grep -qiE "microsoft|wsl" /proc/version 2>/dev/null
+}
+
+open_url_best_effort() {
+  local url="$1"
+
+  # WSL: open in Windows default browser
+  if is_wsl; then
+    if [[ -x "/mnt/c/Windows/System32/cmd.exe" ]]; then
+      /mnt/c/Windows/System32/cmd.exe /c start "" "$url" >/dev/null 2>&1 || true
+      return 0
+    fi
+    if [[ -x "/mnt/c/Windows/system32/cmd.exe" ]]; then
+      /mnt/c/Windows/system32/cmd.exe /c start "" "$url" >/dev/null 2>&1 || true
+      return 0
+    fi
+  fi
+
+  # macOS
+  if command -v open >/dev/null 2>&1; then
+    open "$url" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  # Linux desktop (skip on headless shells)
+  if command -v xdg-open >/dev/null 2>&1 && [[ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]]; then
+    xdg-open "$url" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  return 0
+}
+
 # Parse arguments
 PROJECT_DIR=""
 FOREGROUND="false"
@@ -126,7 +160,11 @@ for i in {1..50}; do
       echo "{\"error\": \"Server started but was killed. Retry in a persistent terminal with: $SCRIPT_DIR/start-server.sh${PROJECT_DIR:+ --project-dir $PROJECT_DIR} --host $BIND_HOST --url-host $URL_HOST --foreground\"}"
       exit 1
     fi
-    grep "server-started" "$LOG_FILE" | head -1
+    server_started_line="$(grep "server-started" "$LOG_FILE" | head -1)"
+    if [[ "$server_started_line" =~ \"url\":\"([^\"]+)\" ]]; then
+      open_url_best_effort "${BASH_REMATCH[1]}"
+    fi
+    echo "$server_started_line"
     exit 0
   fi
   sleep 0.1

--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -40,7 +40,7 @@ scripts/start-server.sh --project-dir /path/to/project
 #           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000"}
 ```
 
-Save `screen_dir` from the response. Tell user to open the URL.
+Save `screen_dir` from the response. The script now attempts to auto-open the URL (WSL2/macOS/Linux desktop) on a best-effort basis. Still echo the URL to the user in case auto-open is unavailable.
 
 **Finding connection info:** The server writes its startup JSON to `$SCREEN_DIR/.server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.superpowers/brainstorm/` for the session directory.
 


### PR DESCRIPTION
Fixes #755

## Problem
`start-server.sh` returns the visual companion URL, but in WSL2 environments users often expect the browser to open automatically. Existing openers either don't run or don't target the Windows browser path from WSL.

## What changed
- Added best-effort browser opener logic to `skills/brainstorming/scripts/start-server.sh`:
  - Detect WSL and open via `cmd.exe /c start`
  - Use `open` on macOS
  - Use `xdg-open` on Linux desktop sessions (only when `DISPLAY`/`WAYLAND_DISPLAY` is set)
- Trigger opener after parsing the server-started JSON line (`url`)
- Updated `skills/brainstorming/visual-companion.md` to document auto-open behavior and fallback expectation (always echo URL).

## Notes
- Best-effort only: failures are swallowed and never block server startup
- Keeps existing JSON startup output unchanged for callers