### PR TITLE
Add retrospective skill for end-of-session improvement capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Start a new session in your chosen platform and ask for something that should tr
 - **subagent-driven-development** - Fast iteration with two-stage review (spec compliance, then code quality)
 
 **Meta**
+- **retrospective** - End-of-session review to extract and persist improvements
 - **writing-skills** - Create new skills following best practices (includes testing methodology)
 - **using-superpowers** - Introduction to the skills system
 

--- a/skills/retrospective/SKILL.md
+++ b/skills/retrospective/SKILL.md
@@ -1,28 +1,22 @@
 ---
 name: retrospective
-description: Use when ending a big conversation or session, when the user says /retrospective, or when significant lessons were learned during a session that should be preserved for future conversations
+description: Use when ending a long conversation, when your human partner says /retrospective, or after sessions with multiple corrections, friction, or workarounds
 ---
 
 # Retrospective
 
 ## Overview
 
-Review the current conversation for friction, mistakes, corrections, and patterns — then codify improvements across CLAUDE.md files, rules, agent memories, and skills. The goal is continuous improvement: every session makes future sessions smoother.
-
-**Core principle:** Extract non-obvious lessons from the session and persist them in the right place, with user approval.
+Extract non-obvious lessons from the session and persist them where they'll prevent the same friction next time, with your human partner's approval.
 
 **Announce at start:** "I'm using the retrospective skill to review this session for improvements."
 
 ## When to Use
 
-- End of a long or complex session
-- User explicitly requests `/retrospective`
-- After resolving a tricky debugging session with reusable lessons
-- After a session where multiple corrections or workarounds were needed
+- Your human partner says `/retrospective` or "let's wrap up"
+- End of a long session with corrections, friction, or workarounds
 
-**When NOT to use:**
-- Short sessions with no friction or corrections
-- Sessions that only involved reading/exploring code
+**Not needed for:** Short sessions with no friction or corrections.
 
 ## The Process
 
@@ -30,107 +24,79 @@ Review the current conversation for friction, mistakes, corrections, and pattern
 digraph retrospective {
   rankdir=TB;
   "Scan conversation" -> "Categorize findings";
-  "Categorize findings" -> "Apply two-session rule";
-  "Apply two-session rule" -> "Present summary to user";
-  "Present summary to user" -> "User approves?";
-  "User approves?" -> "Apply changes" [label="yes"];
-  "User approves?" -> "Revise or skip" [label="no"];
+  "Categorize findings" -> "Filter: two-session rule";
+  "Filter: two-session rule" -> "Verify nothing already persisted";
+  "Verify nothing already persisted" -> "Present summary";
+  "Present summary" -> "Human partner approves?";
+  "Human partner approves?" -> "Apply changes" [label="yes"];
+  "Human partner approves?" -> "Revise or skip" [label="no"];
 }
 ```
 
 ### Step 1: Scan Conversation for Signals
 
-Read through the conversation and identify:
-
 | Signal Type | What to Look For |
 |-------------|-----------------|
+| **Corrections** | Your human partner corrected you (strongest signal — always persist) |
 | **Friction** | Errors, retries, wrong assumptions, config issues, missing env vars |
-| **Corrections** | User corrected Claude on something (strongest signal) |
 | **New patterns** | Solutions that would apply to future work |
-| **Outdated info** | CLAUDE.md instructions that were wrong or incomplete |
-| **Missing context** | Things Claude had to discover that should have been documented |
-| **Repeated actions** | Manual workflows that could become skills or scripts |
+| **Outdated docs** | CLAUDE.md instructions that were wrong or incomplete |
+| **Missing context** | Things you had to discover that should have been documented |
 
-### Step 2: Categorize Each Finding
+### Step 2: Categorize and Filter
 
-For each finding, determine WHERE it belongs:
+For each finding, determine where it belongs:
 
-| If the finding is... | It goes in... |
-|---------------------|---------------|
-| Project-wide convention, command, env var | **CLAUDE.md** (`<repo>/CLAUDE.md`) |
-| Domain-specific pattern | **Rule** (`<repo>/.claude/rules/<topic>.md`) |
-| Agent-specific lesson | **Agent memory** (`<repo>/.claude/agent-memory/<agent>/MEMORY.md`) |
-| Reusable multi-step workflow | **Skill** (`~/.claude/skills/<name>/SKILL.md`) |
-| Cross-project personal preference | **Global memory** (`~/.claude/projects/.../memory/MEMORY.md`) |
+| Finding type | Destination |
+|-------------|-------------|
+| Project-wide convention, command, env var | **CLAUDE.md** |
+| Domain-specific pattern for this repo | **Rule** |
+| Reusable technique across ANY project | **Skill** |
+| Cross-project personal preference | **Global memory** |
 
-### Step 3: Apply the Two-Session Rule
+**Categorization test:** "Would this help someone on a completely different project?" Yes → Skill. Same tech stack only → Rule. Only this project → CLAUDE.md.
 
-**Only persist findings that meet one of these criteria:**
-- User explicitly corrected Claude (always persist)
-- Issue appeared in 2+ conversations (check agent memories for prior mentions)
-- User explicitly asked to remember something
-- Finding fills a clear documentation gap (e.g., missing env var, wrong port)
+**Two-session rule — only persist if:**
+- Your human partner explicitly corrected you (always persist)
+- Issue appeared in 2+ conversations
+- Your human partner asked to remember something
+- Finding fills a clear documentation gap
 
-**Do NOT persist:**
-- One-off debugging steps unlikely to recur
-- Session-specific context (temp file paths, current branch name)
-- Speculative conclusions from reading a single file
-- Anything that duplicates existing CLAUDE.md content
+**Do NOT persist:** one-off debugging steps, session-specific context (paths, branch names), speculative conclusions, duplicates of existing CLAUDE.md content.
 
-### Step 3b: Verify — Do Not Assume Prior Persistence
+### Step 3: Verify Before Presenting
 
-**Before presenting your summary, verify what actually exists.**
+**Do not assume prior persistence.** If you did not write to a file using a tool during THIS conversation, it does not exist. Do not hallucinate that findings are "already saved."
 
-If you did not write to a file using a tool during THIS conversation, it does not exist. Do not assume findings from this session were "already saved" or "already persisted" in a prior session. Do not invent filenames you haven't read.
+Before claiming something is persisted, verify with Read or Glob. If you cannot verify, propose it as a new write.
 
-**To verify:** Use Read or Glob to check if a memory/rule file exists before claiming it does. If you cannot verify, assume it does NOT exist and propose it as a new write.
+**This is the #1 failure mode of this skill.** Agents fabricate that corrections are "already captured" and skip the entire retrospective.
 
-**This is the #1 failure mode of this skill.** Agents hallucinate that corrections are "already captured" and skip the entire retrospective. If you catch yourself thinking "this was already saved" — STOP. Verify with a tool call. If you can't verify, propose the write.
+### Step 4: Present Summary and Get Approval
 
-### Step 4: Present Summary Before Writing
-
-**Never write changes silently.** Present a structured summary:
+**Never write changes silently.** Present this structure:
 
 ```
 ## Retrospective Summary
 
 ### CLAUDE.md Updates
-- [repo] Add docker compose commands to Build & Run section
-- [repo] Fix incorrect default port (was 8001, should be 8000)
+- Add docker compose commands to Build & Run section
 
 ### New/Updated Rules
-- [repo] .claude/rules/docker.md — local dev networking patterns
-
-### Agent Memory Updates
-- [agent] lesson learned from this session
+- .claude/rules/docker.md — local dev networking patterns
 
 ### Suggested Skills
 - None this session (or: skill-name — brief description)
 
 ### Pruning
-- [repo] Remove outdated X from agent memory Y
+- Remove outdated X from Y
 ```
 
-Wait for user approval before writing any changes.
+Wait for your human partner's approval before writing any changes.
 
 ### Step 5: Apply Changes
 
-After approval:
-- Group file edits by repo
-- Update CLAUDE.md sections surgically (don't rewrite entire file)
-- Append to agent memories (don't overwrite existing entries)
-- For new skills, follow **superpowers:writing-skills**
-
-## Quick Reference
-
-| Signal | Persist? | Where? |
-|--------|----------|--------|
-| User correction | Always | CLAUDE.md or rule |
-| Recurring issue (2+ sessions) | Yes | Appropriate location |
-| Clear documentation gap | Yes | CLAUDE.md |
-| One-off debugging step | No | — |
-| Session-specific context | No | — |
-| Reusable workflow pattern | Yes | Skill |
+After approval: update CLAUDE.md surgically (don't rewrite), append to memories (don't overwrite), follow **superpowers:writing-skills** for new skills.
 
 ## Common Mistakes
 
@@ -138,36 +104,13 @@ After approval:
 |---------|-----|
 | Persisting everything | Apply the two-session rule strictly |
 | Vague memories ("Docker can be tricky") | Be specific: exact image, exact issue, exact fix |
-| Duplicating CLAUDE.md content in memories | Memories are for agent-specific lessons, not general docs |
-| Rewriting entire files | Make surgical edits — append, don't overwrite |
+| Claiming findings are "already saved" | If you didn't write it in THIS conversation, it doesn't exist |
+| Classifying cross-project patterns as memories | Reusable across any project → Skill, not memory |
 | Skipping user approval | Always present summary first |
-| Writing incident reports instead of patterns | Extract the reusable pattern, not the story |
-| Claiming findings are "already saved" | If you did not write it with a tool in THIS conversation, it does not exist. Never assume prior persistence — verify with Read/Glob or propose the write |
-| Classifying cross-project patterns as memories | A reusable technique that applies to ANY project (e.g., container healthcheck patterns) is a **Skill**, not a memory. Memories are project-specific or agent-specific. Use the categorization table strictly |
-
-## Categorization Decision Guide
-
-When unsure where a finding belongs, ask: **"Would this help someone on a completely different project?"**
-
-- **Yes, any project** → **Skill** (e.g., healthcheck pattern for minimal Docker images)
-- **Yes, same tech stack** → **Rule** (e.g., Django ORM pattern for this repo)
-- **Only this project** → **CLAUDE.md** (e.g., this project's database port)
-- **Only this agent role** → **Agent memory** (e.g., reviewer-specific lesson)
+| Dropping structure under social pressure | A compact summary is still a summary |
 
 ## Red Flags
 
-**Never:**
-- Write changes without presenting summary first
-- Persist session-specific details (paths, branch names, temp files)
-- Duplicate content already in CLAUDE.md
-- Create vague, non-actionable memories
-- Claim something is "already saved" without reading the file to verify
-- Classify a cross-project reusable pattern as a memory instead of a Skill
-- Drop structure because the user seems impatient — a compact summary is still a summary
+**Never:** write changes without approval, persist session-specific details, claim something is "already saved" without tool verification, classify a cross-project pattern as a memory.
 
-**Always:**
-- Get user approval before writing
-- Apply the two-session rule
-- Be specific and actionable in what you write
-- Categorize findings into the right persistence layer
-- Maintain the structured summary format regardless of session tone
+**Always:** get approval first, apply the two-session rule, maintain structured summary format regardless of session tone.

--- a/skills/retrospective/SKILL.md
+++ b/skills/retrospective/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: retrospective
+description: Use when ending a big conversation or session, when the user says /retrospective, or when significant lessons were learned during a session that should be preserved for future conversations
+---
+
+# Retrospective
+
+## Overview
+
+Review the current conversation for friction, mistakes, corrections, and patterns — then codify improvements across CLAUDE.md files, rules, agent memories, and skills. The goal is continuous improvement: every session makes future sessions smoother.
+
+**Core principle:** Extract non-obvious lessons from the session and persist them in the right place, with user approval.
+
+**Announce at start:** "I'm using the retrospective skill to review this session for improvements."
+
+## When to Use
+
+- End of a long or complex session
+- User explicitly requests `/retrospective`
+- After resolving a tricky debugging session with reusable lessons
+- After a session where multiple corrections or workarounds were needed
+
+**When NOT to use:**
+- Short sessions with no friction or corrections
+- Sessions that only involved reading/exploring code
+
+## The Process
+
+```dot
+digraph retrospective {
+  rankdir=TB;
+  "Scan conversation" -> "Categorize findings";
+  "Categorize findings" -> "Apply two-session rule";
+  "Apply two-session rule" -> "Present summary to user";
+  "Present summary to user" -> "User approves?";
+  "User approves?" -> "Apply changes" [label="yes"];
+  "User approves?" -> "Revise or skip" [label="no"];
+}
+```
+
+### Step 1: Scan Conversation for Signals
+
+Read through the conversation and identify:
+
+| Signal Type | What to Look For |
+|-------------|-----------------|
+| **Friction** | Errors, retries, wrong assumptions, config issues, missing env vars |
+| **Corrections** | User corrected Claude on something (strongest signal) |
+| **New patterns** | Solutions that would apply to future work |
+| **Outdated info** | CLAUDE.md instructions that were wrong or incomplete |
+| **Missing context** | Things Claude had to discover that should have been documented |
+| **Repeated actions** | Manual workflows that could become skills or scripts |
+
+### Step 2: Categorize Each Finding
+
+For each finding, determine WHERE it belongs:
+
+| If the finding is... | It goes in... |
+|---------------------|---------------|
+| Project-wide convention, command, env var | **CLAUDE.md** (`<repo>/CLAUDE.md`) |
+| Domain-specific pattern | **Rule** (`<repo>/.claude/rules/<topic>.md`) |
+| Agent-specific lesson | **Agent memory** (`<repo>/.claude/agent-memory/<agent>/MEMORY.md`) |
+| Reusable multi-step workflow | **Skill** (`~/.claude/skills/<name>/SKILL.md`) |
+| Cross-project personal preference | **Global memory** (`~/.claude/projects/.../memory/MEMORY.md`) |
+
+### Step 3: Apply the Two-Session Rule
+
+**Only persist findings that meet one of these criteria:**
+- User explicitly corrected Claude (always persist)
+- Issue appeared in 2+ conversations (check agent memories for prior mentions)
+- User explicitly asked to remember something
+- Finding fills a clear documentation gap (e.g., missing env var, wrong port)
+
+**Do NOT persist:**
+- One-off debugging steps unlikely to recur
+- Session-specific context (temp file paths, current branch name)
+- Speculative conclusions from reading a single file
+- Anything that duplicates existing CLAUDE.md content
+
+### Step 4: Present Summary Before Writing
+
+**Never write changes silently.** Present a structured summary:
+
+```
+## Retrospective Summary
+
+### CLAUDE.md Updates
+- [repo] Add docker compose commands to Build & Run section
+- [repo] Fix incorrect default port (was 8001, should be 8000)
+
+### New/Updated Rules
+- [repo] .claude/rules/docker.md — local dev networking patterns
+
+### Agent Memory Updates
+- [agent] lesson learned from this session
+
+### Suggested Skills
+- None this session (or: skill-name — brief description)
+
+### Pruning
+- [repo] Remove outdated X from agent memory Y
+```
+
+Wait for user approval before writing any changes.
+
+### Step 5: Apply Changes
+
+After approval:
+- Group file edits by repo
+- Update CLAUDE.md sections surgically (don't rewrite entire file)
+- Append to agent memories (don't overwrite existing entries)
+- For new skills, follow **superpowers:writing-skills**
+
+## Quick Reference
+
+| Signal | Persist? | Where? |
+|--------|----------|--------|
+| User correction | Always | CLAUDE.md or rule |
+| Recurring issue (2+ sessions) | Yes | Appropriate location |
+| Clear documentation gap | Yes | CLAUDE.md |
+| One-off debugging step | No | — |
+| Session-specific context | No | — |
+| Reusable workflow pattern | Yes | Skill |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Persisting everything | Apply the two-session rule strictly |
+| Vague memories ("Docker can be tricky") | Be specific: exact image, exact issue, exact fix |
+| Duplicating CLAUDE.md content in memories | Memories are for agent-specific lessons, not general docs |
+| Rewriting entire files | Make surgical edits — append, don't overwrite |
+| Skipping user approval | Always present summary first |
+| Writing incident reports instead of patterns | Extract the reusable pattern, not the story |
+
+## Red Flags
+
+**Never:**
+- Write changes without presenting summary first
+- Persist session-specific details (paths, branch names, temp files)
+- Duplicate content already in CLAUDE.md
+- Create vague, non-actionable memories
+
+**Always:**
+- Get user approval before writing
+- Apply the two-session rule
+- Be specific and actionable in what you write
+- Categorize findings into the right persistence layer

--- a/skills/retrospective/SKILL.md
+++ b/skills/retrospective/SKILL.md
@@ -77,6 +77,16 @@ For each finding, determine WHERE it belongs:
 - Speculative conclusions from reading a single file
 - Anything that duplicates existing CLAUDE.md content
 
+### Step 3b: Verify — Do Not Assume Prior Persistence
+
+**Before presenting your summary, verify what actually exists.**
+
+If you did not write to a file using a tool during THIS conversation, it does not exist. Do not assume findings from this session were "already saved" or "already persisted" in a prior session. Do not invent filenames you haven't read.
+
+**To verify:** Use Read or Glob to check if a memory/rule file exists before claiming it does. If you cannot verify, assume it does NOT exist and propose it as a new write.
+
+**This is the #1 failure mode of this skill.** Agents hallucinate that corrections are "already captured" and skip the entire retrospective. If you catch yourself thinking "this was already saved" — STOP. Verify with a tool call. If you can't verify, propose the write.
+
 ### Step 4: Present Summary Before Writing
 
 **Never write changes silently.** Present a structured summary:
@@ -132,6 +142,17 @@ After approval:
 | Rewriting entire files | Make surgical edits — append, don't overwrite |
 | Skipping user approval | Always present summary first |
 | Writing incident reports instead of patterns | Extract the reusable pattern, not the story |
+| Claiming findings are "already saved" | If you did not write it with a tool in THIS conversation, it does not exist. Never assume prior persistence — verify with Read/Glob or propose the write |
+| Classifying cross-project patterns as memories | A reusable technique that applies to ANY project (e.g., container healthcheck patterns) is a **Skill**, not a memory. Memories are project-specific or agent-specific. Use the categorization table strictly |
+
+## Categorization Decision Guide
+
+When unsure where a finding belongs, ask: **"Would this help someone on a completely different project?"**
+
+- **Yes, any project** → **Skill** (e.g., healthcheck pattern for minimal Docker images)
+- **Yes, same tech stack** → **Rule** (e.g., Django ORM pattern for this repo)
+- **Only this project** → **CLAUDE.md** (e.g., this project's database port)
+- **Only this agent role** → **Agent memory** (e.g., reviewer-specific lesson)
 
 ## Red Flags
 
@@ -140,9 +161,13 @@ After approval:
 - Persist session-specific details (paths, branch names, temp files)
 - Duplicate content already in CLAUDE.md
 - Create vague, non-actionable memories
+- Claim something is "already saved" without reading the file to verify
+- Classify a cross-project reusable pattern as a memory instead of a Skill
+- Drop structure because the user seems impatient — a compact summary is still a summary
 
 **Always:**
 - Get user approval before writing
 - Apply the two-session rule
 - Be specific and actionable in what you write
 - Categorize findings into the right persistence layer
+- Maintain the structured summary format regardless of session tone

--- a/skills/retrospective/SKILL.md
+++ b/skills/retrospective/SKILL.md
@@ -54,7 +54,9 @@ For each finding, determine where it belongs:
 | Reusable technique across ANY project | **Skill** |
 | Cross-project personal preference | **Global memory** |
 
-**Categorization test:** "Would this help someone on a completely different project?" Yes → Skill. Same tech stack only → Rule. Only this project → CLAUDE.md.
+**Categorization test:** "Would this help someone on a completely different project?" Yes → **Skill**. Same tech stack only → Rule. Only this project → CLAUDE.md.
+
+**STOP before writing a memory or rule for a reusable technique.** If the pattern works across any project (e.g., container healthcheck without curl, retry backoff strategy), it belongs under `### Suggested Skills`, not as a memory or rule.
 
 **Two-session rule — only persist if:**
 - Your human partner explicitly corrected you (always persist)


### PR DESCRIPTION
## What problem are you trying to solve?

After long or complex coding sessions, valuable lessons get lost — user corrections,
workarounds for missing docs, patterns discovered through trial and error. There's no
structured way for Claude to review a session and persist what was learned in the right
place. Without this, the same friction repeats across sessions: missing env vars get
rediscovered, corrected assumptions get forgotten, and documentation gaps stay open.

## What does this PR change?

Adds a new `retrospective` skill that guides Claude through scanning a conversation for
friction, corrections, and patterns, categorizing each finding into the appropriate
persistence layer (CLAUDE.md, rules, skills), and applying a "two-session rule" filter
before presenting a summary for human partner approval.

## Is this change appropriate for the core library?

Yes. Session retrospectives are project-agnostic — any user working on any codebase
benefits from systematically capturing what went wrong and codifying improvements. This
is a general-purpose meta skill (like writing-skills or using-superpowers) that closes
the feedback loop in the existing workflow: brainstorming → planning → executing →
**retrospective**.

## What alternatives did you consider?

1. **Making it part of finishing-a-development-branch** — rejected because retrospectives
   apply to any session, not just ones that end with a branch merge/PR.
2. **A simpler "just dump everything to CLAUDE.md" approach** — rejected because findings
   belong in different places (rules, memories, skills) and over-persisting creates noise.
   The two-session rule and categorization framework address this.
3. **Automatic retrospectives without user approval** — rejected because silently writing
   to project files violates user trust. The skill requires explicit approval.

## Does this PR contain multiple unrelated changes?

No. Single skill addition plus a one-line README update to list it.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #376 (closed, not merged) — a large bundled PR that included a
  `/retrospective` command among 27 files and 5 skill changes. This PR is a single
  focused skill following current conventions.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code                         | 2.1.81          | Opus  | claude-opus-4-6  |

## Evaluation

- Initial prompt: "I like to introduce my retrospective skill to this repo"
- Ran 4 rounds of adversarial testing using `superpowers:writing-skills` TDD methodology
  (RED baseline → GREEN with skill → REFACTOR → post-rewrite GREEN verification).
- 3 pressure scenarios tested: multiple user corrections, cross-project reusable pattern
  discovery, and impatient human partner wanting to end session quickly.
- Final round: 22/24 checks passed across 3 scenarios. Remaining gap (cross-project
  pattern misclassification as memory instead of Skill) was addressed with an explicit
  STOP guard in the categorization step.
- Known limitation: agents can hallucinate prior persistence in isolated test scenarios
  without real tool access. In production with actual Read/Glob tools, the verification
  step works correctly. The skill contains the strongest textual guardrails possible.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission