### PR TITLE
docs: mention OpenClaw Skills version community adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Skills update automatically when you update the plugin:
 
 MIT License - see LICENSE file for details
 
+## Community Implementations
+
+- **OpenClaw Skills version** - an OpenClaw-adapted Skills edition, maintained separately at https://github.com/KarasawaYikiho/Superpower-Skills
+
+This is a downstream Skills-oriented adaptation rather than the canonical upstream repository layout.
+
 ## Community
 
 Superpowers is built by [Jesse Vincent](https://blog.fsck.com) and the rest of the folks at [Prime Radiant](https://primeradiant.com).


### PR DESCRIPTION
## Summary
- add a README note for the OpenClaw Skills version
- link to the separately maintained downstream repository
- clarify that it is a Skills-oriented adaptation, not the canonical upstream layout

## Why
I built and maintain an OpenClaw-adapted Skills edition of Superpowers here:
https://github.com/KarasawaYikiho/Superpower-Skills

This PR does **not** try to replace upstream structure or behavior.
It only adds a small README pointer so users can discover the separate Skills version.

## Notes
- this is intentionally documentation-only
- wording explicitly marks it as a downstream/community adaptation