### PR TITLE
Fix OpenCode skill-name fallback guidance for superpowers skills

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -68,6 +68,11 @@ When skills reference tools you don't have, substitute OpenCode equivalents:
 - \`Skill\` tool → OpenCode's native \`skill\` tool
 - \`Read\`, \`Write\`, \`Edit\`, \`Bash\` → Your native tools
 
+**Skill Name Compatibility (OpenCode):**
+- For superpowers skills, prefer \`superpowers/<skill-name>\` with the \`skill\` tool (example: \`superpowers/brainstorming\`).
+- If OpenCode says \`Skill "<skill-name>" not found\` for a bare name, retry with \`superpowers/<skill-name>\`.
+- Slash-command form \`/superpowers:<skill-name>\` is also acceptable when supported.
+
 **Skills location:**
 Superpowers skills are in \`${configDir}/skills/superpowers/\`
 Use OpenCode's native \`skill\` tool to list and load skills.`;

--- a/tests/opencode/setup.sh
+++ b/tests/opencode/setup.sh
@@ -14,7 +14,9 @@ export OPENCODE_CONFIG_DIR="$TEST_HOME/.config/opencode"
 
 # Install plugin to test location
 mkdir -p "$HOME/.config/opencode/superpowers"
-cp -r "$REPO_ROOT/lib" "$HOME/.config/opencode/superpowers/"
+if [ -d "$REPO_ROOT/lib" ]; then
+    cp -r "$REPO_ROOT/lib" "$HOME/.config/opencode/superpowers/"
+fi
 cp -r "$REPO_ROOT/skills" "$HOME/.config/opencode/superpowers/"
 
 # Copy plugin directory

--- a/tests/opencode/test-plugin-loading.sh
+++ b/tests/opencode/test-plugin-loading.sh
@@ -68,5 +68,25 @@ else
     exit 1
 fi
 
+echo "Test 7: Checking bootstrap skill-name guidance..."
+bootstrap_output=$(PLUGIN_FILE="$plugin_file" node --input-type=module <<'EOF'
+const { SuperpowersPlugin } = await import(process.env.PLUGIN_FILE);
+
+const plugin = await SuperpowersPlugin({ client: {}, directory: process.cwd() });
+const output = { system: [] };
+
+await plugin['experimental.chat.system.transform']({}, output);
+console.log((output.system || []).join('\n'));
+EOF
+)
+
+if echo "$bootstrap_output" | grep -q "If OpenCode says \`Skill .* not found\` for a bare name" \
+   && echo "$bootstrap_output" | grep -q "retry with \`superpowers/<skill-name>\`"; then
+    echo "  [PASS] Bootstrap contains namespaced fallback guidance"
+else
+    echo "  [FAIL] Bootstrap missing namespaced fallback guidance"
+    exit 1
+fi
+
 echo ""
 echo "=== All plugin loading tests passed ==="


### PR DESCRIPTION
## Summary
- Add explicit OpenCode skill-name compatibility guidance to the injected bootstrap prompt so agents retry with `superpowers/<skill-name>` when a bare skill name fails.
- Add a regression check in `tests/opencode/test-plugin-loading.sh` to verify the bootstrap contains this fallback guidance.
- Make `tests/opencode/setup.sh` robust when `lib/` is absent so OpenCode plugin tests can run in the current repository layout.

## Verification
- `bash tests/opencode/test-plugin-loading.sh` (pass)
- `bash tests/opencode/run-tests.sh` (pass)
- `node --check .opencode/plugins/superpowers.js` (pass)
- `bash -n tests/opencode/test-plugin-loading.sh` (pass)
- `bash -n tests/opencode/setup.sh` (pass)

## Notes
- `bash tests/opencode/run-tests.sh --integration` currently fails in this environment because `timeout` is not available on macOS by default.