### PR TITLE
feat: implement mandatory CoT for subagent prompts

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -45,4 +45,8 @@ When reviewing completed work, you will:
    - For implementation problems, provide clear guidance on fixes needed
    - Always acknowledge what was done well before highlighting issues
 
+7. **Mandatory Reasoning Phase**:
+   - Before providing your final review and recommendations, you MUST enclose your internal reasoning, plan alignment analysis, and quality assessment within a `<chain_of_thought>` XML block.
+   - Use this block to deliberate on deviations, evaluate architecture, and decide on issue severity.
+
 Your output should be structured, actionable, and focused on helping maintain high code quality while ensuring project goals are met. Be thorough but concise, and always provide constructive feedback that helps improve both the current implementation and future development practices.

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -24,3 +24,5 @@ Task tool (superpowers:code-reviewer):
 - Did this implementation create new files that are already large, or significantly grow existing files? (Don't flag pre-existing file sizes — focus on what this change contributed.)
 
 **Code reviewer returns:** Strengths, Issues (Critical/Important/Minor), Assessment
+
+**CRITICAL**: Before returning your review, you MUST enclose your step-by-step evaluation of the code quality within a `<chain_of_thought>` XML block.

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -100,6 +100,7 @@ Task tool (general-purpose):
     ## Report Format
 
     When done, report:
+    - **CRITICAL**: Before you output your final report, you MUST enclose your internal reasoning and step-by-step implementation plan within a `<chain_of_thought>` XML block.
     - **Status:** DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
     - What you implemented (or what you attempted, if blocked)
     - What you tested and test results

--- a/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -55,6 +55,8 @@ Task tool (general-purpose):
 
     **Verify by reading code, not by trusting report.**
 
+    **CRITICAL**: Before reporting your findings, you MUST enclose your step-by-step verification of the code against the specification within a `<chain_of_thought>` XML block.
+
     Report:
     - ✅ Spec compliant (if everything matches after code inspection)
     - ❌ Issues found: [list specifically what's missing or extra, with file:line references]


### PR DESCRIPTION
**Subject: Implement mandatory reasoning (CoT) for subagents**

**Summary**
This PR adds a `<chain_of_thought>` requirement to the subagent prompts (Implementer, Code Quality, and Spec Reviewers) and the `code-reviewer` agent. 

**Why it matters**
Subagents currently jump to execution too quickly, which leads to "hallucination loops" and wasted tokens. Forcing an explicit deliberation step inside an XML block makes their logic more stable and catches edge cases before they start writing code.

**Changes**
* Updated `agents/code-reviewer.md`.
* Updated `subagent-driven-development` prompt templates.