### PR TITLE
feat: add safe PR checkout pattern to using-git-worktrees skill

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -152,8 +152,35 @@ Ready to implement <feature-name>
 | Directory not ignored | Add to .gitignore + commit |
 | Tests fail during baseline | Report failures + ask |
 | No package.json/Cargo.toml | Skip dependency install |
+| Checking out a PR          | `gh pr view` + `git fetch` + `git worktree add` (never `gh pr checkout`) |
+
+## Checking Out a PR to a Worktree
+
+To review or work on an existing PR in an isolated worktree, **never use `gh pr checkout`** — it moves HEAD in the current worktree, which can disrupt in-progress work (detached HEAD, uncommitted rebase, etc.).
+
+Instead, fetch the branch by name without touching HEAD:
+
+```bash
+# Get the branch name without checking it out
+branch="$(gh pr view <number> --json headRefName --jq .headRefName)"
+
+# Fetch the branch from the remote
+git fetch origin "$branch"
+
+# Create a worktree tracking the remote branch
+git worktree add .worktrees/"$branch" origin/"$branch"
+```
+
+This creates the worktree directly from the remote ref — the current worktree's HEAD is never moved.
+
+**Directory selection and safety verification still apply** — follow the same priority order and `git check-ignore` checks as for any other worktree.
 
 ## Common Mistakes
+
+### Using `gh pr checkout` before creating a worktree
+
+- **Problem:** Moves HEAD in the current worktree, disrupting in-progress work (detached HEAD, uncommitted rebase, etc.)
+- **Fix:** Use `gh pr view --json headRefName` to get the branch name, then `git fetch` + `git worktree add` directly
 
 ### Skipping ignore verification
 


### PR DESCRIPTION
## Summary

- Adds a new "Checking Out a PR to a Worktree" section to the `using-git-worktrees` skill with a safe pattern: `gh pr view --json` → `git fetch` → `git worktree add`
- Adds a "Common Mistakes" entry warning against using `gh pr checkout` before creating a worktree
- Adds a Quick Reference table row for the PR checkout workflow

## Motivation

Using `gh pr checkout` in a worktree moves HEAD, which can disrupt in-progress work (e.g., detached HEAD with an uncommitted rebase). The safe pattern fetches the remote ref and creates the worktree directly, never touching the current worktree's HEAD.

## Test plan

- [x] Used via `--plugin-dir` for two weeks of daily usage across multiple repos
- [x] Verified correct PR worktree behavior without unintended side effects
- [ ] Review: instructions are clear and match existing skill conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)