### PR TITLE
fix(skills): update plan file checkboxes after completing tasks

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -28,7 +28,7 @@ For each task:
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
 4. Mark as completed
-5. Update the plan file: change `- [ ]` to `- [x]` for completed steps using Edit tool
+5. Update the plan file: change `- [ ]` to `- [x]` for completed steps using the `Edit` tool
 
 ### Step 3: Complete Development
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -28,6 +28,7 @@ For each task:
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
 4. Mark as completed
+5. Update the plan file: change `- [ ]` to `- [x]` for completed steps using Edit tool
 
 ### Step 3: Complete Development
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -125,7 +125,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 
 ## Plan File Tracking
 
-After marking a task complete in TodoWrite, update the plan file on disk — change `- [ ]` to `- [x]` for all completed steps in that task using the Edit tool. This keeps the plan file as a persistent progress record across sessions.
+After marking a task complete in TodoWrite, update the plan file on disk — change `- [ ]` to `- [x]` for all completed steps in that task using the `Edit` tool. This keeps the plan file as a persistent progress record across sessions.
 
 ## Example Workflow
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -55,7 +55,7 @@ digraph process {
         "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
         "Code quality reviewer subagent approves?" [shape=diamond];
         "Implementer subagent fixes quality issues" [shape=box];
-        "Mark task complete in TodoWrite" [shape=box];
+        "Mark task complete in TodoWrite\nand update plan file checkboxes" [shape=box];
     }
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
@@ -76,8 +76,8 @@ digraph process {
     "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
     "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
     "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
-    "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
-    "Mark task complete in TodoWrite" -> "More tasks remain?";
+    "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite\nand update plan file checkboxes" [label="yes"];
+    "Mark task complete in TodoWrite\nand update plan file checkboxes" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
     "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
@@ -123,6 +123,10 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 - `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
 - `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
 
+## Plan File Tracking
+
+After marking a task complete in TodoWrite, update the plan file on disk — change `- [ ]` to `- [x]` for all completed steps in that task using the Edit tool. This keeps the plan file as a persistent progress record across sessions.
+
 ## Example Workflow
 
 ```
@@ -155,6 +159,7 @@ Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
 Code reviewer: Strengths: Good test coverage, clean. Issues: None. Approved.
 
 [Mark Task 1 complete]
+[Update plan file: change - [ ] to - [x] for Task 1 steps]
 
 Task 2: Recovery modes
 
@@ -189,6 +194,7 @@ Implementer: Extracted PROGRESS_INTERVAL constant
 Code reviewer: ✅ Approved
 
 [Mark Task 2 complete]
+[Update plan file: change - [ ] to - [x] for Task 2 steps]
 
 ...
 


### PR DESCRIPTION
## Summary

Fixes #789 — `executing-plans` and `subagent-driven-development` never updated plan file checkboxes (`- [ ]` → `- [x]`), leaving all checkboxes unchecked even after full implementation.

**Root cause:** Both skills used only `TodoWrite` (ephemeral, session-scoped) for progress tracking. The plan file on disk was never modified, despite `writing-plans` promising checkbox tracking in the plan header.

**Fix:** Add explicit instructions for the **orchestrator** (not the subagent) to update checkboxes in the plan file using the Edit tool after each task completes.

## Changes

- **`skills/executing-plans/SKILL.md`** — Add step 5: update plan file checkboxes after task completion
- **`skills/subagent-driven-development/SKILL.md`** — Add "Plan File Tracking" section, update process diagram node, update example workflow with checkbox update steps

## Design decision

The orchestrator updates checkboxes (not the implementer subagent), because:
- The task is only "done" after the two-stage review passes
- Subagents shouldn't read/write the plan file (explicit SDD principle)
- The orchestrator knows the plan file path and task boundaries

## Testing

Verified with a fresh Claude Code instance (`claude -p --plugin-dir <modified-plugin>`):

| Metric | Before | After |
|---|---|---|
| `- [ ]` (unchecked) | 7 | 1 (header template only) |
| `- [x]` (checked) | 0 | **6** |

All 6 task step checkboxes were updated after execution. The remaining `- [ ]` is in the plan header (syntax example, not a step).

Also verified:
- No other mechanism in the codebase handles checkbox updates (grepped hooks, all skills)
- No conflicts with existing functionality
- Consistent with `writing-plans` promise: "Steps use checkbox syntax for tracking"