### PR TITLE
fix(receiving-code-review): add guidance to fetch all 3 PR comment types

### DIFF
--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -56,6 +56,18 @@ You understand 1,2,3,6. Unclear on 4,5.
 ✅ RIGHT: "I understand items 1,2,3,6. Need clarification on 4 and 5 before proceeding."
 ```
 
+## Fetching GitHub PR Feedback
+
+When receiving code review on a GitHub PR, fetch **all three** comment types — each contains different feedback:
+
+```
+gh api repos/{owner}/{repo}/pulls/{pr}/comments    # Inline review comments (line-specific)
+gh api repos/{owner}/{repo}/pulls/{pr}/reviews      # Review bodies (summary, approve/request changes)
+gh api repos/{owner}/{repo}/issues/{pr}/comments    # PR conversation comments (top-level discussion)
+```
+
+**Why all three:** Reviewers often put critical feedback in review summaries or top-level comments, not just inline. Missing any type means missing feedback.
+
 ## Source-Specific Handling
 
 ### From your human partner


### PR DESCRIPTION
## Summary

- Add a "Fetching GitHub PR Feedback" section to the `receiving-code-review` skill
- Documents all three GitHub PR comment types with their `gh api` commands:
  - Inline review comments (`pulls/{pr}/comments`)
  - Review bodies/summaries (`pulls/{pr}/reviews`)
  - Top-level PR comments (`issues/{pr}/comments`)

## Problem

The skill's step 1 ("READ: Complete feedback without reacting") didn't specify how to fetch all feedback from a GitHub PR. In practice, agents using `gh` CLI may only fetch inline comments and miss review summaries or top-level discussion — which often contain the most significant feedback.

## Test Plan

- [ ] Use the skill to process a GitHub PR that has all three comment types
- [ ] Verify the agent fetches from all three API endpoints

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)