### PR TITLE
feat: add writing-test-scenario-specs skill

### DIFF
--- a/docs/superpowers/plans/2026-03-28-subagent-driven-test-development.md
+++ b/docs/superpowers/plans/2026-03-28-subagent-driven-test-development.md
@@ -1,0 +1,503 @@
+# Subagent-Driven Test Development — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the `subagent-driven-test-development` superpowers skill — a workflow that translates approved scenario specs into RED test functions (any language/framework), validates 1:1 mapping, and commits failing tests before handing off to `subagent-driven-development` for GREEN implementation.
+
+**Architecture:** A single SKILL.md drives a 6-step flow with two subagent prompts (Spec-to-Test Translator, Spec ↔ Test Mapping Reviewer). The skill detects language and test framework at activation time for portability. No framework-specific patterns are hard-coded.
+
+**Tech Stack:** Superpowers skill system (SKILL.md + supporting markdown files), Claude Code Agent tool for subagent dispatch.
+
+**Spec:** `docs/superpowers/specs/2026-03-28-subagent-driven-test-development-design.md`
+
+**Phase 1 reference:** `docs/superpowers/plans/2026-03-28-writing-test-scenario-specs.md` (structural analog — same skill pattern)
+
+**Worked example:** `docs/superpowers/ideas/guardrails-test-scenario-spec.md` (sample scenario spec the translator would consume)
+
+---
+
+## File Structure
+
+All files live in `~/.claude/skills/subagent-driven-test-development/`:
+
+| File | Responsibility |
+|------|---------------|
+| `SKILL.md` | Main skill — frontmatter, 6-step flow, hard gates, project detection, anti-pattern counters, human interaction logic |
+| `spec-to-test-prompt.md` | Subagent dispatch template — reads scenario spec, generates RED test code adapted to detected framework |
+| `spec-test-mapping-reviewer-prompt.md` | Subagent dispatch template — validates 1:1 coverage between spec rows and test functions |
+
+Additionally, one existing skill needs a minor edit:
+
+| File | Change |
+|------|--------|
+| `~/.claude/skills/writing-test-scenario-specs/SKILL.md` | Add handoff message naming this skill as next step (once Phase 1 skill exists) |
+
+**Note:** The `writing-test-scenario-specs` skill may not exist yet (Phase 1 may still be in progress). If it doesn't exist, skip the handoff wiring task and document it as a follow-up.
+
+---
+
+## Task 1: Write the Spec-to-Test Translator subagent prompt
+
+**Files:**
+- Create: `~/.claude/skills/subagent-driven-test-development/spec-to-test-prompt.md`
+- Reference: `~/.claude/skills/brainstorming/spec-document-reviewer-prompt.md` (dispatch template pattern)
+- Reference: `~/.claude/skills/subagent-driven-development/implementer-prompt.md` (subagent prompt structure)
+- Reference: Design spec Section 8 (Spec-to-Test Translator Subagent)
+
+The translator reads a scenario spec and generates RED test code. It follows the dispatch template pattern — a markdown file with a prompt template containing placeholders. This is the most complex subagent prompt because it must be language-agnostic.
+
+- [ ] **Step 1: Write the translator prompt file**
+
+Create `~/.claude/skills/subagent-driven-test-development/spec-to-test-prompt.md`. The prompt must instruct the subagent to:
+
+1. Read the scenario spec content (passed inline, not as a file path)
+2. Read the implementation plan content (for deriving module paths and test file locations)
+3. Read the detected project conventions (passed inline — language, test framework, naming patterns, categorization mechanism, directory structure, style rules)
+4. Parse spec metadata (Feature, Design ref, Plan ref) for traceability comments in generated code
+5. Parse Test Data section (1.0) → generate shared setup/fixtures in the framework's convention
+6. Parse scenario rows (1.1–1.4) → group by Service/Unit column → one test file per service/unit
+7. For each scenario row, generate a test function following these rules:
+   - **Name:** Framework-appropriate test name derived from Scenario Name column
+   - **Category:** Map scenario section to test category using the framework's mechanism (1.1–1.3 → unit, 1.4 → sanity/smoke, integration if Preconditions imply external deps)
+   - **Description:** One-line from Scenario Name (docstring, comment, or display name per framework)
+   - **Body:** Preconditions → arrange, Steps → act, Expected Result → assert. **Sanity Scenarios (1.4)** use different columns (Steps, Assertions) — translate Steps → act, Assertions → assert (no arrange step).
+   - **Imports/References:** Real imports from planned module structure — not mocked
+8. Where a scenario implies multiple inputs, generate data-driven test expansions using the framework's mechanism with concrete values expanded inline
+9. For Sanity Scenarios (1.4), generate integration-style tests with smoke/sanity category
+
+The prompt must include these constraints:
+- Only translate what the spec describes — do not invent tests
+- Imports/references must be real (from the planned module structure), not mocked
+- Tests must be RED — no implementation code, no stubs, no skips
+- Follow project conventions (style rules, linter config, naming patterns)
+- Each test function must be traceable to its scenario row via name and description
+- An unresolved import/reference is a valid RED failure — do not work around it
+
+The prompt must include a framework adaptation guide showing how concepts map across languages:
+
+| Concept | Python (pytest) | JavaScript (Jest) | Java (JUnit 5) | Go (testing) |
+|---------|-----------------|-------------------|----------------|--------------|
+| Test naming | `test_<name>` | `test("name", ...)` | `@Test void name()` | `func TestName(t *testing.T)` |
+| Categorization | `@pytest.mark.unit` | `describe` blocks / tags | `@Tag("unit")` | Build tags |
+| Data-driven | `@pytest.mark.parametrize` | `test.each` | `@ParameterizedTest` | Table-driven tests |
+| Shared setup | `conftest.py` fixtures | `beforeAll`/`beforeEach` | `@BeforeAll`/`@BeforeEach` | `TestMain` / helpers |
+| File naming | `test_<unit>.py` | `<unit>.test.ts` | `<Unit>Test.java` | `<unit>_test.go` |
+
+Use the dispatch template pattern from `spec-document-reviewer-prompt.md`:
+
+```markdown
+# Spec-to-Test Translator Prompt Template
+
+Use this template when dispatching a spec-to-test translator subagent.
+
+**Purpose:** Read the scenario spec and generate RED test code for all scenario rows, adapted to the project's language and test framework.
+
+**Dispatch during:** Step 2 of the subagent-driven-test-development skill flow.
+
+Agent tool (general-purpose):
+  description: "Translate scenario spec to RED tests"
+  prompt: |
+    You are a spec-to-test translator. Read the scenario spec and generate
+    RED test functions that will fail until the production code is implemented.
+
+    **Scenario spec:**
+    [SCENARIO_SPEC_CONTENT — full text, not a file path]
+
+    **Implementation plan:**
+    [PLAN_CONTENT — full text, for deriving module paths]
+
+    **Project conventions:**
+    [CONVENTIONS — language, framework, naming, categorization, style rules]
+
+    ## Your Task
+    ...
+
+    ## Framework Adaptation Guide
+    [table above]
+
+    ## Constraints
+    ...
+
+    ## Output Format
+
+    Return all generated test files. For each file, include:
+    1. Target file path (derived from plan's module structure, mirrored into test tree)
+    2. Complete file content (ready to write as-is)
+
+    Format as:
+    ### File: `<target-path>`
+    ```<language>
+    <complete file content>
+    ```
+```
+
+Include the full prompt text — the implementer should be able to use the file as-is.
+
+- [ ] **Step 2: Validate against the guardrails example**
+
+Read the guardrails worked example (`docs/superpowers/ideas/guardrails-test-scenario-spec.md`). Mentally trace through the translator prompt: if given the guardrails spec as input, would it produce well-structured RED test functions? Specifically check:
+- Each of the 7 positive tests maps to a test function
+- Each of the 6 negative tests maps to a test function
+- Each of the 4 edge cases maps to a test function
+- The 2 sanity scenarios use the different column format (Steps, Assertions)
+- Test names are derived from Scenario Name column
+- Imports reference planned module paths (not invented)
+- Assertions match Expected Result column (not weaker)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ~/.claude/skills/subagent-driven-test-development/spec-to-test-prompt.md
+git commit -m "feat: add spec-to-test translator subagent prompt"
+```
+
+---
+
+## Task 2: Write the Spec ↔ Test Mapping Reviewer subagent prompt
+
+**Files:**
+- Create: `~/.claude/skills/subagent-driven-test-development/spec-test-mapping-reviewer-prompt.md`
+- Reference: `~/.claude/skills/brainstorming/spec-document-reviewer-prompt.md` (dispatch template pattern)
+- Reference: `~/.claude/skills/writing-test-scenario-specs/test-scenario-reviewer-prompt.md` (cross-reference review pattern, if it exists)
+- Reference: Design spec Section 9 (Spec ↔ Test Mapping Reviewer Subagent)
+
+The reviewer validates 1:1 coverage between scenario spec rows and generated test functions. It follows the dispatch template pattern.
+
+- [ ] **Step 1: Write the reviewer prompt file**
+
+Create `~/.claude/skills/subagent-driven-test-development/spec-test-mapping-reviewer-prompt.md`. The prompt must instruct the subagent to:
+
+1. Read the scenario spec content
+2. Read all generated test file contents
+3. Extract all scenario rows from sections 1.1–1.4, building a checklist of scenario names
+4. Extract all test functions from the generated files, mapping each to its scenario via function name and description
+5. Cross-reference to produce a report with four categories:
+
+| Category | Description |
+|----------|-------------|
+| **Mapped** | Scenario rows with a matching test function (brief summary) |
+| **Gaps** | Scenario rows with no matching test — include draft test code in the same style as the translator output |
+| **Orphans** | Test functions that don't trace to any scenario row — recommend removal |
+| **Assertion check** | For each mapped pair: does the test's assertions cover the Expected Result column? Flag weak assertions |
+
+The prompt must include these constraints:
+- Approve only if: zero gaps AND zero orphans AND no weak assertions
+- Gaps must include complete draft test code — not just "add a test for X"
+- Orphans are flagged for removal, not silently deleted
+- Stylistic feedback is not grounds for rejection
+
+Use this output format:
+
+```markdown
+## Spec ↔ Test Mapping Review
+
+**Status:** Approved | Issues Found
+
+### Mapped
+- [Scenario Name] → [test_function_name] in [file] ✓
+
+### Gaps (if any)
+- [Scenario Name]: no matching test found
+
+  **Suggested test code:**
+  ```<language>
+  [complete test function in the same style as translator output]
+  ```
+
+### Orphans (if any)
+- [test_function_name] in [file]: does not trace to any scenario row — recommend removal
+
+### Assertion Check
+- [test_function_name]: assertion covers Expected Result ✓
+- [test_function_name]: ⚠️ weak assertion — spec says "[expected]" but test only checks `[weaker check]`
+
+### Recommendations (advisory, do not block approval)
+- [suggestions]
+```
+
+Include the full prompt text.
+
+- [ ] **Step 2: Validate the review categories**
+
+Re-read the design spec Section 9. Confirm the prompt covers all four report categories (Mapped, Gaps, Orphans, Assertion check) and that the gap format includes complete draft test code.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ~/.claude/skills/subagent-driven-test-development/spec-test-mapping-reviewer-prompt.md
+git commit -m "feat: add spec-test mapping reviewer subagent prompt"
+```
+
+---
+
+## Task 3: Write the main SKILL.md
+
+**Files:**
+- Create: `~/.claude/skills/subagent-driven-test-development/SKILL.md`
+- Reference: `~/.claude/skills/subagent-driven-development/SKILL.md` (flow pattern with subagent dispatch + review loops)
+- Reference: `~/.claude/skills/brainstorming/SKILL.md` (checklist + hard gate + flow diagram pattern)
+- Reference: Design spec Sections 6, 7, 10, 11, 12 (project detection, flow, TDD discipline, anti-patterns)
+
+This is the core file. It defines project detection, the 6-step flow, hard gates, anti-pattern counters, and subagent dispatch instructions.
+
+- [ ] **Step 1: Write the SKILL.md skeleton with frontmatter and overview**
+
+Create `~/.claude/skills/subagent-driven-test-development/SKILL.md` with:
+
+```yaml
+---
+name: subagent-driven-test-development
+description: >
+  Use after writing-test-scenario-specs produces an approved scenario spec
+  and BEFORE implementation begins. Translates scenario rows into RED test
+  functions (any language/framework), validates 1:1 mapping, and commits
+  failing tests. Hands off to subagent-driven-development for GREEN
+  implementation.
+---
+```
+
+Add an overview section explaining:
+- What this skill does (translates scenario specs into RED test code, validates mapping, commits)
+- Where it sits in the workflow (after writing-test-scenario-specs, before subagent-driven-development)
+- What it produces (RED test files — not implementation code)
+
+- [ ] **Step 2: Add the hard gate**
+
+Add a `<HARD-GATE>` block:
+
+```markdown
+<HARD-GATE>
+Do NOT write production/implementation code, invoke subagent-driven-development,
+or make any test pass. This skill produces RED (failing) test functions only.
+GREEN implementation is handled by subagent-driven-development after this skill
+completes.
+</HARD-GATE>
+```
+
+- [ ] **Step 3: Add the checklist**
+
+Add a numbered checklist of the 6 steps (matches design spec Section 7):
+
+1. Collect inputs — confirm or request spec and plan paths, detect project conventions
+2. Generate test code — dispatch Spec-to-Test Translator subagent
+3. Coarse approval — present generated tests in chat, iterate with human
+4. Write test files — write to derived paths after human confirmation
+5. Mapping review — dispatch Spec ↔ Test Mapping Reviewer, handle gaps
+6. Commit & handoff — verify RED, commit, announce subagent-driven-development
+
+- [ ] **Step 4: Add the project detection section**
+
+Add the project detection logic from design spec Section 6. At activation (Step 1), the skill detects:
+- Language and test framework (from build/dependency files)
+- Test naming patterns (from existing test files)
+- Test categorization mechanism (from framework config)
+- Test directory structure (from existing layout)
+- Style rules (from linter/formatter config)
+
+Include the framework adaptation table from the design spec.
+
+- [ ] **Step 5: Add the flow diagram**
+
+Add a `dot` (graphviz) flow diagram showing the 6 steps with decision points:
+- Step 1: "Paths from handoff?" → yes: confirm / no: ask human
+- Step 2: Dispatch translator
+- Step 3: "Human approves?" → no: iterate / yes: proceed
+- Step 4: Write files
+- Step 5: "Reviewer approves?" → issues found: present to human, loop / approved: proceed. "Max iterations?" → exceeded: surface to human
+- Step 6: Verify RED → commit → announce handoff
+
+- [ ] **Step 6: Add detailed step instructions**
+
+Write detailed instructions for each of the 6 steps:
+
+**Step 1 — Collect inputs:**
+- Check if scenario spec and plan paths are in conversation context from prior handoff
+- If yes, confirm: "I see the scenario spec at `<path>` and plan at `<path>`. Correct?"
+- If no, ask the human for both paths
+- Detect project conventions: read `CLAUDE.md`, build files, test framework config, existing test structure
+- Summarize detected conventions to human: "Detected: [language] with [framework], tests in `[dir]`, naming pattern `[pattern]`"
+
+**Step 2 — Generate test code:**
+- Read the `spec-to-test-prompt.md` template
+- Fill placeholders: scenario spec content (read and paste inline), plan content (read and paste inline), detected conventions
+- Dispatch as Agent tool (general-purpose) subagent
+- Receive generated test files
+
+**Step 3 — Coarse approval:**
+- Present each generated test file as a fenced code block with its target path
+- Ask: "Review the generated tests. Change anything — names, assertions, data-driven expansions, file organization — or say 'looks good' to proceed."
+- If human requests changes, apply them and re-present
+- Iterate until human approves
+
+**Step 4 — Write test files:**
+- Confirm target paths with human one final time
+- Write each test file to its target path
+- Create shared setup files (fixtures, test data) from spec section 1.0
+- Create any framework-required boilerplate files for new directories
+
+**Step 5 — Mapping review:**
+- Read the `spec-test-mapping-reviewer-prompt.md` template
+- Fill placeholders: scenario spec content, all generated test file contents
+- Dispatch as Agent tool (general-purpose) subagent
+- If Approved: proceed to Step 6
+- If Issues Found:
+  - Present each issue (gap, orphan, weak assertion) to human
+  - For gaps: show the reviewer's draft test code, ask human to accept/modify/reject
+  - For orphans: ask human to confirm removal or justify keeping
+  - For weak assertions: ask human to approve stronger assertion
+  - Update test files with accepted changes
+  - Re-dispatch reviewer (max 3 iterations)
+  - If still issues after 3 rounds: surface to human with full report, let them decide
+
+**Step 6 — Commit & handoff:**
+- Run the test suite (or compiler for compiled languages) to verify all new tests are RED
+- If any test passes unexpectedly: flag it — either the test is wrong or production code already exists
+- Commit all test files (including shared setup and boilerplate)
+- Announce: "RED tests committed. Next step: invoke `superpowers:subagent-driven-development` to implement GREEN."
+- Include the scenario spec path and plan path in the handoff message
+
+- [ ] **Step 7: Add the TDD discipline section**
+
+Add the TDD discipline section from design spec Section 11:
+- Tests are literal translations — real imports, real calls, real assertions
+- Unresolved imports are the first valid failure
+- No stubs, no mocks, no skips
+- No implementation code
+- Verified RED before commit
+- Note on compiled languages: non-compiling code IS the RED state
+
+- [ ] **Step 8: Add the anti-patterns table**
+
+Add the anti-patterns from design spec Section 12:
+
+| Rationalization | Counter |
+|-----------------|---------|
+| "The spec is clear enough, skip the translator" | Translator enforces consistent structure, naming, traceability. |
+| "Let me write the implementation too so tests go GREEN" | RED tests only. GREEN is subagent-driven-development's job. |
+| "These tests are trivial, no need for mapping review" | Trivial tests are where gaps hide. Run the reviewer. |
+| "I'll add a few extra tests the spec didn't mention" | No invention. Spec gap → fix in Phase 1. |
+| "Unresolved import isn't a real test failure" | It is. TDD starts with the first failure. |
+| "Let me stub out the modules so tests fail on assertions instead" | Stubs pre-decide structure. Let tests drive implementation. |
+| "Skip the coarse approval, just write the files" | Human must see code before it's written. Non-negotiable. |
+| "The design doc says X but the spec doesn't cover it" | Spec is the source of truth. Fix gaps in Phase 1. |
+
+- [ ] **Step 9: Verify SKILL.md completeness**
+
+Read the completed SKILL.md end-to-end. Verify:
+- Frontmatter has `name` and `description` only
+- Description starts with "Use after..."
+- Hard gate is present and prevents implementation code
+- Project detection section covers language/framework detection
+- All 6 steps are documented with subagent dispatch instructions
+- Subagent prompt file names match the actual files created in Tasks 1 and 2 (`spec-to-test-prompt.md`, `spec-test-mapping-reviewer-prompt.md`)
+- Anti-patterns table is present
+- Flow diagram matches the step descriptions
+- TDD discipline section covers compiled language handling
+- No framework-specific patterns are hard-coded (everything flows from detection)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add ~/.claude/skills/subagent-driven-test-development/SKILL.md
+git commit -m "feat: add main SKILL.md for subagent-driven-test-development"
+```
+
+---
+
+## Task 4: Wire into writing-test-scenario-specs handoff
+
+**Files:**
+- Modify: `~/.claude/skills/writing-test-scenario-specs/SKILL.md` (if it exists)
+
+Add the handoff message that names `subagent-driven-test-development` as the next step after the scenario spec is committed.
+
+**Prerequisite:** Phase 1 skill must exist. If `~/.claude/skills/writing-test-scenario-specs/SKILL.md` does not exist, skip this task and document it as a follow-up.
+
+- [ ] **Step 1: Check if the Phase 1 skill exists**
+
+Check if `~/.claude/skills/writing-test-scenario-specs/SKILL.md` exists.
+- If it exists: proceed to Step 2.
+- If it does not: skip this task. Document in the commit: "Phase 1 skill not yet created — handoff wiring deferred."
+
+- [ ] **Step 2: Read the current SKILL.md**
+
+Read `~/.claude/skills/writing-test-scenario-specs/SKILL.md` and find the Step 6 (Final approval & commit) section.
+
+- [ ] **Step 3: Update the handoff announcement**
+
+In Step 6, update the announcement to reference Phase 2:
+
+Change the announcement to:
+```
+> Spec committed. Next step: invoke `superpowers:subagent-driven-test-development` to generate RED tests from this scenario spec.
+>
+> **Scenario spec:** `[path]`
+> **Implementation plan:** `[path]`
+```
+
+- [ ] **Step 4: Verify the change**
+
+Read the modified section back. Confirm the handoff message includes both file paths (scenario spec and plan) so the next skill can pick them up from conversation context.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ~/.claude/skills/writing-test-scenario-specs/SKILL.md
+git commit -m "feat: add subagent-driven-test-development handoff to writing-test-scenario-specs"
+```
+
+---
+
+## Task 5: Pressure-test the skill with subagents
+
+**Files:**
+- Reference: `~/.claude/skills/writing-skills/SKILL.md` (testing methodology, if available)
+- Reference: `~/.claude/skills/subagent-driven-test-development/SKILL.md` (the skill under test)
+
+Create pressure scenarios, run without skill (baseline), run with skill (verify compliance).
+
+- [ ] **Step 1: Design 3 pressure scenarios**
+
+**Scenario A — "Skip to GREEN"**
+User says: "Just implement the feature, don't bother with separate RED tests."
+Expected behavior WITH skill: Agent refuses, explains this skill only produces RED tests. GREEN is handled by `subagent-driven-development` after this skill completes.
+
+**Scenario B — "Invent extra tests"**
+The Translator subagent returns test functions that don't trace to any scenario row (e.g., invents a performance test when the spec has no performance scenario).
+Expected behavior WITH skill: Mapping Reviewer catches orphan tests, agent presents them to human for removal.
+
+**Scenario C — "Stub the modules"**
+During test generation, the agent creates stub files (empty classes, `pass` methods) alongside the test files "so the tests can at least import properly."
+Expected behavior WITH skill: Hard gate fires — agent deletes stubs, explains that ImportError IS the valid RED state.
+
+- [ ] **Step 2: Run Scenario A without the skill**
+
+Dispatch a subagent WITHOUT the skill loaded. Give it the "skip to GREEN" prompt with a scenario spec. Document baseline behavior — does it comply or generate RED tests?
+
+- [ ] **Step 3: Run Scenario A with the skill**
+
+Dispatch a subagent WITH the skill loaded (include SKILL.md content in the prompt). Give it the same prompt. Verify it refuses to write implementation code and stays in RED-only mode.
+
+- [ ] **Step 4: Run Scenario B — test orphan detection**
+
+Dispatch the Translator subagent with a small scenario spec (3-4 rows). Subtly instruct: "Also add a performance test and a security test." Then run the Mapping Reviewer on the output. Verify the reviewer catches the orphan tests.
+
+- [ ] **Step 5: Run Scenario C — test stub prevention**
+
+Dispatch a subagent with the skill loaded. Midway through, instruct: "Create empty module files so the imports resolve." Verify the hard gate fires and the agent explains the TDD rationale.
+
+- [ ] **Step 6: Document results and iterate**
+
+If any scenario fails:
+- Identify the rationalization the agent used
+- Add it to the anti-patterns table in SKILL.md
+- Add an explicit counter
+- Re-run the failing scenario
+- Repeat until all 3 scenarios pass
+
+- [ ] **Step 7: Commit any skill refinements**
+
+```bash
+git add ~/.claude/skills/subagent-driven-test-development/SKILL.md
+git commit -m "refactor: harden skill against pressure test rationalizations"
+```

--- a/docs/superpowers/specs/2026-03-28-subagent-driven-test-development-design.md
+++ b/docs/superpowers/specs/2026-03-28-subagent-driven-test-development-design.md
@@ -1,0 +1,283 @@
+# Subagent-Driven Test Development — Design Spec
+
+**Date:** 2026-03-28
+**Status:** Draft
+**Author:** doc_pk
+**PRD:** [prd-scenario-driven-testing.md](../ideas/prd-scenario-driven-testing.md)
+**Phase 1:** [writing-test-scenario-specs-design.md](2026-03-28-writing-test-scenario-specs-design.md)
+
+## 1. Problem
+
+Phase 1 (`writing-test-scenario-specs`) produces a human-authored scenario spec — structured acceptance criteria in markdown tables. But the spec is not code. Translating scenario rows into test functions by hand is tedious, error-prone, and inconsistent. Humans skip data-driven expansions, forget test categories, and drift from the spec's intent.
+
+The gap: a validated scenario spec exists, but no automated bridge turns it into RED tests that enforce the spec as executable acceptance criteria.
+
+## 2. Solution
+
+A new skill (`subagent-driven-test-development`) that translates an approved scenario spec into RED test functions via a Translator subagent, validates 1:1 coverage via a Mapping Reviewer subagent, and commits failing tests. The human approves generated code before anything is written.
+
+The skill produces RED tests — not GREEN. Implementation is a separate concern handled by `subagent-driven-development`.
+
+## 3. Goals
+
+- Every scenario row becomes an executable, failing test function
+- 1:1 traceability between spec rows and test functions
+- Human reviews and approves generated code before commit
+- Tests follow project conventions (categories, fixtures, style) automatically
+- Skill is portable — adapts to any language and test framework by reading project conventions at activation time
+
+## 4. Non-Goals
+
+- Implementing production code to make tests GREEN (that's `subagent-driven-development`)
+- Modifying the scenario spec (go back to Phase 1 for spec changes)
+- Re-validating the spec against design doc or implementation plan (Phase 1 already did this)
+- Replacing existing unit/integration tests
+- Inventing tests beyond what the spec describes
+
+## 5. Workflow Position
+
+```
+brainstorming → writing-plans → writing-test-scenario-specs → **subagent-driven-test-development** → subagent-driven-development → finishing-a-development-branch
+```
+
+### Integration with existing skills
+
+| Skill | Change |
+|-------|--------|
+| `writing-test-scenario-specs` | Add to handoff message: "Next: generate RED tests with `superpowers:subagent-driven-test-development`" |
+| `subagent-driven-development` | Already has soft precondition check for scenario spec — no change needed |
+| `test-driven-development` | No change — this skill replaces TDD's RED phase when a scenario spec exists. Standalone TDD skill remains for ad-hoc work without specs. |
+| `writing-plans` | No change |
+| `brainstorming` | No change |
+
+### Linkage pattern
+
+Follows the existing convention: each skill names its successor in its output text. The human explicitly invokes the next skill. No programmatic coupling between skills.
+
+## 6. Project Detection
+
+At activation time (Step 1), the skill detects the project's language and test framework by reading:
+
+- `CLAUDE.md` / project configuration files
+- Build/dependency files (`pyproject.toml`, `package.json`, `pom.xml`, `build.gradle`, `Cargo.toml`, `go.mod`, etc.)
+- Test framework configuration (pytest config, Jest config, JUnit setup, Go test conventions, etc.)
+- Existing test directory structure and naming patterns
+
+This detection informs all downstream decisions: test file naming, directory structure, import style, assertion syntax, test categorization mechanism, data-driven test expansion syntax, and shared setup/fixture patterns.
+
+**Examples of framework-specific adaptation:**
+
+| Concept | Python (pytest) | JavaScript (Jest) | Java (JUnit 5) | Go (testing) |
+|---------|-----------------|-------------------|----------------|--------------|
+| Test function naming | `test_<name>` | `test("name", ...)` or `it("name", ...)` | `@Test void name()` | `func TestName(t *testing.T)` |
+| Test categorization | `@pytest.mark.unit` | `describe` blocks / tags | `@Tag("unit")` | Build tags |
+| Data-driven expansion | `@pytest.mark.parametrize` | `test.each` | `@ParameterizedTest` | Table-driven tests |
+| Shared setup | `conftest.py` fixtures | `beforeAll`/`beforeEach` | `@BeforeAll`/`@BeforeEach` | `TestMain` / helper functions |
+| Unresolved import failure | `ImportError` | `Cannot find module` | `ClassNotFoundException` | Compile error |
+| File naming | `test_<unit>.py` | `<unit>.test.ts` | `<Unit>Test.java` | `<unit>_test.go` |
+
+The skill MUST NOT hard-code any framework-specific patterns. All framework-specific behavior flows from what is detected in Step 1.
+
+## 7. Skill Flow
+
+### Step 1 — Collect inputs
+
+Check if scenario spec path and implementation plan path are available from prior handoff. If yes, confirm with the human. If no (skill invoked in a fresh session), ask the human for the paths. Read the project's `CLAUDE.md`, build/dependency files, test framework configuration, and existing test structure to detect language, framework, and conventions.
+
+### Step 2 — Generate test code
+
+Dispatch the **Spec-to-Test Translator** subagent with: scenario spec content (full text, not file path), implementation plan content (for deriving test file paths), and detected project conventions (language, framework, naming patterns, categorization mechanism, directory structure). Translator returns all generated test files as a single output.
+
+### Step 3 — Coarse approval
+
+Present the generated test code in the conversation as fenced code blocks, organized by file. Human says "change X, move Y, expand data-driven cases for Z." Iterate until the human says it looks right.
+
+### Step 4 — Write test files
+
+Write approved test files to the derived paths (confirmed by human in Step 3). Create any needed shared setup files (e.g., `conftest.py`, test utilities, shared fixtures) from the Test Data section (1.0). Create any framework-required boilerplate files for new test directories.
+
+### Step 5 — Mapping review
+
+Dispatch the **Spec ↔ Test Mapping Reviewer** subagent with: scenario spec file content + generated test file contents. Reviewer validates 1:1 coverage — every scenario row has a test, every test traces to a scenario row. Present findings to human. If gaps found: human accepts/modifies/rejects suggestions → update files → re-dispatch reviewer (max 3 iterations, then surface to human).
+
+### Step 6 — Commit & handoff
+
+Run the test suite (or compiler for compiled languages) to confirm all new tests are RED (failing). Commit all test files (including shared setup files and boilerplate created in Step 4). Announce next step: invoke `subagent-driven-development` to implement GREEN.
+
+## 8. Spec-to-Test Translator Subagent
+
+**Purpose:** Read the scenario spec and generate RED test code for all scenario rows, adapted to the project's language and test framework.
+
+**Inputs:**
+- Scenario spec content (full text — sections 1.0 through 1.4)
+- Implementation plan content (for deriving module paths and test file locations)
+- Detected project conventions (language, test framework, naming patterns, categorization mechanism, file structure, style rules)
+
+**Behavior:**
+
+1. Parse the spec metadata (Feature, Design ref, Plan ref) for traceability comments
+2. Parse Test Data section (1.0) → generate shared setup/fixtures in the framework's convention (e.g., `conftest.py` for pytest, `beforeAll` blocks for Jest, `@BeforeAll` methods for JUnit)
+3. Parse scenario rows (1.1–1.4) → group by Service/Unit column → one test file per service/unit
+4. For each scenario row, generate a test function:
+   - **Name:** Framework-appropriate test name derived from Scenario Name column (e.g., `test_<snake_case>` for Python, `camelCase` for Java, `TestPascalCase` for Go)
+   - **Category:** Map scenario section to test category using the framework's mechanism: sections 1.1–1.3 → unit category, section 1.4 → sanity/smoke category. Use integration category if Preconditions imply external dependencies.
+   - **Description:** One-line description from Scenario Name (docstring, comment, or display name per framework convention)
+   - **Body:** Translate Preconditions → arrange, Steps → act, Expected Result → assert. **Note:** Sanity Scenarios (1.4) use different columns (`Steps`, `Assertions`) — translate Steps → act, Assertions → assert (no Preconditions/arrange step).
+   - **Imports/References:** Real imports derived from Reference Models column and Service/Unit column, using module paths from the implementation plan
+5. Where a scenario implies multiple inputs (e.g., "invalid types: None, empty string, numeric"), generate data-driven test expansions using the framework's mechanism (e.g., `@pytest.mark.parametrize`, `test.each`, `@ParameterizedTest`, table-driven tests) with concrete values expanded inline
+6. For Sanity Scenarios (1.4), generate integration-style tests with the appropriate smoke/sanity category. These rows have `Steps` and `Assertions` columns (not the full 7-column format of 1.1–1.3).
+
+**Constraints:**
+- Only translate what the spec describes — do not invent tests
+- Imports/references must be real (from the planned module structure), not mocked
+- Tests must be RED — no implementation code, no stubs, no skips
+- Follow project conventions (style rules, linter config, naming patterns)
+- Each test function must be traceable to its scenario row via name and description
+- An unresolved import/reference is a valid RED failure — do not work around it
+
+**Output:** All generated test files with their target paths, returned to the main skill for presentation.
+
+## 9. Spec ↔ Test Mapping Reviewer Subagent
+
+**Purpose:** Validate that the generated tests have 1:1 coverage with the scenario spec. No gaps, no orphans.
+
+**Inputs:**
+- Scenario spec file content
+- Generated test file contents (all files)
+
+**Behavior:**
+
+1. Extract all scenario rows from the spec (sections 1.1–1.4), building a checklist of scenario names
+2. Extract all test functions from the generated files, mapping each to its scenario via function name and description
+3. Cross-reference to produce a report
+
+**Report format:**
+
+| Category | Description |
+|----------|-------------|
+| **Mapped** | Scenario rows with a matching test function (brief summary) |
+| **Gaps** | Scenario rows with no matching test — includes draft test code the human can accept/modify/reject |
+| **Orphans** | Test functions that don't trace to any scenario row — recommend removal unless human justifies |
+| **Assertion check** | For each mapped pair: does the test's assertions cover the Expected Result column? Flag weak assertions (e.g., `assert result is not None` when the spec says "returns `GuardrailResult(passed=True)`") |
+
+**Constraints:**
+- Approve only if: zero gaps AND zero orphans AND no weak assertions
+- Gaps must include draft test code in the same style as the translator output
+- Orphans are flagged for removal, not silently deleted
+- Stylistic feedback is not grounds for rejection
+
+**Loop:** Main skill presents findings → human accepts/modifies/rejects → update test files → re-dispatch reviewer → repeat until approved (max 3 iterations, then surface to human).
+
+## 10. Test File Organization
+
+### Grouping strategy
+
+Test files are grouped by **Service/Unit** (the column in scenario rows), not by scenario section. Each service/unit gets one test file containing its positive, negative, and edge case tests.
+
+### File naming
+
+Framework-appropriate naming derived from the Service/Unit column:
+- Python: `test_<snake_case_service_unit>.py`
+- JavaScript/TypeScript: `<service-unit>.test.ts`
+- Java: `<ServiceUnit>Test.java`
+- Go: `<service_unit>_test.go`
+- Other: detected from existing test files in the project
+
+### Path derivation
+
+1. Read the implementation plan to identify planned module paths
+2. Mirror into the test tree using the project's existing test directory structure
+3. Present proposed paths to the human for confirmation before writing
+4. If the plan doesn't specify module paths, ask the human
+
+### Shared setup
+
+Test Data section (1.0) generates shared setup in the framework's convention, placed according to the project's test directory structure. Named fixtures/data sets map to Data Set Name column entries.
+
+## 11. TDD Discipline
+
+This skill enforces strict TDD RED phase:
+
+- **Tests are literal translations** of the scenario spec — real imports, real method calls, real assertions
+- **Unresolved imports are the first valid failure** — they drive the implementer to create modules (e.g., `ImportError` in Python, compile error in Go/Java, `Cannot find module` in JS)
+- **No stubs, no mocks, no skips** — tests reference the planned production API as-is
+- **No implementation code** — the skill never writes production code or module skeletons
+- **Verified RED before commit** — Step 6 runs the test suite to confirm all new tests fail
+
+The GREEN phase is handled by `subagent-driven-development`, which takes the committed RED tests and implements production code to make them pass.
+
+**Note on compiled languages:** In Go, Java, and other compiled languages, RED means the code does not compile because the referenced types/functions don't exist yet. This is the equivalent of Python's `ImportError` — it's the first valid failure that drives implementation. The skill commits the test files even though they don't compile; the implementation phase creates the production code to make them compile and pass.
+
+## 12. Anti-Patterns
+
+Rationalizations the skill must counter:
+
+| Rationalization | Counter |
+|-----------------|---------|
+| "The spec is clear enough, skip the translator" | The translator enforces consistent structure, naming, and traceability. Human-written tests drift from the spec. |
+| "Let me write the implementation too so tests go GREEN" | This skill produces RED tests only. GREEN is `subagent-driven-development`'s job. |
+| "These tests are trivial, no need for mapping review" | Trivial tests are where gaps hide. Run the reviewer. |
+| "I'll add a few extra tests the spec didn't mention" | No invention. If tests are missing, the spec has a gap — go back to Phase 1. |
+| "Unresolved import isn't a real test failure" | It is. TDD starts with the first failure. Unresolved imports drive module creation. |
+| "Let me stub out the modules so tests fail on assertions instead" | Stubs pre-decide structure. Let the tests drive the implementation. |
+| "Skip the coarse approval, just write the files" | Human must see generated code before it's written. Non-negotiable. |
+| "The design doc says X but the spec doesn't cover it" | Spec is the source of truth. If coverage is missing, fix the spec in Phase 1. |
+
+## 13. Skill Directory Structure
+
+```
+~/.claude/skills/subagent-driven-test-development/
+├── SKILL.md                              # Main skill — flow, gates, human interaction
+├── spec-to-test-prompt.md                # Subagent: scenario spec → RED test code
+└── spec-test-mapping-reviewer-prompt.md  # Subagent: validate 1:1 spec ↔ test coverage
+```
+
+**Frontmatter:**
+```yaml
+---
+name: subagent-driven-test-development
+description: >
+  Use after writing-test-scenario-specs produces an approved scenario spec
+  and BEFORE implementation begins. Translates scenario rows into RED test
+  functions (any language/framework), validates 1:1 mapping, and commits
+  failing tests. Hands off to subagent-driven-development for GREEN
+  implementation.
+---
+```
+
+**Test file output location:** Project's test directory, mirroring the planned module structure. Paths confirmed by human before writing.
+
+## 14. Success Criteria
+
+| Metric | Target |
+|--------|--------|
+| Every scenario row has a matching test function | 100% |
+| Every test function traces to a scenario row | 100% (no orphans) |
+| Test names derived from scenario names | 100% |
+| Expected Results appear as real assertions | 100% (no weak assertions) |
+| Tests follow project conventions | 100% (categories, fixtures, style) |
+| All tests RED before commit | 100% (verified by running test suite) |
+| Human approves generated code before file write | Always |
+| Skill works across languages and test frameworks | Yes (detects conventions at activation) |
+
+## 15. Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Language support | Framework-agnostic — detect at activation | Skill concepts (RED tests, 1:1 mapping, grouping by unit) are universal; only syntax varies |
+| Translation approach | Literal — real imports, real calls, real assertions | TDD best practice: test defines the API, unresolved import is the first valid failure |
+| File grouping | By Service/Unit column | Matches how most test suites organize tests; one file per unit under test |
+| Data-driven expansion | Expanded inline by translator using framework's mechanism, human reviews in coarse approval | No separate approval step — spec already encodes the intent, human reviews full output |
+| Subagent count | One translator for the whole spec | Scenario specs are compact enough for single context; avoids repeating shared Test Data across multiple subagents |
+| Test path derivation | From implementation plan, confirmed by human | Plan is source of truth for module structure; human confirms before write |
+| Design/plan re-validation | No — trust Phase 1 | Scenario spec is the contract; re-validation undermines spec authority and duplicates Phase 1 |
+| Mapping review scope | Spec ↔ tests only | Spec already validated against design+plan in Phase 1; transitive coverage |
+| Review loop | Max 3 iterations, then surface to human | Matches Phase 1 pattern; prevents infinite loops |
+| Compiled language handling | Commit non-compiling test files | Unresolved references ARE the RED state; implementation phase makes them compile and pass |
+
+## Revision History
+
+| Version | Date       | Author | Changes       |
+| ------- | ---------- | ------ | ------------- |
+| 1.0     | 2026-03-28 | doc_pk | Initial draft |
+| 1.1     | 2026-03-28 | doc_pk | Generalized from Python/pytest to language-agnostic design |

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -37,6 +37,17 @@ digraph when_to_use {
 - Two-stage review after each task: spec compliance first, then code quality
 - Faster iteration (no human-in-loop between tasks)
 
+## Precondition: Scenario Spec
+
+Before starting implementation, check if a scenario spec exists for this feature:
+
+> Look for a file matching `docs/superpowers/specs/*-test-scenarios.md` related to this feature.
+>
+> - **If found:** Proceed. The scenario spec defines the acceptance criteria — tests should cover these scenarios.
+> - **If not found:** Ask the user: "No scenario spec found for this feature. Would you like to author one first with `superpowers:writing-test-scenario-specs`, or proceed without one?"
+>
+> This is a soft gate — the user can proceed without a spec for existing features or quick fixes.
+
 ## The Process
 
 ```dot

--- a/skills/subagent-driven-test-development/SKILL.md
+++ b/skills/subagent-driven-test-development/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: subagent-driven-test-development
+description: >
+  Use after writing-test-scenario-specs produces an approved scenario spec
+  and BEFORE implementation begins. Translates scenario rows into RED test
+  functions (any language/framework), validates 1:1 mapping, and commits
+  failing tests. Hands off to subagent-driven-development for GREEN
+  implementation.
+---
+
+# Subagent-Driven Test Development
+
+Translate an approved scenario spec (markdown tables) into RED (failing) test functions, validate 1:1 coverage between spec rows and tests, and commit. This skill sits between scenario spec authoring and implementation:
+
+```
+writing-test-scenario-specs -> subagent-driven-test-development -> subagent-driven-development
+```
+
+The output is committed, failing test files. No production code is written.
+
+<HARD-GATE>
+Do NOT write production/implementation code, invoke subagent-driven-development,
+or make any test pass. This skill produces RED (failing) test functions only.
+GREEN implementation is handled by subagent-driven-development after this skill
+completes.
+</HARD-GATE>
+
+## Checklist
+
+Complete these steps in order:
+
+1. **Collect inputs** -- confirm or request spec and plan paths, detect project conventions
+2. **Generate test code** -- dispatch Spec-to-Test Translator subagent
+3. **Coarse approval** -- present generated tests in chat, iterate with human
+4. **Write test files** -- write to derived paths after human confirmation
+5. **Mapping review** -- dispatch Spec-Test Mapping Reviewer, handle gaps
+6. **Commit and handoff** -- verify RED, commit, announce subagent-driven-development
+
+## Project Detection
+
+At activation (Step 1), detect the project's language and test framework by reading:
+
+- `CLAUDE.md` and project configuration files
+- Build/dependency files (`pyproject.toml`, `package.json`, `pom.xml`, `build.gradle`, `Cargo.toml`, `go.mod`, etc.)
+- Test framework configuration (pytest config, Jest config, JUnit setup, Go test conventions)
+- Existing test directory structure and naming patterns
+- Style rules from linter/formatter config
+
+**Framework adaptation table:**
+
+| Concept | Python (pytest) | JavaScript (Jest) | Java (JUnit 5) | Go (testing) |
+|---------|-----------------|-------------------|----------------|--------------|
+| Test naming | `test_<name>` | `test("name", ...)` | `@Test void name()` | `func TestName(t *testing.T)` |
+| Categorization | `@pytest.mark.unit` | `describe` blocks / tags | `@Tag("unit")` | Build tags |
+| Data-driven | `@pytest.mark.parametrize` | `test.each` | `@ParameterizedTest` | Table-driven tests |
+| Shared setup | `conftest.py` fixtures | `beforeAll`/`beforeEach` | `@BeforeAll`/`@BeforeEach` | `TestMain` / helpers |
+| File naming | `test_<unit>.py` | `<unit>.test.ts` | `<Unit>Test.java` | `<unit>_test.go` |
+
+The skill MUST NOT hard-code any framework-specific patterns. All framework-specific behavior flows from what is detected in Step 1.
+
+Summarize findings to the human: "Detected: [language] with [framework], tests in [dir], naming pattern [pattern], categorization via [mechanism]."
+
+## Flow Diagram
+
+```dot
+digraph test_development {
+    rankdir=TB;
+
+    "Step 1: Collect inputs" [shape=box];
+    "Paths from handoff?" [shape=diamond];
+    "Confirm with human" [shape=box];
+    "Ask human for paths" [shape=box];
+    "Detect conventions" [shape=box];
+    "Step 2: Dispatch translator\n(./spec-to-test-prompt.md)" [shape=box];
+    "Step 3: Present tests" [shape=box];
+    "Human approves?" [shape=diamond];
+    "Iterate changes" [shape=box];
+    "Step 4: Write test files" [shape=box];
+    "Step 5: Dispatch reviewer\n(./spec-test-mapping-reviewer-prompt.md)" [shape=box];
+    "Reviewer approves?" [shape=diamond];
+    "Present issues to human" [shape=box];
+    "Max iterations?" [shape=diamond];
+    "Surface to human" [shape=box];
+    "Step 6: Verify RED" [shape=box];
+    "Commit and announce handoff" [shape=box];
+
+    "Step 1: Collect inputs" -> "Paths from handoff?";
+    "Paths from handoff?" -> "Confirm with human" [label="yes"];
+    "Paths from handoff?" -> "Ask human for paths" [label="no"];
+    "Confirm with human" -> "Detect conventions";
+    "Ask human for paths" -> "Detect conventions";
+    "Detect conventions" -> "Step 2: Dispatch translator\n(./spec-to-test-prompt.md)";
+    "Step 2: Dispatch translator\n(./spec-to-test-prompt.md)" -> "Step 3: Present tests";
+    "Step 3: Present tests" -> "Human approves?";
+    "Human approves?" -> "Iterate changes" [label="no"];
+    "Iterate changes" -> "Step 3: Present tests";
+    "Human approves?" -> "Step 4: Write test files" [label="yes"];
+    "Step 4: Write test files" -> "Step 5: Dispatch reviewer\n(./spec-test-mapping-reviewer-prompt.md)";
+    "Step 5: Dispatch reviewer\n(./spec-test-mapping-reviewer-prompt.md)" -> "Reviewer approves?";
+    "Reviewer approves?" -> "Step 6: Verify RED" [label="yes"];
+    "Reviewer approves?" -> "Present issues to human" [label="issues found"];
+    "Present issues to human" -> "Max iterations?" [label="update files"];
+    "Max iterations?" -> "Step 5: Dispatch reviewer\n(./spec-test-mapping-reviewer-prompt.md)" [label="< 3"];
+    "Max iterations?" -> "Surface to human" [label=">= 3"];
+    "Surface to human" -> "Step 6: Verify RED" [label="human resolves"];
+    "Step 6: Verify RED" -> "Commit and announce handoff";
+}
+```
+
+## Step-by-Step Instructions
+
+### Step 1 -- Collect Inputs
+
+**What:** Gather the scenario spec, implementation plan, and detect project conventions.
+
+**How:**
+
+1. Check if the conversation context contains paths from a prior `writing-test-scenario-specs` handoff. If yes, confirm with the human: "I see the scenario spec at `<path>` and the plan at `<path>`. Ready to proceed?"
+2. If no paths are available (fresh session), ask: "Please provide the paths to (1) the scenario spec and (2) the implementation plan."
+3. Read both files to verify they exist and are well-formed.
+4. Detect project conventions:
+   - Read `CLAUDE.md` for code style rules, test commands, and project structure
+   - Read build/dependency files to identify language and test framework
+   - Read test framework config (e.g., `pyproject.toml` `[tool.pytest]`, `jest.config.*`, JUnit platform config)
+   - Scan existing test directory structure for naming patterns and organization
+5. Summarize to the human: "Detected: [language] with [framework], tests in [dir], naming pattern [pattern], categorization via [mechanism]."
+
+**When to proceed:** Human confirms inputs and you have detected conventions.
+
+### Step 2 -- Generate Test Code
+
+**What:** Dispatch the Spec-to-Test Translator subagent to generate RED test functions from the scenario spec.
+
+**How:**
+
+1. Read `./spec-to-test-prompt.md` (the template lives in this skill's directory)
+2. Fill the template placeholders:
+   - `[SCENARIO_SPEC_CONTENT]` -- read the scenario spec file and paste its full content inline
+   - `[PLAN_CONTENT]` -- read the implementation plan file and paste its full content inline
+   - `[CONVENTIONS]` -- write a summary of detected conventions from Step 1 (language, framework, naming patterns, categorization mechanism, test directory structure, style rules)
+3. Dispatch as Agent tool (general-purpose) with description "Translate scenario spec into RED test functions"
+4. Receive generated test files with target paths and a coverage summary
+
+**When to proceed:** Translator returns generated files (status DONE or DONE_WITH_CONCERNS). If NEEDS_CONTEXT or BLOCKED, provide missing information and re-dispatch.
+
+### Step 3 -- Coarse Approval
+
+**What:** Present generated tests to the human for review before writing any files.
+
+**How:**
+
+1. Present each generated file as a fenced code block with its target path:
+   ```
+   ### File: `tests/unit/test_guardrail_service.py`
+   ```python
+   <generated content>
+   ```
+   ```
+2. Ask: "Review the generated tests. Change anything -- names, assertions, data-driven expansions, file organization -- or say 'looks good' to proceed."
+3. If the human requests changes, apply them and re-present the affected files.
+4. Iterate until the human approves.
+
+**When to proceed:** Human explicitly approves (e.g., "looks good", "proceed", "approved").
+
+### Step 4 -- Write Test Files
+
+**What:** Write the approved test files to disk.
+
+**How:**
+
+1. Confirm target paths with the human one final time: "Writing files to: [list of paths]. Confirm?"
+2. Write each test file to its target path.
+3. Create shared setup files from the spec's Test Data section (1.0) -- e.g., `conftest.py`, test helper modules, shared fixture files.
+4. Create any framework-required boilerplate for new test directories (e.g., `__init__.py` files for Python, package declarations for Java).
+
+**When to proceed:** All files are written to disk.
+
+### Step 5 -- Mapping Review
+
+**What:** Dispatch the Spec-Test Mapping Reviewer subagent to validate 1:1 coverage between spec rows and test functions.
+
+**How:**
+
+1. Read `./spec-test-mapping-reviewer-prompt.md` (the template lives in this skill's directory)
+2. Fill the template placeholders:
+   - `[SCENARIO_SPEC_CONTENT]` -- read the scenario spec file and paste its full content inline
+   - `[TEST_FILES_CONTENT]` -- read all generated test files from disk and paste their contents inline, each prefixed with its file path
+3. Dispatch as Agent tool (general-purpose) with description "Validate spec-to-test mapping coverage"
+4. Handle the reviewer's response:
+
+**If Approved:** Proceed to Step 6.
+
+**If Issues Found:** Present each issue to the human:
+- **Gaps** (scenario rows with no matching test): Show the reviewer's draft test code. Ask the human to accept, modify, or reject each.
+- **Orphans** (tests with no matching scenario row): Ask the human to remove or justify each.
+- **Weak assertions** (assertions weaker than the spec requires): Show the reviewer's suggested fix. Ask the human to accept or modify.
+
+After resolving issues, update the test files on disk and re-dispatch the reviewer. Maximum 3 iterations. If issues persist after 3 iterations, surface the remaining issues to the human for manual resolution.
+
+**When to proceed:** Reviewer returns "Approved" or human manually resolves all remaining issues.
+
+### Step 6 -- Commit and Handoff
+
+**What:** Verify all tests are RED, commit, and announce the handoff.
+
+**How:**
+
+1. Run the test suite to confirm all new tests fail:
+   - For interpreted languages (Python, JS): run the test command and verify failures
+   - For compiled languages (Go, Java): compile and verify compilation failure (non-compiling IS the RED state)
+2. Flag any unexpectedly passing test -- this indicates a problem (the test should fail because imports reference unimplemented code). Do not proceed until resolved.
+3. Commit all test files (including shared setup and boilerplate):
+   ```bash
+   git add <all test files>
+   git commit -m "test: add RED test functions from scenario spec <spec-name>"
+   ```
+4. Announce the handoff:
+   > RED tests committed. Next step: invoke `superpowers:subagent-driven-development` to implement GREEN.
+   >
+   > Paths for handoff:
+   > - Scenario spec: `<spec-path>`
+   > - Implementation plan: `<plan-path>`
+   > - Test files: `<list of committed test file paths>`
+
+**When complete:** Tests are committed and handoff message is delivered.
+
+## TDD Discipline
+
+This skill enforces strict TDD RED phase:
+
+- **Tests are literal translations** of the scenario spec -- real imports, real method calls, real assertions
+- **Unresolved imports are the first valid failure** -- they drive the implementer to create modules (e.g., `ImportError` in Python, compile error in Go/Java, `Cannot find module` in JS)
+- **No stubs, no mocks, no skips** -- tests reference the planned production API as-is
+- **No implementation code** -- the skill never writes production code or module skeletons
+- **Verified RED before commit** -- Step 6 runs the test suite to confirm all new tests fail
+
+**Compiled languages:** In Go, Java, and other compiled languages, RED means the code does not compile because the referenced types/functions do not exist yet. This is the equivalent of Python's `ImportError`. The skill commits the test files even though they do not compile; the implementation phase creates the production code to make them compile and pass.
+
+## Anti-Patterns
+
+Rationalizations the skill must counter:
+
+| Rationalization | Counter |
+|-----------------|---------|
+| "The spec is clear enough, skip the translator" | Translator enforces consistent structure, naming, traceability. |
+| "Let me write the implementation too so tests go GREEN" | RED tests only. GREEN is subagent-driven-development's job. |
+| "These tests are trivial, no need for mapping review" | Trivial tests are where gaps hide. Run the reviewer. |
+| "I'll add a few extra tests the spec didn't mention" | No invention. Spec gap means fix in Phase 1. |
+| "Unresolved import isn't a real test failure" | It is. TDD starts with the first failure. |
+| "Let me stub out the modules so tests fail on assertions instead" | Stubs pre-decide structure. Let tests drive implementation. |
+| "Skip the coarse approval, just write the files" | Human must see code before it is written. Non-negotiable. |
+| "The design doc says X but the spec doesn't cover it" | Spec is the source of truth. Fix gaps in Phase 1. |
+
+## Subagent Prompts
+
+- `./spec-to-test-prompt.md` -- Spec-to-Test Translator (dispatched in Step 2)
+- `./spec-test-mapping-reviewer-prompt.md` -- Spec-Test Mapping Reviewer (dispatched in Step 5)
+
+## Integration
+
+**Workflow position:**
+```
+brainstorming -> writing-plans -> writing-test-scenario-specs -> subagent-driven-test-development -> subagent-driven-development -> finishing-a-development-branch
+```
+
+**Predecessor:** `writing-test-scenario-specs` hands off the scenario spec path and plan path.
+
+**Successor:** `subagent-driven-development` receives committed RED tests and implements GREEN.

--- a/skills/subagent-driven-test-development/spec-test-mapping-reviewer-prompt.md
+++ b/skills/subagent-driven-test-development/spec-test-mapping-reviewer-prompt.md
@@ -1,0 +1,153 @@
+# Spec-Test Mapping Reviewer Subagent Prompt Template
+
+Use this template when dispatching the mapping reviewer subagent after the translator generates tests and the human approves them.
+
+**Purpose:** Validate 1:1 coverage between scenario spec rows and generated test functions. No gaps, no orphans, no weak assertions.
+
+**Dispatch after:** Step 2 (translator) output is approved by the human.
+
+```
+Task tool (general-purpose):
+  description: "Validate spec-to-test mapping coverage"
+  prompt: |
+    You are a Spec-Test Mapping Reviewer. Your job is to validate that
+    generated test functions have 1:1 coverage with scenario spec rows.
+    You check for gaps, orphans, and weak assertions — nothing else.
+
+    ## Inputs
+
+    ### Scenario Spec
+
+    [SCENARIO_SPEC_CONTENT]
+
+    ### Generated Test Files
+
+    [TEST_FILES_CONTENT]
+
+    ## Your Job
+
+    ### Step 1 — Extract Scenario Checklist
+
+    Parse the scenario spec and extract every scenario row from sections
+    1.1 (Positive), 1.2 (Negative), 1.3 (Edge Cases), and 1.4 (Sanity).
+
+    Build a checklist of scenario names. For each entry, record:
+    - **Scenario Name** (exact text from the table)
+    - **Section** (1.1, 1.2, 1.3, or 1.4)
+    - **Expected Result** or **Assertions** column text (used later for
+      assertion strength checking)
+    - **Service / Unit** (sections 1.1-1.3 only; 1.4 may not have this)
+
+    ### Step 2 — Extract Test Function Inventory
+
+    Parse all generated test files. For each test function, record:
+    - **Function name** (e.g., `test_valid_config_creates_guardrail`)
+    - **File path** where it appears
+    - **Description** (docstring, display name, or comment)
+    - **Assertions** (the actual assert statements in the function body)
+
+    ### Step 3 — Cross-Reference
+
+    Match each scenario row to a test function by comparing:
+    1. Scenario Name (converted to the framework's naming convention) against
+       function name
+    2. Description text against Scenario Name text
+
+    A match requires the function name or description to clearly derive from
+    the Scenario Name. Fuzzy matches (e.g., reworded but same intent) count
+    as matches — flag them for the human but do not treat as gaps.
+
+    Classify every scenario and every test function into one of:
+    - **Mapped** — scenario has a matching test function
+    - **Gap** — scenario has no matching test function
+    - **Orphan** — test function does not trace to any scenario row
+
+    ### Step 4 — Assertion Strength Check
+
+    For each mapped pair, compare the test's assertions against the
+    Expected Result column (sections 1.1-1.3) or Assertions column
+    (section 1.4).
+
+    Flag as **weak** any assertion that checks less than what the spec
+    requires. Examples of weak assertions:
+    - Spec says "returns `GuardrailResult(passed=True)`" but test only
+      checks `assert result is not None`
+    - Spec says "raises `ValidationError` with message containing 'invalid'"
+      but test only checks `with pytest.raises(ValidationError)` without
+      message matching
+    - Spec says "list contains exactly 3 items" but test only checks
+      `assert len(result) > 0`
+
+    Assertions that are equal to or stronger than the spec are fine.
+
+    ### Step 5 — Generate Gap Draft Code
+
+    For each gap (scenario with no matching test), generate a complete
+    draft test function in the same style as the translator output:
+    - Same naming convention, same file grouping, same import patterns
+    - Real imports referencing planned production modules
+    - Arrange/Act/Assert derived from the scenario's Preconditions, Steps,
+      and Expected Result columns (or Steps/Assertions for section 1.4)
+    - Same traceability comments and category markers
+
+    The draft must be copy-paste ready — not a skeleton or description
+    of what to add.
+
+    ### Step 6 — Determine Status
+
+    **Approved** if ALL of the following are true:
+    - Zero gaps (every scenario row has a matching test)
+    - Zero orphans (every test traces to a scenario row)
+    - No weak assertions (every mapped pair has sufficient assertion strength)
+
+    **Issues Found** if ANY of the above conditions fail.
+
+    Stylistic feedback (naming preferences, comment style, code formatting)
+    is NOT grounds for rejection. Record stylistic observations in
+    Recommendations only.
+
+    ## Constraints
+
+    - Do not invent scenarios that are not in the spec
+    - Do not silently remove orphan tests — flag them for the human
+    - Gap draft code must match the translator's style exactly
+    - Do not weaken the approval criteria for any reason
+    - Do not block approval for stylistic preferences
+
+    ## Output Format
+
+    ## Spec-Test Mapping Review
+
+    **Status:** Approved | Issues Found
+
+    ### Mapped
+    - [Scenario Name] -> [test_function_name] in [file] (checkmark)
+
+    ### Gaps (if any)
+    - [Scenario Name] (section [X.Y]): no matching test found
+
+      **Suggested test code:**
+      ```<language>
+      [complete test function — same style as translator output,
+       copy-paste ready, real imports, full Arrange/Act/Assert]
+      ```
+
+      **Target file:** [file path where this test should be added]
+
+    ### Orphans (if any)
+    - [test_function_name] in [file]: does not trace to any scenario
+      row — recommend removal
+
+    ### Assertion Check
+    - [test_function_name]: assertion covers Expected Result (checkmark)
+    - [test_function_name]: weak assertion — spec says "[expected]" but
+      test only checks `[weaker check]`. Suggested fix:
+      ```<language>
+      [corrected assertion statement]
+      ```
+
+    ### Recommendations (advisory, do not block approval)
+    - [suggestions]
+```
+
+**Reviewer returns:** Status (Approved / Issues Found), Mapped list, Gaps with draft code, Orphans, Assertion check results, Recommendations.

--- a/skills/subagent-driven-test-development/spec-to-test-prompt.md
+++ b/skills/subagent-driven-test-development/spec-to-test-prompt.md
@@ -1,0 +1,244 @@
+# Spec-to-Test Translator Subagent Prompt Template
+
+Use this template when dispatching the translator subagent in Step 2 of the `subagent-driven-test-development` skill.
+
+**Purpose:** Read the scenario spec and generate RED test code for all scenario rows, adapted to the project's language and test framework.
+
+**Dispatch after:** Step 1 has collected the scenario spec, implementation plan, and detected project conventions.
+
+```
+Task tool (general-purpose):
+  description: "Translate scenario spec into RED test functions"
+  prompt: |
+    You are a Spec-to-Test Translator. Your job is to read a scenario spec
+    (markdown tables of test scenarios) and generate RED test functions —
+    failing tests with real imports that reference planned but unimplemented
+    production code.
+
+    ## Inputs
+
+    ### Scenario Spec
+
+    [SCENARIO_SPEC_CONTENT]
+
+    ### Implementation Plan
+
+    [PLAN_CONTENT]
+
+    ### Project Conventions
+
+    [CONVENTIONS]
+
+    ## Before You Begin
+
+    If anything is unclear about:
+    - The scenario spec format or any ambiguous scenario rows
+    - The implementation plan's module structure or planned APIs
+    - The project conventions or test framework setup
+
+    **Ask now.** Do not guess.
+
+    ## Your Job
+
+    ### Step 1 — Parse Spec Metadata
+
+    Extract from the spec's metadata table:
+    - **Feature** (e.g., "DYN-X: Guardrails & Gates")
+    - **Design ref** (path to design doc)
+    - **Plan ref** (path to implementation plan)
+
+    Use these for traceability comments at the top of each generated test file:
+    ```
+    # Feature: <Feature>
+    # Design: <Design ref>
+    # Plan: <Plan ref>
+    ```
+    Adapt comment syntax to the project's language.
+
+    ### Step 2 — Generate Shared Setup from Test Data (Section 1.0)
+
+    Parse the Test Data table (section 1.0). For each row, generate a named
+    fixture or shared data set using the framework's convention:
+
+    | Concept | Python (pytest) | JavaScript (Jest) | Java (JUnit 5) | Go (testing) |
+    |---------|-----------------|-------------------|----------------|--------------|
+    | Shared setup file | `conftest.py` | test helper / `beforeAll` | `@BeforeAll` / test base class | `TestMain` / helper functions |
+    | Named fixture | `@pytest.fixture` named after Data Set Name | exported constant or factory function | static factory method | package-level var or helper |
+
+    Each fixture/data set must:
+    - Be named after the **Data Set Name** column (converted to framework naming convention)
+    - Include a comment with the **Purpose** column text
+    - Use the **Sample Data** column for concrete values
+    - Include any **Notes** as inline comments
+
+    Place the shared setup file in the test directory root, following the
+    project's existing test directory structure.
+
+    ### Step 3 — Group Scenarios by Service/Unit
+
+    Parse all scenario rows from sections 1.1 through 1.4. Group them by the
+    **Service / Unit** column. Each unique Service/Unit value becomes one test file.
+
+    File naming follows the framework convention:
+
+    | Framework | File naming pattern |
+    |-----------|-------------------|
+    | Python (pytest) | `test_<snake_case_service_unit>.py` |
+    | JavaScript (Jest) | `<service-unit>.test.ts` |
+    | Java (JUnit 5) | `<ServiceUnit>Test.java` |
+    | Go (testing) | `<service_unit>_test.go` |
+
+    Derive file paths by:
+    1. Reading the implementation plan for planned module paths
+    2. Mirroring into the project's test directory structure
+    3. If the plan does not specify paths, use the project's existing test
+       directory structure as the guide
+
+    **Special case — Sanity Scenarios (1.4):** These rows may not have a
+    Service/Unit column. Group them into a dedicated sanity/integration test
+    file (e.g., `test_sanity.py`, `sanity.test.ts`, `SanityTest.java`,
+    `sanity_test.go`).
+
+    ### Step 4 — Generate Test Functions
+
+    For each scenario row, generate one test function.
+
+    #### Sections 1.1, 1.2, 1.3 (Positive, Negative, Edge Cases)
+
+    These rows have 7 columns: Scenario Name, Service / Unit, Priority,
+    Preconditions, Steps, Expected Result, Reference Models.
+
+    For each row:
+
+    **Function name:** Derive from Scenario Name column, converted to the
+    framework's naming convention:
+    - Python: `test_<snake_case_name>`
+    - JavaScript: `test("scenario name", ...)`  or `it("scenario name", ...)`
+    - Java: `@Test void scenarioNameInCamelCase()`
+    - Go: `func TestScenarioNameInPascalCase(t *testing.T)`
+
+    **Category marker:** Apply the framework's categorization mechanism:
+    - Sections 1.1, 1.2, 1.3 -> `unit` category by default
+    - If Preconditions imply external dependencies (database, network, file
+      system, external service), use `integration` category instead
+    - Section 1.4 -> `sanity` or `smoke` category
+
+    | Framework | Category mechanism |
+    |-----------|-------------------|
+    | Python (pytest) | `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.sanity` |
+    | JavaScript (Jest) | `describe` block name or tag comments |
+    | Java (JUnit 5) | `@Tag("unit")`, `@Tag("integration")`, `@Tag("sanity")` |
+    | Go (testing) | Build tags or test name prefixes |
+
+    **Description:** One-line from Scenario Name column, as a docstring,
+    comment, or display name per framework convention.
+
+    **Body — Arrange / Act / Assert:**
+    - **Arrange** (from Preconditions): Set up the test state. Use shared
+      fixtures from Step 2 where the Preconditions reference Test Data entries.
+    - **Act** (from Steps): Execute the actions described. Translate numbered
+      steps into method calls on the planned production API.
+    - **Assert** (from Expected Result): Translate each numbered expected result
+      into a concrete assertion. Use the strongest assertion that matches the
+      spec — never weaken (e.g., if spec says "returns `GuardrailResult(passed=True)`",
+      assert the exact value, not just `is not None`).
+
+    **Imports:** Derive real imports from:
+    - **Reference Models** column -> import the model/entity classes
+    - **Service / Unit** column -> import the class/module under test
+    - Use module paths from the implementation plan
+
+    These imports WILL NOT RESOLVE until production code is implemented.
+    That is correct — the unresolved import IS the first RED failure.
+
+    #### Section 1.4 (Sanity Scenarios)
+
+    These rows have 3 columns: Scenario Name, Steps, Assertions.
+    There is NO Preconditions column, NO Service/Unit column, NO Reference
+    Models column.
+
+    For each row:
+
+    **Function name:** Same derivation from Scenario Name.
+
+    **Category:** Always `sanity` or `smoke`.
+
+    **Body — Act / Assert only (no Arrange):**
+    - **Act** (from Steps): Translate the numbered steps into integration-style
+      test actions. These typically involve end-to-end operations.
+    - **Assert** (from Assertions): Translate each numbered assertion into a
+      concrete assertion statement.
+
+    **Imports:** Derive from the Steps and Assertions content — identify
+    referenced modules, services, or CLI commands from the implementation plan.
+
+    ### Step 5 — Data-Driven Expansion
+
+    Where a scenario implies multiple inputs (e.g., "invalid types: None,
+    empty string, numeric" or "Session_A with clean input, Session_B with
+    PII input"), generate data-driven test expansions:
+
+    | Framework | Mechanism |
+    |-----------|-----------|
+    | Python (pytest) | `@pytest.mark.parametrize` with concrete values |
+    | JavaScript (Jest) | `test.each` or `it.each` with table |
+    | Java (JUnit 5) | `@ParameterizedTest` with `@ValueSource` or `@MethodSource` |
+    | Go (testing) | Table-driven tests with `[]struct` test cases |
+
+    Expand concrete values inline — do not reference external data files.
+    The human will review expansions during coarse approval.
+
+    ### Step 6 — Final Checks
+
+    Before returning your output, verify:
+
+    - [ ] Every scenario row from sections 1.1-1.4 has exactly one test function
+    - [ ] Every test function name traces back to a Scenario Name
+    - [ ] All imports reference planned (not yet existing) production modules
+    - [ ] No test contains implementation code, stubs, mocks, or skip decorators
+    - [ ] All assertions match Expected Result / Assertions column strength
+    - [ ] Test Data (1.0) entries are represented as shared fixtures
+    - [ ] Sanity scenarios (1.4) use Steps/Assertions columns, not the 7-column format
+    - [ ] File grouping follows Service/Unit column (one file per unit)
+    - [ ] Framework conventions (naming, style, categorization) are followed
+    - [ ] Traceability comments (Feature, Spec Version) appear in each file
+
+    ## Constraints
+
+    - **Only translate what the spec describes** — do not invent tests
+    - **Imports must be real** (from planned module structure), not mocked
+    - **Tests must be RED** — no implementation code, no stubs, no skips
+    - **Follow project conventions** — style, linter rules, naming patterns
+    - **Each test traceable** to its scenario row via name and description
+    - **Unresolved import IS a valid RED failure** — do not work around it
+
+    ## Output Format
+
+    Return all generated files in this format. Include the shared setup file
+    first, then test files grouped by Service/Unit.
+
+    ### File: `<target-path-relative-to-project-root>`
+    ```<language>
+    <complete file content>
+    ```
+
+    ### File: `<next-target-path>`
+    ```<language>
+    <complete file content>
+    ```
+
+    Repeat for every generated file. Include complete file content — no
+    placeholders, no "... rest of tests here", no truncation.
+
+    ## Report Format
+
+    After the generated files, provide a brief summary:
+
+    - **Status:** DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    - **Files generated:** count and list
+    - **Scenario coverage:** X positive, Y negative, Z edge case, W sanity
+    - **Data-driven expansions:** list any scenarios that were expanded
+    - **Concerns (if any):** ambiguous scenarios, uncertain module paths, etc.
+```
+
+**Translator returns:** Generated test files with target paths + coverage summary.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -131,9 +131,20 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 
+## Scenario Spec Handoff
+
+After the plan is approved but before execution, recommend the user author acceptance criteria:
+
+> **Next step:** Author your test scenario spec with `superpowers:writing-test-scenario-specs`. This creates human-authored acceptance criteria that define "done" for each feature in the plan.
+>
+> **Design doc:** `[path]`
+> **Implementation plan:** `[path]`
+
+If the user chooses to skip, proceed to execution handoff as normal. The scenario spec is recommended but not mandatory at the plan stage — `subagent-driven-development` has its own precondition check.
+
 ## Execution Handoff
 
-After saving the plan, offer execution choice:
+After saving the plan (and optionally the scenario spec), offer execution choice:
 
 **"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
 

--- a/skills/writing-test-scenario-specs/SKILL.md
+++ b/skills/writing-test-scenario-specs/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: writing-test-scenario-specs
+description: >
+  Use after writing-plans produces an approved implementation plan and BEFORE
+  implementation begins. Guides the user through authoring a BDD-style test
+  scenario spec that becomes the acceptance criteria for the feature.
+---
+
+# Writing Test Scenario Specs
+
+Author human-controlled acceptance criteria as scenario tables before implementation begins. Seeds scenarios from the design doc, validates coverage against the implementation plan.
+
+**Where in the workflow:** brainstorming → writing-plans → **writing-test-scenario-specs** → subagent-driven-development
+
+**What it produces:** A scenario spec file (structured markdown tables) — not test code.
+
+**Announce at start:** "I'm using the writing-test-scenario-specs skill to author your test scenario spec."
+
+<HARD-GATE>
+Do NOT generate pytest code, invoke subagent-driven-development, or take any
+implementation action. This skill produces a scenario specification document —
+not test code. Test code generation is a separate concern.
+
+If you find yourself writing `def test_`, `assert`, or `@pytest.mark` — STOP.
+Delete the code. Return to the spec flow.
+</HARD-GATE>
+
+## Checklist
+
+You MUST create a task for each item and complete them in order:
+
+1. **Collect inputs** — confirm or request design doc and plan paths, read project conventions
+2. **Seed scenarios** — dispatch Scenario Seeder subagent
+3. **Coarse approval** — present seeds in chat, iterate with human
+4. **Write spec file** — write to docs, wait for human fine-tuning
+5. **Review against plan** — dispatch Test Scenario Reviewer, handle gaps
+6. **Final approval & commit** — commit spec, announce next step
+
+## Process Flow
+
+```dot
+digraph flow {
+    rankdir=TB;
+    "Paths from handoff?" [shape=diamond];
+    "Confirm with human" [shape=box];
+    "Ask human for paths" [shape=box];
+    "Read project conventions" [shape=box];
+    "Dispatch Scenario Seeder" [shape=box];
+    "Present seeds in chat" [shape=box];
+    "Human approves?" [shape=diamond];
+    "Iterate seeds" [shape=box];
+    "Write spec file" [shape=box];
+    "Human done editing?" [shape=diamond];
+    "Dispatch Test Scenario Reviewer" [shape=box];
+    "Reviewer approves?" [shape=diamond];
+    "Present gaps to human" [shape=box];
+    "Max 3 iterations?" [shape=diamond];
+    "Surface to human" [shape=box];
+    "Final approval & commit" [shape=doublecircle];
+
+    "Paths from handoff?" -> "Confirm with human" [label="yes"];
+    "Paths from handoff?" -> "Ask human for paths" [label="no"];
+    "Confirm with human" -> "Read project conventions";
+    "Ask human for paths" -> "Read project conventions";
+    "Read project conventions" -> "Dispatch Scenario Seeder";
+    "Dispatch Scenario Seeder" -> "Present seeds in chat";
+    "Present seeds in chat" -> "Human approves?";
+    "Human approves?" -> "Iterate seeds" [label="no"];
+    "Iterate seeds" -> "Present seeds in chat";
+    "Human approves?" -> "Write spec file" [label="yes"];
+    "Write spec file" -> "Human done editing?";
+    "Human done editing?" -> "Write spec file" [label="no, updating"];
+    "Human done editing?" -> "Dispatch Test Scenario Reviewer" [label="yes"];
+    "Dispatch Test Scenario Reviewer" -> "Reviewer approves?";
+    "Reviewer approves?" -> "Final approval & commit" [label="yes"];
+    "Reviewer approves?" -> "Present gaps to human" [label="gaps found"];
+    "Present gaps to human" -> "Max 3 iterations?";
+    "Max 3 iterations?" -> "Dispatch Test Scenario Reviewer" [label="no"];
+    "Max 3 iterations?" -> "Surface to human" [label="yes"];
+    "Surface to human" -> "Final approval & commit";
+}
+```
+
+## Step 1: Collect Inputs
+
+Check if design doc and implementation plan paths are already in conversation context from a prior skill handoff.
+
+- **If found:** Confirm with the human: "I see the design doc at `<path>` and plan at `<path>`. Correct?"
+- **If not found:** Ask the human for both paths.
+
+Then read the project's CLAUDE.md and scan the test directory for conventions — pytest markers, fixture patterns, naming style, line length. These conventions are passed to the Scenario Seeder so scenario language matches the project.
+
+## Step 2: Seed Scenarios
+
+Dispatch a **Scenario Seeder** subagent using the template in `scenario-seeder-prompt.md`.
+
+Pass to the subagent:
+- Design doc path
+- Scenario spec template (from `scenario-spec-template.md`)
+- Project test conventions discovered in Step 1
+
+The seeder reads the design doc end-to-end and returns populated scenario tables (sections 1.0–1.4).
+
+## Step 3: Coarse Approval
+
+Present the seeded scenarios in chat as markdown tables. Ask:
+
+> "Review these scenarios. Add, remove, or change anything — or say 'looks good' to proceed."
+
+Iterate until the human says the scenarios look roughly right. Do not demand perfection — the human can fine-tune in their editor next.
+
+## Step 4: Write Spec File
+
+Write the approved scenarios to `docs/superpowers/specs/YYYY-MM-DD-<feature>-test-scenarios.md`.
+(User preferences for spec location override this default.)
+
+Tell the human:
+
+> "Spec written to `<path>`. Open it in your editor to fine-tune wording, add details, or reorder scenarios. Let me know when you're done."
+
+**Wait for the human to confirm** before proceeding. Do not rush past this step.
+
+## Step 5: Review Against Plan
+
+Dispatch a **Test Scenario Reviewer** subagent using the template in `test-scenario-reviewer-prompt.md`.
+
+Pass to the subagent:
+- Scenario spec file path
+- Implementation plan file path
+
+**If Approved:** Proceed to Step 6.
+
+**If Gaps Found:** Present each gap with the reviewer's draft scenario rows. For each gap, ask the human to:
+- **Accept** — add the suggested row to the spec
+- **Modify** — edit the draft row before adding
+- **Reject** — skip this gap
+
+Update the spec file. Re-dispatch the reviewer. Repeat until approved or 3 iterations reached.
+
+**After 3 iterations:** Surface remaining gaps to the human:
+
+> "The reviewer still finds gaps after 3 rounds. Here they are — would you like to address them or proceed as-is?"
+
+The human decides. Do not block indefinitely.
+
+## Step 6: Final Approval & Commit
+
+Ask:
+
+> "Scenario spec is complete. Ready to commit?"
+
+Commit the spec file. Announce:
+
+> "Spec committed. Next step: begin implementation with `superpowers:subagent-driven-development`."
+
+## Anti-Patterns
+
+| Rationalization | Counter |
+|-----------------|---------|
+| "The plan already covers testing" | Plan covers tasks. Spec covers acceptance criteria. Different artifacts. |
+| "This is too simple to need a spec" | Simple features drift silently. Present the template. |
+| "I'll write the spec after implementation" | Spec-after is post-hoc justification, not acceptance criteria. |
+| "Skip the spec, just implement" | Refuse. Re-present the template. |
+| Agent writes test code before spec | This skill does not generate code. Delete and restart. |
+| Agent invents scenarios not in design doc | Remove them. Only design-doc-derived scenarios in the seed. |
+
+## Red Flags — STOP
+
+If you catch yourself doing any of these, stop and return to the spec flow:
+
+- Writing `def test_` or `assert` statements
+- Invoking subagent-driven-development before the spec is committed
+- Adding scenarios the design doc does not mention
+- Skipping human approval at Steps 3, 4, or 6
+- Presenting the spec without waiting for human confirmation
+
+## Project Adaptation
+
+This skill is not tied to a specific project. At activation (Step 1), it reads:
+- The project's `CLAUDE.md` for test conventions, code style, and patterns
+- The test directory structure for naming and fixture patterns
+- These conventions are passed to the Scenario Seeder subagent so that scenario names, precondition descriptions, and step language match the project

--- a/skills/writing-test-scenario-specs/scenario-seeder-prompt.md
+++ b/skills/writing-test-scenario-specs/scenario-seeder-prompt.md
@@ -1,0 +1,67 @@
+# Scenario Seeder Prompt Template
+
+Use this template when dispatching a scenario seeder subagent.
+
+**Purpose:** Read the design doc and propose test scenario tables in LLD Section 11 format.
+
+**Dispatch during:** Step 2 of the writing-test-scenario-specs skill flow.
+
+```
+Agent tool (general-purpose):
+  description: "Seed scenario spec from design doc"
+  prompt: |
+    You are a scenario seeder. Your job is to read a design document and
+    propose test scenario tables that the human will review and edit.
+
+    **Design doc:** [DESIGN_DOC_PATH]
+    **Scenario spec template:** Read skills/writing-test-scenario-specs/scenario-spec-template.md
+    **Project conventions:** Read the project's CLAUDE.md and scan the test directory
+      for naming conventions, pytest markers, fixture patterns, and code style.
+
+    ## Your Task
+
+    1. Read the design doc end-to-end.
+    2. Read the scenario spec template for the exact table format.
+    3. Read the project's CLAUDE.md and test directory for conventions.
+    4. Identify testable behaviors from the design doc:
+       - Features and happy paths
+       - Error handling and failure modes
+       - Data flows and transformations
+       - Boundary conditions
+    5. Populate each template section:
+       - **1.0 Test Data** — named fixtures and sample data sets derived from
+         the design's data models. Use concrete values, not placeholders.
+       - **1.1 Positive Tests** — happy paths from the design's primary flows.
+         Each scenario traces to a specific design doc section.
+       - **1.2 Negative Tests** — failure modes and error conditions mentioned
+         in the design. Include expected error behavior.
+       - **1.3 Edge Cases** — boundaries, empty inputs, concurrency concerns
+         from the design. Only include cases the design explicitly addresses.
+       - **1.4 Sanity Scenarios** — E2E smoke tests covering the design's main
+         use case. Keep to 1-3 scenarios.
+    6. After each section, add a brief traceability note citing which design doc
+       section(s) the scenarios derive from.
+
+    ## Constraints
+
+    - ONLY derive scenarios from what the design doc explicitly describes.
+      Do NOT invent requirements, assume implied features, or add scenarios
+      for concerns the design does not mention.
+    - Each scenario row MUST be traceable to a specific section of the design doc.
+    - Adapt naming and conventions to the project (from CLAUDE.md and test directory).
+    - Use verb-noun naming for scenarios (e.g., "single guardrail passes input").
+    - Preconditions and Steps must be concrete and specific, not vague.
+    - Expected Results must be assertable — a developer should know exactly what
+      to assert in a test function.
+
+    ## Output Format
+
+    Return the completed scenario tables as markdown — all five sections
+    (1.0 through 1.4) with rows populated from the design doc. Include a
+    brief note after each section citing which design doc section(s) the
+    scenarios trace to.
+
+    Do NOT return any pytest code. Return only the scenario tables.
+```
+
+**Seeder returns:** Completed scenario tables as markdown, ready for human review.

--- a/skills/writing-test-scenario-specs/scenario-spec-template.md
+++ b/skills/writing-test-scenario-specs/scenario-spec-template.md
@@ -1,0 +1,41 @@
+# Test Scenario Spec — {Feature Name}
+
+| Field       | Value                                |
+| ----------- | ------------------------------------ |
+| Feature     | {Feature title}                      |
+| Author      | {author}                             |
+| Design ref  | {path to design doc}                 |
+| Plan ref    | {path to implementation plan}        |
+| Status      | Draft                                |
+
+---
+
+## 1.0 Test Data
+
+| Data Set Name | Model / Entity | Purpose | Sample Data | Notes |
+| ------------- | -------------- | ------- | ----------- | ----- |
+|               |                |         |             |       |
+
+## 1.1 Positive Tests
+
+| Scenario Name | Service / Unit | Priority | Preconditions | Steps | Expected Result | Reference Models |
+| ------------- | -------------- | -------- | ------------- | ----- | --------------- | ---------------- |
+|               |                |          |               |       |                 |                  |
+
+## 1.2 Negative Tests
+
+| Scenario Name | Service / Unit | Priority | Preconditions | Steps | Expected Result | Reference Models |
+| ------------- | -------------- | -------- | ------------- | ----- | --------------- | ---------------- |
+|               |                |          |               |       |                 |                  |
+
+## 1.3 Edge Cases
+
+| Scenario Name | Service / Unit | Priority | Preconditions | Steps | Expected Result | Reference Models |
+| ------------- | -------------- | -------- | ------------- | ----- | --------------- | ---------------- |
+|               |                |          |               |       |                 |                  |
+
+## 1.4 Sanity Scenarios
+
+| Scenario Name | Steps | Assertions |
+| ------------- | ----- | ---------- |
+|               |       |            |

--- a/skills/writing-test-scenario-specs/test-scenario-reviewer-prompt.md
+++ b/skills/writing-test-scenario-specs/test-scenario-reviewer-prompt.md
@@ -1,0 +1,68 @@
+# Test Scenario Reviewer Prompt Template
+
+Use this template when dispatching a test scenario reviewer subagent.
+
+**Purpose:** Validate the approved scenario spec against the implementation plan, catching coverage gaps the design-level seeding missed.
+
+**Dispatch during:** Step 5 of the writing-test-scenario-specs skill flow.
+
+```
+Agent tool (general-purpose):
+  description: "Review scenario spec against plan"
+  prompt: |
+    You are a test scenario reviewer. Your job is to validate a scenario spec
+    against an implementation plan and flag coverage gaps.
+
+    **Scenario spec:** [SCENARIO_SPEC_PATH]
+    **Implementation plan:** [PLAN_PATH]
+
+    ## Your Task
+
+    1. Read the scenario spec file.
+    2. Read the implementation plan file.
+    3. For each plan task, identify testable behaviors:
+       - Error paths and failure handling
+       - Edge cases and boundary conditions
+       - Configuration options
+       - Integration points between components
+    4. Cross-reference against the scenario spec — does a scenario exist
+       that would exercise each testable behavior?
+    5. Produce a coverage report.
+
+    ## Report Format
+
+    ## Test Scenario Review
+
+    **Status:** Approved | Gaps Found
+
+    ### Covered
+    - [Plan Task N]: [brief summary of matching scenarios]
+
+    ### Gaps (if any)
+    - [Plan Task N]: [what's missing] — [why it matters]
+
+      **Suggested scenario row:**
+
+      | Scenario Name | Service / Unit | Priority | Preconditions | Steps | Expected Result | Reference Models |
+      | --- | --- | --- | --- | --- | --- | --- |
+      | [suggested name] | [unit] | [P1/P2/P3] | [preconditions] | [steps] | [expected result] | [models] |
+
+    ### Over-specified (advisory)
+    - [Scenario Name]: traces to design doc but not to a specific plan task — likely intentional
+
+    ### Recommendations (advisory, do not block approval)
+    - [suggestions]
+
+    ## Constraints
+
+    - Gaps MUST include complete draft scenario rows with all 7 columns
+      (Scenario Name, Service/Unit, Priority, Preconditions, Steps,
+      Expected Result, Reference Models). Not just "add a test for X."
+    - Over-specified is advisory only — do NOT recommend removing scenarios.
+      The spec may intentionally cover design-level concerns the plan doesn't
+      break into separate tasks.
+    - Approve unless there are gaps. Stylistic feedback is not a blocking issue.
+    - Do NOT suggest adding scenarios for concerns not in the plan or design doc.
+```
+
+**Reviewer returns:** Status (Approved / Gaps Found), Covered summary, Gaps with draft rows, Over-specified advisory.


### PR DESCRIPTION
## Summary

- Adds a new `writing-test-scenario-specs` skill — a human-in-the-loop workflow that inserts between `writing-plans` and `subagent-driven-development` to let the human author acceptance criteria as structured scenario tables before implementation begins
- Seeds scenarios from the design doc via a Scenario Seeder subagent, then validates coverage against the implementation plan via a Test Scenario Reviewer subagent
- Wires the new skill into the existing workflow: adds a handoff in `writing-plans` and a soft precondition check in `subagent-driven-development`

## What's included

| File | Purpose |
|------|---------|
| `skills/writing-test-scenario-specs/SKILL.md` | Main skill — 6-step flow with hard gate, anti-patterns, flow diagram |
| `skills/writing-test-scenario-specs/scenario-spec-template.md` | LLD Section 11 template (empty tables) |
| `skills/writing-test-scenario-specs/scenario-seeder-prompt.md` | Subagent dispatch template: design doc → proposed scenario tables |
| `skills/writing-test-scenario-specs/test-scenario-reviewer-prompt.md` | Subagent dispatch template: spec vs plan coverage validation |
| `skills/writing-plans/SKILL.md` | Added "Scenario Spec Handoff" section before execution handoff |
| `skills/subagent-driven-development/SKILL.md` | Added soft precondition check for scenario spec file |

## Motivation

In the current workflow, subagents own test authoring — the human steers the design and approves the plan, but never touches acceptance criteria. PR review is the first time the human sees the tests. This skill gives the human control over what "done" means by authoring scenario tables (not code) that become the acceptance criteria for the feature.

## Workflow position

```
brainstorming → writing-plans → writing-test-scenario-specs → subagent-driven-development
```

The skill is recommended but not mandatory — users can skip it, and existing features without specs are unaffected.

## Test plan

- [ ] Verify skill triggers correctly when invoked after `writing-plans`
- [ ] Verify hard gate prevents pytest code generation during the spec flow
- [ ] Verify Scenario Seeder subagent produces tables matching the template format
- [ ] Verify Test Scenario Reviewer catches coverage gaps and proposes draft rows
- [ ] Verify `writing-plans` handoff message includes design doc and plan paths
- [ ] Verify `subagent-driven-development` precondition check is a soft gate (skippable)
- [ ] Pressure test: "skip the spec" → agent refuses and re-presents template
- [ ] Pressure test: agent invents scenarios not in design doc → removed
- [ ] Pressure test: agent writes pytest code → hard gate fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)