### PR TITLE
fix: remove stale brainstorming Phase 4 worktree references from docs [can be closed, reason as follow comment]

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Start a new session in your chosen platform and ask for something that should tr
 
 1. **brainstorming** - Activates before writing code. Refines rough ideas through questions, explores alternatives, presents design in sections for validation. Saves design document.
 
-2. **using-git-worktrees** - Activates after design approval. Creates isolated workspace on new branch, runs project setup, verifies clean test baseline.
+2. **using-git-worktrees** - Activates before writing plans. Creates isolated workspace on new branch, runs project setup, verifies clean test baseline.
 
 3. **writing-plans** - Activates with approved design. Breaks work into bite-sized tasks (2-5 minutes each). Every task has exact file paths, complete code, verification steps.
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -209,7 +209,7 @@ Ready to implement auth feature
 ## Integration
 
 **Called by:**
-- **brainstorming** (Phase 4) - REQUIRED when design is approved and implementation follows
+- **writing-plans** - REQUIRED: should run in a dedicated worktree
 - **subagent-driven-development** - REQUIRED before executing any tasks
 - **executing-plans** - REQUIRED before executing any tasks
 - Any skill needing isolated workspace

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -13,7 +13,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
 
-**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+**Context:** This should be run in a dedicated worktree (created via using-git-worktrees before writing the plan).
 
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)


### PR DESCRIPTION
## Problem
`writing-plans/SKILL.md` states that it should "run in a dedicated worktree (created by brainstorming skill)", 
but the current `brainstorming/SKILL.md` has no worktree creation step. 
Similarly, `using-git-worktrees/SKILL.md` claims it is "Called by brainstorming (Phase 4)", referencing a Phase 4 that no longer exists.

Tracing the git history reveals the evolution:
- **v3.1.0**: brainstorming had an explicit Phase 4 (Worktree Setup) and Phase 5 (Planning Handoff)
- **v3.4.1** (`8e38ab8` "Simplify brainstorming skill"): Phase structure removed, but worktree reference kept in prose
- **v4.3.0** (`7f2ee61` "Enforce brainstorming workflow with hard gates"): worktree reference fully removed, replaced with "Do NOT invoke any other skill. writing-plans is the next step."
However, the cross-references in other files were not updated to match.

## Solution
Since `using-git-worktrees` is currently only called by `subagent-driven-development` and `executing-plans` (both declare it as REQUIRED in their Integration sections), update the stale references to reflect the actual call chain. Change the relationship from "after design approval" to "before writing plans".

## Changes
1. **`skills/writing-plans/SKILL.md`** (line 16): Changed `(created by brainstorming skill)` → `(created via using-git-worktrees before plan begins)`
2. **`skills/using-git-worktrees/SKILL.md`** (line 212): Removed stale `brainstorming (Phase 4)` from "Called by" list, add `writing-plans - REQUIRED: should run in a dedicated worktree` instead
3. **`README.md`** (line 105): Changed `Activates after design approval` → `Activates before writing plans`
