### PR TITLE
fix(subagent-dev): add tool selection guidelines to implementer prompt

### DIFF
--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -26,6 +26,22 @@ Task tool (general-purpose):
 
     **Ask them now.** Raise any concerns before starting work.
 
+    ## Tool Selection
+
+    Use dedicated tools instead of shell commands for file operations. Dedicated tools
+    are faster, require fewer permissions, and produce cleaner output.
+
+    | Task | Use | Instead of |
+    |------|-----|------------|
+    | Read file or lines | `Read(file_path, offset, limit)` | `cat`, `head`, `tail`, `sed -n` |
+    | Search file content | `Grep(pattern, path)` | `grep`, `rg`, `awk` |
+    | Find files by name | `Glob(pattern)` | `find`, `ls` |
+    | Edit files | `Edit` / `Write` | `sed -i`, `awk` |
+    | Run commands in a directory | `Bash(command, cwd="dir")` | `cd dir && command` |
+
+    Reserve `Bash` for commands that genuinely need a shell: running tests, build tools,
+    git operations, and project-specific scripts.
+
     ## Your Job
 
     Once you're clear on requirements:


### PR DESCRIPTION
## Summary

Adds a "Tool Selection" section to `implementer-prompt.md` that guides subagents to prefer dedicated tools (`Read`, `Grep`, `Glob`, `Edit`) over Bash equivalents (`cat`, `sed`, `grep`, `find`).

## Problem

Implementer subagents spawned by `subagent-driven-development` consistently use `Bash` for file operations — `sed -n` to read lines, `grep` to search, `find` to locate files, `cd dir && command` to run in directories. This triggers unnecessary permission prompts and produces noisier output than the dedicated tools designed for these tasks.

The root cause is that `implementer-prompt.md` has no guidance on tool selection. The prompt covers task flow, self-review, escalation, and code organization, but never tells the subagent which tools to prefer.

## Fix

Added a concise "Tool Selection" section between "Before You Begin" and "Your Job" with a mapping table:

| Task | Use | Instead of |
|------|-----|------------|
| Read file or lines | `Read(file_path, offset, limit)` | `cat`, `head`, `tail`, `sed -n` |
| Search file content | `Grep(pattern, path)` | `grep`, `rg`, `awk` |
| Find files by name | `Glob(pattern)` | `find`, `ls` |
| Edit files | `Edit` / `Write` | `sed -i`, `awk` |
| Run commands in a directory | `Bash(command, cwd="dir")` | `cd dir && command` |

The section is placed early in the prompt (before "Your Job") so subagents internalize tool preferences before starting work.

## Testing

- Verified the markdown renders correctly with proper table alignment
- Confirmed no other files are affected (1 file, 16 lines added)
- The fix is additive — no existing behavior is changed or removed

Fixes #805

Made with [Cursor](https://cursor.com)