### PR TITLE
docs(codex-tools): fix subagent wait mapping to wait_agent

### DIFF
--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -24,9 +24,10 @@ multi_agent = true
 
 This enables `spawn_agent`, `wait_agent`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`.
 
-Legacy note: older Codex docs or skill mappings may say `wait` for subagent
-results. In current Codex, use `wait_agent` to wait for spawned agents; use
-`wait` (`exec/wait`) only for waiting on exec / command output.
+Legacy note: Codex builds before `rust-v0.115.0` exposed spawned-agent
+waiting as `wait`. Current Codex uses `wait_agent` for spawned agents. The
+`wait` name now belongs to code-mode `exec/wait`, which resumes a yielded exec
+cell by `cell_id`; it is not the spawned-agent result tool.
 
 ## Named agent dispatch
 

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -6,7 +6,7 @@ Skills use Claude Code tool names. When you encounter these in a skill, use your
 |-----------------|------------------|
 | `Task` tool (dispatch subagent) | `spawn_agent` (see [Named agent dispatch](#named-agent-dispatch)) |
 | Multiple `Task` calls (parallel) | Multiple `spawn_agent` calls |
-| Task returns result | `wait` |
+| Task returns result | `wait_agent` |
 | Task completes automatically | `close_agent` to free slot |
 | `TodoWrite` (task tracking) | `update_plan` |
 | `Skill` tool (invoke a skill) | Skills load natively — just follow the instructions |
@@ -22,7 +22,11 @@ Add to your Codex config (`~/.codex/config.toml`):
 multi_agent = true
 ```
 
-This enables `spawn_agent`, `wait`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`.
+This enables `spawn_agent`, `wait_agent`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`.
+
+Legacy note: older Codex docs or skill mappings may say `wait` for subagent
+results. In current Codex, use `wait_agent` to wait for spawned agents; use
+`wait` (`exec/wait`) only for waiting on exec / command output.
 
 ## Named agent dispatch
 


### PR DESCRIPTION
## Summary

Fix the Codex tool mapping doc so subagent waiting uses `wait_agent` instead of the outdated `wait`.

## Problem

`skills/using-superpowers/references/codex-tools.md` still described `wait` as the tool for collecting spawned subagent results.

That is outdated for current Codex. In current `openai/codex`, subagent waiting is handled by `wait_agent`, while `wait` is the separate exec-waiting surface (`exec/wait`) used for command / exec output.

## Why this is correct

I verified this against the official `openai/codex` source corresponding to CLI `0.117.0` (`rust-v0.117.0`):

### 1. Codex defines a dedicated `wait_agent` tool for subagents

In the tool spec, Codex defines `create_wait_agent_tool_v1()` and `create_wait_agent_tool_v2()`, both named `wait_agent`:

- `name: "wait_agent".to_string()`
- `description: "Wait for agents to reach a final status..."`

Source:
- https://github.com/openai/codex/blob/rust-v0.117.0/codex-rs/core/src/tools/spec.rs#L1616-L1635

### 2. Codex registers the subagent wait handler under `wait_agent`

The multi-agent handler registration uses `wait_agent`, not `wait`:

- `builder.register_handler("wait_agent", Arc::new(WaitAgentHandlerV2));`

Source:
- https://github.com/openai/codex/blob/rust-v0.117.0/codex-rs/core/src/tools/spec.rs#L2808-L2812

### 3. Codex separately defines `wait` as the exec wait tool

Codex also defines a different `wait` tool with exec-specific parameters such as:

- `cell_id`
- `yield_time_ms`
- `max_tokens`
- `terminate`

That is the command / exec waiting surface, not subagent waiting.

Source:
- https://github.com/openai/codex/blob/rust-v0.117.0/codex-rs/core/src/tools/spec.rs#L822-L850

### 4. Codex tests explicitly distinguish the two tool surfaces

The tool-spec tests show:

- multi-agent tools include:
  - `["spawn_agent", "send_input", "wait_agent", "close_agent"]`
- code-mode exec tools include:
  - `["exec", "wait"]`

Sources:
- https://github.com/openai/codex/blob/rust-v0.117.0/codex-rs/core/src/tools/spec_tests.rs#L379-L383
- https://github.com/openai/codex/blob/rust-v0.117.0/codex-rs/core/src/tools/spec_tests.rs#L2840-L2845

### 5. Codex’s own code-mode description ties `wait` to `exec/wait`

Codex’s code-mode description says:

- `Use `exec/wait` tool to run all other tools...`

So `wait` is explicitly associated with the exec/code-mode path.

Source:
- https://github.com/openai/codex/blob/rust-v0.117.0/codex-rs/code-mode/src/description.rs#L8-L10

### 6. The subagent wait implementation operates on agent targets and returns `WaitAgentResult`

The multi-agent wait implementation parses agent targets and returns `WaitAgentResult`, confirming that this path is specifically for waiting on spawned agents.

Sources:
- https://github.com/openai/codex/blob/rust-v0.117.0/codex-rs/core/src/tools/handlers/multi_agents/wait.rs#L37-L45
- https://github.com/openai/codex/blob/rust-v0.117.0/codex-rs/core/src/tools/handlers/multi_agents/wait.rs#L157-L166

### 7. Release reference

Official release tag for the version checked:
- https://github.com/openai/codex/releases/tag/rust-v0.117.0

## Changes

- Updated `Task returns result` mapping from `wait` to `wait_agent`
- Updated the multi-agent support note from `spawn_agent`, `wait`, `close_agent` to `spawn_agent`, `wait_agent`, `close_agent`
- Added a short legacy note clarifying:
  - `wait_agent` = wait for spawned agents
  - `wait` (`exec/wait`) = wait for exec / command output

## Scope

Minimal doc-only change in:

- `skills/using-superpowers/references/codex-tools.md`

## Verification

- Checked the file diff
- Ran:

```bash
git diff --check -- skills/using-superpowers/references/codex-tools.md
```

No diff formatting issues were reported.