### PR TITLE
feat: add Trae IDE support

### DIFF
--- a/.trae/INSTALL.md
+++ b/.trae/INSTALL.md
@@ -1,0 +1,80 @@
+# Installing Superpowers for Trae IDE
+
+## Prerequisites
+
+- [Trae IDE](https://www.trae.ai/) installed
+- Git
+
+## Installation
+
+1. **Clone the superpowers repository:**
+   ```bash
+   git clone https://github.com/obra/superpowers.git ~/.trae/superpowers
+   ```
+
+2. **Install skills as Trae rules:**
+   ```bash
+   ~/.trae/superpowers/.trae/install.sh
+   ```
+
+   This creates a `superpowers-bootstrap.md` rule in your project's `.trae/rules/` that loads the superpowers system on every conversation.
+
+3. **Restart Trae** and start a new conversation to activate superpowers.
+
+## How It Works
+
+Trae uses rules (`.trae/rules/*.md`) to inject context into conversations. The install script creates a single bootstrap rule that:
+
+1. Loads the `using-superpowers` skill content
+2. Registers all available skills
+3. Activates automatically via `alwaysApply: true`
+
+Skills are read from the cloned repository at `~/.trae/superpowers/skills/`. No files are copied — the bootstrap rule references skills by path, so `git pull` updates everything.
+
+## Verify
+
+After installation, start a new conversation and ask:
+
+```
+Tell me about your superpowers
+```
+
+The agent should respond with information about its available skills.
+
+## Updating
+
+```bash
+cd ~/.trae/superpowers && git pull
+```
+
+Skills update instantly since the bootstrap rule reads from the cloned directory.
+
+## Uninstalling
+
+Remove the bootstrap rule from your project:
+
+```bash
+rm .trae/rules/superpowers-bootstrap.md
+```
+
+Optionally delete the clone:
+
+```bash
+rm -rf ~/.trae/superpowers
+```
+
+## Troubleshooting
+
+### Skills not activating
+
+1. Check that the bootstrap rule exists: `cat .trae/rules/superpowers-bootstrap.md`
+2. Verify the clone exists: `ls ~/.trae/superpowers/skills/`
+3. Make sure you started a **new** conversation after installing
+
+### Trae doesn't pick up the rule
+
+Trae discovers rules in `.trae/rules/` at conversation start. If the directory doesn't exist, the install script creates it. Restart Trae if rules aren't being picked up.
+
+## Getting Help
+
+- Report issues: https://github.com/obra/superpowers/issues

--- a/.trae/install.sh
+++ b/.trae/install.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Install superpowers as a Trae IDE rule
+#
+# Creates a bootstrap rule in .trae/rules/ that loads the superpowers
+# skill system. The rule uses alwaysApply: true so it activates on
+# every conversation automatically.
+#
+# Usage:
+#   ~/.trae/superpowers/.trae/install.sh [project_dir]
+#
+# If project_dir is omitted, installs to the current directory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUPERPOWERS_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SKILLS_DIR="${SUPERPOWERS_ROOT}/skills"
+
+PROJECT_DIR="${1:-.}"
+RULES_DIR="${PROJECT_DIR}/.trae/rules"
+
+# Verify skills directory exists
+if [[ ! -d "$SKILLS_DIR" ]]; then
+  echo "Error: Skills directory not found at ${SKILLS_DIR}"
+  echo "Make sure superpowers is properly cloned."
+  exit 1
+fi
+
+# Create rules directory if needed
+mkdir -p "$RULES_DIR"
+
+# Read the using-superpowers skill content
+USING_SUPERPOWERS="${SKILLS_DIR}/using-superpowers/SKILL.md"
+if [[ ! -f "$USING_SUPERPOWERS" ]]; then
+  echo "Error: using-superpowers skill not found at ${USING_SUPERPOWERS}"
+  exit 1
+fi
+
+# Build list of available skills from SKILL.md frontmatter
+skill_list=""
+for skill_dir in "${SKILLS_DIR}"/*/; do
+  skill_file="${skill_dir}SKILL.md"
+  if [[ -f "$skill_file" ]]; then
+    # Extract name and description from YAML frontmatter
+    skill_name=$(sed -n 's/^name: *//p' "$skill_file" | head -1)
+    skill_desc=$(sed -n 's/^description: *//p' "$skill_file" | head -1)
+    if [[ -n "$skill_name" ]]; then
+      skill_list="${skill_list}\n- **${skill_name}**: ${skill_desc}"
+    fi
+  fi
+done
+
+# Read the using-superpowers content (strip frontmatter)
+using_content=$(sed '1{/^---$/d}; /^---$/,/^---$/d' "$USING_SUPERPOWERS")
+
+# Generate the bootstrap rule
+cat > "${RULES_DIR}/superpowers-bootstrap.md" << RULEEOF
+---
+description: Superpowers skill system bootstrap - loads development workflow skills
+alwaysApply: true
+---
+
+# Superpowers
+
+You have superpowers. You are equipped with a comprehensive software development workflow system.
+
+## Available Skills
+${skill_list}
+
+## How to Use Skills
+
+When a task matches a skill's description, read the full skill file before proceeding.
+Skills are located in: ${SKILLS_DIR}/
+
+To load a skill, read the SKILL.md file in the corresponding directory. For example:
+- Planning: ${SKILLS_DIR}/writing-plans/SKILL.md
+- TDD: ${SKILLS_DIR}/test-driven-development/SKILL.md
+- Debugging: ${SKILLS_DIR}/systematic-debugging/SKILL.md
+
+## Core Skill: Using Superpowers
+
+${using_content}
+RULEEOF
+
+echo "Superpowers installed for Trae IDE."
+echo "  Rule: ${RULES_DIR}/superpowers-bootstrap.md"
+echo "  Skills: ${SKILLS_DIR}/"
+echo ""
+echo "Start a new conversation in Trae to activate."

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Thanks!
 
 ## Installation
 
-**Note:** Installation differs by platform. Claude Code or Cursor have built-in plugin marketplaces. Codex and OpenCode require manual setup.
+**Note:** Installation differs by platform. Claude Code or Cursor have built-in plugin marketplaces. Codex, OpenCode, and Trae require manual setup.
 
 ### Claude Code Official Marketplace
 
@@ -81,6 +81,16 @@ Fetch and follow instructions from https://raw.githubusercontent.com/obra/superp
 ```
 
 **Detailed docs:** [docs/README.opencode.md](docs/README.opencode.md)
+
+### Trae IDE
+
+Tell Trae:
+
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.trae/INSTALL.md
+```
+
+**Detailed docs:** [.trae/INSTALL.md](.trae/INSTALL.md)
 
 ### Gemini CLI
 


### PR DESCRIPTION
## Summary

- Add Trae IDE integration (ByteDance's AI-native IDE based on VS Code)
- `.trae/INSTALL.md`: step-by-step installation guide
- `.trae/install.sh`: script to generate a bootstrap rule that loads superpowers skills
- `README.md`: add Trae to the installation section

## How It Works

Trae uses rules (`.trae/rules/*.md`) for context injection, similar to Cursor's rules system. The install script:

1. Scans all skills in the `skills/` directory
2. Generates a single `superpowers-bootstrap.md` rule with `alwaysApply: true`
3. Embeds the `using-superpowers` skill content and lists all available skills
4. Skills are read from the cloned repo, so `git pull` updates everything

## Why This Approach

Trae doesn't have a plugin marketplace like Claude Code or Cursor, but its rules system provides a clean integration point. This follows the same pattern as the Codex integration (clone + local setup), adapted for Trae's rule-based architecture.

## Test Plan

- [ ] Clone superpowers to `~/.trae/superpowers`
- [ ] Run `.trae/install.sh` in a project directory
- [ ] Verify `superpowers-bootstrap.md` is created in `.trae/rules/`
- [ ] Open Trae, start new conversation, ask "Tell me about your superpowers"
- [ ] Verify skills activate when relevant (e.g., "help me plan this feature")

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)