### PR TITLE
fix: add safe bare-skill fallback for native OpenCode skill loading

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -9,6 +9,7 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import { fileURLToPath } from 'url';
+import { rewriteBareSkillName } from '../skill-alias.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -51,6 +52,8 @@ export const SuperpowersPlugin = async ({ client, directory }) => {
   const superpowersSkillsDir = path.resolve(__dirname, '../../skills');
   const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
   const configDir = envConfigDir || path.join(homeDir, '.config/opencode');
+  const userSkillsDir = path.join(configDir, 'skills');
+  const projectSkillsDir = path.join(directory, '.opencode/skills');
 
   // Helper to generate bootstrap content
   const getBootstrapContent = () => {
@@ -102,6 +105,18 @@ ${toolMapping}
       if (bootstrap) {
         (output.system ||= []).push(bootstrap);
       }
+    },
+
+    'tool.execute.before': async (input, output) => {
+      if (input.tool !== 'skill') return;
+      if (!output.args || typeof output.args !== 'object') return;
+      if (typeof output.args.name !== 'string') return;
+
+      output.args.name = rewriteBareSkillName(output.args.name, {
+        projectSkillsDir,
+        userSkillsDir,
+        superpowersSkillsDir
+      });
     }
   };
 };

--- a/.opencode/skill-alias.js
+++ b/.opencode/skill-alias.js
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+
+const hasSkillInDir = (skillsDir, skillName) => {
+  if (!skillsDir || !skillName) return false;
+  let entries;
+  try {
+    entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  const exactDir = entries.find((entry) => entry.isDirectory() && entry.name === skillName);
+  if (!exactDir) return false;
+
+  const skillFile = path.join(skillsDir, exactDir.name, 'SKILL.md');
+  return fs.existsSync(skillFile);
+};
+
+export const rewriteBareSkillName = (skillName, { projectSkillsDir, userSkillsDir, superpowersSkillsDir }) => {
+  if (typeof skillName !== 'string') return skillName;
+
+  const trimmed = skillName.trim();
+  if (!trimmed) return trimmed;
+
+  if (trimmed.includes('/') || trimmed.includes(':')) return trimmed;
+
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(trimmed)) return trimmed;
+
+  if (hasSkillInDir(projectSkillsDir, trimmed)) return trimmed;
+  if (hasSkillInDir(userSkillsDir, trimmed)) return trimmed;
+
+  if (hasSkillInDir(superpowersSkillsDir, trimmed)) return `superpowers/${trimmed}`;
+
+  return trimmed;
+};

--- a/tests/opencode/run-tests.sh
+++ b/tests/opencode/run-tests.sh
@@ -44,6 +44,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Tests:"
             echo "  test-plugin-loading.sh  Verify plugin installation and structure"
+            echo "  test-skill-alias.sh     Test bare-name alias fallback logic"
             echo "  test-tools.sh           Test use_skill and find_skills tools (integration)"
             echo "  test-priority.sh        Test skill priority resolution (integration)"
             exit 0
@@ -59,6 +60,7 @@ done
 # List of tests to run (no external dependencies)
 tests=(
     "test-plugin-loading.sh"
+    "test-skill-alias.sh"
 )
 
 # Integration tests (require OpenCode)

--- a/tests/opencode/test-skill-alias-unit.mjs
+++ b/tests/opencode/test-skill-alias-unit.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { rewriteBareSkillName } from "../../.opencode/skill-alias.js";
+
+const makeSkill = (baseDir, name) => {
+  const skillDir = path.join(baseDir, name);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(path.join(skillDir, "SKILL.md"), `# ${name}\n`, "utf8");
+};
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "sp-skill-alias-"));
+const projectSkillsDir = path.join(root, "project", ".opencode", "skills");
+const userSkillsDir = path.join(root, "user", "skills");
+const superpowersSkillsDir = path.join(root, "superpowers", "skills");
+
+fs.mkdirSync(projectSkillsDir, { recursive: true });
+fs.mkdirSync(userSkillsDir, { recursive: true });
+fs.mkdirSync(superpowersSkillsDir, { recursive: true });
+
+makeSkill(superpowersSkillsDir, "brainstorming");
+makeSkill(superpowersSkillsDir, "writing-plans");
+
+const dirs = { projectSkillsDir, userSkillsDir, superpowersSkillsDir };
+
+assert.equal(rewriteBareSkillName("brainstorming", dirs), "superpowers/brainstorming");
+assert.equal(rewriteBareSkillName("Brainstorming", dirs), "Brainstorming");
+assert.equal(rewriteBareSkillName(" superpowers/brainstorming ", dirs), "superpowers/brainstorming");
+assert.equal(rewriteBareSkillName("superpowers:brainstorming", dirs), "superpowers:brainstorming");
+assert.equal(rewriteBareSkillName("unknown-skill", dirs), "unknown-skill");
+
+makeSkill(projectSkillsDir, "brainstorming");
+assert.equal(rewriteBareSkillName("brainstorming", dirs), "brainstorming");
+
+fs.rmSync(path.join(projectSkillsDir, "brainstorming"), { recursive: true, force: true });
+makeSkill(userSkillsDir, "brainstorming");
+assert.equal(rewriteBareSkillName("brainstorming", dirs), "brainstorming");
+
+console.log("test-skill-alias-unit: PASS");

--- a/tests/opencode/test-skill-alias.sh
+++ b/tests/opencode/test-skill-alias.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== Test: Native skill bare-name alias fallback ==="
+node "$SCRIPT_DIR/test-skill-alias-unit.mjs"
+echo "=== Alias fallback unit test passed ==="


### PR DESCRIPTION
## Summary
- Add a safe bare-skill fallback for the native OpenCode `skill` tool.
- Preserve native direction (no reintroduction of custom `use_skill`/`find_skills` flow).
- Rewrite only unambiguous bare names to `superpowers/<name>`.

## Problem
When users entered bare skill names such as `brainstorming`, they could hit:
`Skill or command "brainstorming" not found. Did you mean: superpowers/brainstorming, /superpowers:brainstorming?`
This created avoidable friction because the first attempt often failed.

## Root Cause
- Native `skill` resolution in OpenCode expects namespaced identifiers for superpowers skills.
- There was no compatibility fallback for bare names.

## Changes
- Hooked `tool.execute.before` in the superpowers plugin and only intercept the native `skill` tool call.
- Added bare-name resolver with strict guards:
  1. Keep explicit namespaced/path input unchanged.
  2. Keep project/user exact matches unchanged (preserve priority).
  3. Rewrite to `superpowers/<name>` only when that superpowers skill is known.
- Added tests and runner integration for alias fallback behavior.

## Files
- `.opencode/plugins/superpowers.js`
- `.opencode/skill-alias.js`
- `tests/opencode/test-skill-alias-unit.mjs`
- `tests/opencode/test-skill-alias.sh`
- `tests/opencode/run-tests.sh`

## Verification
- `node tests/opencode/test-skill-alias-unit.mjs` ✅
- `bash tests/opencode/run-tests.sh --test test-skill-alias.sh` ✅
- Runtime check:
  - `opencode run "Use the skill tool to load brainstorming ..."` -> `Skill "superpowers/brainstorming"` ✅
  - Unknown bare skill remains not found (no over-rewrite) ✅

## Risk / Compatibility
- Scoped to native `skill` tool only.
- No behavior change for explicit namespaced skills.
- Unknown/ambiguous names are not force-rewritten.