### PR TITLE
feat: add verify-install.sh to detect incomplete skill downloads

### DIFF
--- a/verify-install.sh
+++ b/verify-install.sh
@@ -98,16 +98,8 @@ main() {
   done
 
   echo ""
-  echo -e "${YELLOW}To fix, run:${NC}"
-  echo ""
-  echo "  git clone https://github.com/obra/superpowers.git /tmp/superpowers-fix"
-  echo "  cp -r /tmp/superpowers-fix/skills/{$(IFS=,; echo "${missing[*]}")} \\"
-  echo "    $skills_dir/"
-  echo "  rm -rf /tmp/superpowers-fix"
-  echo ""
-  echo "Then restart your Claude Code session."
-  echo ""
   echo -e "${YELLOW}This is a known issue with Claude Code's plugin download mechanism.${NC}"
+  echo "The fix needs to come from Claude Code itself."
   echo "See: https://github.com/anthropics/claude-code/issues/35989"
 
   exit 1


### PR DESCRIPTION
## Summary

- Adds `verify-install.sh` script that checks all expected skill directories are present in the plugin cache
- If skills are missing, reports which ones and points to the upstream Claude Code issue
- **Diagnostic only** — does not attempt to fix the cache (per maintainer feedback, manual patching is fragile)

## Context

Claude Code's plugin download mechanism sometimes clones the `skills/` directory incompletely. We observed inconsistent skill counts across versions and marketplace sources:

| Cache source | v5.0.1 | v5.0.2 | v5.0.4 | v5.0.5 |
|---|---|---|---|---|
| `claude-plugins-official` | 14 | 14 | 14 | 14 |
| `superpowers-marketplace` | 9 | 0 | 10 | 7 |

Users hit `Unknown skill: superpowers:subagent-driven-development` (and other skills) with no indication that the installation is incomplete. This script helps them understand *why* skills are missing.

The root cause is in Claude Code's git clone logic (tracked at anthropics/claude-code#35989).

## Usage

```bash
# Auto-detect plugin location
bash verify-install.sh

# Or specify path
bash verify-install.sh ~/.claude/plugins/cache/superpowers-marketplace/superpowers/5.0.5
```

**Output when all skills present:**
```
Superpowers skill verification: 14/14 skills present
All skills installed correctly.
```

**Output when skills missing:**
```
Superpowers skill verification: 7/14 skills present
Missing skills (7):
  ✗ brainstorming
  ✗ dispatching-parallel-agents
  ...

This is a known issue with Claude Code's plugin download mechanism.
The fix needs to come from Claude Code itself.
See: https://github.com/anthropics/claude-code/issues/35989
```

## Related

- anthropics/claude-code#35989 — root cause in Claude Code's plugin download
- #818 — user-facing impact report

## Test plan

- [x] Tested against complete repo clone (14/14)
- [x] Tested against simulated incomplete install (detects missing, reports correctly)
- [x] Script exits 0 on success, 1 on missing skills
- [ ] Test on macOS (uses POSIX-safe constructs, should work)