### PR TITLE
Fix brainstorm server serving macOS resource fork dotfiles as content

### DIFF
--- a/skills/brainstorming/scripts/server.cjs
+++ b/skills/brainstorming/scripts/server.cjs
@@ -115,7 +115,7 @@ function wrapInFrame(content) {
 
 function getNewestScreen() {
   const files = fs.readdirSync(CONTENT_DIR)
-    .filter(f => f.endsWith('.html'))
+    .filter(f => f.endsWith('.html') && !f.startsWith('.'))
     .map(f => {
       const fp = path.join(CONTENT_DIR, f);
       return { path: fp, mtime: fs.statSync(fp).mtime.getTime() };
@@ -144,8 +144,9 @@ function handleRequest(req, res) {
     res.end(html);
   } else if (req.method === 'GET' && req.url.startsWith('/files/')) {
     const fileName = req.url.slice(7);
-    const filePath = path.join(CONTENT_DIR, path.basename(fileName));
-    if (!fs.existsSync(filePath)) {
+    const safeName = path.basename(fileName);
+    const filePath = path.join(CONTENT_DIR, safeName);
+    if (safeName.startsWith('.') || !fs.existsSync(filePath)) {
       res.writeHead(404);
       res.end('Not found');
       return;
@@ -267,14 +268,14 @@ function startServer() {
   // macOS fs.watch reports 'rename' for both new files and overwrites,
   // so we can't rely on eventType alone.
   const knownFiles = new Set(
-    fs.readdirSync(CONTENT_DIR).filter(f => f.endsWith('.html'))
+    fs.readdirSync(CONTENT_DIR).filter(f => f.endsWith('.html') && !f.startsWith('.'))
   );
 
   const server = http.createServer(handleRequest);
   server.on('upgrade', handleUpgrade);
 
   const watcher = fs.watch(CONTENT_DIR, (eventType, filename) => {
-    if (!filename || !filename.endsWith('.html')) return;
+    if (!filename || !filename.endsWith('.html') || filename.startsWith('.')) return;
 
     if (debounceTimers.has(filename)) clearTimeout(debounceTimers.get(filename));
     debounceTimers.set(filename, setTimeout(() => {

--- a/tests/brainstorm-server/server.test.js
+++ b/tests/brainstorm-server/server.test.js
@@ -179,6 +179,20 @@ async function runTests() {
       assert(!res.body.includes('"not"'), 'Should not serve JSON');
     });
 
+    await test('ignores macOS resource fork dotfiles (._*.html)', async () => {
+      // macOS creates ._filename resource forks containing binary metadata
+      // like "Mac OS X  2ATTR...com.apple.provenance" — these must not be served
+      fs.writeFileSync(path.join(CONTENT_DIR, '._resource-fork.html'), 'Mac OS X  2\x00ATTR\x00\x00com.apple.provenance');
+      await sleep(300);
+
+      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      assert(!res.body.includes('com.apple.provenance'), 'Should not serve resource fork content');
+      assert(!res.body.includes('ATTR'), 'Should not contain resource fork data');
+
+      const filesRes = await fetch(`http://localhost:${TEST_PORT}/files/._resource-fork.html`);
+      assert.strictEqual(filesRes.status, 404, 'Should return 404 for dotfile via /files/');
+    });
+
     await test('returns 404 for non-root paths', async () => {
       const res = await fetch(`http://localhost:${TEST_PORT}/other`);
       assert.strictEqual(res.status, 404);


### PR DESCRIPTION
On macOS, ._*.html resource fork files pass the .endsWith('.html') filter and get served as page content, showing binary metadata instead of the actual brainstorm screen. Filter out dotfiles in all four places where content directory files are listed or served.


## What problem are you trying to solve?

On macOS, the brainstorm visual companion serves binary garbage `(Mac OS X 2ATTR...com.apple.provenance`) instead of HTML content. macOS creates ._filename resource fork files
  alongside real files. These ._screen.html files pass the .endsWith('.html') filter in server.cjs and get picked as the newest screen, serving their binary metadata to the browser.
  
This is a blocker for using visual asistant if project folder is localted on external drives, in my case it's `ExFAT`

## What does this PR change?

Adds !f.startsWith('.') dotfile guards to all four places in server.cjs where content directory files are listed or served. Adds one integration test covering the ._*.html case.

## Is this change appropriate for the core library?

Yes — affects any macOS user running the brainstorm visual companion. Not project-specific, not third-party.

## What alternatives did you consider?

Filtering only ._ prefix (!f.startsWith('._')). Chose !f.startsWith('.') instead because it covers all hidden/dotfiles per Unix convention (.DS_Store, .hidden.html, etc.) and is the
  standard approach.

## Does this PR contain multiple unrelated changes?

No. Single bug fix + its test.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art


## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
|            Claude Code              |    2.1.85       | Claude   |  claude-opus-4-6              |

## Evaluation

- Initial prompt: "fix the brainstorm visual companion serving macOS resource fork binary data instead of HTML content"
- Ran the full test suite (node --test tests/brainstorm-server/server.test.js) — 26/26 pass including the new dotfile test
- Before: ._*.html files pass the .endsWith('.html') filter and binary content is served to the browser
- After: dotfiles are rejected at all four entry points — getNewestScreen(), /files/ endpoint, knownFiles init, fs.watch handler
- Manual testing:
<img width="665" height="217" alt="SCR-20260327-ideo" src="https://github.com/user-attachments/assets/9afb768b-9279-48d1-9618-c841aafcd2f4" />
<img width="620" height="436" alt="SCR-20260327-icwf" src="https://github.com/user-attachments/assets/96345ed0-baa7-4407-8cb7-8014aa00a594" />
<img width="1178" height="738" alt="SCR-20260327-icro" src="https://github.com/user-attachments/assets/778b07c5-d4c9-4d99-a0ab-098a0e1e13d8" />

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement


## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->
