### PR TITLE
fix: connect EnterPlanMode check in flow diagram

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -62,6 +62,7 @@ digraph skill_flow {
     "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
     "Invoke brainstorming skill" -> "Might any skill apply?";
 
+    "User message received" -> "About to EnterPlanMode?" [label="check first"];
     "User message received" -> "Might any skill apply?";
     "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
     "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];


### PR DESCRIPTION
## Summary

The flow diagram defines an "About to EnterPlanMode?" node and a "User message received" node but has no edge between them. Adds the missing connection.

## Changes

- `skills/using-superpowers/SKILL.md` — 1 line added to dot graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)