### PR TITLE
feat(vibe): add Mistral Vibe harness support

### DIFF
--- a/VIBE.md
+++ b/VIBE.md
@@ -1,0 +1,2 @@
+@./skills/using-superpowers/SKILL.md
+@./skills/using-superpowers/references/vibe-tools.md

--- a/docs/README.vibe.md
+++ b/docs/README.vibe.md
@@ -1,0 +1,98 @@
+# Superpowers for Mistral Vibe
+
+Guide for using Superpowers with Mistral Vibe via skill path configuration.
+
+## Quick Install
+
+1. Clone the repo:
+   ```bash
+   git clone https://github.com/obra/superpowers.git ~/.superpowers
+   ```
+
+2. Add the skills path to your Vibe config (`~/.vibe/config.toml`):
+   ```toml
+   skill_paths = ["~/.superpowers/skills"]
+   ```
+
+3. Restart Vibe.
+
+## How It Works
+
+Mistral Vibe discovers skills by scanning directories listed in `skill_paths`. Each directory is checked for subdirectories containing a `SKILL.md` file. Adding the superpowers skills path makes all skills available via Vibe's native `skill` tool.
+
+The `using-superpowers` skill is discovered automatically and enforces skill usage discipline — no additional configuration needed.
+
+## Context File
+
+Copy `VIBE.md` from the superpowers repo to your project root to load the tool mapping automatically:
+
+```bash
+cp ~/.superpowers/VIBE.md /path/to/your/project/VIBE.md
+```
+
+This maps Claude Code tool names used in skills to their Mistral Vibe equivalents.
+
+## Usage
+
+Skills are discovered automatically. Vibe activates them when:
+- You mention a skill by name (e.g., "use brainstorming")
+- The task matches a skill's description
+- The `using-superpowers` skill directs Vibe to use one
+
+### Personal Skills
+
+Create your own skills in `~/.vibe/skills/`:
+
+```bash
+mkdir -p ~/.vibe/skills/my-skill
+```
+
+Create `~/.vibe/skills/my-skill/SKILL.md`:
+
+```markdown
+---
+name: my-skill
+description: Use when [condition] - [what it does]
+---
+
+# My Skill
+
+[Your skill content here]
+```
+
+The `description` field is how Vibe decides when to activate a skill automatically — write it as a clear trigger condition.
+
+## Updating
+
+```bash
+cd ~/.superpowers && git pull
+```
+
+Skills update instantly through the configured path.
+
+## Uninstalling
+
+Remove the skills path from `~/.vibe/config.toml`:
+
+```toml
+skill_paths = []
+```
+
+Optionally delete the clone: `rm -rf ~/.superpowers`.
+
+## Troubleshooting
+
+### Skills not showing up
+
+1. Verify the path in config: `grep skill_paths ~/.vibe/config.toml`
+2. Check skills exist: `ls ~/.superpowers/skills`
+3. Restart Vibe — skills are discovered at startup
+
+### Tool mapping not loaded
+
+Copy `VIBE.md` to your project root. Vibe reads `AGENTS.md` files from `.vibe/` directories, but the tool mapping in `VIBE.md` must be placed where Vibe can discover it.
+
+## Getting Help
+
+- Report issues: https://github.com/obra/superpowers/issues
+- Main documentation: https://github.com/obra/superpowers

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -19,11 +19,11 @@ This is not negotiable. This is not optional. You cannot rationalize your way ou
 
 Superpowers skills override default system prompt behavior, but **user instructions always take precedence**:
 
-1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
+1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, VIBE.md, AGENTS.md, direct requests) — highest priority
 2. **Superpowers skills** — override default system behavior where they conflict
 3. **Default system prompt** — lowest priority
 
-If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+If CLAUDE.md, GEMINI.md, VIBE.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
 
 ## How to Access Skills
 
@@ -33,11 +33,13 @@ If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "alw
 
 **In Gemini CLI:** Skills activate via the `activate_skill` tool. Gemini loads skill metadata at session start and activates the full content on demand.
 
+**In Mistral Vibe:** Use the `skill` tool. Skills are discovered from directories listed in `skill_paths` in your Vibe config. The `skill` tool works the same as Claude Code's `Skill` tool.
+
 **In other environments:** Check your platform's documentation for how skills are loaded.
 
 ## Platform Adaptation
 
-Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-tools.md` (Copilot CLI), `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
+Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-tools.md` (Copilot CLI), `references/codex-tools.md` (Codex), `references/vibe-tools.md` (Mistral Vibe) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md. Mistral Vibe users get the tool mapping loaded automatically via VIBE.md.
 
 # Using Skills
 

--- a/skills/using-superpowers/references/vibe-tools.md
+++ b/skills/using-superpowers/references/vibe-tools.md
@@ -1,0 +1,44 @@
+# Mistral Vibe Tool Mapping
+
+Skills use Claude Code tool names. When you encounter these in a skill, use your platform equivalent:
+
+| Skill references | Mistral Vibe equivalent |
+|-----------------|------------------------|
+| `Read` (file reading) | `read_file` |
+| `Write` (file creation) | `write_file` |
+| `Edit` (file editing) | `search_replace` |
+| `Bash` (run commands) | `bash` |
+| `Grep` (search file content) | `grep` |
+| `Glob` (search files by name) | Use `bash` with `find` or `grep` for file discovery |
+| `TodoWrite` (task tracking) | `todo` (use action="write" with todo items) |
+| `Skill` tool (invoke a skill) | `skill` |
+| `WebSearch` | `websearch` |
+| `WebFetch` | `webfetch` |
+| `Task` tool (dispatch subagent) | `task` (default agent: `explore`) |
+| `EnterPlanMode` | Switch to `plan` agent via `--agent plan` or agent switching |
+| `ExitPlanMode` | `exit_plan_mode` |
+
+## Subagent support
+
+Mistral Vibe supports subagent dispatch via the `task` tool. Available subagent types:
+
+| Agent | Purpose |
+|-------|---------|
+| `explore` | Read-only codebase exploration (default) |
+| `default` | General-purpose with approval gates |
+| `accept-edits` | Auto-approves file modifications |
+| `auto-approve` | Approves all actions without confirmation |
+
+When a skill dispatches a named agent (e.g., `superpowers:code-reviewer`), use the `task` tool with the `default` agent and include the agent's prompt content from `agents/code-reviewer.md` in the task description.
+
+## Additional Mistral Vibe tools
+
+These tools are available in Mistral Vibe but have no Claude Code equivalent:
+
+| Tool | Purpose |
+|------|---------|
+| `ask_user_question` | Request structured input from the user with choices |
+
+## Context files
+
+Mistral Vibe automatically discovers and injects `AGENTS.md` files from `.vibe/` directories. Use these for project-specific instructions.


### PR DESCRIPTION
## What problem are you trying to solve?

[Mistral Vibe](https://github.com/mistralai/mistral-vibe) is Mistral AI's open-source agentic CLI for software development. It has native skill discovery via `skill_paths` in config, a `skill` tool, subagent dispatch via `task`, and plan mode. It currently has no way to use superpowers skills. Users must manually figure out tool mappings and installation.

## What does this PR change?

Adds Mistral Vibe as a supported harness: tool mapping reference, context file, installation guide, and platform entry in `using-superpowers`.

## Is this change appropriate for the core library?

Yes — this adds support for a new harness (CLI tool), which is explicitly listed as acceptable in CLAUDE.md. Zero dependencies added. No domain-specific or third-party promotion.

## What alternatives did you consider?

- OpenCode-style JS plugin with config injection — not possible, Vibe has no plugin system
- Hook-based bootstrap like Claude Code/Cursor — not possible, Vibe has no hooks
- Chose the Gemini/Codex pattern: context file + path-based skill discovery, which matches Vibe's architecture

## Does this PR contain multiple unrelated changes?

No. All changes are for Mistral Vibe harness support.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Mistral Vibe | 2.7.0 | devstral-2 | mistral-vibe-cli-latest |

## Evaluation

- Configured `skill_paths` pointing to superpowers skills directory
- Vibe discovered all 14 skills
- Loaded `using-superpowers` skill and confirmed it mentions Mistral Vibe with correct instructions
- Tool mapping verified against vibe v2.7.0 source code

## Rigor

- [x] No behavior-shaping content modified (Red Flags table, rationalizations, "human partner" language untouched)
- [x] SKILL.md changes are additive only (new platform entry, new reference link)
- [x] Tested on actual Mistral Vibe installation

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission