### PR TITLE
Add blind-review skill for spec-only final review before merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Start a new session in your chosen platform and ask for something that should tr
 - **executing-plans** - Batch execution with checkpoints
 - **dispatching-parallel-agents** - Concurrent subagent workflows
 - **requesting-code-review** - Pre-review checklist
+- **blind-review** - Spec-only final review to catch drift, security gaps, and deployment issues
 - **receiving-code-review** - Responding to feedback
 - **using-git-worktrees** - Parallel development branches
 - **finishing-a-development-branch** - Merge/PR decision workflow

--- a/skills/blind-review/SKILL.md
+++ b/skills/blind-review/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: blind-review
-description: Use when a major implementation is complete and ready for final review before merge — dispatches a reviewer with ONLY the spec, no implementation context, to catch spec drift, security gaps, and deployment issues that implementation-aware reviewers miss
+description: Use when a major implementation is complete and all per-task reviews have passed, before finishing-a-development-branch — the final quality gate before merge
 ---
 
 # Blind Review
 
 ## Overview
 
-Dispatch a review agent that receives ONLY the original spec or requirements — no implementation summaries, no file lists, no context about how the code was built. The reviewer must read the code independently and evaluate it purely against what was requested.
+Dispatch a review agent that receives ONLY the original spec — no implementation summaries, no file lists, no context about how the code was built. The reviewer reads code independently and evaluates purely against what was requested.
 
-**Core principle:** A reviewer who only knows the *spec* naturally focuses on "does this do what was asked?" rather than "does this code look reasonable?" This catches entire categories of bugs that implementation-aware reviewers miss.
+A reviewer who only knows the *spec* focuses on "does this do what was asked?" rather than "does this code look reasonable?" — catching spec drift, security gaps, race conditions, and deployment issues that implementation-aware reviewers systematically miss.
 
 **Announce at start:** "I'm using the blind-review skill to validate this implementation against the spec."
 
@@ -21,57 +21,28 @@ digraph when_to_use {
     "Standard reviews passed?" [shape=diamond];
     "Dispatch blind reviewer" [shape=box];
     "Run standard reviews first" [shape=box];
-    "Not ready for blind review" [shape=box];
+    "Not ready" [shape=box];
 
     "Major implementation complete?" -> "Standard reviews passed?" [label="yes"];
-    "Major implementation complete?" -> "Not ready for blind review" [label="no"];
+    "Major implementation complete?" -> "Not ready" [label="no"];
     "Standard reviews passed?" -> "Dispatch blind reviewer" [label="yes"];
     "Standard reviews passed?" -> "Run standard reviews first" [label="no"];
 }
 ```
 
-**Mandatory after:**
-- All tasks complete in subagent-driven-development (before finishing-a-development-branch)
-- Multi-file feature implementations
-- Plan execution completion
+**Mandatory after:** all tasks in subagent-driven-development, multi-file features, plan execution completion.
 
-**Not needed for:**
-- Single-file bug fixes with clear test coverage
-- Documentation-only changes
-- Refactors that don't change behavior
-
-## Why Blind Review Catches Different Bugs
-
-Standard code review happens with implementation context — the reviewer knows what was built, how it was built, and tends to evaluate "does this code look reasonable?" Blind review forces evaluation from the spec outward.
-
-| Review Type | Perspective | Catches |
-|-------------|------------|---------|
-| Standard (implementation-aware) | "Does this code work?" | Logic errors, style issues, test gaps |
-| Blind (spec-only) | "Does this match what was asked?" | Spec drift, missing requirements, security gaps, deployment issues |
-
-**Bug classes blind review consistently catches:**
-- **Spec drift** — features subtly different from what was requested
-- **Missing requirements** — items skipped or only partially implemented
-- **Security gaps** — empty secret defaults, missing auth checks, fail-open paths
-- **Race conditions** — TOCTOU gaps between check and action
-- **Deployment issues** — missing retry paths, backward-incompatible data changes
-- **Over-engineering** — features added that weren't in the spec
+**Not needed for:** single-file bug fixes, documentation-only changes, behavior-preserving refactors.
 
 ## The Process
 
 ### Step 1: Gather the Spec
 
-Extract the original requirements — the plan, spec document, or task description. This is the ONLY context the reviewer gets.
+Extract the original requirements. This is the ONLY context the reviewer gets.
 
-**Do NOT include:**
-- Implementation summaries or reports
-- File lists or changed paths
-- Notes about how it was built
-- Implementer's self-review
+**Do NOT include:** implementation summaries, file lists, notes about how it was built, implementer's self-review.
 
 ### Step 2: Dispatch Blind Reviewer
-
-Use the prompt template below. The reviewer must read the codebase independently.
 
 ```
 Task tool (general-purpose):
@@ -92,98 +63,58 @@ Task tool (general-purpose):
 
     **Check for:**
 
-    1. **Spec compliance**
-       - Every requirement implemented? Line by line.
-       - Anything built that wasn't requested?
-       - Requirements interpreted differently than intended?
+    1. **Spec compliance** — Every requirement implemented? Anything
+       extra? Requirements misinterpreted?
 
-    2. **Security and deployment readiness**
-       - Secrets with empty/insecure defaults?
-       - Auth checks missing on endpoints?
-       - Fail-open paths (what happens when auth/validation fails)?
-       - Race conditions (check-then-act patterns)?
+    2. **Security and deployment readiness** — Secrets with empty
+       defaults? Missing auth checks? Fail-open paths? Race conditions
+       (check-then-act)?
 
-    3. **Data safety**
-       - Backward compatibility with existing data?
-       - Migration paths for format changes?
-       - What happens with malformed or missing data?
+    3. **Data safety** — Backward compatibility? Migration paths?
+       Malformed/missing data handling?
 
-    4. **Missing error paths**
-       - Token expiry, network failure, partial writes?
-       - Retry and recovery mechanisms?
+    4. **Missing error paths** — Token expiry, network failure, partial
+       writes? Retry and recovery?
 
-    **IMPORTANT: Even if you cannot find the implementation files, you MUST
-    still produce a full report.** Enumerate every spec requirement, flag
-    every security concern derivable from the spec, and list what you would
-    verify in code. "Code not found" is a Critical finding, not a reason
-    to stop. The spec alone contains enough information to identify risks
-    (e.g., "JWT auth" implies token expiry handling, secret management,
-    refresh token rotation).
+    **IMPORTANT: If you cannot find implementation files, you MUST still
+    produce a full report.** Enumerate every spec requirement, flag every
+    security concern derivable from the spec. "Code not found" is a
+    Critical finding, not a reason to stop.
 
     **Report format:**
     - Critical: Must fix before merge (security, data loss, spec violations)
-    - Important: Should fix before merge (missing error handling, race conditions)
-    - Minor: Nice to fix (style, naming, minor improvements)
-    - Spec compliance: ✅ Met / ❌ Not met — with line-by-line breakdown
-    - Spec-derived risks: Concerns derivable from the spec that MUST be
-      verified in code (even if you haven't seen the code yet)
+    - Important: Should fix (missing error handling, race conditions)
+    - Minor: Nice to fix (style, naming)
+    - Spec compliance: ✅ Met / ❌ Not met — line-by-line breakdown
+    - Spec-derived risks: Concerns to verify in code
 ```
 
 ### Step 3: Act on Findings
 
-- **Critical issues:** Fix immediately, re-run blind review on affected areas
-- **Important issues:** Fix before merge
-- **Minor issues:** Fix or note for follow-up
-- If reviewer found zero issues, be suspicious — ensure they actually read the code
+- **Critical:** Fix immediately, re-run blind review on affected areas
+- **Important:** Fix before merge
+- **Minor:** Fix or note for follow-up
+- Zero issues found? Be suspicious — verify the reviewer actually read code (check for file:line references)
 
-## Quick Reference
+## Integration
 
-| Step | Action | Key Rule |
-|------|--------|----------|
-| 1 | Gather spec | Spec only — no implementation context |
-| 2 | Dispatch reviewer | Reviewer reads code independently |
-| 3 | Act on findings | Fix Critical/Important before merge |
-
-## Integration with Existing Workflows
-
-**Subagent-Driven Development:**
 ```
-Per-task spec review → Per-task code quality review → ... → All tasks done →
-BLIND REVIEW (entire implementation vs full spec) → finishing-a-development-branch
+subagent-driven-development: Per-task reviews → All tasks done → BLIND REVIEW → finishing-a-development-branch
+executing-plans:             All batches done → BLIND REVIEW → finishing-a-development-branch
 ```
-
-**Executing Plans:**
-```
-All batches complete → BLIND REVIEW → finishing-a-development-branch
-```
-
-The blind review is the final quality gate before branch completion. Per-task reviews catch task-level issues; blind review catches system-level issues across the full implementation.
 
 ## Common Mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Including implementation context in the prompt | Spec only — let reviewer find code independently |
+| Including implementation context | Spec only — let reviewer find code independently |
 | Skipping because per-task reviews passed | Per-task reviews catch different bugs than whole-spec review |
-| Trusting "zero issues" result | Verify reviewer actually read the code (check for file references) |
-| Only running on happy path features | Run on security-sensitive and data-handling code especially |
-| Treating it as optional | It's the final gate — mandatory before merge for major implementations |
-| Short-circuiting on "code not found" | "Code not found" is a Critical finding, not a stop signal. Still enumerate every spec requirement and flag spec-derived security risks |
-| Cutting corners under time pressure | "We need to merge today" is not a reason to do a "quick review." Blind review is the final gate — rushing it defeats its purpose |
+| Trusting "zero issues" result | Verify reviewer read the code (check for file references) |
+| Short-circuiting on "code not found" | Still enumerate every spec requirement and flag spec-derived risks |
+| Cutting corners under time pressure | "Merge today" is not a reason for a "quick review" |
 
 ## Red Flags
 
-**Never:**
-- Give the reviewer implementation summaries, file lists, or build context
-- Skip blind review because "standard reviews already passed"
-- Merge with unresolved Critical findings
-- Trust a review that doesn't reference specific files and lines
-- Do a "quick" or "abbreviated" blind review under time pressure
-- Stop the review because implementation files weren't found — enumerate spec-derived risks regardless
+**Never:** give the reviewer implementation context, skip because standard reviews passed, merge with unresolved Critical findings, do a "quick" blind review under time pressure, stop because files weren't found.
 
-**Always:**
-- Provide only the spec/requirements
-- Let the reviewer find and read code independently
-- Enumerate spec-derived risks even before reading code (e.g., "JWT auth" → token expiry, secret rotation, refresh token security)
-- Fix Critical and Important findings before merge
-- Re-review if significant changes were made to fix findings
+**Always:** provide only the spec, let the reviewer find code independently, enumerate spec-derived risks before reading code, fix Critical/Important before merge, re-review after significant fixes.

--- a/skills/blind-review/SKILL.md
+++ b/skills/blind-review/SKILL.md
@@ -112,11 +112,21 @@ Task tool (general-purpose):
        - Token expiry, network failure, partial writes?
        - Retry and recovery mechanisms?
 
+    **IMPORTANT: Even if you cannot find the implementation files, you MUST
+    still produce a full report.** Enumerate every spec requirement, flag
+    every security concern derivable from the spec, and list what you would
+    verify in code. "Code not found" is a Critical finding, not a reason
+    to stop. The spec alone contains enough information to identify risks
+    (e.g., "JWT auth" implies token expiry handling, secret management,
+    refresh token rotation).
+
     **Report format:**
     - Critical: Must fix before merge (security, data loss, spec violations)
     - Important: Should fix before merge (missing error handling, race conditions)
     - Minor: Nice to fix (style, naming, minor improvements)
     - Spec compliance: ✅ Met / ❌ Not met — with line-by-line breakdown
+    - Spec-derived risks: Concerns derivable from the spec that MUST be
+      verified in code (even if you haven't seen the code yet)
 ```
 
 ### Step 3: Act on Findings
@@ -158,6 +168,8 @@ The blind review is the final quality gate before branch completion. Per-task re
 | Trusting "zero issues" result | Verify reviewer actually read the code (check for file references) |
 | Only running on happy path features | Run on security-sensitive and data-handling code especially |
 | Treating it as optional | It's the final gate — mandatory before merge for major implementations |
+| Short-circuiting on "code not found" | "Code not found" is a Critical finding, not a stop signal. Still enumerate every spec requirement and flag spec-derived security risks |
+| Cutting corners under time pressure | "We need to merge today" is not a reason to do a "quick review." Blind review is the final gate — rushing it defeats its purpose |
 
 ## Red Flags
 
@@ -166,9 +178,12 @@ The blind review is the final quality gate before branch completion. Per-task re
 - Skip blind review because "standard reviews already passed"
 - Merge with unresolved Critical findings
 - Trust a review that doesn't reference specific files and lines
+- Do a "quick" or "abbreviated" blind review under time pressure
+- Stop the review because implementation files weren't found — enumerate spec-derived risks regardless
 
 **Always:**
 - Provide only the spec/requirements
 - Let the reviewer find and read code independently
+- Enumerate spec-derived risks even before reading code (e.g., "JWT auth" → token expiry, secret rotation, refresh token security)
 - Fix Critical and Important findings before merge
 - Re-review if significant changes were made to fix findings

--- a/skills/blind-review/SKILL.md
+++ b/skills/blind-review/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: blind-review
+description: Use when a major implementation is complete and ready for final review before merge — dispatches a reviewer with ONLY the spec, no implementation context, to catch spec drift, security gaps, and deployment issues that implementation-aware reviewers miss
+---
+
+# Blind Review
+
+## Overview
+
+Dispatch a review agent that receives ONLY the original spec or requirements — no implementation summaries, no file lists, no context about how the code was built. The reviewer must read the code independently and evaluate it purely against what was requested.
+
+**Core principle:** A reviewer who only knows the *spec* naturally focuses on "does this do what was asked?" rather than "does this code look reasonable?" This catches entire categories of bugs that implementation-aware reviewers miss.
+
+**Announce at start:** "I'm using the blind-review skill to validate this implementation against the spec."
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Major implementation complete?" [shape=diamond];
+    "Standard reviews passed?" [shape=diamond];
+    "Dispatch blind reviewer" [shape=box];
+    "Run standard reviews first" [shape=box];
+    "Not ready for blind review" [shape=box];
+
+    "Major implementation complete?" -> "Standard reviews passed?" [label="yes"];
+    "Major implementation complete?" -> "Not ready for blind review" [label="no"];
+    "Standard reviews passed?" -> "Dispatch blind reviewer" [label="yes"];
+    "Standard reviews passed?" -> "Run standard reviews first" [label="no"];
+}
+```
+
+**Mandatory after:**
+- All tasks complete in subagent-driven-development (before finishing-a-development-branch)
+- Multi-file feature implementations
+- Plan execution completion
+
+**Not needed for:**
+- Single-file bug fixes with clear test coverage
+- Documentation-only changes
+- Refactors that don't change behavior
+
+## Why Blind Review Catches Different Bugs
+
+Standard code review happens with implementation context — the reviewer knows what was built, how it was built, and tends to evaluate "does this code look reasonable?" Blind review forces evaluation from the spec outward.
+
+| Review Type | Perspective | Catches |
+|-------------|------------|---------|
+| Standard (implementation-aware) | "Does this code work?" | Logic errors, style issues, test gaps |
+| Blind (spec-only) | "Does this match what was asked?" | Spec drift, missing requirements, security gaps, deployment issues |
+
+**Bug classes blind review consistently catches:**
+- **Spec drift** — features subtly different from what was requested
+- **Missing requirements** — items skipped or only partially implemented
+- **Security gaps** — empty secret defaults, missing auth checks, fail-open paths
+- **Race conditions** — TOCTOU gaps between check and action
+- **Deployment issues** — missing retry paths, backward-incompatible data changes
+- **Over-engineering** — features added that weren't in the spec
+
+## The Process
+
+### Step 1: Gather the Spec
+
+Extract the original requirements — the plan, spec document, or task description. This is the ONLY context the reviewer gets.
+
+**Do NOT include:**
+- Implementation summaries or reports
+- File lists or changed paths
+- Notes about how it was built
+- Implementer's self-review
+
+### Step 2: Dispatch Blind Reviewer
+
+Use the prompt template below. The reviewer must read the codebase independently.
+
+```
+Task tool (general-purpose):
+  description: "Blind spec review for [feature name]"
+  prompt: |
+    You are a hostile auditor reviewing code you've never seen before.
+    You know ONLY what was supposed to be built. You must find the code,
+    read it, and determine if it does what the spec says.
+
+    ## The Specification
+
+    [PASTE FULL SPEC/REQUIREMENTS — NOTHING ELSE]
+
+    ## Your Job
+
+    Read the actual codebase and verify against the spec above.
+    You have NO implementation context. Find the code yourself.
+
+    **Check for:**
+
+    1. **Spec compliance**
+       - Every requirement implemented? Line by line.
+       - Anything built that wasn't requested?
+       - Requirements interpreted differently than intended?
+
+    2. **Security and deployment readiness**
+       - Secrets with empty/insecure defaults?
+       - Auth checks missing on endpoints?
+       - Fail-open paths (what happens when auth/validation fails)?
+       - Race conditions (check-then-act patterns)?
+
+    3. **Data safety**
+       - Backward compatibility with existing data?
+       - Migration paths for format changes?
+       - What happens with malformed or missing data?
+
+    4. **Missing error paths**
+       - Token expiry, network failure, partial writes?
+       - Retry and recovery mechanisms?
+
+    **Report format:**
+    - Critical: Must fix before merge (security, data loss, spec violations)
+    - Important: Should fix before merge (missing error handling, race conditions)
+    - Minor: Nice to fix (style, naming, minor improvements)
+    - Spec compliance: ✅ Met / ❌ Not met — with line-by-line breakdown
+```
+
+### Step 3: Act on Findings
+
+- **Critical issues:** Fix immediately, re-run blind review on affected areas
+- **Important issues:** Fix before merge
+- **Minor issues:** Fix or note for follow-up
+- If reviewer found zero issues, be suspicious — ensure they actually read the code
+
+## Quick Reference
+
+| Step | Action | Key Rule |
+|------|--------|----------|
+| 1 | Gather spec | Spec only — no implementation context |
+| 2 | Dispatch reviewer | Reviewer reads code independently |
+| 3 | Act on findings | Fix Critical/Important before merge |
+
+## Integration with Existing Workflows
+
+**Subagent-Driven Development:**
+```
+Per-task spec review → Per-task code quality review → ... → All tasks done →
+BLIND REVIEW (entire implementation vs full spec) → finishing-a-development-branch
+```
+
+**Executing Plans:**
+```
+All batches complete → BLIND REVIEW → finishing-a-development-branch
+```
+
+The blind review is the final quality gate before branch completion. Per-task reviews catch task-level issues; blind review catches system-level issues across the full implementation.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Including implementation context in the prompt | Spec only — let reviewer find code independently |
+| Skipping because per-task reviews passed | Per-task reviews catch different bugs than whole-spec review |
+| Trusting "zero issues" result | Verify reviewer actually read the code (check for file references) |
+| Only running on happy path features | Run on security-sensitive and data-handling code especially |
+| Treating it as optional | It's the final gate — mandatory before merge for major implementations |
+
+## Red Flags
+
+**Never:**
+- Give the reviewer implementation summaries, file lists, or build context
+- Skip blind review because "standard reviews already passed"
+- Merge with unresolved Critical findings
+- Trust a review that doesn't reference specific files and lines
+
+**Always:**
+- Provide only the spec/requirements
+- Let the reviewer find and read code independently
+- Fix Critical and Important findings before merge
+- Re-review if significant changes were made to fix findings


### PR DESCRIPTION
## What problem are you trying to solve?

Standard code reviews happen with implementation context — the reviewer knows what was
built, how it was built, and evaluates "does this code look reasonable?" This creates a
systematic blind spot: spec drift, missing requirements, security gaps, and deployment
issues slip through because the reviewer's mental model is anchored to the implementation
rather than the specification.

In production use across a multi-repo project (3 services, 5+ major features), blind
reviews — where the reviewer receives ONLY the spec — consistently caught critical
issues that standard per-task reviews missed: empty secret defaults, TOCTOU race
conditions, missing retry paths, backward-incompatible data changes, and billing bypass
paths.

## What does this PR change?

Adds a new `blind-review` skill with a reviewer prompt template. The reviewer receives
only the spec/requirements, reads the codebase independently, and evaluates against four
dimensions: spec compliance, security/deployment readiness, data safety, and error paths.
Integrates as the final quality gate before `finishing-a-development-branch`.

## Is this change appropriate for the core library?

Yes. The blind review technique is project-agnostic and language-agnostic — any
implementation benefits from a reviewer who evaluates against the spec without
implementation bias. It complements existing Collaboration skills:
- `requesting-code-review` — standard review with implementation context
- `blind-review` — spec-only review without implementation context
- `receiving-code-review` — handling feedback from either type

## What alternatives did you consider?

1. **Extending requesting-code-review** — rejected because the two techniques have
   fundamentally different reviewer prompts and mental frames. Combining would dilute both.
2. **Adding a "blind mode" flag to the code-reviewer agent** — rejected because a blind
   reviewer is a "hostile auditor" who finds code independently, not a standard reviewer
   with a flag toggled.
3. **Making it part of subagent-driven-development** — rejected because blind review
   applies to any workflow (executing-plans, ad-hoc development), not just subagent-driven.

## Does this PR contain multiple unrelated changes?

No. Single skill addition plus a one-line README update to list it under Collaboration.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #65 (closed) — "Add generic multi-agent invocation for comprehensive
  reviews" — different approach (multi-agent review orchestration vs. spec-isolation
  technique).

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code                         | 2.1.81          | Opus  | claude-opus-4-6  |

## Evaluation

- Initial prompt: "create new pr for blind review agent"
- Ran 3 rounds of adversarial testing using `superpowers:writing-skills` TDD methodology
  (RED baseline → GREEN with skill → REFACTOR → post-rewrite GREEN verification).
- 3 pressure scenarios tested: standard post-implementation review, review with
  implementation context pressure ("I've already summarized everything"), and time
  pressure ("merge today, release tomorrow, do a quick review").
- RED baseline showed total deadlock — agents produced zero review output without files.
- Final round: 24/24 checks passed across all 3 scenarios after compression from 1221
  to 688 words. Agents refused implementation summaries, searched independently,
  enumerated spec-derived risks even without code, and resisted time pressure.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission