### PR TITLE
fix: sync package.json version and remove external skill reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "type": "module",
   "main": ".opencode/plugins/superpowers.js"
 }

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -113,7 +113,7 @@ digraph brainstorming {
 
 - Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
-- Use elements-of-style:writing-clearly-and-concisely skill if available
+- Write clearly and concisely — prefer short sentences, active voice, and plain language
 - Commit the design document to git
 
 **Spec Review Loop:**


### PR DESCRIPTION
## Summary

- **Version sync:** `package.json` says `5.0.4` but `.claude-plugin/plugin.json` says `5.0.5`. Updated `package.json` to match.
- **External skill reference:** `skills/brainstorming/SKILL.md` line 116 references `elements-of-style:writing-clearly-and-concisely`, a skill that doesn't exist in this project. Replaced with inline writing guidance that conveys the same intent without depending on an external skill.

## Test plan

- [ ] Verify `package.json` version matches `plugin.json`
- [ ] Verify brainstorming skill still reads naturally at line 116
- [ ] No behavioral changes — documentation/metadata only