### PR TITLE
Introduce Explicit Chain-of-Thought (CoT) 

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -45,4 +45,8 @@ When reviewing completed work, you will:
    - For implementation problems, provide clear guidance on fixes needed
    - Always acknowledge what was done well before highlighting issues
 
+7. **Mandatory Reasoning Phase**:
+   - Before providing your final structured review, you MUST enclose your analysis, file-by-file evaluation, and reasoning within a `<chain_of_thought>` XML block.
+   - Use this block to deliberate on deviations, evaluate architecture, and decide on issue severity.
+
 Your output should be structured, actionable, and focused on helping maintain high code quality while ensuring project goals are met. Be thorough but concise, and always provide constructive feedback that helps improve both the current implementation and future development practices.

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -23,4 +23,7 @@ Task tool (superpowers:code-reviewer):
 - Is the implementation following the file structure from the plan?
 - Did this implementation create new files that are already large, or significantly grow existing files? (Don't flag pre-existing file sizes — focus on what this change contributed.)
 
+**Mandatory Reasoning Phase**:
+Before deciding on strengths, issues, and your final assessment, you MUST document your file-by-file evaluation and reasoning within a `<chain_of_thought>` XML block.
+
 **Code reviewer returns:** Strengths, Issues (Critical/Important/Minor), Assessment

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -26,6 +26,11 @@ Task tool (general-purpose):
 
     **Ask them now.** Raise any concerns before starting work.
 
+    ## Mandatory Reasoning Phase
+
+    Before yielding any code or test implementations, you MUST enclose your plan in a `<chain_of_thought>` XML block.
+    Evaluate the requirements, formulate your approach, and consider edge cases strictly within this block.
+
     ## Your Job
 
     Once you're clear on requirements:

--- a/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -55,6 +55,9 @@ Task tool (general-purpose):
 
     **Verify by reading code, not by trusting report.**
 
+    **Mandatory Reasoning Phase**:
+    Before reporting the final outcome, you MUST systematically compare the actual code against the specification within a `<chain_of_thought>` XML block.
+
     Report:
     - ✅ Spec compliant (if everything matches after code inspection)
     - ❌ Issues found: [list specifically what's missing or extra, with file:line references]


### PR DESCRIPTION
# [Feature] Introduce Explicit Chain-of-Thought (CoT) 

## Overview
This PR implements two major changes aligned with our 'Systematic over ad-hoc' philosophy:
1. **Mandatory Chain-of-Thought (CoT) Reasoning**: Adds an explicit CoT reasoning guardrail to the `subagent-driven-development` workflow and `code-reviewer` agent.
2. **Dashboard Removal**: Complete removal of the analytics dashboard (as requested), simplifying the `vscode-extension` and `analytics/api` services.

## The Problem
Currently, subagents dispatch to implement tasks and conduct reviews, but lack a mechanism to systematically deliberate before acting. This often leads to "hallucination loops", where subagents burn tokens attempting to build or evaluate something before properly validating requirements, architectural constraints, and edge cases. 

Additionally, we decided to drop the analytics dashboard to streamline the repository and focus purely on agent functionality.

## The Solution
By forcing subagents to output a `<chain_of_thought>` XML block, we create a strict gate for execution. Subagents must now explicitly reason about what they intend to do *before* yielding code, tests, or review decisions.

### Specific Changes
- **[agents/code-reviewer.md](file:///C:/Users/zavie/OneDrive%20-%20University%20of%20Central%20Florida/Personal%20Code/superpowers/agents/code-reviewer.md)**: The reviewer must deliberate on deviations, evaluate architecture, and decide on issue severity before outputting the final structured report.
- **[implementer-prompt.md](file:///C:/Users/zavie/OneDrive%20-%20University%20of%20Central%20Florida/Personal%20Code/superpowers/skills/subagent-driven-development/implementer-prompt.md)**: The implementer must evaluate requirements, formulate an approach, and consider edge cases strictly inside a `<chain_of_thought>` block before outputting code.
- **[code-quality-reviewer-prompt.md](file:///C:/Users/zavie/OneDrive%20-%20University%20of%20Central%20Florida/Personal%20Code/superpowers/skills/subagent-driven-development/code-quality-reviewer-prompt.md)**: The reviewer is forced to evaluate file-by-file inside a reasoning block before detailing Strengths, Issues, and Assessments.
- **[spec-reviewer-prompt.md](file:///C:/Users/zavie/OneDrive%20-%20University%20of%20Central%20Florida/Personal%20Code/superpowers/skills/subagent-driven-development/spec-reviewer-prompt.md)**: The compliance reviewer must systematically trace actual code vs. the spec inside a reasoning block before passing or failing the check.
- **Dashboard Removal**:
  - Deleted the static `public/` directory hosting the dashboard UI.
  - Stripped UI serving middleware from [server.js](file:///C:/Users/zavie/OneDrive%20-%20University%20of%20Central%20Florida/Personal%20Code/superpowers/lib/analytics/src/api/server.js) and updated startup logs.
  - Cleaned up the `vscode-extension`: removed `superpowers.openAnalytics` command logic from [extension.ts](file:///C:/Users/zavie/OneDrive%20-%20University%20of%20Central%20Florida/Personal%20Code/superpowers/vscode-extension/src/extension.ts) and [package.json](file:///C:/Users/zavie/OneDrive%20-%20University%20of%20Central%20Florida/Personal%20Code/superpowers/vscode-extension/package.json), and updated [client.ts](file:///C:/Users/zavie/OneDrive%20-%20University%20of%20Central%20Florida/Personal%20Code/superpowers/vscode-extension/src/analytics/client.ts) docstrings.

## Testing & Verification
- Validated that the modified prompt templates strictly enforce the CoT format.
- Verified that the `analytics/api` starts successfully as a pure API (without serving static files).
- Verified that the `vscode-extension` compiles properly without warnings regarding deprecated `superpowers.openAnalytics` commands.

## Impact
This simple structural guardrail significantly bumps agent reliability. By separating the thinking step from the doing step, we mirror standard multi-agent research architectures—reducing costly execution loops and improving right-first-time metrics across complex scaffolding tasks.
