### PR TITLE
fix(opencode): add skill naming convention to bootstrap

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -68,9 +68,15 @@ When skills reference tools you don't have, substitute OpenCode equivalents:
 - \`Skill\` tool → OpenCode's native \`skill\` tool
 - \`Read\`, \`Write\`, \`Edit\`, \`Bash\` → Your native tools
 
+**Skill Naming Convention for OpenCode:**
+In OpenCode, superpowers skills MUST be loaded with the \`superpowers:\` prefix:
+- Use \`skill(name="superpowers:systematic-debugging")\` — NOT \`skill(name="systematic-debugging")\`
+- Use \`skill(name="superpowers:brainstorming")\` — NOT \`skill(name="brainstorming")\`
+- This applies to ALL superpowers skills. The bare skill names shown in using-superpowers (e.g., "systematic-debugging", "test-driven-development") are Claude Code conventions and will produce "Did you mean?" warnings in OpenCode.
+
 **Skills location:**
-Superpowers skills are in \`${configDir}/skills/superpowers/\`
-Use OpenCode's native \`skill\` tool to list and load skills.`;
+Superpowers skills are registered by this plugin automatically.
+Use OpenCode's native \`skill\` tool with the \`superpowers:\` prefix to load them.`;
 
     return `<EXTREMELY_IMPORTANT>
 You have superpowers.


### PR DESCRIPTION
## Summary

OpenCode requires the `superpowers:` prefix when loading plugin skills (e.g., `skill(name="superpowers:systematic-debugging")`). The `using-superpowers` skill content (written for Claude Code) instructs bare skill names, which triggers "Did you mean?" warnings in OpenCode.

## Problem

The bootstrap injected by `.opencode/plugins/superpowers.js` maps tool names (TodoWrite → todowrite, etc.) but omits the skill naming convention. When models follow the `using-superpowers` instructions and call `skill(name="systematic-debugging")`, OpenCode responds with "Did you mean: /superpowers:systematic-debugging?" — adding friction and wasted tokens to every session.

## Fix

Adds an explicit "Skill Naming Convention for OpenCode" section to the tool mapping in the bootstrap, with examples showing correct (`superpowers:skill-name`) vs incorrect (`skill-name`) usage.

## Test

1. Configure opencode.json with `"superpowers@git+https://github.com/katsugtgz/superpowers.git#fix/opencode-skill-naming"`
2. Restart OpenCode
3. Start a new session — verify the bootstrap now includes skill naming instructions
4. Observe that models use `skill(name="superpowers:systematic-debugging")` instead of bare names
5. No more "Did you mean?" warnings

## Related

- Related to #942 (OpenCode plugin auto-update)
- Related to #894 (OpenCode system messages compatibility)