### PR TITLE
fix(opencode): align skills path messaging and tests

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -69,7 +69,7 @@ When skills reference tools you don't have, substitute OpenCode equivalents:
 - \`Read\`, \`Write\`, \`Edit\`, \`Bash\` → Your native tools
 
 **Skills location:**
-Superpowers skills are in \`${configDir}/skills/superpowers/\`
+Superpowers skills are loaded from \`${superpowersSkillsDir}\`
 Use OpenCode's native \`skill\` tool to list and load skills.`;
 
     return `<EXTREMELY_IMPORTANT>

--- a/tests/opencode/run-tests.sh
+++ b/tests/opencode/run-tests.sh
@@ -44,7 +44,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Tests:"
             echo "  test-plugin-loading.sh  Verify plugin installation and structure"
-            echo "  test-tools.sh           Test use_skill and find_skills tools (integration)"
+            echo "  test-tools.sh           Test native skill tool integration"
             echo "  test-priority.sh        Test skill priority resolution (integration)"
             exit 0
             ;;

--- a/tests/opencode/setup.sh
+++ b/tests/opencode/setup.sh
@@ -14,7 +14,7 @@ export OPENCODE_CONFIG_DIR="$TEST_HOME/.config/opencode"
 
 # Install plugin to test location
 mkdir -p "$HOME/.config/opencode/superpowers"
-cp -r "$REPO_ROOT/lib" "$HOME/.config/opencode/superpowers/"
+cp "$REPO_ROOT/package.json" "$HOME/.config/opencode/superpowers/"
 cp -r "$REPO_ROOT/skills" "$HOME/.config/opencode/superpowers/"
 
 # Copy plugin directory

--- a/tests/opencode/test-plugin-loading.sh
+++ b/tests/opencode/test-plugin-loading.sh
@@ -32,7 +32,9 @@ fi
 
 # Test 2: Verify skills directory is populated
 echo "Test 2: Checking skills directory..."
-skill_count=$(find "$HOME/.config/opencode/superpowers/skills" -name "SKILL.md" | wc -l)
+plugin_file="$HOME/.config/opencode/superpowers/.opencode/plugins/superpowers.js"
+runtime_skills_dir=$(node --input-type=module -e "import path from 'path'; console.log(path.resolve(process.argv[1], '../../skills'));" "$(dirname "$plugin_file")")
+skill_count=$(find "$runtime_skills_dir" -name "SKILL.md" | wc -l)
 if [ "$skill_count" -gt 0 ]; then
     echo "  [PASS] Found $skill_count skills installed"
 else
@@ -42,7 +44,7 @@ fi
 
 # Test 4: Check using-superpowers skill exists (critical for bootstrap)
 echo "Test 4: Checking using-superpowers skill (required for bootstrap)..."
-if [ -f "$HOME/.config/opencode/superpowers/skills/using-superpowers/SKILL.md" ]; then
+if [ -f "$runtime_skills_dir/using-superpowers/SKILL.md" ]; then
     echo "  [PASS] using-superpowers skill exists"
 else
     echo "  [FAIL] using-superpowers skill not found (required for bootstrap)"
@@ -51,11 +53,26 @@ fi
 
 # Test 5: Verify plugin JavaScript syntax (basic check)
 echo "Test 5: Checking plugin JavaScript syntax..."
-plugin_file="$HOME/.config/opencode/superpowers/.opencode/plugins/superpowers.js"
 if node --check "$plugin_file" 2>/dev/null; then
     echo "  [PASS] Plugin JavaScript syntax is valid"
 else
     echo "  [FAIL] Plugin has JavaScript syntax errors"
+    exit 1
+fi
+
+# Test 5b: Verify bootstrap help text matches runtime path model
+echo "Test 5b: Checking bootstrap skills path text..."
+if grep -q '\${configDir}/skills/superpowers/' "$plugin_file"; then
+    echo "  [FAIL] Plugin still references old symlink-based skills path"
+    exit 1
+else
+    echo "  [PASS] Plugin does not reference old symlink-based skills path"
+fi
+
+if grep -q '\${superpowersSkillsDir}' "$plugin_file"; then
+    echo "  [PASS] Plugin references runtime skills path"
+else
+    echo "  [FAIL] Plugin does not reference runtime skills path"
     exit 1
 fi
 

--- a/tests/opencode/test-priority.sh
+++ b/tests/opencode/test-priority.sh
@@ -17,9 +17,12 @@ trap cleanup_test_env EXIT
 # Create same skill "priority-test" in all three locations with different markers
 echo "Setting up priority test fixtures..."
 
+plugin_file="$HOME/.config/opencode/superpowers/.opencode/plugins/superpowers.js"
+superpowers_skills_dir=$(node --input-type=module -e "import path from 'path'; console.log(path.resolve(process.argv[1], '../../skills'));" "$(dirname "$plugin_file")")
+
 # 1. Create in superpowers location (lowest priority)
-mkdir -p "$HOME/.config/opencode/superpowers/skills/priority-test"
-cat > "$HOME/.config/opencode/superpowers/skills/priority-test/SKILL.md" <<'EOF'
+mkdir -p "$superpowers_skills_dir/priority-test"
+cat > "$superpowers_skills_dir/priority-test/SKILL.md" <<'EOF'
 ---
 name: priority-test
 description: Superpowers version of priority test skill
@@ -65,7 +68,7 @@ echo "  Created priority-test skill in all three locations"
 echo ""
 echo "Test 1: Verifying test fixtures..."
 
-if [ -f "$HOME/.config/opencode/superpowers/skills/priority-test/SKILL.md" ]; then
+if [ -f "$superpowers_skills_dir/priority-test/SKILL.md" ]; then
     echo "  [PASS] Superpowers version exists"
 else
     echo "  [FAIL] Superpowers version missing"
@@ -103,7 +106,7 @@ echo "  Running from outside project directory..."
 
 # Run from HOME (not in project) - should get personal version
 cd "$HOME"
-output=$(timeout 60s opencode run --print-logs "Use the use_skill tool to load the priority-test skill. Show me the exact content including any PRIORITY_MARKER text." 2>&1) || {
+output=$(timeout 60s opencode run --print-logs "Use the skill tool to load the priority-test skill. Show me the exact content including any PRIORITY_MARKER text." 2>&1) || {
     exit_code=$?
     if [ $exit_code -eq 124 ]; then
         echo "  [FAIL] OpenCode timed out after 60s"
@@ -129,7 +132,7 @@ echo "  Running from project directory..."
 
 # Run from project directory - should get project version
 cd "$TEST_HOME/test-project"
-output=$(timeout 60s opencode run --print-logs "Use the use_skill tool to load the priority-test skill. Show me the exact content including any PRIORITY_MARKER text." 2>&1) || {
+output=$(timeout 60s opencode run --print-logs "Use the skill tool to load the priority-test skill. Show me the exact content including any PRIORITY_MARKER text." 2>&1) || {
     exit_code=$?
     if [ $exit_code -eq 124 ]; then
         echo "  [FAIL] OpenCode timed out after 60s"
@@ -156,7 +159,7 @@ echo ""
 echo "Test 4: Testing superpowers: prefix forces superpowers version..."
 
 cd "$TEST_HOME/test-project"
-output=$(timeout 60s opencode run --print-logs "Use the use_skill tool to load superpowers:priority-test specifically. Show me the exact content including any PRIORITY_MARKER text." 2>&1) || {
+output=$(timeout 60s opencode run --print-logs "Use the skill tool to load superpowers:priority-test specifically. Show me the exact content including any PRIORITY_MARKER text." 2>&1) || {
     exit_code=$?
     if [ $exit_code -eq 124 ]; then
         echo "  [FAIL] OpenCode timed out after 60s"
@@ -178,7 +181,7 @@ echo ""
 echo "Test 5: Testing project: prefix forces project version..."
 
 cd "$HOME"  # Run from outside project but with project: prefix
-output=$(timeout 60s opencode run --print-logs "Use the use_skill tool to load project:priority-test specifically. Show me the exact content." 2>&1) || {
+output=$(timeout 60s opencode run --print-logs "Use the skill tool to load project:priority-test specifically. Show me the exact content." 2>&1) || {
     exit_code=$?
     if [ $exit_code -eq 124 ]; then
         echo "  [FAIL] OpenCode timed out after 60s"

--- a/tests/opencode/test-tools.sh
+++ b/tests/opencode/test-tools.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test: Tools Functionality
-# Verifies that use_skill and find_skills tools work correctly
+# Verifies that the native skill tool works correctly
 # NOTE: These tests require OpenCode to be installed and configured
 set -euo pipefail
 
@@ -21,12 +21,12 @@ if ! command -v opencode &> /dev/null; then
     exit 0
 fi
 
-# Test 1: Test find_skills tool via direct invocation
-echo "Test 1: Testing find_skills tool..."
-echo "  Running opencode with find_skills request..."
+# Test 1: Test native skill listing via direct invocation
+echo "Test 1: Testing skill tool listing..."
+echo "  Running opencode with skill listing request..."
 
 # Use timeout to prevent hanging, capture both stdout and stderr
-output=$(timeout 60s opencode run --print-logs "Use the find_skills tool to list available skills. Just call the tool and show me the raw output." 2>&1) || {
+output=$(timeout 60s opencode run --print-logs "Use the skill tool to list available skills. Just call the tool and show me the raw output." 2>&1) || {
     exit_code=$?
     if [ $exit_code -eq 124 ]; then
         echo "  [FAIL] OpenCode timed out after 60s"
@@ -37,9 +37,9 @@ output=$(timeout 60s opencode run --print-logs "Use the find_skills tool to list
 
 # Check for expected patterns in output
 if echo "$output" | grep -qi "superpowers:brainstorming\|superpowers:using-superpowers\|Available skills"; then
-    echo "  [PASS] find_skills tool discovered superpowers skills"
+    echo "  [PASS] skill tool discovered superpowers skills"
 else
-    echo "  [FAIL] find_skills did not return expected skills"
+    echo "  [FAIL] skill tool did not return expected skills"
     echo "  Output was:"
     echo "$output" | head -50
     exit 1
@@ -47,17 +47,17 @@ fi
 
 # Check if personal test skill was found
 if echo "$output" | grep -qi "personal-test"; then
-    echo "  [PASS] find_skills found personal test skill"
+    echo "  [PASS] skill tool found personal test skill"
 else
     echo "  [WARN] personal test skill not found in output (may be ok if tool returned subset)"
 fi
 
-# Test 2: Test use_skill tool
+# Test 2: Test native skill loading
 echo ""
-echo "Test 2: Testing use_skill tool..."
-echo "  Running opencode with use_skill request..."
+echo "Test 2: Testing skill tool loading..."
+echo "  Running opencode with skill loading request..."
 
-output=$(timeout 60s opencode run --print-logs "Use the use_skill tool to load the personal-test skill and show me what you get." 2>&1) || {
+output=$(timeout 60s opencode run --print-logs "Use the skill tool to load the personal-test skill and show me what you get." 2>&1) || {
     exit_code=$?
     if [ $exit_code -eq 124 ]; then
         echo "  [FAIL] OpenCode timed out after 60s"
@@ -68,20 +68,20 @@ output=$(timeout 60s opencode run --print-logs "Use the use_skill tool to load t
 
 # Check for the skill marker we embedded
 if echo "$output" | grep -qi "PERSONAL_SKILL_MARKER_12345\|Personal Test Skill\|Launching skill"; then
-    echo "  [PASS] use_skill loaded personal-test skill content"
+    echo "  [PASS] skill tool loaded personal-test skill content"
 else
-    echo "  [FAIL] use_skill did not load personal-test skill correctly"
+    echo "  [FAIL] skill tool did not load personal-test skill correctly"
     echo "  Output was:"
     echo "$output" | head -50
     exit 1
 fi
 
-# Test 3: Test use_skill with superpowers: prefix
+# Test 3: Test skill tool with superpowers: prefix
 echo ""
-echo "Test 3: Testing use_skill with superpowers: prefix..."
+echo "Test 3: Testing skill tool with superpowers: prefix..."
 echo "  Running opencode with superpowers:brainstorming skill..."
 
-output=$(timeout 60s opencode run --print-logs "Use the use_skill tool to load superpowers:brainstorming and tell me the first few lines of what you received." 2>&1) || {
+output=$(timeout 60s opencode run --print-logs "Use the skill tool to load superpowers:brainstorming and tell me the first few lines of what you received." 2>&1) || {
     exit_code=$?
     if [ $exit_code -eq 124 ]; then
         echo "  [FAIL] OpenCode timed out after 60s"
@@ -92,9 +92,9 @@ output=$(timeout 60s opencode run --print-logs "Use the use_skill tool to load s
 
 # Check for expected content from brainstorming skill
 if echo "$output" | grep -qi "brainstorming\|Launching skill\|skill.*loaded"; then
-    echo "  [PASS] use_skill loaded superpowers:brainstorming skill"
+    echo "  [PASS] skill tool loaded superpowers:brainstorming skill"
 else
-    echo "  [FAIL] use_skill did not load superpowers:brainstorming correctly"
+    echo "  [FAIL] skill tool did not load superpowers:brainstorming correctly"
     echo "  Output was:"
     echo "$output" | head -50
     exit 1


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

Closes #847

## What problem are you trying to solve?
The OpenCode integration drifted into three different skill path models after the auto-register change. At runtime, the plugin loads bundled skills from the installed package path (for example `node_modules/superpowers/skills`), but the bootstrap text still told users that skills lived in `~/.config/opencode/skills/superpowers/`, and the OpenCode tests were still checking `~/.config/opencode/superpowers/skills`.

That mismatch makes installation debugging and maintenance confusing: the product behavior, user-facing guidance, and test suite were no longer describing the same system.

## What does this PR change?
This PR updates the OpenCode bootstrap text to report the actual runtime skills path and updates the OpenCode test scripts to derive and validate the runtime-installed skills directory instead of hardcoding older path layouts. It also updates outdated OpenCode test wording that still referred to the removed `use_skill` / `find_skills` flow.

## Is this change appropriate for the core library?
Yes. This is a core OpenCode integration consistency fix for Superpowers itself. It affects bundled plugin behavior and the repository's own OpenCode test suite, and is useful to any OpenCode user or contributor working with Superpowers.

## What alternatives did you consider?
- Keep the old bootstrap wording and only adjust tests. I rejected this because it would preserve user-facing misinformation.
- Revert runtime behavior back to a config-directory-based path. I rejected this because it would fight the newer auto-register design introduced for OpenCode.
- Only document the discrepancy in comments or README text. I rejected this because the inconsistency exists in executable code and tests, so the fix should live there.

## Does this PR contain multiple unrelated changes?
No. All changes are part of the same OpenCode path-consistency fix: aligning runtime messaging and tests with the actual bundled-skills loading model.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: `#330`, `#753`, `#216`

`#330` moved OpenCode to native skills and a symlink-based model. `#753` later switched to auto-registering bundled skills from the plugin package, which is where the current runtime/message split appears to have been introduced. `#216` discussed OpenCode skill path mismatches more generally, but was about a different `skill` vs `skills` claim and was closed as unreproducible.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| OpenCode | | GPT-5.4 | openai/gpt-5.4 |

## Evaluation
- Initial prompt: `fix issue #847`
- Eval sessions run after the change: 2 direct test runs plus 1 suite run
- Before: `tests/opencode/test-plugin-loading.sh` passed legacy path assumptions and did not guard against stale bootstrap text; the OpenCode integration still reported an outdated skills path. After: `bash tests/opencode/test-plugin-loading.sh` fails if the plugin references the old symlink path and now passes with the runtime-path message; `bash tests/opencode/run-tests.sh --verbose` also passes with the updated checks.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

Adversarial coverage used here:
- Added a test assertion that explicitly fails if `.opencode/plugins/superpowers.js` still contains the old `\${configDir}/skills/superpowers/` path.
- Re-ran the OpenCode plugin test script after updating the implementation.
- Re-ran the non-integration OpenCode test suite to confirm the updated path checks work end-to-end.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->
