### PR TITLE
fix: sync Cursor plugin.json version to 5.0.5

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "superpowers",
   "displayName": "Superpowers",
   "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "5.0.2",
+  "version": "5.0.5",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"


### PR DESCRIPTION
## Summary
- Sync `.cursor-plugin/plugin.json` version from `5.0.2` to `5.0.5` to match `.claude-plugin/plugin.json`

The Cursor plugin manifest was 3 versions behind the Claude Code manifest. This ensures users on both platforms see the correct version.

## Test plan
- [x] Verified `.claude-plugin/plugin.json` is at `5.0.5`
- [x] Updated `.cursor-plugin/plugin.json` to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)