### PR TITLE
Fix plan generation skipping TDD for config/tooling tasks

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -33,6 +33,23 @@ Before defining tasks, map out which files will be created or modified and what 
 
 This structure informs the task decomposition. Each task should produce self-contained changes that make sense independently.
 
+## TDD Structure Is Mandatory
+
+<HARD-GATE>
+Every task that produces or modifies code MUST follow RED-GREEN-REFACTOR structure: write failing test → verify it fails → write minimal implementation → verify it passes → commit. No exceptions.
+</HARD-GATE>
+
+**This includes tasks that feel "untestable":**
+- **Configuration/tooling setup** — write a smoke test that imports/runs the config and asserts expected values
+- **Build pipeline changes** — write a test that runs the build and checks output
+- **Scaffolding/boilerplate** — write a test that verifies the scaffold works (e.g., app starts, route responds)
+
+If a task genuinely cannot have a test (e.g., "create .gitignore"), it must not contain any functional code. The moment a task includes logic, behavior, or integration — it needs a test first.
+
+### Anti-Pattern: "Tests at the end"
+
+Plans that put all tests in a final "Add tests" task are NOT TDD. Tests written after implementation prove nothing — they pass immediately and you never see them catch the bug. Each task must have its own test step BEFORE its implementation step.
+
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -36,7 +36,7 @@ This structure informs the task decomposition. Each task should produce self-con
 ## TDD Structure Is Mandatory
 
 <HARD-GATE>
-Every task that produces or modifies code MUST follow RED-GREEN-REFACTOR structure: write failing test → verify it fails → write minimal implementation → verify it passes → commit. No exceptions.
+Every task that introduces or changes behavior MUST follow RED-GREEN-REFACTOR structure: write failing test → verify it fails → write minimal implementation → verify it passes → refactor → commit. No exceptions.
 </HARD-GATE>
 
 **This includes tasks that feel "untestable":**
@@ -44,7 +44,7 @@ Every task that produces or modifies code MUST follow RED-GREEN-REFACTOR structu
 - **Build pipeline changes** — write a test that runs the build and checks output
 - **Scaffolding/boilerplate** — write a test that verifies the scaffold works (e.g., app starts, route responds)
 
-If a task genuinely cannot have a test (e.g., "create .gitignore"), it must not contain any functional code. The moment a task includes logic, behavior, or integration — it needs a test first.
+If a task genuinely cannot have a test (e.g., "create .gitignore"), it must not contain any functional code. For tasks that only refactor, format, or make mechanically equivalent changes, rely on running the existing test suite rather than writing a new failing test. The moment a task introduces or changes logic, behavior, or integration — it needs a new or updated test first.
 
 ### Anti-Pattern: "Tests at the end"
 

--- a/skills/writing-plans/plan-document-reviewer-prompt.md
+++ b/skills/writing-plans/plan-document-reviewer-prompt.md
@@ -22,7 +22,7 @@ Task tool (general-purpose):
     | Completeness | TODOs, placeholders, incomplete tasks, missing steps |
     | Spec Alignment | Plan covers spec requirements, no major scope creep |
     | Task Decomposition | Tasks have clear boundaries, steps are actionable |
-    | TDD Structure | Every task with code follows RED-GREEN: write failing test → verify fails → implement → verify passes. Tests must NOT be deferred to a final task. Flag any task that has implementation before tests. |
+    | TDD Structure | Every task that introduces or changes behavior follows RED-GREEN-REFACTOR: write failing test → verify fails → implement → verify passes → refactor → commit. Refactor-only tasks may rely on existing tests. Tests must NOT be deferred to a final task. Flag any task that has implementation before tests. |
     | Buildability | Could an engineer follow this plan without getting stuck? |
 
     ## Calibration

--- a/skills/writing-plans/plan-document-reviewer-prompt.md
+++ b/skills/writing-plans/plan-document-reviewer-prompt.md
@@ -22,6 +22,7 @@ Task tool (general-purpose):
     | Completeness | TODOs, placeholders, incomplete tasks, missing steps |
     | Spec Alignment | Plan covers spec requirements, no major scope creep |
     | Task Decomposition | Tasks have clear boundaries, steps are actionable |
+    | TDD Structure | Every task with code follows RED-GREEN: write failing test → verify fails → implement → verify passes. Tests must NOT be deferred to a final task. Flag any task that has implementation before tests. |
     | Buildability | Could an engineer follow this plan without getting stuck? |
 
     ## Calibration


### PR DESCRIPTION
## Summary

Fixes #853 — Plans generated by `writing-plans` did not enforce TDD structure, especially when early tasks involved configuration or tooling. The plan reviewer also lacked TDD criteria, allowing non-TDD plans to pass review.

### Root cause

Two gaps in the planning pipeline:

1. **`writing-plans/SKILL.md`** mentioned TDD only in passing (`"DRY. YAGNI. TDD."`) without enforcement. No `<HARD-GATE>`, no anti-rationalization guidance. When early tasks were config/tooling, the planner skipped TDD for those — and the habit carried to subsequent tasks.

2. **`plan-document-reviewer-prompt.md`** checked Completeness, Spec Alignment, Task Decomposition, and Buildability — but had **no TDD criteria**. Non-TDD plans were approved without question.

### Changes

**`skills/writing-plans/SKILL.md`:**
- Added `<HARD-GATE>` requiring RED-GREEN-REFACTOR for every code-producing task
- Added concrete guidance for tasks that feel "untestable": config (smoke test), build pipeline (output check), scaffolding (startup check)
- Added anti-pattern section: "Tests at the end" — plans that defer all tests to a final task are explicitly flagged as NOT TDD

**`skills/writing-plans/plan-document-reviewer-prompt.md`:**
- Added "TDD Structure" category to the reviewer checklist
- Reviewer now checks: test before implementation in every task, no deferred test tasks

## Test plan

- [x] Brainstorm a project with config/tooling first steps → verify plan uses RED-GREEN per task
- [x] Verify plan reviewer flags plans with implementation-before-test ordering
- [x] Verify plan reviewer flags plans with a single "Add tests" task at the end