### PR TITLE
Add GitHub Copilot CLI compatibility docs

### DIFF
--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -33,6 +33,8 @@ HEAD_SHA=$(git rev-parse HEAD)
 
 Use Task tool with superpowers:code-reviewer type, fill template at `code-reviewer.md`
 
+GitHub Copilot CLI note: use the personal `code-reviewer` agent from `~/.copilot/agents/code-reviewer.agent.md`.
+
 **Placeholders:**
 - `{WHAT_WAS_IMPLEMENTED}` - What you just built
 - `{PLAN_OR_REQUIREMENTS}` - What it should do

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -29,13 +29,15 @@ If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "alw
 
 **In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you—follow it directly. Never use the Read tool on skill files.
 
+**In GitHub Copilot CLI:** Skills load from `~/.copilot/skills`. When a skill applies, read its `SKILL.md` and follow it directly. Custom agents live in `~/.copilot/agents/*.agent.md`.
+
 **In Gemini CLI:** Skills activate via the `activate_skill` tool. Gemini loads skill metadata at session start and activates the full content on demand.
 
 **In other environments:** Check your platform's documentation for how skills are loaded.
 
 ## Platform Adaptation
 
-Skills use Claude Code tool names. Non-CC platforms: see `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
+Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-tools.md` (GitHub Copilot CLI) or `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
 
 # Using Skills
 

--- a/skills/using-superpowers/references/copilot-tools.md
+++ b/skills/using-superpowers/references/copilot-tools.md
@@ -1,0 +1,21 @@
+# GitHub Copilot CLI Tool Mapping
+
+Skills use Claude Code tool names. When you encounter these in a skill, use the GitHub Copilot CLI equivalent:
+
+| Skill references | GitHub Copilot CLI equivalent |
+| --- | --- |
+| `Skill` tool (invoke a skill) | Skills load natively from `~/.copilot/skills` |
+| `Task` tool (dispatch subagent) | Use a built-in or custom agent from `~/.copilot/agents/*.agent.md` |
+| Multiple `Task` calls (parallel) | Use multiple agents in parallel if your Copilot surface supports it; otherwise run them sequentially |
+| `Read`, `Write`, `Edit` (files) | Use Copilot's native file tools |
+| `Bash` (run commands) | Use Copilot's native shell/terminal tools |
+
+## Named Agent Mapping
+
+Some Superpowers skills refer to named Claude agents such as `superpowers:code-reviewer`.
+
+In GitHub Copilot CLI, install the reviewer as a personal custom agent named `code-reviewer` at `~/.copilot/agents/code-reviewer.agent.md`.
+
+## Fallbacks
+
+If the current Copilot surface cannot dispatch custom agents or parallel agents, fall back to single-session execution with `executing-plans`.


### PR DESCRIPTION
## Summary
- add GitHub Copilot CLI guidance to the superpowers bootstrap skill
- add a Copilot-specific tool mapping reference
- document the custom code-reviewer agent path for Copilot CLI

## Testing
- not run (docs-only change)