### PR TITLE
fix(brainstorming): leverage existing project context before asking questions

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -73,6 +73,7 @@ digraph brainstorming {
 **Understanding the idea:**
 
 - Check out the current project state first (files, docs, recent commits)
+- **Use context already in your conversation.** CLAUDE.md, memory, git status, and system reminders are loaded before you start. Never ask questions whose answers are already there (e.g., don't ask "what type of project?" when CLAUDE.md describes the project). Your first question should demonstrate awareness of this existing context.
 - Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
 - If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
 - For appropriately-scoped projects, ask questions one at a time to refine the idea


### PR DESCRIPTION
## Summary

Closes #849

The brainstorming skill's "Understanding the idea" section tells the LLM to "check out the current project state" but never explicitly states that **CLAUDE.md, memory, git status, and system reminders are already loaded in the conversation context**. This causes the LLM to treat step 1 as blank-slate discovery and ask generic questions (e.g., "What type of project is this?") even when the answers are already available.

## Changes

Added a single bullet to the "Understanding the idea" section in `skills/brainstorming/SKILL.md`:

> **Use context already in your conversation.** CLAUDE.md, memory, git status, and system reminders are loaded before you start. Never ask questions whose answers are already there (e.g., don't ask "what type of project?" when CLAUDE.md describes the project). Your first question should demonstrate awareness of this existing context.

This is placed right after the existing "Check out the current project state first" bullet, so the LLM reads the awareness instruction immediately after being told to explore context.

## Test plan

- [ ] Start a brainstorming session in a project with a detailed CLAUDE.md — verify the first question reflects project-specific context rather than generic discovery
- [ ] Start a brainstorming session in a project with no CLAUDE.md — verify normal discovery questions still work