### PR TITLE
fix(brainstorming): honor CLAUDE.md Output Paths before defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ Start a new session in your chosen platform and ask for something that should tr
 
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
 
+## Output Path Overrides
+
+By default, skills write specs and plans to `docs/superpowers/specs/` and `docs/superpowers/plans/`. If your project defines custom locations in `CLAUDE.md`, those paths take precedence.
+
+Example:
+
+```markdown
+## Output Paths
+| Artifact | Location |
+|---|---|
+| Design specs | `docs/design-docs/` |
+| Implementation plans | `docs/implementation-plans/` |
+```
+
+When this table is present, skills should write to the configured locations above rather than the default `docs/superpowers/...` paths.
+
 ## What's Inside
 
 ### Skills Library

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -26,7 +26,7 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Write design doc** — check `CLAUDE.md` for an `Output Paths` table first; if `Design specs` is configured, use it. Otherwise use `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`. Commit the spec.
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
@@ -108,8 +108,9 @@ digraph brainstorming {
 
 **Documentation:**
 
-- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
-  - (User preferences for spec location override this default)
+- Write the validated design (spec) using this precedence:
+  1. Check `CLAUDE.md` for an `Output Paths` table. If `Design specs` has a configured location, use it.
+  2. If no output path is configured, use `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`.
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -15,8 +15,9 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill).
 
-**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
-- (User preferences for plan location override this default)
+**Save plans using this precedence:**
+1. Check `CLAUDE.md` for an `Output Paths` table. If `Implementation plans` has a configured location, use it.
+2. If no output path is configured, use `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`.
 
 ## Scope Check
 
@@ -135,7 +136,7 @@ If you find issues, fix them inline. No need to re-review — just fix and move 
 
 After saving the plan, offer execution choice:
 
-**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+**"Plan complete and saved to `<resolved-plan-path>`. Two execution options:**
 
 **1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
 


### PR DESCRIPTION
## Summary
- make brainstorming explicitly check `CLAUDE.md` `Output Paths` before default spec path
- make writing-plans explicitly check `CLAUDE.md` `Output Paths` before default plan path
- add README example showing `Output Paths` overrides and precedence

## Why
Issue #939 reports that the concrete default path in skill text wins over configured output locations. This change makes override precedence explicit in both skills and user-facing docs.

Closes #939