### PR TITLE
convert brainstorm server.js syntax from CJS to ESM

### DIFF
--- a/skills/brainstorming/scripts/server.js
+++ b/skills/brainstorming/scripts/server.js
@@ -1,7 +1,10 @@
-const crypto = require('crypto');
-const http = require('http');
-const fs = require('fs');
-const path = require('path');
+import crypto from 'crypto';
+import http from 'http';
+import fs from 'fs';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ========== WebSocket Protocol (RFC 6455) ==========
 
@@ -331,8 +334,8 @@ function startServer() {
   });
 }
 
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   startServer();
 }
 
-module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };
+export { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };

--- a/tests/brainstorm-server/package.json
+++ b/tests/brainstorm-server/package.json
@@ -6,5 +6,6 @@
   },
   "dependencies": {
     "ws": "^8.19.0"
-  }
+  },
+  "type": "module"
 }

--- a/tests/brainstorm-server/server.test.js
+++ b/tests/brainstorm-server/server.test.js
@@ -8,13 +8,15 @@
  * not shipped to end users).
  */
 
-const { spawn } = require('child_process');
-const http = require('http');
-const WebSocket = require('ws');
-const fs = require('fs');
-const path = require('path');
-const assert = require('assert');
+import { spawn } from 'child_process';
+import http from 'http';
+import { WebSocket } from 'ws';
+import fs from 'fs';
+import path, { dirname } from 'path';
+import assert from 'assert';
+import { fileURLToPath } from 'url';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER_PATH = path.join(__dirname, '../../skills/brainstorming/scripts/server.js');
 const TEST_PORT = 3334;
 const TEST_DIR = '/tmp/brainstorm-test';

--- a/tests/brainstorm-server/ws-protocol.test.js
+++ b/tests/brainstorm-server/ws-protocol.test.js
@@ -11,24 +11,26 @@
  *   - OPCODES: { TEXT, CLOSE, PING, PONG }
  */
 
-const assert = require('assert');
-const crypto = require('crypto');
-const path = require('path');
+import assert from 'assert';
+import crypto from 'crypto';
+import path, { dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 // The module under test — will be the new zero-dep server file
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER_PATH = path.join(__dirname, '../../skills/brainstorming/scripts/server.js');
-let ws;
 
+let computeAcceptKey, encodeFrame, decodeFrame, OPCODES;
 try {
-  ws = require(SERVER_PATH);
+  ({ computeAcceptKey, encodeFrame, decodeFrame, OPCODES } =
+    await import(pathToFileURL(SERVER_PATH).href));
 } catch (e) {
-  // Module doesn't exist yet (TDD — tests written before implementation)
   console.error(`Cannot load ${SERVER_PATH}: ${e.message}`);
   console.error('This is expected if running tests before implementation.');
   process.exit(1);
 }
 
-function runTests() {
+async function runTests() {
   let passed = 0;
   let failed = 0;
 
@@ -52,13 +54,13 @@ function runTests() {
     // The magic GUID is "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
     const clientKey = 'dGhlIHNhbXBsZSBub25jZQ==';
     const expected = 's3pPLMBiTxaQ9kYGzzhZRbK+xOo=';
-    assert.strictEqual(ws.computeAcceptKey(clientKey), expected);
+    assert.strictEqual(computeAcceptKey(clientKey), expected);
   });
 
   test('computeAcceptKey produces valid base64 for random keys', () => {
     for (let i = 0; i < 10; i++) {
       const randomKey = crypto.randomBytes(16).toString('base64');
-      const result = ws.computeAcceptKey(randomKey);
+      const result = computeAcceptKey(randomKey);
       // Result should be valid base64
       assert.strictEqual(Buffer.from(result, 'base64').toString('base64'), result);
       // SHA-1 output is 20 bytes, base64 encoded = 28 chars
@@ -71,7 +73,7 @@ function runTests() {
 
   test('encodes small text frame (< 126 bytes)', () => {
     const payload = 'Hello';
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, Buffer.from(payload));
+    const frame = encodeFrame(OPCODES.TEXT, Buffer.from(payload));
     // FIN bit + TEXT opcode = 0x81, length = 5
     assert.strictEqual(frame[0], 0x81);
     assert.strictEqual(frame[1], 5);
@@ -80,7 +82,7 @@ function runTests() {
   });
 
   test('encodes empty text frame', () => {
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, Buffer.alloc(0));
+    const frame = encodeFrame(OPCODES.TEXT, Buffer.alloc(0));
     assert.strictEqual(frame[0], 0x81);
     assert.strictEqual(frame[1], 0);
     assert.strictEqual(frame.length, 2);
@@ -88,7 +90,7 @@ function runTests() {
 
   test('encodes medium text frame (126-65535 bytes)', () => {
     const payload = Buffer.alloc(200, 0x41); // 200 'A's
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, payload);
+    const frame = encodeFrame(OPCODES.TEXT, payload);
     assert.strictEqual(frame[0], 0x81);
     assert.strictEqual(frame[1], 126); // extended length marker
     assert.strictEqual(frame.readUInt16BE(2), 200);
@@ -98,7 +100,7 @@ function runTests() {
 
   test('encodes frame at exactly 126 bytes (boundary)', () => {
     const payload = Buffer.alloc(126, 0x42);
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, payload);
+    const frame = encodeFrame(OPCODES.TEXT, payload);
     assert.strictEqual(frame[1], 126); // extended length marker
     assert.strictEqual(frame.readUInt16BE(2), 126);
     assert.strictEqual(frame.length, 130);
@@ -106,14 +108,14 @@ function runTests() {
 
   test('encodes frame at exactly 125 bytes (max small)', () => {
     const payload = Buffer.alloc(125, 0x43);
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, payload);
+    const frame = encodeFrame(OPCODES.TEXT, payload);
     assert.strictEqual(frame[1], 125);
     assert.strictEqual(frame.length, 127);
   });
 
   test('encodes large frame (> 65535 bytes)', () => {
     const payload = Buffer.alloc(70000, 0x44);
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, payload);
+    const frame = encodeFrame(OPCODES.TEXT, payload);
     assert.strictEqual(frame[0], 0x81);
     assert.strictEqual(frame[1], 127); // 64-bit length marker
     // 8-byte extended length at offset 2
@@ -123,21 +125,21 @@ function runTests() {
   });
 
   test('encodes close frame', () => {
-    const frame = ws.encodeFrame(ws.OPCODES.CLOSE, Buffer.alloc(0));
+    const frame = encodeFrame(OPCODES.CLOSE, Buffer.alloc(0));
     assert.strictEqual(frame[0], 0x88); // FIN + CLOSE
     assert.strictEqual(frame[1], 0);
   });
 
   test('encodes pong frame with payload', () => {
     const payload = Buffer.from('ping-data');
-    const frame = ws.encodeFrame(ws.OPCODES.PONG, payload);
+    const frame = encodeFrame(OPCODES.PONG, payload);
     assert.strictEqual(frame[0], 0x8A); // FIN + PONG
     assert.strictEqual(frame[1], payload.length);
     assert.strictEqual(frame.slice(2).toString(), 'ping-data');
   });
 
   test('server frames are never masked (per RFC 6455)', () => {
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, Buffer.from('test'));
+    const frame = encodeFrame(OPCODES.TEXT, Buffer.from('test'));
     // Bit 7 of byte 1 is the mask bit — must be 0 for server frames
     assert.strictEqual(frame[1] & 0x80, 0);
   });
@@ -180,25 +182,25 @@ function runTests() {
 
   test('decodes small masked text frame', () => {
     const frame = makeClientFrame(0x01, 'Hello');
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert(result, 'Should return a result');
-    assert.strictEqual(result.opcode, ws.OPCODES.TEXT);
+    assert.strictEqual(result.opcode, OPCODES.TEXT);
     assert.strictEqual(result.payload.toString(), 'Hello');
     assert.strictEqual(result.bytesConsumed, frame.length);
   });
 
   test('decodes empty masked text frame', () => {
     const frame = makeClientFrame(0x01, '');
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert(result, 'Should return a result');
-    assert.strictEqual(result.opcode, ws.OPCODES.TEXT);
+    assert.strictEqual(result.opcode, OPCODES.TEXT);
     assert.strictEqual(result.payload.length, 0);
   });
 
   test('decodes medium masked text frame (126-65535 bytes)', () => {
     const payload = 'A'.repeat(200);
     const frame = makeClientFrame(0x01, payload);
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert(result, 'Should return a result');
     assert.strictEqual(result.payload.toString(), payload);
   });
@@ -206,7 +208,7 @@ function runTests() {
   test('decodes large masked text frame (> 65535 bytes)', () => {
     const payload = 'B'.repeat(70000);
     const frame = makeClientFrame(0x01, payload);
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert(result, 'Should return a result');
     assert.strictEqual(result.payload.length, 70000);
     assert.strictEqual(result.payload.toString(), payload);
@@ -214,21 +216,21 @@ function runTests() {
 
   test('decodes masked close frame', () => {
     const frame = makeClientFrame(0x08, '');
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert(result, 'Should return a result');
-    assert.strictEqual(result.opcode, ws.OPCODES.CLOSE);
+    assert.strictEqual(result.opcode, OPCODES.CLOSE);
   });
 
   test('decodes masked ping frame', () => {
     const frame = makeClientFrame(0x09, 'ping!');
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert(result, 'Should return a result');
-    assert.strictEqual(result.opcode, ws.OPCODES.PING);
+    assert.strictEqual(result.opcode, OPCODES.PING);
     assert.strictEqual(result.payload.toString(), 'ping!');
   });
 
   test('returns null for incomplete frame (not enough header bytes)', () => {
-    const result = ws.decodeFrame(Buffer.from([0x81]));
+    const result = decodeFrame(Buffer.from([0x81]));
     assert.strictEqual(result, null, 'Should return null for 1-byte buffer');
   });
 
@@ -236,7 +238,7 @@ function runTests() {
     // Create a valid frame then truncate it
     const frame = makeClientFrame(0x01, 'Hello World');
     const truncated = frame.slice(0, frame.length - 3);
-    const result = ws.decodeFrame(truncated);
+    const result = decodeFrame(truncated);
     assert.strictEqual(result, null, 'Should return null for truncated frame');
   });
 
@@ -246,7 +248,7 @@ function runTests() {
     buf[0] = 0x81;
     buf[1] = 0x80 | 126; // masked, 16-bit extended
     // Missing the 2 length bytes + mask
-    const result = ws.decodeFrame(buf);
+    const result = decodeFrame(buf);
     assert.strictEqual(result, null);
   });
 
@@ -256,7 +258,7 @@ function runTests() {
     buf[0] = 0x81; // FIN + TEXT
     buf[1] = 5;    // length 5, NO mask bit
     Buffer.from('Hello').copy(buf, 2);
-    assert.throws(() => ws.decodeFrame(buf), /mask/i, 'Should reject unmasked client frame');
+    assert.throws(() => decodeFrame(buf), /mask/i, 'Should reject unmasked client frame');
   });
 
   test('handles multiple frames in a single buffer', () => {
@@ -264,12 +266,12 @@ function runTests() {
     const frame2 = makeClientFrame(0x01, 'second');
     const combined = Buffer.concat([frame1, frame2]);
 
-    const result1 = ws.decodeFrame(combined);
+    const result1 = decodeFrame(combined);
     assert(result1, 'Should decode first frame');
     assert.strictEqual(result1.payload.toString(), 'first');
     assert.strictEqual(result1.bytesConsumed, frame1.length);
 
-    const result2 = ws.decodeFrame(combined.slice(result1.bytesConsumed));
+    const result2 = decodeFrame(combined.slice(result1.bytesConsumed));
     assert(result2, 'Should decode second frame');
     assert.strictEqual(result2.payload.toString(), 'second');
   });
@@ -290,7 +292,7 @@ function runTests() {
     mask.copy(header, 2);
     const frame = Buffer.concat([header, masked]);
 
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert.strictEqual(result.payload.toString(), 'ABCDEFGH');
   });
 
@@ -299,7 +301,7 @@ function runTests() {
 
   test('encodes frame at exactly 65535 bytes (max 16-bit)', () => {
     const payload = Buffer.alloc(65535, 0x45);
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, payload);
+    const frame = encodeFrame(OPCODES.TEXT, payload);
     assert.strictEqual(frame[1], 126);
     assert.strictEqual(frame.readUInt16BE(2), 65535);
     assert.strictEqual(frame.length, 4 + 65535);
@@ -307,7 +309,7 @@ function runTests() {
 
   test('encodes frame at exactly 65536 bytes (min 64-bit)', () => {
     const payload = Buffer.alloc(65536, 0x46);
-    const frame = ws.encodeFrame(ws.OPCODES.TEXT, payload);
+    const frame = encodeFrame(OPCODES.TEXT, payload);
     assert.strictEqual(frame[1], 127);
     assert.strictEqual(Number(frame.readBigUInt64BE(2)), 65536);
     assert.strictEqual(frame.length, 10 + 65536);
@@ -316,7 +318,7 @@ function runTests() {
   test('decodes frame at 65535 bytes boundary', () => {
     const payload = 'X'.repeat(65535);
     const frame = makeClientFrame(0x01, payload);
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert(result);
     assert.strictEqual(result.payload.length, 65535);
   });
@@ -324,7 +326,7 @@ function runTests() {
   test('decodes frame at 65536 bytes boundary', () => {
     const payload = 'Y'.repeat(65536);
     const frame = makeClientFrame(0x01, payload);
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     assert(result);
     assert.strictEqual(result.payload.length, 65536);
   });
@@ -337,8 +339,8 @@ function runTests() {
     const statusBuf = Buffer.alloc(2);
     statusBuf.writeUInt16BE(1000); // Normal closure
     const frame = makeClientFrame(0x08, statusBuf);
-    const result = ws.decodeFrame(frame);
-    assert.strictEqual(result.opcode, ws.OPCODES.CLOSE);
+    const result = decodeFrame(frame);
+    assert.strictEqual(result.opcode, OPCODES.CLOSE);
     assert.strictEqual(result.payload.readUInt16BE(0), 1000);
   });
 
@@ -348,8 +350,8 @@ function runTests() {
     payload.writeUInt16BE(1000);
     payload.write(reason, 2);
     const frame = makeClientFrame(0x08, payload);
-    const result = ws.decodeFrame(frame);
-    assert.strictEqual(result.opcode, ws.OPCODES.CLOSE);
+    const result = decodeFrame(frame);
+    assert.strictEqual(result.opcode, OPCODES.CLOSE);
     assert.strictEqual(result.payload.slice(2).toString(), reason);
   });
 
@@ -359,7 +361,7 @@ function runTests() {
   test('roundtrip encode/decode of JSON message', () => {
     const msg = { type: 'reload' };
     const payload = Buffer.from(JSON.stringify(msg));
-    const serverFrame = ws.encodeFrame(ws.OPCODES.TEXT, payload);
+    const serverFrame = encodeFrame(OPCODES.TEXT, payload);
 
     // Verify we can read what we encoded (unmasked server frame)
     // Server frames don't go through decodeFrame (that expects masked),
@@ -379,7 +381,7 @@ function runTests() {
   test('roundtrip masked client JSON message', () => {
     const msg = { type: 'click', choice: 'a', text: 'Option A', timestamp: 1706000101 };
     const frame = makeClientFrame(0x01, JSON.stringify(msg));
-    const result = ws.decodeFrame(frame);
+    const result = decodeFrame(frame);
     const decoded = JSON.parse(result.payload.toString());
     assert.deepStrictEqual(decoded, msg);
   });
@@ -389,4 +391,4 @@ function runTests() {
   if (failed > 0) process.exit(1);
 }
 
-runTests();
+await runTests();


### PR DESCRIPTION
Fixes [Issue #783](https://github.com/obra/superpowers/issues/783) — converts `skills/brainstorming/scripts/server.js` from CommonJS to ESM so the brainstorming skill no longer crashes on startup.

## Motivation and Context
`server.js` used `require()`/`module.exports` but `package.json` declares `"type": "module"`, causing Node.js to throw `ReferenceError: require is not defined` immediately when `start-server.sh` runs `node server.js`.

## How Has This Been Tested?
- 31/31 unit tests pass (`node tests/brainstorm-server/ws-protocol.test.js`)
- 24/25 integration tests pass (`node tests/brainstorm-server/server.test.js`) — the one failure is a pre-existing string mismatch unrelated to this fix
- Manually verified server starts correctly via `start-server.sh`

## Breaking Changes
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Chose ESM conversion over the `.cjs` rename workaround since the project's main entry point already uses ESM and there are no `.cjs` files in the codebase. Also updated the two test files and added `"type": "module"` to `tests/brainstorm-server/package.json` (required because a subdirectory `package.json` shadows the root's module type declaration).