### PR TITLE
fix(finish): cd to main repo before worktree removal

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -144,6 +144,16 @@ git worktree list | grep $(git branch --show-current)
 
 If yes:
 ```bash
+# IMPORTANT: Before removing a worktree, we must change to a directory outside it.
+# If the current working directory is inside the worktree, git worktree remove will fail with:
+#   fatal: cannot remove worktree '<path>': '<path>' is the current working directory
+# Get main repo path (first entry in worktree list is always main)
+main_repo=$(git worktree list | head -1 | awk '{print $1}')
+
+# Change to main repo before removal
+cd "$main_repo"
+
+# Now safe to remove
 git worktree remove <worktree-path>
 ```
 


### PR DESCRIPTION
## Summary

Fixes #238

## Problem

The `/finish` workflow's Step 5 runs `git worktree remove <path>` without first changing the working directory. When the current shell session is inside the worktree being removed, this fails:

```
fatal: cannot remove worktree '<path>': '<path>' is the current working directory
```

This is a common scenario when Claude Code's shell is still inside the feature worktree.

## Solution

Before running `git worktree remove`, change directory to the main repository:

```bash
# Get main repo path (first entry in worktree list is always main)
main_repo=$(git worktree list | head -1 | awk '{print $1}')

# Change to main repo before removal
cd "$main_repo"

# Now safe to remove
git worktree remove <worktree-path>
```

## Testing

- Verified that `git worktree list | head -1 | awk '{print $1}'` correctly returns the main repo path
- Removal succeeds after cd-ing out of the worktree

## Files Changed

- `skills/finishing-a-development-branch/SKILL.md` — Updated Step 5 with directory change