### PR TITLE
fix(commands): forward deprecated commands to replacement skills

### DIFF
--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -2,4 +2,6 @@
 description: "Deprecated - use the superpowers:brainstorming skill instead"
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers brainstorming" skill instead.
+Note: `/superpowers:brainstorm` is deprecated and will be removed in the next major release. The new name is `/superpowers:brainstorming`.
+
+Now invoke the superpowers:brainstorming skill to handle this request.

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -2,4 +2,6 @@
 description: "Deprecated - use the superpowers:executing-plans skill instead"
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers executing-plans" skill instead.
+Note: `/superpowers:execute-plan` is deprecated and will be removed in the next major release. The new name is `/superpowers:executing-plans`.
+
+Now invoke the superpowers:executing-plans skill to handle this request.

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -2,4 +2,6 @@
 description: "Deprecated - use the superpowers:writing-plans skill instead"
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers writing-plans" skill instead.
+Note: `/superpowers:write-plan` is deprecated and will be removed in the next major release. The new name is `/superpowers:writing-plans`.
+
+Now invoke the superpowers:writing-plans skill to handle this request.


### PR DESCRIPTION
## Summary

Fixes #833

The three deprecated commands (`brainstorm`, `execute-plan`, `write-plan`) currently block skill invocation by instructing the model to just tell the user the command is deprecated. This means running `/superpowers:brainstorm` does nothing useful.

This PR changes the deprecated commands to:
1. **Inform** the user that the command is deprecated and what the new name is
2. **Forward** to the replacement skill automatically so the user's intent is still fulfilled

### Changes

| Command | Forwards to |
|---------|------------|
| `brainstorm` | `superpowers:brainstorming` |
| `execute-plan` | `superpowers:executing-plans` |
| `write-plan` | `superpowers:writing-plans` |

### Why forward instead of remove?

As discussed in #756, the maintainer prefers a deprecation period before removal. Forwarding preserves backward compatibility while ensuring the user's request is actually handled — the best of both worlds during the transition.