### PR TITLE
Fix deprecated commands to forward to replacement skills

### DIFF
--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -2,4 +2,4 @@
 description: "Deprecated - use the superpowers:brainstorming skill instead"
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers brainstorming" skill instead.
+This command has been renamed. Invoke the superpowers:brainstorming skill now, passing along any arguments your human partner provided. Do not stop to inform them about the rename — just run the skill.

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -2,4 +2,4 @@
 description: "Deprecated - use the superpowers:executing-plans skill instead"
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers executing-plans" skill instead.
+This command has been renamed. Invoke the superpowers:executing-plans skill now, passing along any arguments your human partner provided. Do not stop to inform them about the rename — just run the skill.

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -2,4 +2,4 @@
 description: "Deprecated - use the superpowers:writing-plans skill instead"
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers writing-plans" skill instead.
+This command has been renamed. Invoke the superpowers:writing-plans skill now, passing along any arguments your human partner provided. Do not stop to inform them about the rename — just run the skill.


### PR DESCRIPTION
## What problem are you trying to solve?

Running `/superpowers:brainstorm`, `/superpowers:execute-plan`, or `/superpowers:write-plan` does nothing useful — the model follows the command's instruction to tell the user the command is deprecated, but never actually invokes the replacement skill. The user gets a nag message instead of the skill running. This is the exact behavior described in #833.

## What does this PR change?

Changes the three deprecated command files to transparently forward to their replacement skills (`brainstorming`, `executing-plans`, `writing-plans`) instead of blocking invocation with a deprecation notice.

## Is this change appropriate for the core library?

Yes — this fixes a bug in the core command infrastructure that affects all users. The deprecated commands ship with superpowers and currently break skill invocation for anyone who uses the old command names.

## What alternatives did you consider?

1. **Remove the commands entirely** — This was option 2 in the issue. However, keeping them as forwarding aliases is more user-friendly since people will naturally try the shorter names. Removing them would make those names silently unavailable.
2. **Show deprecation notice AND forward** — Considered having the command inform the user about the rename before forwarding, but this adds friction and the description field already communicates the deprecation. The user's intent is to run the skill, not to learn about internal renames.

## Does this PR contain multiple unrelated changes?

No. All three files are the same fix applied to the same pattern.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found addressing #833

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 1.0.41 | Claude | claude-opus-4-6 |

## Evaluation

- The change was motivated by issue #833 which has 6 thumbs-up reactions
- Before: running `/superpowers:brainstorm` produces a deprecation message and the skill never loads
- After: the command transparently forwards to `superpowers:brainstorming` and the skill runs immediately
- The fix is intentionally minimal — one line changed per file, same pattern across all three

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is a command fix, not a skills change. The wording "Do not stop to inform them about the rename — just run the skill" is deliberately explicit to prevent the model from hedging or adding its own deprecation commentary.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission