### PR TITLE
fix(dispatching-parallel-agents): align "Use when" threshold with description

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -34,7 +34,7 @@ digraph when_to_use {
 ```
 
 **Use when:**
-- 3+ test files failing with different root causes
+- 2+ test files failing with different root causes
 - Multiple subsystems broken independently
 - Each problem can be understood without context from others
 - No shared state between investigations


### PR DESCRIPTION
## What problem are you trying to solve?

The frontmatter description says "2+ independent tasks" but the "Use when" bullet list says "3+ test files failing with different root causes". An agent reading this skill gets conflicting signals about when to dispatch parallel agents — should it wait for 3 failures or 2?

## What does this PR change?

Changes "3+" to "2+" in the "Use when" section to match the frontmatter description.

## Is this change appropriate for the core library?

Yes — it's a one-line consistency fix in an existing core skill. No new functionality.

## What alternatives did you consider?

1. Change description to "3+" instead — but the skill's purpose is dispatching for any set of independent failures, and 2 independent failures already justify parallel dispatch.
2. Leave both — but conflicting thresholds cause unpredictable agent behavior.

## Does this PR contain multiple unrelated changes?

No. Single file, single line.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #829 (worktree/brainstorming fix — separate issue, originally bundled in my earlier #798 which I've now closed)

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 1.0.33 | Claude Opus 4.6 | claude-opus-4-6 |

## Evaluation

Verified by reading the file: `description` field on line 3 says "2+ independent tasks", "Use when" on line 37 said "3+". After change, both say "2+".

Not a behavior-shaping change (rationalization table, red flags, etc.) — purely a number consistency fix.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing — N/A, this is a number fix, not a workflow/behavior change
- [x] This change was tested adversarially, not just on the happy path — verified no other references to "3+" exist in the file
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission