### PR TITLE
fix(subagent-prompts): instruct subagents to read CLAUDE.md for project conventions

### DIFF
--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -17,6 +17,8 @@ Task tool (superpowers:code-reviewer):
   DESCRIPTION: [task summary]
 ```
 
+**If the project has a CLAUDE.md (or AGENTS.md), read it — use its conventions as review criteria.**
+
 **In addition to standard code quality concerns, the reviewer should check:**
 - Does each file have one clear responsibility with a well-defined interface?
 - Are units decomposed so they can be understood and tested independently?

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -18,6 +18,8 @@ Task tool (general-purpose):
 
     ## Before You Begin
 
+    Read CLAUDE.md (or AGENTS.md) in the project root if it exists — its conventions are binding on your work.
+
     If you have questions about:
     - The requirements or acceptance criteria
     - The approach or implementation strategy

--- a/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -36,6 +36,8 @@ Task tool (general-purpose):
 
     ## Your Job
 
+    If the project has a CLAUDE.md (or AGENTS.md), read it — verify the implementation follows its conventions.
+
     Read the implementation code and verify:
 
     **Missing requirements:**


### PR DESCRIPTION
## Summary

- Adds a one-liner to each of the three subagent dispatch templates instructing subagents to read CLAUDE.md (or AGENTS.md) before starting work
- **implementer-prompt.md**: "Read CLAUDE.md... its conventions are binding on your work" in the Before You Begin section
- **spec-reviewer-prompt.md**: "verify the implementation follows its conventions" in the Your Job section  
- **code-quality-reviewer-prompt.md**: "use its conventions as review criteria" before the review checklist

## Why

Subagents spawned via the Agent tool start with a fresh context — no CLAUDE.md pre-loaded. They pattern-match existing code well, but miss cross-cutting conventions only documented in CLAUDE.md (test location, DB mocking policy, architectural boundaries, error format conventions).

RED/GREEN tested across multiple scenarios including legacy codebases with conflicting patterns. Without the fix, subagents copy legacy anti-patterns (if/else, try/catch, console.log, argument mutation). With the fix, subagents read CLAUDE.md first and follow its conventions over conflicting existing code.

## Test plan

- [x] RED tested: subagents without fix copy legacy patterns from existing code
- [x] GREEN tested: subagents with fix read CLAUDE.md and follow its conventions over conflicting code
- [x] Verified fix works with empty projects (CLAUDE.md only, no existing code)
- [x] Verified fix works with conflicting legacy code (no disclaimer comments)
- [ ] Manual verification in a real SDD workflow

Closes #793
Related: #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)