### PR TITLE
feat: add explicit brainstorm state-dir selection

### DIFF
--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Start the brainstorm server and output connection info
-# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--foreground] [--background]
+# Usage: start-server.sh [--state-dir <path>] [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--foreground] [--background]
 #
 # Starts server on a random high port, outputs JSON with URL.
 # Each session gets its own directory to avoid conflicts.
 #
 # Options:
-#   --project-dir <path>  Store session files under <path>/.superpowers/brainstorm/
-#                         instead of /tmp. Files persist after server stops.
+#   --state-dir <path>    Store session files under <path>/<session-id>/.
+#                         This is the primary persistent storage option.
+#   --project-dir <path>  Compatibility alias. Stores session files under
+#                         <path>/.superpowers/brainstorm/<session-id>/.
 #   --host <bind-host>    Host/interface to bind (default: 127.0.0.1).
 #                         Use 0.0.0.0 in remote/containerized environments.
 #   --url-host <host>     Hostname shown in returned URL JSON.
@@ -17,6 +19,7 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Parse arguments
+STATE_ROOT=""
 PROJECT_DIR=""
 FOREGROUND="false"
 FORCE_BACKGROUND="false"
@@ -24,6 +27,10 @@ BIND_HOST="127.0.0.1"
 URL_HOST=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --state-dir)
+      STATE_ROOT="$2"
+      shift 2
+      ;;
     --project-dir)
       PROJECT_DIR="$2"
       shift 2
@@ -77,11 +84,19 @@ fi
 # Generate unique session directory
 SESSION_ID="$$-$(date +%s)"
 
-if [[ -n "$PROJECT_DIR" ]]; then
-  SESSION_DIR="${PROJECT_DIR}/.superpowers/brainstorm/${SESSION_ID}"
+DEFAULT_STATE_ROOT="${XDG_DATA_HOME:-${HOME:-/tmp}/.local/share}/superpowers/brainstorm"
+
+if [[ -n "$STATE_ROOT" ]]; then
+  :
+elif [[ -n "${SUPERPOWERS_STATE_DIR:-}" ]]; then
+  STATE_ROOT="${SUPERPOWERS_STATE_DIR}"
+elif [[ -n "$PROJECT_DIR" ]]; then
+  STATE_ROOT="${PROJECT_DIR}/.superpowers/brainstorm"
 else
-  SESSION_DIR="/tmp/brainstorm-${SESSION_ID}"
+  STATE_ROOT="${DEFAULT_STATE_ROOT}"
 fi
+
+SESSION_DIR="${STATE_ROOT}/${SESSION_ID}"
 
 STATE_DIR="${SESSION_DIR}/state"
 PID_FILE="${STATE_DIR}/server.pid"

--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -33,26 +33,26 @@ The server watches a directory for HTML files and serves the newest one to the b
 ## Starting a Session
 
 ```bash
-# Start server with persistence (mockups saved to project)
-scripts/start-server.sh --project-dir /path/to/project
+# Start server with persistent state stored outside the working tree
+scripts/start-server.sh --state-dir /path/to/brainstorm-state
 
 # Returns: {"type":"server-started","port":52341,"url":"http://localhost:52341",
-#           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/content",
-#           "state_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/state"}
+#           "screen_dir":"/path/to/brainstorm-state/12345-1706000000/content",
+#           "state_dir":"/path/to/brainstorm-state/12345-1706000000/state"}
 ```
 
 Save `screen_dir` and `state_dir` from the response. Tell user to open the URL.
 
-**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.superpowers/brainstorm/` for the session directory.
+**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port.
 
-**Note:** Pass the project root as `--project-dir` so mockups persist in `.superpowers/brainstorm/` and survive server restarts. Without it, files go to `/tmp` and get cleaned up. Remind the user to add `.superpowers/` to `.gitignore` if it's not already there.
+**Note:** By default, brainstorm sessions are stored in a user-owned data directory outside the working tree. Use `--state-dir` to choose a different storage root. `SUPERPOWERS_STATE_DIR` sets a persistent default. `--project-dir` remains available as a compatibility alias when you explicitly want sessions under `<project>/.superpowers/brainstorm/`.
 
 **Launching the server by platform:**
 
 **Claude Code (macOS / Linux):**
 ```bash
 # Default mode works — the script backgrounds the server itself
-scripts/start-server.sh --project-dir /path/to/project
+scripts/start-server.sh --state-dir /path/to/brainstorm-state
 ```
 
 **Claude Code (Windows):**
@@ -60,7 +60,7 @@ scripts/start-server.sh --project-dir /path/to/project
 # Windows auto-detects and uses foreground mode, which blocks the tool call.
 # Use run_in_background: true on the Bash tool call so the server survives
 # across conversation turns.
-scripts/start-server.sh --project-dir /path/to/project
+scripts/start-server.sh --state-dir /path/to/brainstorm-state
 ```
 When calling this via the Bash tool, set `run_in_background: true`. Then read `$STATE_DIR/server-info` on the next turn to get the URL and port.
 
@@ -68,14 +68,14 @@ When calling this via the Bash tool, set `run_in_background: true`. Then read `$
 ```bash
 # Codex reaps background processes. The script auto-detects CODEX_CI and
 # switches to foreground mode. Run it normally — no extra flags needed.
-scripts/start-server.sh --project-dir /path/to/project
+scripts/start-server.sh --state-dir /path/to/brainstorm-state
 ```
 
 **Gemini CLI:**
 ```bash
 # Use --foreground and set is_background: true on your shell tool call
 # so the process survives across turns
-scripts/start-server.sh --project-dir /path/to/project --foreground
+scripts/start-server.sh --state-dir /path/to/brainstorm-state --foreground
 ```
 
 **Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.
@@ -84,7 +84,7 @@ If the URL is unreachable from your browser (common in remote/containerized setu
 
 ```bash
 scripts/start-server.sh \
-  --project-dir /path/to/project \
+  --state-dir /path/to/brainstorm-state \
   --host 0.0.0.0 \
   --url-host localhost
 ```
@@ -279,7 +279,7 @@ If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser 
 scripts/stop-server.sh $SESSION_DIR
 ```
 
-If the session used `--project-dir`, mockup files persist in `.superpowers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
+Sessions stored outside `/tmp` persist after `stop-server.sh` so the mockups remain available for later reference.
 
 ## Reference
 

--- a/tests/brainstorm-server/start-server-paths.test.sh
+++ b/tests/brainstorm-server/start-server-paths.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${SUPERPOWERS_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+START_SCRIPT="$REPO_ROOT/skills/brainstorming/scripts/start-server.sh"
+TEST_DIR="${TMPDIR:-/tmp}/brainstorm-paths-test-$$"
+FAKE_NODE_DIR="$TEST_DIR/fake-bin"
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_NODE_DIR"
+cat > "$FAKE_NODE_DIR/node" <<'FAKENODE'
+#!/usr/bin/env bash
+printf 'DIR=%s\n' "${BRAINSTORM_DIR:-}"
+exit 0
+FAKENODE
+chmod +x "$FAKE_NODE_DIR/node"
+
+run_case() {
+  env PATH="$FAKE_NODE_DIR:$PATH" "$@"
+}
+
+require_match() {
+  local output="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if ! echo "$output" | grep -q "$pattern"; then
+    echo "FAIL: $description"
+    echo "Expected pattern: $pattern"
+    echo "Output:"
+    echo "$output"
+    exit 1
+  fi
+}
+
+project_output="$(run_case bash "$START_SCRIPT" --project-dir "$TEST_DIR/repo" --foreground 2>/dev/null || true)"
+state_output="$(run_case bash "$START_SCRIPT" --state-dir "$TEST_DIR/state-root" --foreground 2>/dev/null || true)"
+env_output="$(SUPERPOWERS_STATE_DIR="$TEST_DIR/from-env" run_case bash "$START_SCRIPT" --foreground 2>/dev/null || true)"
+default_output="$(HOME="$TEST_DIR/home" XDG_DATA_HOME="$TEST_DIR/xdg" run_case bash "$START_SCRIPT" --foreground 2>/dev/null || true)"
+precedence_output="$(SUPERPOWERS_STATE_DIR="$TEST_DIR/from-env" run_case bash "$START_SCRIPT" --state-dir "$TEST_DIR/flag-wins" --project-dir "$TEST_DIR/repo2" --foreground 2>/dev/null || true)"
+
+require_match "$project_output" "$TEST_DIR/repo/.superpowers/brainstorm/" "--project-dir should map to in-repo compatibility path"
+require_match "$state_output" "$TEST_DIR/state-root/" "--state-dir should set the storage root directly"
+require_match "$env_output" "$TEST_DIR/from-env/" "SUPERPOWERS_STATE_DIR should control the storage root when no flag is set"
+require_match "$default_output" "$TEST_DIR/xdg/superpowers/brainstorm/" "default storage should use XDG data dir when available"
+require_match "$precedence_output" "$TEST_DIR/flag-wins/" "--state-dir should take precedence over env var and compatibility alias"
+
+echo "PASS: start-server path selection"


### PR DESCRIPTION
## What problem are you trying to solve?

The brainstorm companion currently pushes persistent session state into the working tree when `--project-dir` is used, under `<project>/.superpowers/brainstorm/`.

For open source repos, that creates repo pollution and leads users toward `.gitignore` churn just to hide AI-tool state. Persistent brainstorm state should default to a user-owned location outside the repository, while still allowing explicit in-repo storage when someone really wants it.

## What does this PR change?

This adds a new `--state-dir` flag and `SUPERPOWERS_STATE_DIR` environment variable for explicit brainstorm state storage.

It also changes the default persistent storage root to a user-owned data directory outside the working tree, and keeps `--project-dir` as a compatibility alias that still resolves to `<project>/.superpowers/brainstorm/<session-id>/`.

## Is this change appropriate for the core library?

Yes.

This is general-purpose core behavior for brainstorm session storage, not a project-specific workflow or third-party integration. Any user of the brainstorm companion can hit the same repo-pollution problem.

## What alternatives did you consider?

1. Remove `--project-dir` immediately.
   Rejected because it would break existing workflows that already rely on in-repo persistence.

2. Keep `/tmp` as the default persistent location.
   Rejected because it is ephemeral and may be unsuitable for retaining brainstorm sessions across restarts.

3. Add a more complex platform-specific storage abstraction.
   Rejected because a simple user-owned default path plus explicit override mechanisms solves the problem with less complexity.

## Does this PR contain multiple unrelated changes?

No. This PR is limited to brainstorm session storage selection and the associated documentation/tests.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop | current | GPT-5.4 | GPT-5.4 |

## Evaluation

- What was the initial prompt you (or your human partner) used to start the session that led to this change?
  - Investigate issue #975 and implement a minimal fix that moves brainstorm state out of the working tree by default while preserving compatibility.

- How many eval sessions did you run AFTER making the change?
  - One targeted shell test pass for path selection plus one manual smoke run of `start-server.sh` with `--state-dir`.

- How did outcomes change compared to before the change?
  - Before: the script only supported `--project-dir`, and persistent in-repo storage was the documented path.
  - After: the script supports `--state-dir` and `SUPERPOWERS_STATE_DIR`, defaults to a user-owned storage directory outside the working tree, and still accepts `--project-dir` as a compatibility alias.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-plans` style discipline for scoped implementation and added targeted test coverage for the new path-selection behavior
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Verification run:
- `bash tests/brainstorm-server/start-server-paths.test.sh`
- `git diff --check`
- manual smoke run:
  - `bash skills/brainstorming/scripts/start-server.sh --state-dir /tmp/sp-state-smoke --foreground`

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
