### PR TITLE
feat(subagent-dev): add optional external delegate mode for implementation tasks

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -99,6 +99,45 @@ Use the least powerful model that can handle each role to conserve cost and incr
 - Touches multiple files with integration concerns → standard model
 - Requires design judgment or broad codebase understanding → most capable model
 
+## External Delegate (Optional)
+
+When configured in AGENTS.md (`external-delegate: <cli-name>`), mechanical implementation tasks can be delegated to an external CLI tool instead of a same-provider subagent. This extends the "least powerful model" principle across providers - when a cheaper, faster tool can handle the task, use it.
+
+**When to delegate externally:**
+- Task is cheap-model tier (1-2 files, complete spec, isolated function)
+- External CLI is available and responding
+- The delegate hasn't failed 3+ times this session
+
+**When NOT to delegate externally:**
+- Integration tasks touching multiple files with coordination concerns
+- Architecture or design decisions
+- Review tasks - spec compliance and code quality reviews always use same-provider subagents
+- The external CLI has hit the circuit breaker (3 consecutive failures)
+
+**How it works:**
+
+The controller's responsibilities stay the same. Only the implementer dispatch changes:
+
+1. Check delegate availability: `which <cli-name> >/dev/null 2>&1`
+2. Build the implementation prompt using `./external-delegate-prompt.md` (a streamlined implementer prompt without self-review or escalation sections - the controller handles those)
+3. Write the prompt to a temp file and pipe it to the delegate: `cat /tmp/sp-delegate-prompt.md | <cli-name> <flags>`
+4. Review the diff: verify it's non-empty, in-scope, and contains no rogue operations
+5. If the diff looks good, proceed to spec compliance review (same as the normal flow)
+6. If the diff is empty or out-of-scope, fall back to a same-provider subagent for this task
+7. The controller always commits - the delegate should not touch git
+
+**Circuit breaker:** If the external delegate fails 3 consecutive times in one session, disable it for the remainder and use same-provider subagents for all remaining tasks. Reset the counter on any successful delegation.
+
+**Configuration example in AGENTS.md:**
+
+```markdown
+## External Delegate
+
+external-delegate: codex
+```
+
+The controller reads this at session start. If the key is absent or empty, all tasks use same-provider subagents (the default behavior, unchanged).
+
 ## Handling Implementer Status
 
 Implementer subagents report one of four statuses. Handle each appropriately:
@@ -120,6 +159,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 ## Prompt Templates
 
 - `./implementer-prompt.md` - Dispatch implementer subagent
+- `./external-delegate-prompt.md` - Dispatch external delegate (streamlined implementer prompt)
 - `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
 - `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
 
@@ -230,6 +270,7 @@ Done!
 - Controller does more prep work (extracting all tasks upfront)
 - Review loops add iterations
 - But catches issues early (cheaper than debugging later)
+- With external delegate: mechanical tasks use the delegate's token budget instead of the controller's, reducing same-provider token consumption on sessions with many implementation tasks
 
 ## Red Flags
 
@@ -246,6 +287,9 @@ Done!
 - Let implementer self-review replace actual review (both are needed)
 - **Start code quality review before spec compliance is ✅** (wrong order)
 - Move to next task while either review has open issues
+- Delegate review tasks to an external CLI (reviews must use same-provider subagents)
+- Skip the diff review after external delegation (verify before proceeding)
+- Ignore the circuit breaker (3 consecutive delegate failures = disable for session)
 
 **If subagent asks questions:**
 - Answer clearly and completely

--- a/skills/subagent-driven-development/external-delegate-prompt.md
+++ b/skills/subagent-driven-development/external-delegate-prompt.md
@@ -1,0 +1,43 @@
+# External Delegate Prompt Template
+
+Use this template when dispatching a task to an external CLI tool configured via `external-delegate` in AGENTS.md. This is a streamlined version of the implementer prompt - it removes self-review and escalation sections that the controller handles.
+
+```
+Implement Task N: [task name]
+
+## Task Description
+
+[FULL TEXT of task from plan - paste it here]
+
+## Context
+
+[Scene-setting: where this fits, dependencies, architectural context]
+
+## Your Job
+
+1. Implement exactly what the task specifies
+2. Write tests (following TDD if task says to)
+3. Verify implementation works
+
+Work from: [directory]
+
+## Code Organization
+
+- Follow the file structure defined in the task
+- Each file should have one clear responsibility
+- In existing codebases, follow established patterns
+- Do not restructure code outside your task scope
+
+## Rules
+
+- Do NOT run git commit, git push, or git add
+- Do NOT create pull requests or branches
+- Do NOT modify files outside the scope of this task
+- After implementation, run: git status && git diff --stat
+```
+
+**Notes for the controller:**
+
+- The delegate does not self-review or escalate. The controller handles both via the spec compliance and code quality review subagents.
+- The delegate should not commit. The controller reviews the diff and commits after validation.
+- If the delegate produces no changes or out-of-scope changes, fall back to a same-provider subagent for this task.


### PR DESCRIPTION
## What problem are you trying to solve?

Users on metered plans (Claude Pro, Codex weekly credits) burn through their token allocation running superpowers sessions with many mechanical tasks. Each implementation subagent consumes tokens from the same provider as the controller. On a session with 8+ tasks, the implementer subagents account for the majority of token spend, even though most mechanical tasks (1-2 files, clear spec) don't need the controller's model.

The skill already says "use the least powerful model that can handle each role" - but that principle stops at the provider boundary. There's no way to route cheap tasks to a different provider's CLI that might be faster, cheaper, or better suited for mechanical implementation.

Related issues:
- #730 (4 thumbs up) - requests cross-model collaboration via external CLI tools
- #750 (7 comments) - users exhausting weekly credits in one session
- #895 - @obra noted "the intent is that you should be able to use haiku (or even less capable models) as the implementers"

## What does this PR change?

Adds an optional "External Delegate" section to subagent-driven-development. When users configure `external-delegate: <cli-name>` in their AGENTS.md, mechanical implementation tasks (cheap-model tier) get piped to the external CLI instead of spawning a same-provider subagent. Also adds `external-delegate-prompt.md` - a streamlined implementer prompt for delegates.

## Is this change appropriate for the core library?

Yes. This is provider-agnostic infrastructure, not a third-party integration. It works with any CLI that accepts a prompt on stdin and writes to the filesystem. The AGENTS.md example uses `codex` but the mechanism is generic. It extends an existing design pattern (model selection tiers) rather than adding a new one.

The feature is opt-in. Without `external-delegate` in AGENTS.md, behavior is identical to today. No new dependencies, no scripts, no external service calls from superpowers itself.

## What alternatives did you consider?

1. **Cross-model review only** (#730's original proposal) - smaller scope but only addresses the bias problem, not token conservation. If the delegate interface exists for implementation, adding review delegation later is trivial.

2. **Token budget tracking** - auto-switch to delegate when nearing billing limits. Too complex, too many assumptions about billing APIs. Explicit opt-in via AGENTS.md is simpler. Also aligns with @obra's response on #750: "You can do that today - just put those things in your AGENTS.md."

3. **Separate skill** - a standalone `external-delegate` skill instead of extending subagent-driven-development. This would fragment the execution flow and require users to choose between two competing execution skills. Extending the existing skill preserves the single execution path.

## Does this PR contain multiple unrelated changes?

No. One feature: external delegate mode. Two files: the section in SKILL.md and the prompt template.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #113 (closed, Nov 2025), #730 (open issue), #750 (open issue), #887 (open, mine - different feature: accumulated discoveries)

PR #113 was a larger scope ("comprehensive Codex CLI integration" with utility scripts, hooks, config files). This PR is instruction-only - 44 lines of markdown added to SKILL.md plus a prompt template. No code, no scripts, no config files. The approach is fundamentally different: opt-in via AGENTS.md rather than automatic delegation.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|----------------|-------|------------------|
| Claude Code | 1.0.33 | Claude | claude-opus-4-6 |

## Evaluation

Initial prompt: "Research obra/superpowers for external delegate/Codex delegation patterns. If none exist, propose adding one."

This change adds skill instructions (markdown), not executable code. The evaluation is structural:
- The new section slots cleanly after Model Selection, extending the existing cheap/standard/capable tier system
- The prompt template follows the same structure as `implementer-prompt.md` with sections removed that the controller handles (self-review, escalation)
- The circuit breaker and fallback patterns match how superpowers handles other failure modes
- Red Flags additions are consistent with existing entries

I have not run multi-session evals comparing sessions with and without external delegation. The instructions are new and untested at scale. I'd welcome feedback on the circuit breaker threshold (currently 3 failures) and the task-tier classification rules.

## Video Demo

![Demo](https://files.catbox.moe/wj1thz.gif)

## Rigor

- [x] If this is a skills change: I reviewed `superpowers:writing-skills` patterns. Adversarial pressure testing was not performed (this is a new feature proposal, not a modification to existing behavior-shaping content).
- [x] This change was reviewed for edge cases: delegate unavailable (fallback), delegate fails (circuit breaker), out-of-scope changes (diff review + fallback), git operations (controller-only)
- [x] I did not modify any existing behavior-shaping content. All changes are additive.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

This contribution was developed with AI assistance (Claude Code).

Relates to #730, #750