### PR TITLE
fix: sync version across gemini-extension.json and OpenCode docs

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -52,7 +52,7 @@ To pin a specific version:
 
 ```json
 {
-  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git#v5.0.3"]
+  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git#v5.0.5"]
 }
 ```
 

--- a/docs/README.opencode.md
+++ b/docs/README.opencode.md
@@ -84,7 +84,7 @@ To pin a specific version, use a branch or tag:
 
 ```json
 {
-  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git#v5.0.3"]
+  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git#v5.0.5"]
 }
 ```
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
   "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "5.0.0",
+  "version": "5.0.5",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary

- **gemini-extension.json** version is `5.0.0` but plugin.json and marketplace.json are at `5.0.5`. Updated to match.
- **OpenCode docs** (`.opencode/INSTALL.md` and `docs/README.opencode.md`) pin examples reference `v5.0.3` which is two releases behind. Updated to `v5.0.5`.

**Note:** `package.json` version sync (`5.0.4` → `5.0.5`) is handled separately in #909.

## Test plan

- [ ] Verify all version references are consistent across manifests
- [ ] No behavioral changes — metadata and documentation only