### PR TITLE
fix: add explanation for Rigid/Flexible skill types

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -104,6 +104,8 @@ When multiple skills could apply, use this order:
 
 ## Skill Types
 
+Rigid skills enforce non-negotiable disciplines where shortcuts cause compounding damage. Flexible skills guide creative processes where adaptation is expected.
+
 **Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline.
 
 **Flexible** (patterns): Adapt principles to context.


### PR DESCRIPTION
## Summary

Adds a one-sentence summary explaining WHY the Rigid/Flexible distinction matters, before the existing bullet definitions.

> Rigid skills enforce non-negotiable disciplines where shortcuts cause compounding damage. Flexible skills guide creative processes where adaptation is expected.

## Changes

- `skills/using-superpowers/SKILL.md` — 2 lines added

🤖 Generated with [Claude Code](https://claude.com/claude-code)