### PR TITLE
feat: add env var to skip SessionStart context injection

### DIFF
--- a/hooks/session-start
+++ b/hooks/session-start
@@ -3,6 +3,11 @@
 
 set -euo pipefail
 
+# Allow users to skip session context injection via env var
+if [ "${SUPERPOWERS_SKIP_SESSION_CONTEXT:-}" = "true" ]; then
+    exit 0
+fi
+
 # Determine plugin root directory
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"


### PR DESCRIPTION
## Problem

Closes #951.

The `hooks/session-start` script unconditionally injects ~1,500 tokens of `SKILL.md` content on every session. There is no mechanism to opt out. For power users running 20+ sessions/day this costs ~30,000 tokens/day in context that arrives before the user's first message — tokens that pay for content already implicitly available via the `Skill` tool.

## Solution

Add a single env var guard immediately after `set -euo pipefail`:

```bash
# Allow users to skip session context injection via env var
if [ "${SUPERPOWERS_SKIP_SESSION_CONTEXT:-}" = "true" ]; then
    exit 0
fi
```

Setting `SUPERPOWERS_SKIP_SESSION_CONTEXT=true` (e.g. in `~/.claude/settings.json` → `env`) causes the hook to exit cleanly with no output, skipping all context injection. All skills remain fully available via the explicit `Skill` tool invocation — nothing is removed from the plugin, just the automatic injection.

**Default behaviour is unchanged** — the env var defaults to unset, so existing users see no difference.

## Usage

In `~/.claude/settings.json`:
```json
{
  "env": {
    "SUPERPOWERS_SKIP_SESSION_CONTEXT": "true"
  }
}
```

Or export in your shell profile:
```bash
export SUPERPOWERS_SKIP_SESSION_CONTEXT=true
```
