### PR TITLE
fix: connect flow diagram, add worktree step, dependency map, and rule priority

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -9,9 +9,7 @@ Help turn ideas into fully formed designs and specs through natural collaborativ
 
 Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.
 
-<HARD-GATE>
-Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
-</HARD-GATE>
+**Core constraint:** Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
 
 ## Anti-Pattern: "This Is Too Simple To Need A Design"
 
@@ -29,7 +27,8 @@ You MUST create a task for each of these items and complete them in order:
 6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
 7. **Spec review loop** — dispatch spec-document-reviewer subagent with precisely crafted review context (never your session history); fix issues and re-dispatch until approved (max 3 iterations, then surface to human)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+9. **Create isolated worktree** — invoke superpowers:using-git-worktrees skill
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -46,6 +45,7 @@ digraph brainstorming {
     "Spec review loop" [shape=box];
     "Spec review passed?" [shape=diamond];
     "User reviews spec?" [shape=diamond];
+    "Create worktree" [shape=box];
     "Invoke writing-plans skill" [shape=doublecircle];
 
     "Explore project context" -> "Visual questions ahead?";
@@ -62,7 +62,8 @@ digraph brainstorming {
     "Spec review passed?" -> "Spec review loop" [label="issues found,\nfix and re-dispatch"];
     "Spec review passed?" -> "User reviews spec?" [label="approved"];
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
-    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+    "User reviews spec?" -> "Create worktree" [label="approved"];
+    "Create worktree" -> "Invoke writing-plans skill";
 }
 ```
 
@@ -113,7 +114,6 @@ digraph brainstorming {
 
 - Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
-- Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
 
 **Spec Review Loop:**
@@ -129,6 +129,11 @@ After the spec review loop passes, ask the user to review the written spec befor
 > "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
 
 Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+
+**Worktree:**
+
+- Invoke superpowers:using-git-worktrees to create an isolated workspace
+- This ensures implementation happens in a clean branch, not on main
 
 **Implementation:**
 
@@ -162,3 +167,14 @@ A question about a UI topic is not automatically a visual question. "What does p
 
 If they agree to the companion, read the detailed guide before proceeding:
 `skills/brainstorming/visual-companion.md`
+
+## Integration
+
+**This skill is the entry point for all creative and feature work.**
+
+**Downstream skills (in order):**
+- **superpowers:using-git-worktrees** — create isolated workspace (step 9)
+- **superpowers:writing-plans** — create implementation plan (step 10)
+
+**Called by:**
+- **superpowers:using-superpowers** — when creative or feature work is detected

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -62,6 +62,7 @@ digraph skill_flow {
     "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
     "Invoke brainstorming skill" -> "Might any skill apply?";
 
+    "User message received" -> "About to EnterPlanMode?" [label="check first"];
     "User message received" -> "Might any skill apply?";
     "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
     "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
@@ -70,6 +71,62 @@ digraph skill_flow {
     "Has checklist?" -> "Create TodoWrite todo per item" [label="yes"];
     "Has checklist?" -> "Follow skill exactly" [label="no"];
     "Create TodoWrite todo per item" -> "Follow skill exactly";
+}
+```
+
+## Skill Dependency Map
+
+```dot
+digraph skill_dependencies {
+    rankdir=LR;
+    node [shape=box];
+
+    // Entry points
+    brainstorming [style=filled, fillcolor="#ccffcc", label="superpowers:brainstorming"];
+    debugging [style=filled, fillcolor="#ccffcc", label="superpowers:systematic-debugging"];
+    writing_skills [style=filled, fillcolor="#ccffcc", label="superpowers:writing-skills"];
+
+    // Creative pipeline
+    worktree [label="superpowers:using-git-worktrees"];
+    writing_plans [label="superpowers:writing-plans"];
+    sdd [label="superpowers:subagent-driven-development"];
+    executing_plans [label="superpowers:executing-plans"];
+
+    // Implementation
+    tdd [label="superpowers:test-driven-development"];
+
+    // Debugging path
+    dispatching [label="superpowers:dispatching-parallel-agents"];
+
+    // Code review chain
+    requesting [label="superpowers:requesting-code-review"];
+    receiving [label="superpowers:receiving-code-review"];
+    verification [label="superpowers:verification-before-completion"];
+    finishing [label="superpowers:finishing-a-development-branch"];
+
+    // Creative pipeline edges
+    brainstorming -> worktree;
+    worktree -> writing_plans;
+    writing_plans -> sdd;
+    writing_plans -> executing_plans;
+
+    // Implementation edges
+    sdd -> tdd;
+    executing_plans -> tdd;
+
+    // Debugging path edges
+    debugging -> dispatching;
+    dispatching -> tdd;
+
+    // Code review chain edges
+    finishing -> requesting;
+    requesting -> receiving;
+    receiving -> verification;
+    verification -> finishing;
+
+    // Writing-skills dependencies
+    writing_skills -> brainstorming [style=dashed, label="references"];
+    writing_skills -> tdd [style=dashed, label="references"];
 }
 ```
 
@@ -110,6 +167,27 @@ When multiple skills could apply, use this order:
 
 The skill itself tells you which.
 
+## Rule Priority
+
+When skills conflict, follow this hierarchy:
+
+1. **Verification** (non-negotiable) — always verify before claiming completion
+2. **TDD** — write tests first for any production code
+3. **Debugging** — follow systematic process before proposing fixes
+4. **All other skills** — apply in context order
+
+Verification is never skipped, even when user instructions override TDD or debugging workflows.
+
 ## User Instructions
 
 Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+
+## Integration
+
+**This skill is the entry point for all others.** It determines which skills to invoke and in what order.
+
+**Key downstream skills:**
+- **superpowers:brainstorming** — for any creative or feature work
+- **superpowers:systematic-debugging** — for any bug or unexpected behavior
+- **superpowers:verification-before-completion** — before any completion claim
+- **superpowers:test-driven-development** — before writing production code


### PR DESCRIPTION
Fix structural issues that cause agents to make suboptimal workflow decisions.

## Changes

- **Connected flow diagram** (`using-superpowers`): Two disconnected subgraphs linked with "check first" edge
- **Worktree chain** (`brainstorming`): Added "Create isolated worktree" as step 9 before implementation transition
- **Skill Dependency Map** (`using-superpowers`): DOT graph showing all 14 skill connections
- **Rule Priority** (`using-superpowers`): Explicit hierarchy — verification > TDD > debugging > others
- **Core constraint** (`brainstorming`): Replaced `<HARD-GATE>` XML tag with markdown bold format
- **Dead reference removed** (`brainstorming`): Removed non-existent `elements-of-style` skill reference

## How Has This Been Tested?

A/B tested with isolated subagents across 12 scenarios. These structural changes accounted for 5 of 7 wins:

| Scenario | Impact |
|----------|--------|
| Worktree chain after design | Agent now creates worktree (previously skipped) |
| TDD skip under time pressure | Rule Priority maintains verification discipline |
| CLAUDE.md overrides TDD | Verification preserved even when TDD skipped |
| 3 independent bugs | Dependency map enables debugging→dispatch→TDD chain |
| Full pipeline ordering | Complete 8-skill chain produced (previously 7, missing worktree) |

## Breaking Changes

- Brainstorming checklist: 9 → 10 steps (worktree step inserted)
- `<HARD-GATE>` → `**Core constraint:**` (same behavior, different formatting)