### PR TITLE
fix: replace hardcoded /Users/jesse paths with generic placeholders

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -149,7 +149,7 @@ python3 tests/claude-code/analyze-token-usage.py ~/.claude/projects/<project-dir
 Session transcripts are stored in `~/.claude/projects/` with the working directory path encoded:
 
 ```bash
-# Example for /Users/jesse/Documents/GitHub/superpowers/superpowers
+# Example for ~/Documents/GitHub/superpowers/superpowers
 SESSION_DIR="$HOME/.claude/projects/-Users-jesse-Documents-GitHub-superpowers-superpowers"
 
 # Find recent sessions

--- a/skills/systematic-debugging/CREATION-LOG.md
+++ b/skills/systematic-debugging/CREATION-LOG.md
@@ -4,7 +4,7 @@ Reference example of extracting, structuring, and bulletproofing a critical skil
 
 ## Source Material
 
-Extracted debugging framework from `/Users/jesse/.claude/CLAUDE.md`:
+Extracted debugging framework from `~/.claude/CLAUDE.md`:
 - 4-phase systematic process (Investigation → Pattern Analysis → Hypothesis → Implementation)
 - Core mandate: ALWAYS find root cause, NEVER fix symptoms
 - Rules designed to resist time pressure and rationalization

--- a/skills/systematic-debugging/root-cause-tracing.md
+++ b/skills/systematic-debugging/root-cause-tracing.md
@@ -33,7 +33,7 @@ digraph when_to_use {
 
 ### 1. Observe the Symptom
 ```
-Error: git init failed in /Users/jesse/project/packages/core
+Error: git init failed in ~/project/packages/core
 ```
 
 ### 2. Find Immediate Cause

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -186,7 +186,7 @@ You: I'm using the using-git-worktrees skill to set up an isolated workspace.
 [Run npm install]
 [Run npm test - 47 passing]
 
-Worktree ready at /Users/jesse/myproject/.worktrees/auth
+Worktree ready at ~/myproject/.worktrees/auth
 Tests passing (47 tests, 0 failures)
 Ready to implement auth feature
 ```


### PR DESCRIPTION
## Summary

Fixes issue #858 - Replace hardcoded sample paths with generic placeholders

## Changes

Replaced all hardcoded `/Users/jesse` paths with generic `~` placeholders in:
- `docs/testing.md`
- `skills/using-git-worktrees/SKILL.md`
- `skills/systematic-debugging/CREATION-LOG.md`
- `skills/systematic-debugging/root-cause-tracing.md`

## Testing

Verified no remaining `/Users/jesse` paths in the repository.