### PR TITLE
docs(writing-plans): add context gathering guidelines

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -22,6 +22,15 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
 
+## Context Gathering
+
+Gather only the context needed to write the plan — don't explore the entire codebase.
+
+- **Always read:** The spec/requirements document
+- **Read selectively:** Only files directly referenced by the spec or that you'll need to modify
+- **Don't:** Launch broad codebase exploration agents, read unrelated modules, or list entire directories
+- **Rule of thumb:** If you need more than ~5 targeted file reads before writing, you're probably over-gathering. The plan should document what the *implementer* needs, not require the *planner* to have read everything first.
+
 ## File Structure
 
 Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.


### PR DESCRIPTION
## Problem

The `writing-plans` skill tells the agent to "document everything they need to know" and "map out which files will be created or modified," but provides no guidance on **how much context to gather** before writing the plan.

In practice, this causes agents to over-explore: launching multiple broad codebase exploration agents (e.g., full backend + frontend scans consuming 130k+ tokens), reading dozens of unrelated files, and listing entire directories — all before writing a single line of the plan. This wastes significant context window and delays plan creation.

## Solution

Add a **"Context Gathering"** section before "File Structure" with explicit boundaries:

- Always read the spec/requirements document
- Read only files directly referenced by the spec or that need modification
- Don't launch broad exploration agents, read unrelated modules, or list entire directories
- Rule of thumb: if you need more than ~5 targeted file reads, you're over-gathering

## Key insight

The skill's job is to write a plan that documents what the *implementer* needs — it doesn't require the *planner* to have read the entire codebase first. Targeted reads of the spec + directly relevant files provide sufficient context for accurate plan writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)