### PR TITLE
Add CLAUDE.md reading instructions to subagent prompts

### DIFF
--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -9,6 +9,10 @@ You are reviewing code changes for production readiness.
 4. Categorize issues by severity
 5. Assess production readiness
 
+## Project Conventions
+
+**Important:** Before you begin, read the project's CLAUDE.md file (if it exists). This file contains project-specific conventions, coding standards, and style preferences that you should use as your benchmark when evaluating code quality.
+
 ## What Was Implemented
 
 {DESCRIPTION}

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -8,6 +8,10 @@ Task tool (general-purpose):
   prompt: |
     You are implementing Task N: [task name]
 
+    ## Project Conventions
+
+    **Important:** Before you begin, read the project's CLAUDE.md file (if it exists). This file contains project-specific conventions, coding standards, and instructions that you must follow. If CLAUDE.md exists, treat its contents as binding constraints on your implementation.
+
     ## Task Description
 
     [FULL TEXT of task from plan - paste it here, don't make subagent read file]

--- a/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -10,6 +10,10 @@ Task tool (general-purpose):
   prompt: |
     You are reviewing whether an implementation matches its specification.
 
+    ## Project Conventions
+
+    **Important:** Before you begin, read the project's CLAUDE.md file (if it exists). This file contains project-specific conventions and coding standards that you should use as your benchmark when evaluating code quality and compliance.
+
     ## What Was Requested
 
     [FULL TEXT of task requirements]


### PR DESCRIPTION
## Summary

Subagent prompts should include explicit instructions to read the project's CLAUDE.md file to ensure they follow project-specific conventions and coding standards.

This addresses issue #793 where subagents were not respecting project conventions defined in CLAUDE.md.

## Changes

Added a "Project Conventions" section at the beginning of:
- `implementer-prompt.md` - Instructs implementer agents to read CLAUDE.md before starting
- `spec-reviewer-prompt.md` - Instructs spec reviewer agents to read CLAUDE.md as their quality benchmark
- `requesting-code-review/code-reviewer.md` - Instructs code reviewer agents to read CLAUDE.md for style preferences

## Testing

The changes are template updates only. The new instructions will take effect when new subagents are dispatched using these templates.