### PR TITLE
fix: add Copilot CLI platform detection for sessionStart context injection

### DIFF
--- a/hooks/session-start
+++ b/hooks/session-start
@@ -35,23 +35,23 @@ warning_escaped=$(escape_for_json "$warning_message")
 session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
-# Cursor hooks expect additional_context.
-# Claude Code hooks expect hookSpecificOutput.additionalContext.
-# Claude Code reads BOTH fields without deduplication, so we must only
-# emit the field consumed by the current platform to avoid double injection.
+# Cursor hooks expect additional_context (snake_case).
+# Claude Code hooks expect hookSpecificOutput.additionalContext (nested).
+# Copilot CLI and others expect additionalContext (top-level, SDK standard).
+# Claude Code reads BOTH additional_context and hookSpecificOutput without
+# deduplication, so we must emit only the field the current platform consumes.
 #
-# Uses printf instead of heredoc (cat <<EOF) to work around a bash 5.3+
-# bug where heredoc variable expansion hangs when content exceeds ~512 bytes.
+# Uses printf instead of heredoc to work around bash 5.3+ heredoc hang.
 # See: https://github.com/obra/superpowers/issues/571
 if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
-  # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT) — emit additional_context
+  # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
   printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
-elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
-  # Claude Code sets CLAUDE_PLUGIN_ROOT — emit only hookSpecificOutput
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
+  # Claude Code sets CLAUDE_PLUGIN_ROOT without COPILOT_CLI
   printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context"
 else
-  # Other platforms — emit additional_context as fallback
-  printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
+  # Copilot CLI (sets COPILOT_CLI) or unknown platform — SDK standard format
+  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
 fi
 
 exit 0


### PR DESCRIPTION
# fix: add Copilot CLI platform detection for sessionStart context injection

## What problem are you trying to solve?

Copilot CLI v1.0.11 now reads `additionalContext` from sessionStart hook output, but the `session-start` script only emits the Claude Code-specific nested format (`hookSpecificOutput.additionalContext`). Copilot CLI never receives the bootstrap context.

Fixes #792

## What does this PR change?

Adds `COPILOT_CLI` env var detection to `hooks/session-start` so Copilot CLI gets top-level `additionalContext` (SDK standard) while Claude Code continues getting `hookSpecificOutput`.

## Is this change appropriate for the core library?

Yes — platform detection infrastructure that makes the existing bootstrap work on Copilot CLI.

## What alternatives did you consider?

1. **Emit both fields in one JSON** — Rejected. Claude Code reads both `additional_context` and `hookSpecificOutput` without deduplication (bug fixed in 74f2b1c), so adding a top-level field risks double injection.
2. **Emit only top-level `additionalContext`** — Would break Claude Code.

## Does this PR contain multiple unrelated changes?

No.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #660 (duplication fix, committed as 74f2b1c), #722 and #533 (Copilot CLI support — closed, too broad)

## Environment tested

| Harness     | Version | Model           | Model version/ID |
|-------------|---------|-----------------|------------------|
| Copilot CLI | 1.0.11  | Claude Opus 4.6 | claude-opus-4.6  |

## Evaluation

- Tested all 4 platform branches (Cursor, Copilot CLI, Claude Code, fallback) with assertion-based JSON validation
- Live-tested on Copilot CLI 1.0.11: agent auto-invoked `skill(using-superpowers)` and `skill(brainstorming)` at session start
- Confirmed `COPILOT_CLI=1` is set by Copilot CLI runtime

## Rigor

- [x] This change was only tested on Copilot CLI v1.0.11 — Claude Code and Cursor were not available for testing
- [x] I did not modify carefully-tuned content without extensive evals

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

---

**Question for @obra**: Is detecting `COPILOT_CLI` env var the right approach here, or would you prefer a different mechanism? Happy to adjust if there's a better way to distinguish Copilot CLI from Claude Code (both set `CLAUDE_PLUGIN_ROOT`).
