### PR TITLE
fix: replace ≠ unicode with plain text in verification skill

### DIFF
--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -65,11 +65,11 @@ Skip any step = lying, not verifying
 | Excuse | Reality |
 |--------|---------|
 | "Should work now" | RUN the verification |
-| "I'm confident" | Confidence ≠ evidence |
+| "I'm confident" | Confidence does not equal evidence |
 | "Just this once" | No exceptions |
-| "Linter passed" | Linter ≠ compiler |
+| "Linter passed" | Linter does not equal compiler |
 | "Agent said success" | Verify independently |
-| "I'm tired" | Exhaustion ≠ excuse |
+| "I'm tired" | Exhaustion does not equal excuse |
 | "Partial check is enough" | Partial proves nothing |
 | "Different words so rule doesn't apply" | Spirit over letter |
 


### PR DESCRIPTION
## Summary

Replace `≠` unicode symbols with "does not equal" in the rationalization prevention table.

LLMs can tokenize unicode symbols inconsistently — plain text is more reliably parsed.

## Changes

- `skills/verification-before-completion/SKILL.md` — 3 lines: `≠` → "does not equal"

🤖 Generated with [Claude Code](https://claude.com/claude-code)