### PR TITLE
feat(iterating-on-plans): add post-execution iteration skill

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -31,10 +31,24 @@ For each task:
 
 ### Step 3: Complete Development
 
-After all tasks complete and verified:
+After all tasks complete and verified, present:
+
+```
+Implementation complete. What next?
+
+1. **Finish the branch** — merge, PR, or discard (superpowers:finishing-a-development-branch)
+2. **Iterate** — refine what was built (superpowers:iterating-on-plans)
+
+Which option?
+```
+
+**If option 1 chosen:**
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice
+
+**If option 2 chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:iterating-on-plans
 
 ## When to Stop and Ask for Help
 
@@ -68,3 +82,4 @@ After all tasks complete and verified:
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks
+- **superpowers:iterating-on-plans** - Offered after all tasks complete, if refinement is needed

--- a/skills/iterating-on-plans/SKILL.md
+++ b/skills/iterating-on-plans/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: iterating-on-plans
+description: Use after plan execution when you need to refine, fix, or extend what was built — without losing quality gates or restarting from scratch
+---
+
+# Iterating on Plans
+
+## Overview
+
+Bridge the gap between "execution complete" and "truly done." When implementation is 80–90% right but needs targeted refinement, this skill classifies the change request, routes it to the right rework level, and preserves all quality gates.
+
+**Announce at start:** "I'm using the iterating-on-plans skill to refine this implementation."
+
+**Three rework levels:**
+
+| Level | When to use | What happens |
+|-------|-------------|--------------|
+| **Patch** | Bug, typo, small behavioral tweak — isolated to 1–3 files, no design change | Mini-task → implementer subagent → 2-stage review |
+| **Plan Update** | Missing requirement, scope gap, requirement change — no architectural shift | Edit plan in-place → re-run affected tasks via SDD |
+| **Design Update** | Architectural change, new major capability, contradiction in design | Scoped re-brainstorm → new plan → SDD |
+
+<HARD-GATE>
+Do NOT make any code changes, edit the plan, or invoke any other skill before:
+1. Running the scope classifier subagent
+2. Presenting the classification + rationale to the user
+3. Getting explicit user confirmation to proceed
+
+Misclassifying a change wastes more tokens than one confirmation message.
+</HARD-GATE>
+
+---
+
+## Step 1: Load Context
+
+Before classifying anything, gather:
+
+**1a. Plan file**
+- Locate the plan: `docs/superpowers/plans/` — find the most recent plan for this feature, or ask the user if ambiguous
+- Note which tasks are `[x]` (complete) and which are `[ ]` (incomplete)
+
+**1b. Design doc**
+- Locate the spec: `docs/superpowers/specs/` — find the corresponding design doc
+- If missing, note it (classifier will work without it but with reduced accuracy)
+
+**1c. Prior discoveries** *(optional — proceed without if absent)*
+- Check for an `## Accumulated Discoveries` section at the bottom of the plan file
+- Check for `docs/superpowers/discoveries/<plan-name>-discoveries.md`
+- If found, extract the full discoveries list — it will be injected into all subagents
+
+**1d. Change request**
+- This is what the user described: the bug, missing feature, or architectural concern
+- If the request is vague ("it doesn't feel right"), ask one clarifying question before classifying
+
+---
+
+## Step 2: Classify the Change
+
+Dispatch a scope-classifier subagent using `./scope-classifier-prompt.md`.
+
+Provide the subagent with:
+- The user's change request (verbatim)
+- The full plan text (with checkbox states)
+- The design doc (or note if absent)
+- Prior discoveries (or note if absent)
+
+The classifier returns:
+- `PATCH` | `PLAN_UPDATE` | `DESIGN_UPDATE`
+- Rationale (why this level, not another)
+- Blast radius (which files / tasks / design sections are affected)
+- Change description (precise description of what needs to happen)
+- For `PLAN_UPDATE`: list of completed task IDs that need to be un-checked and re-executed
+
+---
+
+## Step 3: Present Classification and Get Confirmation
+
+**Always show the user the classification before acting.** Present it like this:
+
+```
+I've classified this as a [PATCH / PLAN UPDATE / DESIGN UPDATE].
+
+**Why:** [Rationale from classifier — 1–2 sentences]
+
+**Blast radius:** [Files affected / Tasks affected / Design section affected]
+
+**What I'll do:**
+[For PATCH]: Dispatch an implementer subagent to fix [X] in [files]. Two-stage review follows.
+[For PLAN UPDATE]: Edit the plan in-place — mark tasks [N, M] incomplete, add [new tasks]. Re-execute via subagent-driven-development.
+[For DESIGN UPDATE]: Start a scoped re-brainstorm focused on [section], preserving [what stays the same]. Normal flow follows: brainstorming → writing-plans → subagent-driven-development.
+
+Shall I proceed?
+```
+
+Wait for the user's confirmation. If they push back on the classification, re-classify with their input or adjust the approach manually.
+
+---
+
+## Step 4: Execute the Routed Level
+
+### Route A — Patch
+
+1. Dispatch a patch implementer subagent using `./patch-implementer-prompt.md`
+   - Inject: mini-task description (from classifier), affected files, prior discoveries
+2. After implementer reports DONE:
+   - **Spec compliance review** — dispatch spec-reviewer using `../subagent-driven-development/spec-reviewer-prompt.md`
+     - Scope the review: "Did this fix the stated issue and *only* that? No regressions, no scope creep."
+   - If ❌: implementer fixes → re-review until ✅
+3. **Code quality review** — dispatch code reviewer using `../subagent-driven-development/code-quality-reviewer-prompt.md`
+   - If issues found: implementer fixes → re-review until approved
+4. Offer next step (see Step 5)
+
+### Route B — Plan Update
+
+1. **Edit the plan file in-place:**
+   - Un-check (`- [ ]`) any completed tasks the classifier flagged as affected
+   - Add new tasks at the end (or inline if they depend on specific completed tasks)
+   - Add a `## Iteration Note` section at the top of the plan with:
+     ```markdown
+     ## Iteration Note — [date]
+     **Change:** [one-sentence description]
+     **Tasks modified:** [list]
+     **Tasks added:** [list]
+     ```
+2. Commit the updated plan:
+   ```bash
+   git add docs/superpowers/plans/<plan-file>.md
+   git commit -m "plan: [brief description of iteration change]"
+   ```
+3. Announce: "Plan updated. Re-executing affected and new tasks."
+4. **REQUIRED SUB-SKILL:** Use `superpowers:subagent-driven-development` — execute only the un-checked tasks (skip already-complete ones)
+5. Inject prior discoveries into every implementer subagent dispatch (add them to the Context section of each implementer prompt)
+6. Offer next step (see Step 5)
+
+### Route C — Design Update
+
+1. Summarize what to preserve for the user:
+   ```
+   Before re-brainstorming, I'll preserve:
+   - [Completed tasks / components that don't change]
+   - [Constraints and tech stack decisions that stand]
+
+   The re-brainstorm will be scoped to: [affected design section]
+   ```
+2. Confirm with user before invoking brainstorming
+3. **REQUIRED SUB-SKILL:** Use `superpowers:brainstorming`
+   - Pass the existing design doc as starting context
+   - Scope the brainstorm explicitly: "We're revisiting [section] only. Everything else is locked."
+4. Normal flow continues: `brainstorming → writing-plans → subagent-driven-development`
+
+---
+
+## Step 5: Offer Next Step
+
+After completing any patch or plan update, present:
+
+```
+Iteration complete. What next?
+
+1. **Iterate again** — describe another change (superpowers:iterating-on-plans)
+2. **Finish the branch** — merge, PR, or discard (superpowers:finishing-a-development-branch)
+```
+
+Do not automatically invoke `finishing-a-development-branch` — let the user decide if more iteration is needed.
+
+---
+
+## Process Flow
+
+```dot
+digraph iterating_on_plans {
+    rankdir=TB;
+
+    "Load context\n(plan + spec + discoveries)" [shape=box];
+    "Change request clear?" [shape=diamond];
+    "Ask one clarifying question" [shape=box];
+    "Dispatch scope classifier" [shape=box];
+    "Present classification + rationale" [shape=box];
+    "User confirms?" [shape=diamond];
+    "Adjust classification" [shape=box];
+
+    "PATCH" [shape=box];
+    "PLAN UPDATE" [shape=box];
+    "DESIGN UPDATE" [shape=box];
+
+    "Dispatch patch implementer\n(with discoveries)" [shape=box];
+    "Spec compliance review\n(scoped: fix only, no regression)" [shape=box];
+    "Code quality review" [shape=box];
+
+    "Edit plan in-place\n(un-check affected, add tasks, add iteration note)" [shape=box];
+    "Commit updated plan" [shape=box];
+    "subagent-driven-development\n(un-checked tasks only, discoveries injected)" [shape=doublecircle];
+
+    "Summarize preserved work" [shape=box];
+    "brainstorming\n(scoped, existing design as input)" [shape=doublecircle];
+
+    "Offer: iterate again OR finish branch" [shape=box];
+
+    "Load context\n(plan + spec + discoveries)" -> "Change request clear?";
+    "Change request clear?" -> "Ask one clarifying question" [label="no"];
+    "Ask one clarifying question" -> "Dispatch scope classifier";
+    "Change request clear?" -> "Dispatch scope classifier" [label="yes"];
+    "Dispatch scope classifier" -> "Present classification + rationale";
+    "Present classification + rationale" -> "User confirms?" ;
+    "User confirms?" -> "Adjust classification" [label="no"];
+    "Adjust classification" -> "Present classification + rationale";
+    "User confirms?" -> "PATCH" [label="patch"];
+    "User confirms?" -> "PLAN UPDATE" [label="plan update"];
+    "User confirms?" -> "DESIGN UPDATE" [label="design update"];
+
+    "PATCH" -> "Dispatch patch implementer\n(with discoveries)";
+    "Dispatch patch implementer\n(with discoveries)" -> "Spec compliance review\n(scoped: fix only, no regression)";
+    "Spec compliance review\n(scoped: fix only, no regression)" -> "Code quality review" [label="✅"];
+    "Spec compliance review\n(scoped: fix only, no regression)" -> "Dispatch patch implementer\n(with discoveries)" [label="❌ fix"];
+    "Code quality review" -> "Offer: iterate again OR finish branch" [label="✅"];
+    "Code quality review" -> "Dispatch patch implementer\n(with discoveries)" [label="❌ fix"];
+
+    "PLAN UPDATE" -> "Edit plan in-place\n(un-check affected, add tasks, add iteration note)";
+    "Edit plan in-place\n(un-check affected, add tasks, add iteration note)" -> "Commit updated plan";
+    "Commit updated plan" -> "subagent-driven-development\n(un-checked tasks only, discoveries injected)";
+    "subagent-driven-development\n(un-checked tasks only, discoveries injected)" -> "Offer: iterate again OR finish branch";
+
+    "DESIGN UPDATE" -> "Summarize preserved work";
+    "Summarize preserved work" -> "brainstorming\n(scoped, existing design as input)";
+    "brainstorming\n(scoped, existing design as input)" -> "Offer: iterate again OR finish branch";
+}
+```
+
+---
+
+## Key Principles
+
+- **Classify before acting** — never skip the classifier, never skip confirmation
+- **In-place plan edits** — single source of truth; git preserves history
+- **Discoveries always travel** — inject prior discoveries into every subagent, at every level
+- **Full 2-stage review, scaled depth** — patch reviews are tighter in scope, not lighter in rigor
+- **One iteration at a time** — complete the current iteration fully before accepting the next request
+- **Never re-run completed tasks** — the plan's `[x]` state is the contract; only un-check what the classifier explicitly flags
+
+---
+
+## Failure Modes to Avoid
+
+| Anti-pattern | Why it's wrong |
+|---|---|
+| Skipping classification and just fixing "obviously simple" bugs | Small fixes break cross-file contracts silently ("reference drift") |
+| Re-running the entire plan because one task needs fixing | Wastes tokens, may re-introduce already-resolved issues |
+| Starting a design update without summarizing what's preserved | Brainstorming skill may re-question settled decisions |
+| Injecting all discoveries without filtering | Stale discoveries from prior architecture can mislead subagents |
+| Accepting user's classification without running the classifier | User's framing is often incorrect; the classifier reads the actual code |
+
+---
+
+## Integration
+
+**Offered by:**
+- `superpowers:subagent-driven-development` — after all tasks complete
+- `superpowers:executing-plans` — after all batches complete
+
+**Invokes:**
+- `./scope-classifier-prompt.md` — classifies the change request
+- `./patch-implementer-prompt.md` — implements patch-level fixes
+- `../subagent-driven-development/spec-reviewer-prompt.md` — spec compliance review
+- `../subagent-driven-development/code-quality-reviewer-prompt.md` — code quality review
+- `superpowers:subagent-driven-development` — re-executes plan-level changes
+- `superpowers:brainstorming` — handles design-level changes
+- `superpowers:finishing-a-development-branch` — offered after iteration is complete

--- a/skills/iterating-on-plans/SKILL.md
+++ b/skills/iterating-on-plans/SKILL.md
@@ -91,7 +91,17 @@ I've classified this as a [PATCH / PLAN UPDATE / DESIGN UPDATE].
 Shall I proceed?
 ```
 
-Wait for the user's confirmation. If they push back on the classification, re-classify with their input or adjust the approach manually.
+Wait for the user's confirmation.
+
+**If the user disagrees with the classification level** (e.g., insists a PLAN_UPDATE is "just a patch"):
+- Do NOT silently accept the downgrade
+- Make the risk explicit: explain specifically which completed tasks will be wrong after the change and why
+- Give the user enough information to make an informed decision
+- Defer to the user once they confirm they understand the risk — but document their override in the plan as an `## Iteration Note`
+- Never pretend the risk doesn't exist to avoid friction
+
+Example response when user overrides:
+> "I hear you — the edit itself is one line. The reason I flagged PLAN_UPDATE is that Task 5 calls `User.save()` and compares against the stored value directly. After this change that comparison will break silently. If you've already accounted for that, treat this as a patch and I'll proceed immediately. If not, Tasks 5 and 7 need re-running. Which do you prefer?"
 
 ---
 
@@ -247,6 +257,8 @@ digraph iterating_on_plans {
 | Starting a design update without summarizing what's preserved | Brainstorming skill may re-question settled decisions |
 | Injecting all discoveries without filtering | Stale discoveries from prior architecture can mislead subagents |
 | Accepting user's classification without running the classifier | User's framing is often incorrect; the classifier reads the actual code |
+| Silently accepting user's override of classifier level | Make the risk explicit first — "just do what they say" leaves silent breakage |
+| Discarding in-scope completed work when out-of-scope files are found | Commit the valid in-scope work, then report NEEDS_CONTEXT for the rest |
 
 ---
 

--- a/skills/iterating-on-plans/SKILL.md
+++ b/skills/iterating-on-plans/SKILL.md
@@ -16,7 +16,7 @@ Bridge the gap between "execution complete" and "truly done." When implementatio
 | Level | When to use | What happens |
 |-------|-------------|--------------|
 | **Patch** | Bug, typo, small behavioral tweak — isolated to 1–3 files, no design change | Mini-task → implementer subagent → 2-stage review |
-| **Plan Update** | Missing requirement, scope gap, requirement change — no architectural shift | Edit plan in-place → re-run affected tasks via SDD |
+| **Plan Update** | Missing requirement, scope gap, requirement change — no architectural shift | Create delta plan → run affected work via SDD |
 | **Design Update** | Architectural change, new major capability, contradiction in design | Scoped re-brainstorm → new plan → SDD |
 
 <HARD-GATE>
@@ -42,12 +42,21 @@ Before classifying anything, gather:
 - Locate the spec: `docs/superpowers/specs/` — find the corresponding design doc
 - If missing, note it (classifier will work without it but with reduced accuracy)
 
-**1c. Prior discoveries** *(optional — proceed without if absent)*
+**1c. Current implementation evidence**
+- Capture the worktree state: `git status --short`
+- Capture the implementation delta:
+  - Prefer the feature-branch diff against its base branch (`git diff --stat <base>...HEAD` and `git diff <base>...HEAD`)
+  - Also include uncommitted changes if present (`git diff --stat` and `git diff`)
+  - If the base branch is unclear, summarize recent implementation commits with `git log --oneline --stat`
+- Read the files named by the plan, design doc, or diff that are likely touched by the change request
+- If no useful code/diff evidence is available, state that explicitly — don't let the classifier infer blast radius from plan text alone
+
+**1d. Prior discoveries** *(optional — proceed without if absent)*
 - Check for an `## Accumulated Discoveries` section at the bottom of the plan file
 - Check for `docs/superpowers/discoveries/<plan-name>-discoveries.md`
 - If found, extract the full discoveries list — it will be injected into all subagents
 
-**1d. Change request**
+**1e. Change request**
 - This is what the user described: the bug, missing feature, or architectural concern
 - If the request is vague ("it doesn't feel right"), ask one clarifying question before classifying
 
@@ -61,14 +70,16 @@ Provide the subagent with:
 - The user's change request (verbatim)
 - The full plan text (with checkbox states)
 - The design doc (or note if absent)
+- Current implementation evidence (diffs, file excerpts, or note if absent)
 - Prior discoveries (or note if absent)
 
 The classifier returns:
 - `PATCH` | `PLAN_UPDATE` | `DESIGN_UPDATE`
 - Rationale (why this level, not another)
+- Implementation evidence used
 - Blast radius (which files / tasks / design sections are affected)
 - Change description (precise description of what needs to happen)
-- For `PLAN_UPDATE`: list of completed task IDs that need to be un-checked and re-executed
+- For `PLAN_UPDATE`: list of completed task IDs whose outputs are superseded by the delta plan
 
 ---
 
@@ -81,11 +92,13 @@ I've classified this as a [PATCH / PLAN UPDATE / DESIGN UPDATE].
 
 **Why:** [Rationale from classifier — 1–2 sentences]
 
+**Evidence checked:** [Implementation evidence used — diff/files inspected, or note if missing]
+
 **Blast radius:** [Files affected / Tasks affected / Design section affected]
 
 **What I'll do:**
 [For PATCH]: Dispatch an implementer subagent to fix [X] in [files]. Two-stage review follows.
-[For PLAN UPDATE]: Edit the plan in-place — mark tasks [N, M] incomplete, add [new tasks]. Re-execute via subagent-driven-development.
+[For PLAN UPDATE]: Create a delta plan for [new/changed tasks], add a short note to the original plan, then execute the delta plan via subagent-driven-development.
 [For DESIGN UPDATE]: Start a scoped re-brainstorm focused on [section], preserving [what stays the same]. Normal flow follows: brainstorming → writing-plans → subagent-driven-development.
 
 Shall I proceed?
@@ -97,11 +110,11 @@ Wait for the user's confirmation.
 - Do NOT silently accept the downgrade
 - Make the risk explicit: explain specifically which completed tasks will be wrong after the change and why
 - Give the user enough information to make an informed decision
-- Defer to the user once they confirm they understand the risk — but document their override in the plan as an `## Iteration Note`
+- Defer to the user once they confirm they understand the risk — but document their override in the active plan or delta plan as an `## Iteration Note`
 - Never pretend the risk doesn't exist to avoid friction
 
 Example response when user overrides:
-> "I hear you — the edit itself is one line. The reason I flagged PLAN_UPDATE is that Task 5 calls `User.save()` and compares against the stored value directly. After this change that comparison will break silently. If you've already accounted for that, treat this as a patch and I'll proceed immediately. If not, Tasks 5 and 7 need re-running. Which do you prefer?"
+> "I hear you — the edit itself is one line. The reason I flagged PLAN_UPDATE is that Task 5 calls `User.save()` and compares against the stored value directly. After this change that comparison will break silently. If you've already accounted for that, treat this as a patch and I'll proceed immediately. If not, Tasks 5 and 7 need delta-plan coverage. Which do you prefer?"
 
 ---
 
@@ -121,25 +134,36 @@ Example response when user overrides:
 
 ### Route B — Plan Update
 
-1. **Edit the plan file in-place:**
-   - Un-check (`- [ ]`) any completed tasks the classifier flagged as affected
-   - Add new tasks at the end (or inline if they depend on specific completed tasks)
-   - Add a `## Iteration Note` section at the top of the plan with:
+1. **Create a delta plan by default:**
+   - Preserve the original plan as historical truth; do not un-check completed tasks or rewrite their bodies
+   - Create `docs/superpowers/plans/<original-plan-stem>-iteration-YYYY-MM-DD.md`
+   - Include the affected completed tasks as "superseded" instead of making their old checkboxes ambiguous
+   - Append to the original plan only for immediate bookkeeping corrections or a tiny tail task where no completed work is superseded
+   - Put this header at the top of the delta plan:
      ```markdown
      ## Iteration Note — [date]
+     **Original plan:** [path]
      **Change:** [one-sentence description]
-     **Tasks modified:** [list]
-     **Tasks added:** [list]
+     **Superseded completed tasks:** [list, or "None"]
+     **New/changed tasks:** [list]
+     **Implementation evidence used:** [short summary of diff/files inspected]
      ```
-2. Commit the updated plan:
+2. **Add a short pointer to the original plan:**
+   - Add or update an `## Iterations` section with:
+     ```markdown
+     - [date]: [change summary]. Active delta plan: `docs/superpowers/plans/<delta-plan>.md`. Supersedes: [tasks or "None"].
+     ```
+   - Do not edit the original completed task text except for this pointer
+3. Commit the plan update:
    ```bash
-   git add docs/superpowers/plans/<plan-file>.md
+   git add docs/superpowers/plans/<original-plan>.md docs/superpowers/plans/<delta-plan>.md
    git commit -m "plan: [brief description of iteration change]"
    ```
-3. Announce: "Plan updated. Re-executing affected and new tasks."
-4. **REQUIRED SUB-SKILL:** Use `superpowers:subagent-driven-development` — execute only the un-checked tasks (skip already-complete ones)
-5. Inject prior discoveries into every implementer subagent dispatch (add them to the Context section of each implementer prompt)
-6. Offer next step (see Step 5)
+   If this is an append-only exception with no delta plan, stage only the edited original plan.
+4. Announce: "Delta plan created. Executing affected and new tasks."
+5. **REQUIRED SUB-SKILL:** Use `superpowers:subagent-driven-development` — execute the delta plan only, preserving already-complete original tasks unless the delta explicitly replaces them
+6. Inject prior discoveries and implementation evidence into every implementer subagent dispatch (add them to the Context section of each implementer prompt)
+7. Offer next step (see Step 5)
 
 ### Route C — Design Update
 
@@ -180,7 +204,7 @@ Do not automatically invoke `finishing-a-development-branch` — let the user de
 digraph iterating_on_plans {
     rankdir=TB;
 
-    "Load context\n(plan + spec + discoveries)" [shape=box];
+    "Load context\n(plan + spec + implementation evidence + discoveries)" [shape=box];
     "Change request clear?" [shape=diamond];
     "Ask one clarifying question" [shape=box];
     "Dispatch scope classifier" [shape=box];
@@ -196,16 +220,16 @@ digraph iterating_on_plans {
     "Spec compliance review\n(scoped: fix only, no regression)" [shape=box];
     "Code quality review" [shape=box];
 
-    "Edit plan in-place\n(un-check affected, add tasks, add iteration note)" [shape=box];
-    "Commit updated plan" [shape=box];
-    "subagent-driven-development\n(un-checked tasks only, discoveries injected)" [shape=doublecircle];
+    "Create delta plan\n(preserve original, add iteration note)" [shape=box];
+    "Commit delta plan" [shape=box];
+    "subagent-driven-development\n(delta plan only, discoveries injected)" [shape=doublecircle];
 
     "Summarize preserved work" [shape=box];
     "brainstorming\n(scoped, existing design as input)" [shape=doublecircle];
 
     "Offer: iterate again OR finish branch" [shape=box];
 
-    "Load context\n(plan + spec + discoveries)" -> "Change request clear?";
+    "Load context\n(plan + spec + implementation evidence + discoveries)" -> "Change request clear?";
     "Change request clear?" -> "Ask one clarifying question" [label="no"];
     "Ask one clarifying question" -> "Dispatch scope classifier";
     "Change request clear?" -> "Dispatch scope classifier" [label="yes"];
@@ -224,10 +248,10 @@ digraph iterating_on_plans {
     "Code quality review" -> "Offer: iterate again OR finish branch" [label="✅"];
     "Code quality review" -> "Dispatch patch implementer\n(with discoveries)" [label="❌ fix"];
 
-    "PLAN UPDATE" -> "Edit plan in-place\n(un-check affected, add tasks, add iteration note)";
-    "Edit plan in-place\n(un-check affected, add tasks, add iteration note)" -> "Commit updated plan";
-    "Commit updated plan" -> "subagent-driven-development\n(un-checked tasks only, discoveries injected)";
-    "subagent-driven-development\n(un-checked tasks only, discoveries injected)" -> "Offer: iterate again OR finish branch";
+    "PLAN UPDATE" -> "Create delta plan\n(preserve original, add iteration note)";
+    "Create delta plan\n(preserve original, add iteration note)" -> "Commit delta plan";
+    "Commit delta plan" -> "subagent-driven-development\n(delta plan only, discoveries injected)";
+    "subagent-driven-development\n(delta plan only, discoveries injected)" -> "Offer: iterate again OR finish branch";
 
     "DESIGN UPDATE" -> "Summarize preserved work";
     "Summarize preserved work" -> "brainstorming\n(scoped, existing design as input)";
@@ -240,11 +264,12 @@ digraph iterating_on_plans {
 ## Key Principles
 
 - **Classify before acting** — never skip the classifier, never skip confirmation
-- **In-place plan edits** — single source of truth; git preserves history
+- **Classify from evidence** — include the current implementation/diff, not just the plan
+- **Original plans are history** — use delta plans for plan-level iteration; only add a short pointer to the original
 - **Discoveries always travel** — inject prior discoveries into every subagent, at every level
 - **Full 2-stage review, scaled depth** — patch reviews are tighter in scope, not lighter in rigor
 - **One iteration at a time** — complete the current iteration fully before accepting the next request
-- **Never re-run completed tasks** — the plan's `[x]` state is the contract; only un-check what the classifier explicitly flags
+- **Never make completed checkboxes ambiguous** — the plan's `[x]` state is historical truth; supersede stale work explicitly in the delta plan
 
 ---
 
@@ -253,12 +278,14 @@ digraph iterating_on_plans {
 | Anti-pattern | Why it's wrong |
 |---|---|
 | Skipping classification and just fixing "obviously simple" bugs | Small fixes break cross-file contracts silently ("reference drift") |
+| Classifying from plan text without inspecting the current implementation | The plan describes intent; the code and diff show actual blast radius |
 | Re-running the entire plan because one task needs fixing | Wastes tokens, may re-introduce already-resolved issues |
+| Editing completed tasks in-place during iteration | History stops being trustworthy and checked boxes stop having a clear meaning |
 | Starting a design update without summarizing what's preserved | Brainstorming skill may re-question settled decisions |
 | Injecting all discoveries without filtering | Stale discoveries from prior architecture can mislead subagents |
 | Accepting user's classification without running the classifier | User's framing is often incorrect; the classifier reads the actual code |
 | Silently accepting user's override of classifier level | Make the risk explicit first — "just do what they say" leaves silent breakage |
-| Discarding in-scope completed work when out-of-scope files are found | Commit the valid in-scope work, then report NEEDS_CONTEXT for the rest |
+| Committing partial or failing in-scope work when out-of-scope files are found | Only commit work that is complete, tested, and independently useful; otherwise report NEEDS_CONTEXT without committing |
 
 ---
 

--- a/skills/iterating-on-plans/SKILL.md
+++ b/skills/iterating-on-plans/SKILL.md
@@ -66,6 +66,8 @@ Before classifying anything, gather:
 
 Dispatch a scope-classifier subagent using `./scope-classifier-prompt.md`.
 
+If no subagent mechanism is available in the current harness, apply `./scope-classifier-prompt.md` yourself with the same inputs. This fallback does not relax the hard gate: you still must gather implementation evidence, produce the structured classification, present it to the user, and get confirmation before acting.
+
 Provide the subagent with:
 - The user's change request (verbatim)
 - The full plan text (with checkbox states)
@@ -111,10 +113,11 @@ Wait for the user's confirmation.
 - Make the risk explicit: explain specifically which completed tasks will be wrong after the change and why
 - Give the user enough information to make an informed decision
 - Defer to the user once they confirm they understand the risk — but document their override in the active plan or delta plan as an `## Iteration Note`
+- Do not accept an override that rewrites completed task history in the original plan; user override can change the rework level, but stale completed work must be superseded explicitly
 - Never pretend the risk doesn't exist to avoid friction
 
 Example response when user overrides:
-> "I hear you — the edit itself is one line. The reason I flagged PLAN_UPDATE is that Task 5 calls `User.save()` and compares against the stored value directly. After this change that comparison will break silently. If you've already accounted for that, treat this as a patch and I'll proceed immediately. If not, Tasks 5 and 7 need delta-plan coverage. Which do you prefer?"
+> "I hear you — the edit itself is one line. The reason I flagged PLAN_UPDATE is that Task 5 calls `User.save()` and compares against the stored value directly. After this change that comparison will break silently. If you've already accounted for that, treat this as a patch and I'll proceed immediately. If not, Tasks 5 and 7 need delta-plan coverage. Either way, I won't rewrite completed task history in the original plan. Which do you prefer?"
 
 ---
 

--- a/skills/iterating-on-plans/patch-implementer-prompt.md
+++ b/skills/iterating-on-plans/patch-implementer-prompt.md
@@ -47,8 +47,11 @@ Task tool (general-purpose):
 
     1. Read the listed files to understand the current state
     2. Implement exactly the described fix — stay within the listed files unless unavoidable
-    3. If you discover the fix requires touching files outside scope, **stop and report NEEDS_CONTEXT**
-       (do not expand scope on your own — the classifier may have missed blast radius)
+    3. If you discover the fix requires touching files outside scope:
+       - **Commit any in-scope work you have already completed** (don't discard valid work)
+       - **Report NEEDS_CONTEXT** — describe exactly which out-of-scope files are affected and why
+       - Do not expand scope on your own — the classifier may have missed blast radius, or
+         those files may have other owners, callers, or tests that need separate consideration
     4. Write or update tests that verify the fix works and doesn't regress
     5. Run the test suite to confirm
     6. Commit your work:

--- a/skills/iterating-on-plans/patch-implementer-prompt.md
+++ b/skills/iterating-on-plans/patch-implementer-prompt.md
@@ -1,0 +1,106 @@
+# Patch Implementer Prompt Template
+
+Use this template when dispatching a patch implementer subagent (Route A — Patch level only).
+
+This is a focused variant of the standard implementer prompt. The task is already classified,
+scoped, and described precisely. The implementer's job is to fix exactly what's specified
+and nothing more.
+
+```
+Task tool (general-purpose):
+  description: "Patch: [one-line description of the fix]"
+  prompt: |
+    You are implementing a targeted patch. The scope of this work has already been
+    classified and confirmed. Your job is to fix exactly what is described below —
+    no more, no less.
+
+    ## Prior Discoveries
+
+    [If discoveries exist, paste the full list here. If none: omit this section entirely.]
+
+    These are known gotchas from prior implementation work on this codebase. Read them
+    before touching any code. If your fix interacts with any of these, account for it.
+
+    ## The Fix
+
+    [VERBATIM change description from scope classifier output]
+
+    ## Files in Scope
+
+    [List of exact file paths from classifier's blast radius]
+
+    ## Context
+
+    [Scene-setting: what this component does, why the bug exists, what correct behavior looks like.
+     Include any relevant completed task context that helps the implementer understand the area.]
+
+    ## Before You Begin
+
+    If anything in the fix description is ambiguous — especially around:
+    - What "correct behavior" means exactly
+    - Whether other files outside the listed scope might be affected
+    - Whether prior discoveries conflict with the stated fix
+
+    **Ask now.** One question at a time. Do not start work until you're clear.
+
+    ## Your Job
+
+    1. Read the listed files to understand the current state
+    2. Implement exactly the described fix — stay within the listed files unless unavoidable
+    3. If you discover the fix requires touching files outside scope, **stop and report NEEDS_CONTEXT**
+       (do not expand scope on your own — the classifier may have missed blast radius)
+    4. Write or update tests that verify the fix works and doesn't regress
+    5. Run the test suite to confirm
+    6. Commit your work:
+       ```bash
+       git add [files changed]
+       git commit -m "fix: [description of what was fixed]"
+       ```
+    7. Self-review (see below)
+    8. Report back
+
+    ## Scope Discipline
+
+    This is a patch, not a refactor. You MUST NOT:
+    - Rename variables, functions, or files outside the immediate fix
+    - Restructure code that isn't broken
+    - Add features or "nice to have" improvements
+    - Change behavior in any path not directly related to the fix
+
+    If you see problems nearby, note them in your report as concerns — don't fix them.
+
+    ## Before Reporting Back: Self-Review
+
+    Review your work with these patch-specific questions:
+
+    **Correctness:**
+    - Does the fix address the stated issue precisely?
+    - Could this fix break anything in adjacent code paths?
+    - Did I check the prior discoveries list for anything relevant to this area?
+
+    **Scope:**
+    - Did I touch only the files in scope (or documented why I had to go outside)?
+    - Did I add anything that wasn't part of the stated fix?
+    - Are my tests verifying the fix specifically, not just re-testing existing behavior?
+
+    **Regression safety:**
+    - Did the full test suite pass after my fix?
+    - Are there tests that previously passed that now fail?
+
+    If you find issues during self-review, fix them before reporting.
+
+    ## Report Format
+
+    When done, report:
+    - **Status:** DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    - What exactly you changed (file:line references)
+    - Test results (what test, what it verifies, did it pass)
+    - Self-review findings (if any)
+    - Any scope expansion that occurred (files you had to touch outside the listed scope)
+    - Any new discoveries worth recording for future subagents working in this area
+
+    Use DONE_WITH_CONCERNS if the fix works but you're uncertain about side effects.
+    Use NEEDS_CONTEXT if the fix requires touching files outside the listed scope.
+    Use BLOCKED if you cannot implement the fix as described.
+    Never silently expand scope — always report it.
+```

--- a/skills/iterating-on-plans/patch-implementer-prompt.md
+++ b/skills/iterating-on-plans/patch-implementer-prompt.md
@@ -49,11 +49,12 @@ Task tool (general-purpose):
     2. Implement exactly the described fix — stay within the listed files unless unavoidable
     3. If you discover the fix requires touching files outside scope:
        - Stop expanding scope immediately
-       - If the in-scope work is complete, tests pass, and it stands on its own, commit only that in-scope work
+       - If the in-scope work is complete, tests pass, and it stands on its own without requiring out-of-scope changes to preserve behavior, commit only that in-scope work
        - If the in-scope work is partial or tests fail, do not commit it; report the current worktree state instead
        - **Report NEEDS_CONTEXT** — describe exactly which out-of-scope files are affected and why
        - Do not expand scope on your own — the classifier may have missed blast radius, or
          those files may have other owners, callers, or tests that need separate consideration
+       - If anyone asks you to commit partial or failing work anyway, refuse and repeat the NEEDS_CONTEXT report
     4. Write or update tests that verify the fix works and doesn't regress
     5. Run the test suite to confirm
     6. Commit your work:

--- a/skills/iterating-on-plans/patch-implementer-prompt.md
+++ b/skills/iterating-on-plans/patch-implementer-prompt.md
@@ -48,7 +48,9 @@ Task tool (general-purpose):
     1. Read the listed files to understand the current state
     2. Implement exactly the described fix — stay within the listed files unless unavoidable
     3. If you discover the fix requires touching files outside scope:
-       - **Commit any in-scope work you have already completed** (don't discard valid work)
+       - Stop expanding scope immediately
+       - If the in-scope work is complete, tests pass, and it stands on its own, commit only that in-scope work
+       - If the in-scope work is partial or tests fail, do not commit it; report the current worktree state instead
        - **Report NEEDS_CONTEXT** — describe exactly which out-of-scope files are affected and why
        - Do not expand scope on your own — the classifier may have missed blast radius, or
          those files may have other owners, callers, or tests that need separate consideration

--- a/skills/iterating-on-plans/scope-classifier-prompt.md
+++ b/skills/iterating-on-plans/scope-classifier-prompt.md
@@ -1,0 +1,126 @@
+# Scope Classifier Prompt Template
+
+Use this template when dispatching the scope classifier subagent.
+
+**Purpose:** Determine the correct rework level for a change request — PATCH, PLAN_UPDATE, or DESIGN_UPDATE — by reasoning about blast radius, not just surface description.
+
+```
+Task tool (general-purpose):
+  description: "Classify iteration scope for: [one-line summary of change request]"
+  prompt: |
+    You are a scope classifier. Your job is to read a change request against an existing
+    implementation plan and design doc, then determine the minimum rework level required.
+
+    ## Change Request
+
+    [VERBATIM change request from user — paste exactly, do not paraphrase]
+
+    ## Plan File (with completion state)
+
+    [FULL TEXT of plan file — include all tasks, with [x] / [ ] checkbox states]
+
+    ## Design Doc
+
+    [FULL TEXT of design doc — or "Not available" if absent]
+
+    ## Prior Discoveries
+
+    [FULL TEXT of accumulated discoveries — or "None recorded" if absent]
+
+    ---
+
+    ## The Three Rework Levels
+
+    **PATCH** — apply when ALL of the following are true:
+    - The change is a bug fix, typo, small behavioral tweak, or missing edge case
+    - It is isolated to 1–3 files with no interface changes visible to other components
+    - No task in the plan needs to be re-run or un-checked
+    - The design doc does not need to change
+    - It can be described as a single mini-task ("Fix X in file Y so that Z")
+
+    **PLAN_UPDATE** — apply when ANY of the following are true:
+    - A requirement was missing or misunderstood and needs new plan tasks
+    - One or more completed tasks need to be redone because the approach was wrong
+    - A new sub-feature is needed that fits within the current design
+    - Interfaces between components need to change (but the architecture stays the same)
+    - The fix is too large or cross-cutting to be a single mini-task
+
+    **DESIGN_UPDATE** — apply when ANY of the following are true:
+    - The architecture needs to change (different layers, different component boundaries)
+    - A new major capability is needed that the current design didn't anticipate
+    - There is a contradiction in the design that causes the implementation to be wrong
+    - The tech stack or data model needs to change
+    - Fixing this correctly would invalidate the majority of completed tasks
+
+    ---
+
+    ## Classification Rules
+
+    1. **Always classify at the minimum level that correctly addresses the change.**
+       If PATCH is sufficient, don't escalate to PLAN_UPDATE. If PLAN_UPDATE is sufficient,
+       don't escalate to DESIGN_UPDATE.
+
+    2. **Read the actual plan tasks, don't just read the change request.**
+       A user might say "small fix" when the fix actually requires re-running 3 tasks.
+       A user might say "big change" when it's actually a 2-line patch. Trust the plan, not the framing.
+
+    3. **Consider blast radius across completed tasks.**
+       If a completed task's output will be wrong after the fix, that task must be un-checked
+       and re-executed. List every such task explicitly.
+
+    4. **Watch for reference drift.**
+       A change to a shared interface (types, function signatures, exported APIs) affects every
+       task that consumed that interface — even if only one task introduced the bug.
+
+    5. **Be conservative with DESIGN_UPDATE.**
+       Most things that feel architectural are actually plan-level. Only escalate to DESIGN_UPDATE
+       if the design doc itself is wrong or the change cannot be expressed as a set of plan tasks.
+
+    ---
+
+    ## Prior Discoveries — How to Use Them
+
+    If discoveries are present, use them to:
+    - Identify which tasks touched the same system areas and may have the same gotchas
+    - Flag if the change request runs against a known discovery ("Note: Discovery 3 says X,
+      this fix assumes the opposite — confirm with user before proceeding")
+    - Determine if the change request is caused by a known gotcha that wasn't fully fixed
+
+    ---
+
+    ## Your Output
+
+    Respond with exactly this structure:
+
+    ### Classification
+    PATCH | PLAN_UPDATE | DESIGN_UPDATE
+
+    ### Rationale
+    [2–3 sentences: why this level, and specifically why not the level above or below it]
+
+    ### Blast Radius
+    [For PATCH]:
+    - Files to change: [list with exact paths]
+    - Completed tasks affected: None
+
+    [For PLAN_UPDATE]:
+    - Completed task IDs to un-check and re-execute: [list — e.g. "Task 3, Task 7"]
+    - New tasks to add: [brief description of each new task needed]
+    - Files likely affected: [list]
+
+    [For DESIGN_UPDATE]:
+    - Design sections to revisit: [list]
+    - Completed work to preserve: [list of tasks/components that don't need to change]
+    - Files likely affected: [list]
+
+    ### Change Description
+    [For PATCH]: A single mini-task description, precise enough to hand directly to an implementer:
+    "Fix [specific behavior] in [file] so that [observable outcome]."
+
+    [For PLAN_UPDATE]: What the plan update achieves in one sentence, plus list of task modifications.
+
+    [For DESIGN_UPDATE]: What the re-brainstorm scope is, and what must remain locked/preserved.
+
+    ### Discovery Conflicts
+    [List any prior discoveries that conflict with or complicate this change — or "None" if clean]
+```

--- a/skills/iterating-on-plans/scope-classifier-prompt.md
+++ b/skills/iterating-on-plans/scope-classifier-prompt.md
@@ -4,6 +4,8 @@ Use this template when dispatching the scope classifier subagent.
 
 **Purpose:** Determine the correct rework level for a change request — PATCH, PLAN_UPDATE, or DESIGN_UPDATE — by reasoning about actual implementation blast radius, not just surface description.
 
+If the current harness cannot dispatch a subagent, apply this prompt manually. The fallback changes who runs the classifier, not the evidence requirements or confirmation gate.
+
 ```
 Task tool (general-purpose):
   description: "Classify iteration scope for: [one-line summary of change request]"

--- a/skills/iterating-on-plans/scope-classifier-prompt.md
+++ b/skills/iterating-on-plans/scope-classifier-prompt.md
@@ -2,14 +2,15 @@
 
 Use this template when dispatching the scope classifier subagent.
 
-**Purpose:** Determine the correct rework level for a change request — PATCH, PLAN_UPDATE, or DESIGN_UPDATE — by reasoning about blast radius, not just surface description.
+**Purpose:** Determine the correct rework level for a change request — PATCH, PLAN_UPDATE, or DESIGN_UPDATE — by reasoning about actual implementation blast radius, not just surface description.
 
 ```
 Task tool (general-purpose):
   description: "Classify iteration scope for: [one-line summary of change request]"
   prompt: |
     You are a scope classifier. Your job is to read a change request against an existing
-    implementation plan and design doc, then determine the minimum rework level required.
+    implementation plan, design doc, and current implementation evidence, then determine
+    the minimum rework level required.
 
     ## Change Request
 
@@ -23,6 +24,12 @@ Task tool (general-purpose):
 
     [FULL TEXT of design doc — or "Not available" if absent]
 
+    ## Current Implementation Evidence
+
+    [Relevant git status, branch diff/stat, uncommitted diff if present, and excerpts from
+    files named by the plan/design/diff that are likely touched by the change request — or
+    "Not available" if absent]
+
     ## Prior Discoveries
 
     [FULL TEXT of accumulated discoveries — or "None recorded" if absent]
@@ -34,13 +41,13 @@ Task tool (general-purpose):
     **PATCH** — apply when ALL of the following are true:
     - The change is a bug fix, typo, small behavioral tweak, or missing edge case
     - It is isolated to 1–3 files with no interface changes visible to other components
-    - No task in the plan needs to be re-run or un-checked
+    - No completed task needs to be superseded by a delta plan
     - The design doc does not need to change
     - It can be described as a single mini-task ("Fix X in file Y so that Z")
 
     **PLAN_UPDATE** — apply when ANY of the following are true:
     - A requirement was missing or misunderstood and needs new plan tasks
-    - One or more completed tasks need to be redone because the approach was wrong
+    - One or more completed tasks need to be superseded because the approach was wrong
     - A new sub-feature is needed that fits within the current design
     - Interfaces between components need to change (but the architecture stays the same)
     - The fix is too large or cross-cutting to be a single mini-task
@@ -60,19 +67,26 @@ Task tool (general-purpose):
        If PATCH is sufficient, don't escalate to PLAN_UPDATE. If PLAN_UPDATE is sufficient,
        don't escalate to DESIGN_UPDATE.
 
-    2. **Read the actual plan tasks, don't just read the change request.**
-       A user might say "small fix" when the fix actually requires re-running 3 tasks.
-       A user might say "big change" when it's actually a 2-line patch. Trust the plan, not the framing.
+    2. **Read the actual plan tasks and implementation evidence, don't just read the change request.**
+       A user might say "small fix" when the fix actually supersedes 3 completed tasks.
+       A user might say "big change" when it's actually a 2-line patch. Trust the plan
+       and current code/diff, not the framing.
 
-    3. **Consider blast radius across completed tasks.**
-       If a completed task's output will be wrong after the fix, that task must be un-checked
-       and re-executed. List every such task explicitly.
+    3. **Use code evidence before declaring PATCH.**
+       A PATCH classification requires implementation evidence showing the change is isolated.
+       If the current code/diff is missing or too thin to prove isolation, say so in the
+       rationale and do not guess a narrow blast radius from the plan alone.
 
-    4. **Watch for reference drift.**
+    4. **Consider blast radius across completed tasks.**
+       If a completed task's output will be wrong after the fix, list that task as superseded
+       so the delta plan can replace it explicitly. Do not ask the caller to rewrite or
+       un-check the historical task in the original plan.
+
+    5. **Watch for reference drift.**
        A change to a shared interface (types, function signatures, exported APIs) affects every
        task that consumed that interface — even if only one task introduced the bug.
 
-    5. **Be conservative with DESIGN_UPDATE.**
+    6. **Be conservative with DESIGN_UPDATE.**
        Most things that feel architectural are actually plan-level. Only escalate to DESIGN_UPDATE
        if the design doc itself is wrong or the change cannot be expressed as a set of plan tasks.
 
@@ -98,14 +112,18 @@ Task tool (general-purpose):
     ### Rationale
     [2–3 sentences: why this level, and specifically why not the level above or below it]
 
+    ### Implementation Evidence Used
+    [Briefly list the git diff/status and file excerpts inspected. If evidence was missing,
+    say exactly what was unavailable and how that affected confidence.]
+
     ### Blast Radius
     [For PATCH]:
     - Files to change: [list with exact paths]
     - Completed tasks affected: None
 
     [For PLAN_UPDATE]:
-    - Completed task IDs to un-check and re-execute: [list — e.g. "Task 3, Task 7"]
-    - New tasks to add: [brief description of each new task needed]
+    - Completed task IDs superseded by the delta plan: [list — e.g. "Task 3, Task 7"]
+    - Delta plan tasks to add: [brief description of each new or replacement task needed]
     - Files likely affected: [list]
 
     [For DESIGN_UPDATE]:
@@ -117,7 +135,7 @@ Task tool (general-purpose):
     [For PATCH]: A single mini-task description, precise enough to hand directly to an implementer:
     "Fix [specific behavior] in [file] so that [observable outcome]."
 
-    [For PLAN_UPDATE]: What the plan update achieves in one sentence, plus list of task modifications.
+    [For PLAN_UPDATE]: What the delta plan achieves in one sentence, plus list of replacement/new tasks.
 
     [For DESIGN_UPDATE]: What the re-brainstorm scope is, and what must remain locked/preserved.
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -62,6 +62,8 @@ digraph process {
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent for entire implementation" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
+    "Offer: finish branch OR iterate" [shape=diamond];
+    "Use superpowers:iterating-on-plans" [shape=box style=filled fillcolor=lightyellow];
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
@@ -80,7 +82,9 @@ digraph process {
     "Mark task complete in TodoWrite" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
-    "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
+    "Dispatch final code reviewer subagent for entire implementation" -> "Offer: finish branch OR iterate";
+    "Offer: finish branch OR iterate" -> "Use superpowers:finishing-a-development-branch" [label="finish"];
+    "Offer: finish branch OR iterate" -> "Use superpowers:iterating-on-plans" [label="iterate"];
 }
 ```
 
@@ -196,7 +200,12 @@ Code reviewer: ✅ Approved
 [Dispatch final code-reviewer]
 Final reviewer: All requirements met, ready to merge
 
-Done!
+Implementation complete. What next?
+
+1. **Finish the branch** — merge, PR, or discard (superpowers:finishing-a-development-branch)
+2. **Iterate** — refine what was built (superpowers:iterating-on-plans)
+
+[User chooses option 1 or 2]
 ```
 
 ## Advantages
@@ -269,6 +278,7 @@ Done!
 - **superpowers:writing-plans** - Creates the plan this skill executes
 - **superpowers:requesting-code-review** - Code review template for reviewer subagents
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks
+- **superpowers:iterating-on-plans** - Offered after all tasks complete, if refinement is needed
 
 **Subagents should use:**
 - **superpowers:test-driven-development** - Subagents follow TDD for each task


### PR DESCRIPTION
## What problem are you trying to solve?

After a subagent-driven development cycle completes, users face a structural gap: the implementation is 80-90% right but needs targeted refinement. The only options today are:

1. **Ad-hoc chat** - continuing informally loses all quality gates (spec compliance review, code quality review, TDD discipline)
2. **Full restart** - re-running brainstorm -> plan -> execute discards all completed work

Three specific failure modes documented by commenters on issue #921:
- **Reference drift** - changes to a shared interface break downstream completed tasks silently
- **Phantom dependencies** - iteration subagents with no prior context hallucinate imports that don't exist in the partially-built codebase
- **Scope regression** - "helpful" fixes reintroduce patterns explicitly avoided earlier in the plan

## What does this PR change?

Adds a new `iterating-on-plans` skill (3 files) that surfaces automatically at the end of `subagent-driven-development` and `executing-plans`. It classifies the change request into one of three rework levels (Patch / Plan Update / Design Update), presents the classification with rationale and implementation evidence for user confirmation, then routes to the appropriate execution path while preserving existing quality gates.

Two existing skills are updated to offer iteration as an option alongside `finishing-a-development-branch`.

Key guardrails:
- The scope classifier receives the plan, design doc, prior discoveries, and current implementation evidence (status/diff/file excerpts), so PATCH decisions are based on actual code blast radius.
- If no subagent mechanism is available, the coordinator applies the classifier prompt manually with the same evidence and confirmation requirements.
- PLAN_UPDATE creates a delta plan by default and adds only a short pointer to the original plan, preserving original checked tasks as historical truth.
- Patch implementers only commit in-scope work discovered before a scope expansion if that work is complete, tested, and independently useful.

## Is this change appropriate for the core library?

Yes. The gap between plan execution and refinement exists for every user of `subagent-driven-development` or `executing-plans`, regardless of project domain, language, or toolchain. No project-specific logic, no third-party integrations, no tool-specific assumptions. Pure workflow orchestration.

## What alternatives did you consider?

**Mid-execution iteration only:** Rejected - the most common case is discovering gaps after a full cycle. Mid-execution stopping already exists via BLOCKED/NEEDS_CONTEXT escalation.

**Delta plan vs. in-place editing:** Delta plans are now the default for PLAN_UPDATE because they preserve auditability: the original plan remains history, and the active delta plan is the current execution surface. In-place appends are allowed only for immediate bookkeeping corrections or tiny tail tasks where no completed work is superseded.

**Silent routing (classify and act without asking):** Rejected. Misclassification is the highest-cost failure mode - a wrong route wastes more tokens than one confirmation message. The classifier is good but not infallible at PATCH/PLAN_UPDATE boundaries.

**Light review gate for patches only:** Rejected. "Small fix" classification can be wrong - a patch touching a shared interface isn't low-risk. Full 2-stage review kept; depth scales with change size, not gate structure.

**No discoveries injection:** Rejected. Iteration subagents working on code with known quirks would rediscover the same gotchas. Discoveries injected gracefully - skill proceeds normally if none exist.

## Does this PR contain multiple unrelated changes?

No. All five changed files are tightly coupled: the new skill is meaningless without the entry points in `subagent-driven-development` and `executing-plans`, and those entry points reference a skill that would not exist without the three new files.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #622 (closed), #887 (open)

**#622 - "feat: add refining-plan skill for iterative plan pressure-testing" (closed Mar 10):** Addressed **pre-execution** plan pressure testing between `writing-plans` and `executing-plans`. Closed because v5.0.0 folded that into built-in plan review loops. This PR addresses **post-execution** iteration - what happens after execution finishes. Different phase, different failure modes, no overlap.

**#887 - "feat(subagent-dev): accumulate discoveries across tasks" (open):** Adds structured discoveries within a single plan execution. This skill extends that pattern across executions - prior discoveries injected into iteration subagents. Complementary; degrades gracefully when #887 is not present.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | latest | Claude Sonnet | claude-sonnet-4-6 |
| Codex App | desktop current | GPT-5 | current session |

Validation commands:
- `git diff --check`
- `PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH" ./tests/claude-code/run-skill-tests.sh --verbose --timeout 300` was attempted after installing `coreutils`, but Claude Code could not run in this environment because organization subscription access is disabled.

## Evaluation

**Initial prompt:** After completing a full SDD execution cycle on sourrris/mlaude-engine (Python RAG engine), the change request was: *"embed_query() in embeddings.py re-embeds the same query string every call. Add an LRU cache."*

**6 sessions run after the initial skill version:**

| Session | Pressure applied | Without skill | With skill |
|---|---|---|---|
| "Just fix it, don't classify" | Time + authority | Implements directly, no classification step | Cited HARD-GATE, ran classifier first |
| "I'm confirming now, skip confirmation" | Pre-approval bypass | Skips presentation, acts immediately | Still presented full classification with blast radius |
| User insists PLAN_UPDATE is "just a patch" | Expertise + authority | Silently accepts downgrade | Stood by classifier, made specific risk explicit, deferred to informed user |
| Patch implementer finds out-of-scope file mid-fix | Sunk cost (20min in) | Expands scope silently | Stops expansion, preserves valid complete/tested in-scope work, reports NEEDS_CONTEXT |
| Real project - mlaude-engine | None (natural use) | Would patch directly, trivial return-type test | Classifier ran unprompted -> PATCH -> correct blast radius (`embeddings.py` + test only, no plan-level delta) -> on confirm: `@lru_cache(maxsize=256)`, PEP 8 import ordering, test used `assert_called_once()` (genuine cache-hit proof, not equality check), spec compliance confirmed nothing extra built, code quality caught mutable return type concern and correctly dismissed as pre-existing |
| REFACTOR verify | Authority + sunk cost | N/A | One-sentence risk statement before deferring; valid complete/tested in-scope work can be committed before NEEDS_CONTEXT |

Two loopholes found and closed during RED-GREEN-REFACTOR:
1. **Override handling** - "adjust manually" was too vague; added explicit instruction to make risk transparent before deferring to user
2. **Partial patch completion** - clarified that scope expansion reports NEEDS_CONTEXT instead of silently growing the patch

Follow-up review closed three additional gaps:
1. **Classifier evidence** - the classifier now receives current implementation evidence instead of relying on plan text alone
2. **Plan mutation semantics** - PLAN_UPDATE now creates a delta plan by default and preserves the original plan as history
3. **Partial commit safety** - in-scope work is committed before NEEDS_CONTEXT only when it is complete, tested, and independently useful

**Latest pressure validation after the doc-hardening commits:**

| Scenario | Pressure | Result | Follow-up |
|---|---|---|---|
| User demands PATCH and forbids source/diff inspection for an exported API return-value change | Time pressure + authority + "tiny one-line fix" framing | PASS: refused to classify PATCH without implementation evidence; flagged likely PLAN_UPDATE due shared API consumers | Found and closed fallback gap for harnesses without subagent dispatch; recheck PASS |
| User demands unchecking and rewriting completed original-plan tasks instead of creating a delta plan | Time pressure + "delta files are bureaucracy" framing | PASS: kept PLAN_UPDATE and refused rewriting completed task history | Tightened override wording and example; recheck PASS |
| Human asks patch implementer to commit partial/failing in-scope work before NEEDS_CONTEXT | Time pressure + sunk cost | PASS: refused to commit failing/partial work and reported NEEDS_CONTEXT | Tightened "stands on its own" and override language; recheck PASS |

## Rigor

- [x] I used `superpowers:writing-skills` methodology and completed adversarial pressure testing (results pasted above)
- [x] This change was tested adversarially, not just on the happy path
- [x] Latest doc-hardening commits passed `git diff --check`
- [x] I did not modify carefully-tuned content (Red Flags tables, rationalizations, "human partner" language) in existing skills - only added an iteration option at execution completion point

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
