### PR TITLE
Add deployment guidance and full frontmatter reference to writing-skills

### DIFF
--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -9,7 +9,7 @@ description: Use when creating new skills, editing existing skills, or verifying
 
 **Writing skills IS Test-Driven Development applied to process documentation.**
 
-**Personal skills live in agent-specific directories (`~/.claude/skills` for Claude Code, `~/.agents/skills/` for Codex)** 
+**Personal skills live in agent-specific directories (`~/.claude/skills` for Claude Code, `~/.agents/skills/` for Codex)**
 
 You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
 
@@ -71,6 +71,28 @@ API docs, syntax guides, tool documentation (office docs)
 
 ## Directory Structure
 
+### Where skills live
+
+Where you store a skill determines who can use it:
+
+| Location | Path | Applies to |
+|---|---|---|
+| Enterprise | See managed settings | All users in your organization |
+| Personal | `~/.claude/skills/<skill-name>/SKILL.md` | All your projects |
+| Project | `.claude/skills/<skill-name>/SKILL.md` (at project root) | This project only |
+| Plugin | `<plugin>/skills/<skill-name>/SKILL.md` | Where plugin is enabled |
+
+**Default to personal** (`~/.claude/skills/`) for standalone skills. Personal skills are durable, discoverable across all projects, and survive plugin updates.
+
+**Project skills** (`.claude/skills/`) live at the project root (same level as `./CLAUDE.md`) and are for team conventions committed to version control. In monorepos, Claude Code also discovers skills from nested `.claude/skills/` directories (e.g., `packages/frontend/.claude/skills/`).
+
+Higher-priority locations win when names conflict: enterprise > personal > project.
+
+### Naming
+
+The `name` field is optional — if omitted, Claude Code uses the directory name. If set, keep it consistent with the directory name to avoid confusion (Claude Code does not enforce a match).
+
+### Skill directory layout
 
 ```
 skills/
@@ -93,14 +115,25 @@ skills/
 ## SKILL.md Structure
 
 **Frontmatter (YAML):**
-- Only two fields supported: `name` and `description`
-- Max 1024 characters total
-- `name`: Use letters, numbers, and hyphens only (no parentheses, special chars)
-- `description`: Third-person, describes ONLY when to use (NOT what it does)
+
+Required fields:
+- `name`: Lowercase letters, numbers, and hyphens only. Max 64 characters. Defaults to directory name if omitted.
+- `description`: Max 1024 characters. Third-person, describes ONLY when to use (NOT what it does).
   - Start with "Use when..." to focus on triggering conditions
   - Include specific symptoms, situations, and contexts
   - **NEVER summarize the skill's process or workflow** (see CSO section for why)
   - Keep under 500 characters if possible
+
+Optional fields (Claude Code):
+- `argument-hint`: Autocomplete hint, e.g., `[issue-number]`
+- `disable-model-invocation`: `true` to prevent auto-triggering (manual `/name` only)
+- `user-invocable`: `false` to hide from `/` menu (background knowledge only)
+- `allowed-tools`: Tools permitted without approval when skill is active
+- `model`: Model override when skill is active
+- `effort`: Effort level override (`low`, `medium`, `high`, `max`; `max` is Opus 4.6 only)
+- `context`: `fork` to run in an isolated subagent
+- `agent`: Subagent type when `context: fork` is set (`Explore`, `Plan`, etc.)
+- `hooks`: Hooks scoped to this skill's lifecycle
 
 ```markdown
 ---
@@ -604,7 +637,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 
 **GREEN Phase - Write Minimal Skill:**
 - [ ] Name uses only letters, numbers, hyphens (no parentheses/special chars)
-- [ ] YAML frontmatter with only name and description (max 1024 chars)
+- [ ] YAML frontmatter has `name` and `description`; add optional fields only if needed (see Frontmatter section)
 - [ ] Description starts with "Use when..." and includes specific triggers/symptoms
 - [ ] Description written in third person
 - [ ] Keywords throughout for search (errors, symptoms, tools)
@@ -629,6 +662,9 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 - [ ] Supporting files only for tools or heavy reference
 
 **Deployment:**
+- [ ] Copy skill directory to a discovery path (see "Where skills live" table in Directory Structure)
+- [ ] Test that the skill triggers on expected user queries
+- [ ] Clean up any workspace/test directories from skill discovery paths
 - [ ] Commit skill to git and push to your fork (if configured)
 - [ ] Consider contributing back via PR (if broadly useful)
 


### PR DESCRIPTION
## What problem are you trying to solve?

Skills created following the writing-skills guide fail to trigger because
the guide doesn't tell users where to place the finished skill. The
"Directory Structure" section showed the internal layout (`skills/skill-name/
SKILL.md`) but not which discovery path to use (`~/.claude/skills/`,
`.claude/skills/`, plugin, or enterprise). Users create the skill in their
working directory and it never gets discovered.

Secondary issue: the frontmatter section said "Only two fields supported:
name and description" — but Claude Code supports 11 fields. The GREEN
phase checklist reinforced this by saying "YAML frontmatter with only name
and description", which contradicts any attempt to add fields like
`disable-model-invocation` or `context: fork`.

Failure mode: user follows the guide, creates a skill, it doesn't trigger,
they don't know why. Observed across multiple sessions — skills ended up in
working directories, ~/Downloads, or other non-discovery paths.

## What does this PR change?

Adds a placement table (enterprise/personal/project/plugin with paths and
priority ordering), documents all Claude Code frontmatter fields as
optional, fixes the checklist item that contradicted the new fields, and
clarifies the name-field-to-directory relationship.

## Is this change appropriate for the core library?

Yes — this corrects gaps in writing-skills, the core guide for creating
skills in superpowers. Every user creating skills benefits from knowing
where to put them. No new files, no new skills, no third-party integrations.

## What alternatives did you consider?

1. Adding a separate "deploying-skills" skill — rejected because deployment
   is part of the creation workflow, not a separate concern. Splitting it
   would mean users need to invoke two skills.
2. Adding a comprehensive reference file with all official docs — rejected
   because PR #471 tried a broader approach and was closed as too large.
   This PR stays minimal: only deployment guidance and frontmatter fields.
3. Doing nothing and relying on users reading the official Claude Code docs
   separately — rejected because the whole point of writing-skills is to be
   the authoritative guide for skill creation within superpowers.

## Does this PR contain multiple unrelated changes?

No. All changes serve one goal: ensuring skills created with this guide end
up in a discoverable location with correct frontmatter. The placement table,
frontmatter fields, and checklist fix are all part of the same gap.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #471 (closed as stale after v5.0.0 rework — tried a much
  broader alignment with Anthropic docs including 300+ lines of new
  reference files). This PR is narrower: only deployment paths and
  frontmatter fields, no new files. #89 (closed — unrelated frontmatter
  validation issue).

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|----------------|-------|------------------|
| Claude Code | 2.1.71 | Claude Opus 4.6 | claude-opus-4-6 |

## Evaluation

- **Initial prompt:** "I want you to download the latest docs about Claude
  skill creation" — led to downloading official Anthropic docs from
  code.claude.com and platform.claude.com, comparing against both
  skill-creator and writing-skills, and identifying the deployment gap.

- **Eval sessions after the change:** 6 subagent runs (3 baseline without
  skill, 3 with updated skill) across 3 pressure scenarios.

- **Before/after comparison:**

| Metric | Baseline (no skill) | With updated skill |
|--------|--------------------|--------------------|
| Correct discovery path | 1/3 | 3/3 |
| Correct directory structure | 1/3 | 3/3 |
| Correct frontmatter fields (no hallucinations) | 0/3 | 3/3 |
| Correct priority ordering | 0/1 | 1/1 |
| Hallucinated fields/variables | 4 | 0 |
| Used deprecated commands system | 1 | 0 |
| CSO-compliant descriptions | 0/3 | 3/3 |

**Test 1 (manual-invoke skill):** Baseline hallucinated `trigger: manual`.
With skill used correct `disable-model-invocation: true`.

**Test 2 (skill in ~/Downloads not triggering):** Baseline diagnosed using
the deprecated `.claude/commands/` system and flat files. With skill correctly
identified `~/.claude/skills/api-linter/SKILL.md` discovery path.

**Test 3 (monorepo + subagent + dynamic injection):** Baseline hallucinated
`agent: true`, `tools:`, and `$GIT_BRANCH` fields, and got priority ordering
backwards (project > personal). With skill used correct `context: fork` +
`agent: Explore`, correct priority (enterprise > personal > project), and
mentioned monorepo nested discovery.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

This PR modifies only the Directory Structure section, the Frontmatter
fields list, and the Deployment checklist. No behavior-shaping content
(rationalization tables, pressure testing methodology, Iron Law, CSO
section) was changed.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission