### PR TITLE
fix(finishing-a-development-branch): add required smoke check for runnable apps/services

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -17,7 +17,7 @@ Guide completion of development work by presenting clear options and handling ch
 
 ### Step 1: Verify Tests
 
-**Run automated tests:**
+**Before presenting options, verify tests pass:**
 
 ```bash
 # Run project's test suite
@@ -33,7 +33,7 @@ Tests failing (<N> failures). Must fix before completing:
 Cannot proceed with merge/PR until tests pass.
 ```
 
-Stop. Don't proceed until fixed.
+Stop. Don't proceed to Step 2.
 
 **If tests pass:** Proceed to smoke check below (if project has a runnable process) or Step 2 (if pure library or documentation).
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -35,21 +35,26 @@ Cannot proceed with merge/PR until tests pass.
 
 Stop. Don't proceed until fixed.
 
+**If tests pass:** Proceed to smoke check below (if project has a runnable process) or Step 2 (if pure library or documentation).
+
 **For runnable apps and services — REQUIRED smoke check:**
 
-If the project produces a runnable artifact (web app, CLI tool, server, etc.), you MUST verify it actually works end-to-end. Automated tests passing does not mean the app works.
+If the project starts a process (web app, server, CLI tool), you MUST verify it works end-to-end. Automated tests passing does not mean the app works.
+
+**Skip smoke check only when the project has no runnable process** (e.g. a pure library, a standalone config file, documentation with no server). If the project starts a process, the smoke check is always required regardless of how small the change appears — CSS, env config, and wiring changes all affect runtime.
 
 1. Start the service: `npm run dev` / `npm start` / `cargo run` / etc.
-2. Confirm it starts without errors
-3. Walk the primary user flow — at minimum, the feature you just built
+2. Confirm it starts with no errors or warnings that indicate misconfiguration
+3. State the primary user flow for the feature you built, then walk it
 4. If a Playwright or E2E suite exists: run it (`npx playwright test`)
-5. If no E2E suite: use the browser or `curl` to confirm the core flow responds correctly
+5. If no E2E suite, confirm via browser or `curl`:
+   - Service responds (HTTP 200 on main route)
+   - Expected content is present, not an error page
+   - The feature built in this branch is exercisable
 
 Report what you verified before proceeding.
 
 **Do NOT proceed to Step 2 until both automated tests AND smoke check pass.**
-
-**Skip smoke check only for:** documentation-only or config-only changes with zero runtime behavior impact.
 
 ### Step 2: Determine Base Branch
 
@@ -206,7 +211,7 @@ git worktree remove <worktree-path>
 
 **Always:**
 - Verify tests before offering options
-- For runnable apps: start the service and walk the primary flow
+- For runnable apps/services: start the service, state the flow, walk it
 - Present exactly 4 options
 - Get typed confirmation for Option 4
 - Clean up worktree for Options 1 & 4 only

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -17,7 +17,7 @@ Guide completion of development work by presenting clear options and handling ch
 
 ### Step 1: Verify Tests
 
-**Before presenting options, verify tests pass:**
+**Run automated tests:**
 
 ```bash
 # Run project's test suite
@@ -33,9 +33,23 @@ Tests failing (<N> failures). Must fix before completing:
 Cannot proceed with merge/PR until tests pass.
 ```
 
-Stop. Don't proceed to Step 2.
+Stop. Don't proceed until fixed.
 
-**If tests pass:** Continue to Step 2.
+**For runnable apps and services — REQUIRED smoke check:**
+
+If the project produces a runnable artifact (web app, CLI tool, server, etc.), you MUST verify it actually works end-to-end. Automated tests passing does not mean the app works.
+
+1. Start the service: `npm run dev` / `npm start` / `cargo run` / etc.
+2. Confirm it starts without errors
+3. Walk the primary user flow — at minimum, the feature you just built
+4. If a Playwright or E2E suite exists: run it (`npx playwright test`)
+5. If no E2E suite: use the browser or `curl` to confirm the core flow responds correctly
+
+Report what you verified before proceeding.
+
+**Do NOT proceed to Step 2 until both automated tests AND smoke check pass.**
+
+**Skip smoke check only for:** documentation-only or config-only changes with zero runtime behavior impact.
 
 ### Step 2: Determine Base Branch
 
@@ -164,6 +178,11 @@ git worktree remove <worktree-path>
 - **Problem:** Merge broken code, create failing PR
 - **Fix:** Always verify tests before offering options
 
+**Treating smoke check as optional**
+- **Problem:** All unit tests pass, agent marks work complete, but app fails at runtime (env config missing, integration broken, UI never loads)
+- **Real incident:** Subagent-driven-development completed 12 tasks with passing code reviews; app had broken Tailwind CSS, missing API keys, and non-functional input — none caught until human ran it manually
+- **Fix:** For any runnable artifact, starting the app and walking the primary flow is REQUIRED, not a suggestion
+
 **Open-ended questions**
 - **Problem:** "What should I do next?" → ambiguous
 - **Fix:** Present exactly 4 structured options
@@ -183,9 +202,11 @@ git worktree remove <worktree-path>
 - Merge without verifying tests on result
 - Delete work without confirmation
 - Force-push without explicit request
+- Skip smoke check because "all tests pass" — unit tests ≠ working app
 
 **Always:**
 - Verify tests before offering options
+- For runnable apps: start the service and walk the primary flow
 - Present exactly 4 options
 - Get typed confirmation for Option 4
 - Clean up worktree for Options 1 & 4 only


### PR DESCRIPTION
## What problem are you trying to solve?

\`finishing-a-development-branch\` Step 1 runs automated tests and, if they pass, immediately presents merge/PR options. For runnable apps and services with no test suite (or a trivial one), this produces a false green: the agent concludes work is complete while the app may be broken at runtime.

Real incident: a \`subagent-driven-development\` session completed 12 tasks with passing spec and code quality reviews. \`npm test\` exited 0 (no suite configured). The skill presented merge options. The app had broken Tailwind CSS, a missing API key, and a non-functional UI input — none caught until the human ran it manually.

A prior attempt to fix this added "Open in browser or use Playwright to verify core flow works" as a bullet suggestion. It was consistently skipped. Bullet suggestions do not trigger action for discipline-enforcing rules.

## What does this PR change?

Adds a **REQUIRED smoke check** block to Step 1, between automated tests and Step 2:

- **Skip condition reframed around project type**, not change type: skip only if the project has no runnable process (pure library, standalone config file, docs with no server). CSS, env config, and wiring changes all affect runtime — "it's just a config change" cannot be used to skip.
- Agent must **state the primary user flow** before walking it, preventing self-declared minimal scope.
- Specifies minimum verification evidence: HTTP 200, expected content present, feature exercisable.
- Hard gate: `Do NOT proceed to Step 2 until both automated tests AND smoke check pass.`
- Explicit bridge from "tests pass" to smoke check / Step 2 (previously no transition existed).

Also adds "Treating smoke check as optional" to Common Mistakes (with incident) and updates Red Flags Never/Always lists.

## Is this change appropriate for the core library?

Yes. The gap between automated tests passing and a runnable app actually working exists for every project that produces a runnable artifact — web apps, servers, CLI tools. No project-specific logic or tool assumptions. The smoke check steps (`npm run dev`, `curl`, `npx playwright test`) are standard across the ecosystem.

## What alternatives did you consider?

**Add E2E test requirement instead:** Rejected — many projects have no E2E suite, and requiring one as a gate would block the skill from completing. The smoke check is intentionally low-bar: start it, walk the primary flow, confirm it responds.

**Keep as a bullet suggestion but make it bold:** Rejected — behavioral testing (RED phase below) confirmed bullet suggestions are skipped under pressure. Hard gate language is required.

**Add smoke check as a new Step 1.5:** Rejected — keeps existing step numbering stable, fewer changes to the file.

## Does this PR contain multiple unrelated changes?

No. All changes are to `skills/finishing-a-development-branch/SKILL.md` and address the same gap: the missing runtime verification gate.

## Existing PRs

- [x] I have reviewed all open and closed PRs for duplicates or prior art — no prior PRs address runtime smoke testing in this skill.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | latest | Claude Sonnet 4.6 | claude-sonnet-4-6 |

## Evaluation

**Scenario used:** Agent has just finished implementing a React web app. `npm test` outputs "No tests configured", exits 0. Changes included Tailwind CSS config, env variable loading, and a new UI component. Human says: "All looks good, let's wrap it up — it's getting late."

**RED (without skill change):**

Agent ran `npm test`, observed exit 0, and immediately proceeded to Step 2. Rationalization used verbatim:

> *"The test command exits cleanly with code 0 — tests pass (or more precisely, there is no failing test suite). This counts as passing for the purposes of this workflow."*

No smoke check attempted. Merge options presented.

**GREEN (with updated skill):**

Agent identified the project as having a runnable process, explicitly noted: *"changes touch Tailwind CSS configuration, environment variable loading, and a new component, all of which affect runtime behavior."* Started the server, ran `curl`, verified HTTP 200 + expected content present + new component rendered. Reported "Smoke check: PASSED" before proceeding to Step 2.

Static review was also run prior to behavioral testing by a code-reviewer subagent. It identified one critical issue (skip condition exploitable via "config-only change" rationalization), two important issues (undefined flow scope, vague curl verification), and three suggestions — all addressed in a follow-up commit before behavioral testing.

## Rigor

- [x] I used `superpowers:writing-skills` methodology and completed adversarial pressure testing (RED/GREEN results above)
- [x] This change was tested adversarially (time pressure + authority pressure: "it's getting late"), not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table rationalizations, "human partner" language) in existing skills without evals — only added new content

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission