### PR TITLE
Fix inconsistent worktree cleanup for Option 2

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -103,7 +103,7 @@ EOF
 )"
 ```
 
-Then: Cleanup worktree (Step 5)
+**Don't cleanup worktree** - PR is open; you may need to make follow-up changes.
 
 #### Option 3: Keep As-Is
 
@@ -135,7 +135,7 @@ Then: Cleanup worktree (Step 5)
 
 ### Step 5: Cleanup Worktree
 
-**For Options 1, 2, 4:**
+**For Options 1, 4:**
 
 Check if in worktree:
 ```bash


### PR DESCRIPTION
## Summary
- Remove `Then: Cleanup worktree (Step 5)` from Option 2 in `finishing-a-development-branch` skill, replacing it with an explicit "Don't cleanup worktree" note
- Change Step 5 from `For Options 1, 2, 4:` to `For Options 1, 4:` so it no longer includes Option 2

This makes the file internally consistent — Option 2 (Push and Create PR) keeps the worktree everywhere: Quick Reference table, Common Mistakes, Always section, and now also the Option 2 instructions and Step 5.

## Test plan
- [x] Verify all references to Option 2 in the file consistently say "keep worktree"
- [x] Verify Quick Reference table, Common Mistakes, Always section, and Step 5 all agree

Fixes #940