### PR TITLE
Replace hardcoded /Users/jesse paths with generic placeholders

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -149,8 +149,8 @@ python3 tests/claude-code/analyze-token-usage.py ~/.claude/projects/<project-dir
 Session transcripts are stored in `~/.claude/projects/` with the working directory path encoded:
 
 ```bash
-# Example for /Users/jesse/Documents/GitHub/superpowers/superpowers
-SESSION_DIR="$HOME/.claude/projects/-Users-jesse-Documents-GitHub-superpowers-superpowers"
+# Example for /Users/<username>/Projects/superpowers
+SESSION_DIR="$HOME/.claude/projects/-Users-<username>-Projects-superpowers"
 
 # Find recent sessions
 ls -lt "$SESSION_DIR"/*.jsonl | head -5

--- a/skills/systematic-debugging/CREATION-LOG.md
+++ b/skills/systematic-debugging/CREATION-LOG.md
@@ -4,7 +4,7 @@ Reference example of extracting, structuring, and bulletproofing a critical skil
 
 ## Source Material
 
-Extracted debugging framework from `/Users/jesse/.claude/CLAUDE.md`:
+Extracted debugging framework from `~/.claude/CLAUDE.md`:
 - 4-phase systematic process (Investigation → Pattern Analysis → Hypothesis → Implementation)
 - Core mandate: ALWAYS find root cause, NEVER fix symptoms
 - Rules designed to resist time pressure and rationalization

--- a/skills/systematic-debugging/root-cause-tracing.md
+++ b/skills/systematic-debugging/root-cause-tracing.md
@@ -33,7 +33,7 @@ digraph when_to_use {
 
 ### 1. Observe the Symptom
 ```
-Error: git init failed in /Users/jesse/project/packages/core
+Error: git init failed in ~/project/packages/core
 ```
 
 ### 2. Find Immediate Cause

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -186,7 +186,7 @@ You: I'm using the using-git-worktrees skill to set up an isolated workspace.
 [Run npm install]
 [Run npm test - 47 passing]
 
-Worktree ready at /Users/jesse/myproject/.worktrees/auth
+Worktree ready at ~/myproject/.worktrees/auth
 Tests passing (47 tests, 0 failures)
 Ready to implement auth feature
 ```


### PR DESCRIPTION
## Summary
- Replaced all hardcoded `/Users/jesse/...` example paths with generic placeholders (`~`, `/Users/<username>`) across 4 documentation files
- Ensures examples stay portable and don't embed a personal path

Fixes #858

## Files changed
- `docs/testing.md` — use `/Users/<username>/...` placeholder
- `skills/systematic-debugging/CREATION-LOG.md` — use `~/.claude/CLAUDE.md`
- `skills/systematic-debugging/root-cause-tracing.md` — use `~/project/...`
- `skills/using-git-worktrees/SKILL.md` — use `~/myproject/...`

## Test plan
- [x] `grep -r "/Users/jesse" .` returns zero matches