### PR TITLE
feat(skills): add project memory workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Start a new session in your chosen platform and ask for something that should tr
 
 7. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
 
+8. **using-memory** - Retrieves only the smallest useful slice of project history, using `Use When` / `Avoid When` to choose which memory types to inspect before reading indexes or entries.
+
+9. **record-memory** - Records closed reviewable change units in `docs/superpowers/memory/`, using `Record When` / `Avoid Recording When` to choose the right memory type and repairing missing structure only when needed.
+
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
 
 ## What's Inside
@@ -137,6 +141,10 @@ Start a new session in your chosen platform and ask for something that should tr
 - **using-git-worktrees** - Parallel development branches
 - **finishing-a-development-branch** - Merge/PR decision workflow
 - **subagent-driven-development** - Fast iteration with two-stage review (spec compliance, then code quality)
+
+**Project Memory**
+- **record-memory** - Records closed reviewable change units in `docs/superpowers/memory/`, routing with `Record When` / `Avoid Recording When` and repairing structure only when needed
+- **using-memory** - Retrieves the smallest useful slice of project history, routing with `Use When` / `Avoid When` before reading `INDEX.md` or entries
 
 **Meta**
 - **writing-skills** - Create new skills following best practices (includes testing methodology)

--- a/skills/record-memory/SKILL.md
+++ b/skills/record-memory/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: record-memory
+description: Use when a closed, reviewable change unit should be recorded in docs/superpowers/memory/
+---
+
+# Record Memory
+
+## Overview
+
+Record durable project memory for a completed change unit.
+
+## Entry Conditions
+
+Create a memory entry only when all of the following are true:
+
+1. The work has one clear goal.
+2. The work forms one coherent, reviewable change unit.
+3. The work is complete enough to preserve as durable project memory.
+
+Do not use memory entries as work logs for exploration, partial work, or scattered trivial changes.
+
+## Discovery Order
+
+Every entry belongs to exactly one type.
+
+If discovery cannot identify one unique type, stop and ask the user to clarify.
+
+Discover the target type in this order:
+
+1. Scan `docs/superpowers/memory/*/MEMORY.md`.
+2. Read each candidate header's `Type`, `Record When`, `Avoid Recording When`, and `Entry Template`.
+3. Choose the best-matching type for the completed change unit.
+4. After selecting the type, read only that type's `entry.md` before writing.
+5. Write the entry under `docs/superpowers/memory/<type>/entries/<YYYY-MM>/`.
+6. Update only that type's `INDEX.md` at `docs/superpowers/memory/<type>/INDEX.md`.
+
+Do not hardcode type names or type meaning from this skill alone. Repository memory files are the source of truth.
+This skill only routes recording work. It never retrieves, summarizes, or pre-reads historical memory for the current task.
+If the task first needs project history to reduce uncertainty, hand off to `using-memory`; `Use When` / `Avoid When` are retrieval-facing fields and are not recording fallbacks.
+
+## Stop Conditions
+
+Stop and ask the user to clarify when:
+
+- multiple discovered types fit and no clear choice exists
+- no discovered type fits and a new type may be needed
+- the completed work cannot be reduced to one reviewable change unit
+
+## Bootstrap Handoff
+
+Read `bootstrap.md`, restore only the minimum missing structure, then restart discovery when:
+
+- `docs/superpowers/memory/` is missing
+- scanning finds no usable `docs/superpowers/memory/*/MEMORY.md`
+- a scanned `MEMORY.md` is missing required record-facing fields, or cannot be parsed; treat that type as structurally damaged
+- the selected type is missing `entry.md`
+- the selected type is missing `INDEX.md`
+- the selected type is missing its target month bucket under `entries/<YYYY-MM>/`

--- a/skills/record-memory/SKILL.md
+++ b/skills/record-memory/SKILL.md
@@ -30,7 +30,7 @@ Discover the target type in this order:
 1. Scan `docs/superpowers/memory/*/MEMORY.md`.
 2. Read each candidate header's `Type`, `Record When`, `Avoid Recording When`, and `Entry Template`.
 3. Choose the best-matching type for the completed change unit.
-4. After selecting the type, read only that type's `entry.md` before writing.
+4. After selecting the type, read only that type's `ENTRY.md` before writing.
 5. Write the entry under `docs/superpowers/memory/<type>/entries/<YYYY-MM>/`.
 6. Update only that type's `INDEX.md` at `docs/superpowers/memory/<type>/INDEX.md`.
 
@@ -53,6 +53,6 @@ Read `bootstrap.md`, restore only the minimum missing structure, then restart di
 - `docs/superpowers/memory/` is missing
 - scanning finds no usable `docs/superpowers/memory/*/MEMORY.md`
 - a scanned `MEMORY.md` is missing required record-facing fields, or cannot be parsed; treat that type as structurally damaged
-- the selected type is missing `entry.md`
+- the selected type is missing `ENTRY.md`
 - the selected type is missing `INDEX.md`
 - the selected type is missing its target month bucket under `entries/<YYYY-MM>/`

--- a/skills/record-memory/bootstrap.md
+++ b/skills/record-memory/bootstrap.md
@@ -11,7 +11,7 @@ Restore the minimum repository-owned memory structure so `record-memory` can res
 - Root: `docs/superpowers/memory/`
 - Type definition protocol: `docs/superpowers/memory/<type>/MEMORY.md`
 - Type index only: `docs/superpowers/memory/<type>/INDEX.md`
-- Type entry template: `docs/superpowers/memory/<type>/entry.md`
+- Type entry template: `docs/superpowers/memory/<type>/ENTRY.md`
 - Entries: `docs/superpowers/memory/<type>/entries/<YYYY-MM>/YYYY-MM-DD-N.md`
 
 ## Cold Start
@@ -26,7 +26,7 @@ When the memory root is missing, or when scanning `docs/superpowers/memory/*/MEM
 3. For each default type, create:
    - `docs/superpowers/memory/<type>/MEMORY.md`
    - `docs/superpowers/memory/<type>/INDEX.md`
-   - `docs/superpowers/memory/<type>/entry.md`
+   - `docs/superpowers/memory/<type>/ENTRY.md`
    - `docs/superpowers/memory/<type>/entries/<YYYY-MM>/`
 4. Initialize each new `INDEX.md` with the minimum index skeleton only:
    - `| Page ID | Date | Title | Path | Related Change Unit | Keywords |`
@@ -37,13 +37,13 @@ When the memory root is missing, or when scanning `docs/superpowers/memory/*/MEM
 
 When a selected type cannot be recorded to, or when a scanned `docs/superpowers/memory/<type>/MEMORY.md` is missing required retrieval-facing or record-facing fields, or cannot be parsed:
 
-- If the selected or damaged type is one of the repository-shipped defaults and its `MEMORY.md`, `INDEX.md`, or `entry.md` is missing, restore the missing docs file(s) from `template/type/<type>/`.
+- If the selected or damaged type is one of the repository-shipped defaults and its `MEMORY.md`, `INDEX.md`, or `ENTRY.md` is missing, restore the missing docs file(s) from `template/type/<type>/`.
 - If a repository-shipped default type's `MEMORY.md` exists but the file is unparsable, restore `MEMORY.md` from `template/type/<type>/MEMORY.md`.
 - If `INDEX.md` is missing for any recoverable type, restore it as the minimum index-only file using the fixed two-line skeleton:
   - `| Page ID | Date | Title | Path | Related Change Unit | Keywords |`
   - `| --- | --- | --- | --- | --- | --- |`
 - If only `entries/<YYYY-MM>/` is missing, create only that month bucket.
-- If the selected or damaged type is custom and its `MEMORY.md` still exists with intact, parseable retrieval-facing and record-facing sections, treat the type as recoverable: restore a missing `INDEX.md` with the minimum index-only skeleton, restore a missing `entry.md` with the minimum structure needed, and create a missing `entries/<YYYY-MM>/` bucket directly.
+- If the selected or damaged type is custom and its `MEMORY.md` still exists with intact, parseable retrieval-facing and record-facing sections, treat the type as recoverable: restore a missing `INDEX.md` with the minimum index-only skeleton, restore a missing `ENTRY.md` with the minimum structure needed, and create a missing `entries/<YYYY-MM>/` bucket directly.
 - If the selected or damaged type is custom and its `MEMORY.md` is missing, lacks required retrieval-facing or record-facing sections, is unparsable, or the type semantics cannot be recovered from that file, stop and ask the user to confirm or provide that type's semantics before restoring anything. Never use `INDEX.md` to recover type semantics or routing decisions.
 
 ## New Type Introduction
@@ -53,11 +53,11 @@ When no existing type fits and the user explicitly confirms a new one:
 1. Start from:
    - `template/type/base/MEMORY.md`
    - `template/type/base/INDEX.md`
-   - `template/type/base/entry.md`
+   - `template/type/base/ENTRY.md`
 2. Create:
    - `docs/superpowers/memory/<type>/MEMORY.md`
    - `docs/superpowers/memory/<type>/INDEX.md`
-   - `docs/superpowers/memory/<type>/entry.md`
+   - `docs/superpowers/memory/<type>/ENTRY.md`
    - `docs/superpowers/memory/<type>/entries/<YYYY-MM>/`
 3. In the new `docs/superpowers/memory/<type>/MEMORY.md`, set:
     - `## Type` to the confirmed type name
@@ -65,7 +65,7 @@ When no existing type fits and the user explicitly confirms a new one:
     - `## Avoid When` to the confirmed retrieval cues for when `using-memory` should skip this type
     - `## Record When` to the confirmed recording cues for this type
     - `## Avoid Recording When` to the confirmed non-fit cues for this type
-    - `## Entry Template` to `docs/superpowers/memory/<type>/entry.md`
+    - `## Entry Template` to `docs/superpowers/memory/<type>/ENTRY.md`
 4. If the user can only confirm recording cues or only confirm retrieval cues, stop and ask for the missing field semantics before creating the new type. Do not invent one side from the other.
 5. Initialize the new `docs/superpowers/memory/<type>/INDEX.md` as an index-only file with the fixed two-line skeleton and no type semantics.
 6. The new type becomes discoverable immediately because `record-memory` and `using-memory` both scan `docs/superpowers/memory/*/MEMORY.md` directly.

--- a/skills/record-memory/bootstrap.md
+++ b/skills/record-memory/bootstrap.md
@@ -1,0 +1,82 @@
+# Record Memory Bootstrap
+
+Use this file only when `docs/superpowers/memory/` is missing, when scanning finds no usable type definitions, or when a selected or scanned type has structurally damaged docs that must be restored.
+
+## Goal
+
+Restore the minimum repository-owned memory structure so `record-memory` can resume direct type discovery and recording.
+
+## Canonical Paths
+
+- Root: `docs/superpowers/memory/`
+- Type definition protocol: `docs/superpowers/memory/<type>/MEMORY.md`
+- Type index only: `docs/superpowers/memory/<type>/INDEX.md`
+- Type entry template: `docs/superpowers/memory/<type>/entry.md`
+- Entries: `docs/superpowers/memory/<type>/entries/<YYYY-MM>/YYYY-MM-DD-N.md`
+
+## Cold Start
+
+When the memory root is missing, or when scanning `docs/superpowers/memory/*/MEMORY.md` finds no usable type definitions:
+
+1. Create `docs/superpowers/memory/`.
+2. Create the repository-shipped default types from `template/type/`:
+   - `milestone`
+   - `debug`
+   - `refactor`
+3. For each default type, create:
+   - `docs/superpowers/memory/<type>/MEMORY.md`
+   - `docs/superpowers/memory/<type>/INDEX.md`
+   - `docs/superpowers/memory/<type>/entry.md`
+   - `docs/superpowers/memory/<type>/entries/<YYYY-MM>/`
+4. Initialize each new `INDEX.md` with the minimum index skeleton only:
+   - `| Page ID | Date | Title | Path | Related Change Unit | Keywords |`
+   - `| --- | --- | --- | --- | --- | --- |`
+5. After structure exists, return to `SKILL.md` and restart discovery by scanning type-local `MEMORY.md` files.
+
+## Existing Type Repair
+
+When a selected type cannot be recorded to, or when a scanned `docs/superpowers/memory/<type>/MEMORY.md` is missing required retrieval-facing or record-facing fields, or cannot be parsed:
+
+- If the selected or damaged type is one of the repository-shipped defaults and its `MEMORY.md`, `INDEX.md`, or `entry.md` is missing, restore the missing docs file(s) from `template/type/<type>/`.
+- If a repository-shipped default type's `MEMORY.md` exists but the file is unparsable, restore `MEMORY.md` from `template/type/<type>/MEMORY.md`.
+- If `INDEX.md` is missing for any recoverable type, restore it as the minimum index-only file using the fixed two-line skeleton:
+  - `| Page ID | Date | Title | Path | Related Change Unit | Keywords |`
+  - `| --- | --- | --- | --- | --- | --- |`
+- If only `entries/<YYYY-MM>/` is missing, create only that month bucket.
+- If the selected or damaged type is custom and its `MEMORY.md` still exists with intact, parseable retrieval-facing and record-facing sections, treat the type as recoverable: restore a missing `INDEX.md` with the minimum index-only skeleton, restore a missing `entry.md` with the minimum structure needed, and create a missing `entries/<YYYY-MM>/` bucket directly.
+- If the selected or damaged type is custom and its `MEMORY.md` is missing, lacks required retrieval-facing or record-facing sections, is unparsable, or the type semantics cannot be recovered from that file, stop and ask the user to confirm or provide that type's semantics before restoring anything. Never use `INDEX.md` to recover type semantics or routing decisions.
+
+## New Type Introduction
+
+When no existing type fits and the user explicitly confirms a new one:
+
+1. Start from:
+   - `template/type/base/MEMORY.md`
+   - `template/type/base/INDEX.md`
+   - `template/type/base/entry.md`
+2. Create:
+   - `docs/superpowers/memory/<type>/MEMORY.md`
+   - `docs/superpowers/memory/<type>/INDEX.md`
+   - `docs/superpowers/memory/<type>/entry.md`
+   - `docs/superpowers/memory/<type>/entries/<YYYY-MM>/`
+3. In the new `docs/superpowers/memory/<type>/MEMORY.md`, set:
+    - `## Type` to the confirmed type name
+    - `## Use When` to the confirmed retrieval cues for when `using-memory` should consult this type
+    - `## Avoid When` to the confirmed retrieval cues for when `using-memory` should skip this type
+    - `## Record When` to the confirmed recording cues for this type
+    - `## Avoid Recording When` to the confirmed non-fit cues for this type
+    - `## Entry Template` to `docs/superpowers/memory/<type>/entry.md`
+4. If the user can only confirm recording cues or only confirm retrieval cues, stop and ask for the missing field semantics before creating the new type. Do not invent one side from the other.
+5. Initialize the new `docs/superpowers/memory/<type>/INDEX.md` as an index-only file with the fixed two-line skeleton and no type semantics.
+6. The new type becomes discoverable immediately because `record-memory` and `using-memory` both scan `docs/superpowers/memory/*/MEMORY.md` directly.
+7. Return to `SKILL.md` and continue normal discovery.
+
+## Constraints
+
+- Create only the minimum missing structure needed for the current recording task.
+- Treat `INDEX.md` as index-only state, never as a source for type discovery, semantic recovery, or routing.
+- Never leave `Entry Template` as a placeholder.
+- Never leave a newly created type without both retrieval-facing fields (`Use When` / `Avoid When`) and record-facing fields (`Record When` / `Avoid Recording When`).
+- Keep `MEMORY.md` as the only repository-owned source of type semantics unless the user explicitly confirms replacements.
+- Do not invent custom type semantics without user confirmation.
+- Do not overwrite existing memory entries.

--- a/skills/record-memory/template/type/base/INDEX.md
+++ b/skills/record-memory/template/type/base/INDEX.md
@@ -1,0 +1,2 @@
+| Page ID | Date | Title | Path | Related Change Unit | Keywords |
+| --- | --- | --- | --- | --- | --- |

--- a/skills/record-memory/template/type/base/MEMORY.md
+++ b/skills/record-memory/template/type/base/MEMORY.md
@@ -1,0 +1,17 @@
+## Type
+[type-name]
+
+## Use When
+[what kind of past memory someone should retrieve this type for]
+
+## Avoid When
+[what retrieval intent should be routed away from this type]
+
+## Record When
+[what kind of completed work should be written as this type]
+
+## Avoid Recording When
+[what kind of completed work should not be written as this type, even if related]
+
+## Entry Template
+`docs/superpowers/memory/[type-name]/entry.md`

--- a/skills/record-memory/template/type/base/MEMORY.md
+++ b/skills/record-memory/template/type/base/MEMORY.md
@@ -14,4 +14,4 @@
 [what kind of completed work should not be written as this type, even if related]
 
 ## Entry Template
-`docs/superpowers/memory/[type-name]/entry.md`
+`docs/superpowers/memory/[type-name]/ENTRY.md`

--- a/skills/record-memory/template/type/base/entry.md
+++ b/skills/record-memory/template/type/base/entry.md
@@ -1,0 +1,29 @@
+# YYYY-MM-DD-N
+
+## Date
+YYYY-MM-DD
+
+## Type
+[type-name]
+
+## Title
+[Short memory title]
+
+## Why This Matters
+[Why this change unit is worth remembering]
+
+## Direction
+[What larger direction, closure, or conclusion this memory preserves]
+
+## Boundary
+[What belongs to this memory unit and what does not]
+
+## Lasting Guidance
+- [What future readers should preserve]
+- [What future readers should avoid or re-check]
+
+## Related Commits
+- abc123d type(scope): summary
+
+## Links
+- Spec/Plan: [optional path]

--- a/skills/record-memory/template/type/debug/INDEX.md
+++ b/skills/record-memory/template/type/debug/INDEX.md
@@ -1,0 +1,2 @@
+| Page ID | Date | Title | Path | Related Change Unit | Keywords |
+| --- | --- | --- | --- | --- | --- |

--- a/skills/record-memory/template/type/debug/MEMORY.md
+++ b/skills/record-memory/template/type/debug/MEMORY.md
@@ -18,4 +18,4 @@ debug
 - The work is mainly about maintainability or architectural cleanup.
 
 ## Entry Template
-`docs/superpowers/memory/debug/entry.md`
+`docs/superpowers/memory/debug/ENTRY.md`

--- a/skills/record-memory/template/type/debug/MEMORY.md
+++ b/skills/record-memory/template/type/debug/MEMORY.md
@@ -1,0 +1,21 @@
+## Type
+debug
+
+## Use When
+- You want historical context about a concrete failure, its root cause, and why the fix was trusted.
+- You need prior debugging evidence that explains how the issue happened and how it was verified closed.
+
+## Avoid When
+- You are mainly looking for how a new capability or workflow was shaped.
+- You are mainly looking for maintainability or architectural cleanup history.
+
+## Record When
+- The work closes a concrete failure loop with confirmed symptom, root cause, and verification.
+- The main value to preserve is why the issue happened and why the closure is trustworthy.
+
+## Avoid Recording When
+- The work is mainly about delivering a new capability or workflow.
+- The work is mainly about maintainability or architectural cleanup.
+
+## Entry Template
+`docs/superpowers/memory/debug/entry.md`

--- a/skills/record-memory/template/type/debug/entry.md
+++ b/skills/record-memory/template/type/debug/entry.md
@@ -1,0 +1,29 @@
+# YYYY-MM-DD-N
+
+## Date
+YYYY-MM-DD
+
+## Type
+debug
+
+## Title
+[Short issue-oriented title]
+
+## Why This Closure Matters
+[Why this debugging closure is worth remembering]
+
+## Symptom and Root Cause
+[What failed and what was confirmed as the cause]
+
+## Closure Boundary
+[What this fix closes and what it does not claim to solve]
+
+## Verification Signal
+- [What evidence made the closure trustworthy]
+- [What future readers should re-check if the issue reappears]
+
+## Related Commits
+- abc123d type(scope): summary
+
+## Links
+- Spec/Plan: [optional path]

--- a/skills/record-memory/template/type/milestone/INDEX.md
+++ b/skills/record-memory/template/type/milestone/INDEX.md
@@ -1,0 +1,2 @@
+| Page ID | Date | Title | Path | Related Change Unit | Keywords |
+| --- | --- | --- | --- | --- | --- |

--- a/skills/record-memory/template/type/milestone/MEMORY.md
+++ b/skills/record-memory/template/type/milestone/MEMORY.md
@@ -1,0 +1,21 @@
+## Type
+milestone
+
+## Use When
+- You want historical context about a major direction choice, stage transition, or decision that changed what the work was aiming toward.
+- You need prior reasoning about why a product, workflow, or project direction was chosen over alternatives.
+
+## Avoid When
+- You are mainly looking for debugging evidence, root cause, or fix verification.
+- You are mainly looking for how a structure was cleaned up, split, or reorganized without the decision itself being the main historical value.
+
+## Record When
+- The work closes a major direction choice, stage transition, or decision that should guide later work.
+- The main value to preserve is the direction or decision itself: why it was chosen, what it unlocked, or what it committed the project to next.
+
+## Avoid Recording When
+- The main value is debugging evidence or root-cause closure.
+- The main value is structural cleanup, boundary improvement, or internal reorganization, even if it supported a larger milestone.
+
+## Entry Template
+`docs/superpowers/memory/milestone/entry.md`

--- a/skills/record-memory/template/type/milestone/MEMORY.md
+++ b/skills/record-memory/template/type/milestone/MEMORY.md
@@ -18,4 +18,4 @@ milestone
 - The main value is structural cleanup, boundary improvement, or internal reorganization, even if it supported a larger milestone.
 
 ## Entry Template
-`docs/superpowers/memory/milestone/entry.md`
+`docs/superpowers/memory/milestone/ENTRY.md`

--- a/skills/record-memory/template/type/milestone/entry.md
+++ b/skills/record-memory/template/type/milestone/entry.md
@@ -1,0 +1,29 @@
+# YYYY-MM-DD-N
+
+## Date
+YYYY-MM-DD
+
+## Type
+milestone
+
+## Title
+[Short direction-oriented title]
+
+## Why This Direction
+[Why this plan or direction was chosen]
+
+## Direction
+[What larger product, architecture, or workflow direction this change unit establishes]
+
+## Boundary
+[What belongs to this change unit and what does not]
+
+## Lasting Impact
+- [What future readers should preserve or continue]
+- [What assumption or constraint now matters]
+
+## Related Commits
+- abc123d type(scope): summary
+
+## Links
+- Spec/Plan: [optional path]

--- a/skills/record-memory/template/type/refactor/INDEX.md
+++ b/skills/record-memory/template/type/refactor/INDEX.md
@@ -1,0 +1,2 @@
+| Page ID | Date | Title | Path | Related Change Unit | Keywords |
+| --- | --- | --- | --- | --- | --- |

--- a/skills/record-memory/template/type/refactor/MEMORY.md
+++ b/skills/record-memory/template/type/refactor/MEMORY.md
@@ -18,4 +18,4 @@ refactor
 - The main value is fixing a concrete failure mode.
 
 ## Entry Template
-`docs/superpowers/memory/refactor/entry.md`
+`docs/superpowers/memory/refactor/ENTRY.md`

--- a/skills/record-memory/template/type/refactor/MEMORY.md
+++ b/skills/record-memory/template/type/refactor/MEMORY.md
@@ -1,0 +1,21 @@
+## Type
+refactor
+
+## Use When
+- You want historical context about a meaningful structural cleanup or boundary improvement.
+- You need prior decisions that explain why the old shape was a burden and what new shape should be maintained.
+
+## Avoid When
+- You are mainly looking for a major direction choice, stage transition, or milestone decision.
+- You are mainly looking for debugging history about a concrete failure mode.
+
+## Record When
+- The work closes a meaningful structural cleanup or boundary improvement.
+- The main value to preserve is why the old structure was a burden and what cleaner shape, boundary, or maintenance rule should be kept.
+
+## Avoid Recording When
+- The main value is a direction choice, milestone decision, or stage transition rather than the cleanup itself.
+- The main value is fixing a concrete failure mode.
+
+## Entry Template
+`docs/superpowers/memory/refactor/entry.md`

--- a/skills/record-memory/template/type/refactor/entry.md
+++ b/skills/record-memory/template/type/refactor/entry.md
@@ -1,0 +1,29 @@
+# YYYY-MM-DD-N
+
+## Date
+YYYY-MM-DD
+
+## Type
+refactor
+
+## Title
+[Short structure-oriented title]
+
+## Why This Refactor
+[Why this structural direction was chosen]
+
+## Structural Shift
+[What maintenance burden or boundary problem changed]
+
+## Boundary
+[What structural area this refactor covers and what remains outside it]
+
+## Lasting Guidance
+- [What future readers should preserve in the new structure]
+- [What old pattern should not return]
+
+## Related Commits
+- abc123d type(scope): summary
+
+## Links
+- Spec/Plan: [optional path]

--- a/skills/using-memory/SKILL.md
+++ b/skills/using-memory/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: using-memory
+description: Use when design, planning, or implementation may depend on prior project decisions, existing boundaries, or earlier similar work
+---
+
+# Using Memory
+
+## Overview
+
+Use project memory only when history can materially improve the current decision.
+
+This skill is retrieval-only. It helps find the smallest amount of relevant history, then stop.
+
+## When to Use
+
+Memory is worth consulting when one or more of these are true:
+
+- current work depends on why something was designed, fixed, or reorganized before
+- the task may already have a precedent worth reusing
+- the task needs to stay consistent with earlier project decisions or boundaries
+- several reasonable directions exist and project history may narrow the choice
+
+Do not use memory when the current request, code, spec, and plan already make the path clear.
+Do not keep reading once extra history would add background but not change the decision.
+
+## Retrieval Order
+
+1. Start by scanning `docs/superpowers/memory/*/MEMORY.md`.
+2. Use `grep` to find only the `## Use When` and `## Avoid When` field titles first.
+3. Use the reported line numbers to `read` only small windows around those sections.
+4. Expand the read window only if the section boundary is still unclear.
+5. Choose the smallest useful set of candidate memory types.
+6. Only after choosing candidate types, inspect their `INDEX.md` files.
+7. From those candidates, inspect only the specific entries that look relevant.
+8. Stop as soon as the current task has enough history to move forward.
+
+`MEMORY.md` files define when a type is worth consulting. `INDEX.md` helps find likely entries inside a chosen type. Specific entries provide evidence only after the type has already been chosen.
+
+If `docs/superpowers/memory/` is missing, or scanning finds no usable `MEMORY.md` files, stop and report that no project memory is available. This skill does not create or repair memory structure.
+
+## Stop Conditions
+
+Stop reading when any of these are true:
+
+- you can tell whether relevant precedent exists
+- you have the 1-3 history constraints that matter for the task
+- you know the needed background well enough to continue safely
+- reading more would add detail but not change the decision
+- continuing would require whole-file or whole-index reading instead of targeted lookup
+
+Never:
+
+- reading whole `MEMORY.md` files by default
+- treating `INDEX.md` as type-definition metadata
+- doing global history summaries when the task only needs local precedent
+- writing new memory entries from the retrieval skill
+- reading entries before deciding which memory type is worth consulting
+
+## Output Contract
+
+Return only:
+
+- whether relevant memory was found
+- the small set of sources used
+- the history facts or constraints that matter now
+- any open questions that still need another source

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -124,6 +124,8 @@ From 24 failure memories:
 - Moving to next task
 - Delegating to agents
 
+After verification confirms a closed change unit, check whether the repository expects a memory decision. If memory recording is part of the repository workflow, invoke `record-memory` to decide whether this completed unit should be recorded before closing the task.
+
 **Rule applies to:**
 - Exact phrases
 - Paraphrases and synonyms


### PR DESCRIPTION
## What problem are you trying to solve?

Superpowers currently has no core workflow for preserving and reusing durable project memory across sessions.

Closes #551 

That shows up in two ways:

- new sessions do not have a structured way to retrieve small, relevant pieces of prior project history before continuing design or implementation work
- completed work leaves behind commits and code, but not a durable memory workflow for preserving why a decision mattered or what future sessions should keep consistent

Superpowers needs a general-purpose memory system. This PR is one concrete solution to that problem.

## What does this PR change?

This PR introduces one concrete memory workflow in core Superpowers:

- adds `using-memory` for incremental retrieval of relevant project history
- adds `record-memory` for recording closed, reviewable change units as durable memory
- updates README and verification integration to reflect the new memory workflow

It also replaces the older `memory-tracker` naming and updates the shipped memory type templates so retrieval and recording use separate routing fields.

The core design is:

- one skill for retrieval (`using-memory`)
- one skill for recording (`record-memory`)
- one repository-owned memory layout under `docs/superpowers/memory/`

The resulting directory structure is:

```text
docs/superpowers/memory/
  <type>/
    MEMORY.md
    INDEX.md
    ENTRY.md
    entries/
      YYYY-MM/
        YYYY-MM-DD-N.md
```

This PR also includes the context-engineering rules needed to keep retrieval cheap and predictable:

- `MEMORY.md` is the type-definition layer
- `INDEX.md` is an index-only lookup layer
- entry files are evidence, not discovery metadata
- retrieval follows progressive disclosure instead of broad reads

In practice, `using-memory` is designed to:

1. scan `docs/superpowers/memory/*/MEMORY.md`
2. `grep` only `Use When` / `Avoid When`
3. read only small windows around those fields
4. choose candidate types before touching `INDEX.md`
5. inspect only the smallest useful number of entries
6. stop once the task has enough history to move forward

`record-memory` follows the complementary write path:

1. confirm the work is one closed, reviewable change unit
2. scan type-local `MEMORY.md` files
3. route with `Record When` / `Avoid Recording When`
4. write a single durable entry and update only that type's `INDEX.md`

## Is this change appropriate for the core library?

Yes.

This is general workflow infrastructure for multi-session agentic development. It is not tied to one domain, one repository layout outside Superpowers' own docs area, or any third-party tool or service. The same need appears in feature work, debugging, refactoring, and long-running design iteration.

## What alternatives did you consider?

I considered three broader alternatives before landing on this implementation:

1. using spec and plan documents as the memory system
2. using git commits as the memory system
3. relying on always-loaded markdown files such as `AGENTS.md` or `CLAUDE.md` instead of introducing a dedicated workflow

I rejected them because they either make retrieval too expensive, fail to preserve reusable project history in a disciplined form, or cause context rot by mixing historical memory into always-loaded instruction files. This PR's memory workflow is intended to complement existing artifacts, not replace them.

## Does this PR contain multiple unrelated changes?

No.

The changes are related parts of one memory-workflow refactor:

- retrieval skill
- recording skill
- type routing/template updates needed to support both
- minimal README / verification updates needed to integrate them coherently

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #555 

`#555` explored the same general problem space. This PR narrows the solution to a memory workflow split between retrieval and recording.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| OpenCode | current local CLI | gpt-5.4 | openai/gpt-5.4 |

## Evaluation
- Initial prompt: design a memory-oriented workflow that supports both recording and retrieval while keeping context use small
- Evaluation so far: I have tried parts of this workflow in a few of my own projects, but not with broad or deep usage yet
- Before: the proposal centered on a single progress-style skill and did not clearly teach agents how to retrieve prior memory with minimal context
- After: the workflow is split into retrieval and recording, retrieval now follows a clear incremental path, and the memory type protocol distinguishes lookup routing from recording routing

This PR is intended as a draft. I have tried this workflow in a few of my own projects, but not with broad or deep enough usage to treat the current shape as fully proven.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Adversarial / review results used during development:

- checked whether retrieval and recording were being incorrectly injected at the same lifecycle point
- checked whether `using-memory` could be discovered with a minimal description instead of broader workflow injection
- checked whether retrieval was truly incremental instead of degenerating into whole-file reads
- checked whether default memory types were hardcoded into runtime routing instead of discovered from type-local files
- checked whether the new skills matched repository naming and writing style closely enough to feel native

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
