### PR TITLE
fix(code-review): fix placeholder mismatch in reviewer template

### DIFF
--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -15,7 +15,7 @@ You are reviewing code changes for production readiness.
 
 ## Requirements/Plan
 
-{PLAN_REFERENCE}
+{PLAN_OR_REQUIREMENTS}
 
 ## Git Range to Review
 


### PR DESCRIPTION
## What problem are you trying to solve?

The `code-reviewer.md` template has two placeholder locations for the requirements/plan section:

- **Line 7:** `{PLAN_OR_REQUIREMENTS}` (correct — matches `SKILL.md` docs)
- **Line 18:** `{PLAN_REFERENCE}` (wrong — not in `SKILL.md` placeholder list)

The `requesting-code-review/SKILL.md` documents these placeholders for callers:
```
{WHAT_WAS_IMPLEMENTED}, {PLAN_OR_REQUIREMENTS}, {BASE_SHA}, {HEAD_SHA}, {DESCRIPTION}
```

Since `{PLAN_REFERENCE}` is not in that list, callers never fill it. The reviewer agent sees a literal `{PLAN_REFERENCE}` string in the Requirements/Plan section instead of the actual plan content.

## What does this PR change?

Replaces `{PLAN_REFERENCE}` with `{PLAN_OR_REQUIREMENTS}` on line 18 of `code-reviewer.md` to match line 7 and the `SKILL.md` placeholder documentation.

## Is this change appropriate for the core library?

Yes — this fixes a broken placeholder in a core agent template. The code reviewer is general-purpose infrastructure used by all users.

## What alternatives did you consider?

1. **Add `{PLAN_REFERENCE}` to the SKILL.md placeholder list** — Rejected because callers already use `{PLAN_OR_REQUIREMENTS}` based on the documented API. Adding a second name for the same thing creates confusion.
2. **Update all callers to also fill `{PLAN_REFERENCE}`** — Rejected because it spreads the inconsistency rather than fixing it at the source.

## Does this PR contain multiple unrelated changes?

No. Single placeholder name fix.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 1.0.33 | Claude | claude-opus-4-20250514 |

## Evaluation

- Initial prompt: "Audit code reviewer template placeholders against SKILL.md documentation"
- Verified by searching all callers of the code-reviewer template and confirming they use `{PLAN_OR_REQUIREMENTS}`, not `{PLAN_REFERENCE}`.
- Before: the Requirements/Plan section showed literal `{PLAN_REFERENCE}`. After: it correctly receives the plan content.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This changes a placeholder name in an agent template, not behavior-shaping prose.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission