### PR TITLE
feat(writing-plans): add parallel suitability check to plan handoff

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -57,6 +57,8 @@ This structure informs the task decomposition. Each task should produce self-con
 
 **Tech Stack:** [Key technologies/libraries]
 
+**Execution Recommendation:** [Iterative | Parallel-safe] - [One sentence explaining why]
+
 ---
 ```
 
@@ -69,6 +71,14 @@ This structure informs the task decomposition. Each task should produce self-con
 - Create: `exact/path/to/file.py`
 - Modify: `exact/path/to/existing.py:123-145`
 - Test: `tests/exact/path/to/test.py`
+
+**Depends on:** [None | Task 1, Task 2]
+
+**Write Scope:** `exact/path/to/file.py`, `tests/exact/path/to/test.py`
+
+**Verify:** `pytest tests/path/test.py::test_name -v`
+
+**Potential Conflicts:** [None | Shared contract in `src/types.py` means this task should serialize with Task 4]
 
 - [ ] **Step 1: Write the failing test**
 
@@ -129,23 +139,56 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
 
+**4. Parallel suitability:** Can an implementer tell which tasks are independent, which tasks share write scope, and which tasks must serialize? Every task should make `Depends on`, `Write Scope`, `Verify`, and `Potential Conflicts` explicit enough that the execution path is obvious.
+
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
+
+## Parallel Suitability Check
+
+Before handing the plan off for implementation, explicitly classify it:
+
+**Parallel-safe plans:**
+- 2+ tasks are independent
+- Each independent task has a clear write scope
+- Each independent task has a minimal verification command
+- Shared files, contracts, config, or schema changes are either absent or clearly serialized
+
+**Iterative plans:**
+- Tasks mostly build on each other
+- Multiple tasks need the same files or shared contracts
+- Verification depends on previous tasks landing first
+- The safest path is review-and-integrate one task at a time
+
+When in doubt, recommend iterative execution. Superpowers values correctness over raw speed.
 
 ## Execution Handoff
 
-After saving the plan, offer execution choice:
+After saving the plan, recommend an execution mode first, then offer the most appropriate options:
 
-**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`.
 
-**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+**Recommended execution mode:** [Iterative | Parallel-safe]
+**Why:** [1-2 sentences based on dependencies, write scope, verification, and conflict risk]
 
-**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+**If Iterative:**
+- **Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+- **Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
 
-**Which approach?"**
+**If Parallel-safe:**
+- **Subagent-Driven (recommended default)** - Still safest when correctness matters more than speed
+- **Parallel-safe execution** - Only if the plan clearly isolates ownership, verification, and conflict boundaries
+- **Inline Execution** - Execute tasks in this session using executing-plans when parallel execution is unavailable
+
+Which approach?"**
 
 **If Subagent-Driven chosen:**
 - **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
 - Fresh subagent per task + two-stage review
+
+**If Parallel-safe chosen:**
+- Only use it when the plan has explicit task boundaries, write scope, verification, and conflict notes
+- Keep shared contracts, root config, schema, and integration work serialized
+- Review and integrate after the parallel work finishes before declaring the project done
 
 **If Inline Execution chosen:**
 - **REQUIRED SUB-SKILL:** Use superpowers:executing-plans

--- a/skills/writing-plans/plan-document-reviewer-prompt.md
+++ b/skills/writing-plans/plan-document-reviewer-prompt.md
@@ -23,6 +23,7 @@ Task tool (general-purpose):
     | Spec Alignment | Plan covers spec requirements, no major scope creep |
     | Task Decomposition | Tasks have clear boundaries, steps are actionable |
     | Buildability | Could an engineer follow this plan without getting stuck? |
+    | Execution Readiness | Dependencies, write scope, verification, and conflict risks are clear enough to choose iterative vs parallel-safe execution |
 
     ## Calibration
 

--- a/tests/explicit-skill-requests/prompts/after-planning-flow.txt
+++ b/tests/explicit-skill-requests/prompts/after-planning-flow.txt
@@ -6,9 +6,12 @@ Here's a summary of what we designed:
 - Task 3: Add JWT middleware for protected routes
 - Task 4: Write tests for all auth functionality
 
-Two execution options:
-1. Subagent-Driven (this session) - dispatch a fresh subagent per task
-2. Parallel Session (separate) - open new Claude Code session
+Recommended execution mode: Iterative
+Why: The tasks build on each other and should land with review between steps.
+
+Execution options:
+1. Subagent-Driven (recommended) - dispatch a fresh subagent per task
+2. Inline Execution - execute the plan in this session with review checkpoints
 
 Which approach do you want?
 

--- a/tests/explicit-skill-requests/prompts/claude-suggested-it.txt
+++ b/tests/explicit-skill-requests/prompts/claude-suggested-it.txt
@@ -1,9 +1,12 @@
 [Previous assistant message]:
 Plan complete and saved to docs/superpowers/plans/auth-system.md.
 
-Two execution options:
-1. Subagent-Driven (this session) - I dispatch a fresh subagent per task, review between tasks, fast iteration within this conversation
-2. Parallel Session (separate) - Open a new Claude Code session with the execute-plan skill, batch execution with review checkpoints
+Recommended execution mode: Iterative
+Why: The plan has shared dependencies, so the safest path is task-by-task review and integration.
+
+Execution options:
+1. Subagent-Driven (recommended) - I dispatch a fresh subagent per task, review between tasks, fast iteration within this conversation
+2. Inline Execution - Execute tasks in this session using executing-plans, batch execution with review checkpoints
 
 Which approach do you want to use for implementation?
 


### PR DESCRIPTION
## Summary

This is a narrow `writing-plans` improvement aimed at making execution routing more explicit **without** making Superpowers parallel-first.

It adds:
- per-task execution metadata in the plan template:
  - `Depends on`
  - `Write Scope`
  - `Verify`
  - `Potential Conflicts`
- a short **Parallel Suitability Check** section before execution handoff
- a handoff pattern that gives a **recommended execution mode** (`Iterative` or `Parallel-safe`) with reasoning
- plan-reviewer guidance to check whether the plan is explicit enough to choose the right execution path
- small prompt fixture updates so the explicit-skill-request prompts reflect the new handoff wording

## Why

Today `writing-plans` decomposes work into tasks, but the handoff does not make it easy to tell:
- which tasks are truly independent
- which tasks share write scope or contracts
- whether the safest next step is iterative execution or a parallel-safe path

This PR keeps the current correctness-first bias, but makes plans clearer and more actionable when some tasks are independent.

## Non-goals

This PR does **not**:
- make Superpowers parallel-by-default
- introduce a new orchestration skill
- replace heavier multi-agent flows like `agent-teams` / `assemble`
- change the recommendation that iterative execution is safest when tasks are coupled

## Related discussion

- Refs #777
- Related to #801
- Consistent with the correctness-first preference discussed in #945

## Verification

Ran targeted verification directly related to these documentation/prompt changes:
- `git diff --check`
- grep/rg checks for the new handoff markers (`Execution Recommendation`, `Parallel Suitability Check`, `Execution Readiness`)
- confirmed changed file set stayed limited to the intended 4 files

I did **not** claim broader build/test coverage because this change is limited to skill/prompt markdown and there is no direct unit/build target for it in this repo.