### PR TITLE
fix(brainstorming): HARD-GATE visual companion per-question decision

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -153,12 +153,14 @@ A browser-based companion for showing mockups, diagrams, and visual options duri
 
 **This offer MUST be its own message.** Do not combine it with clarifying questions, context summaries, or any other content. The message should contain ONLY the offer above and nothing else. Wait for the user's response before continuing. If they decline, proceed with text-only brainstorming.
 
-**Per-question decision:** Even after the user accepts, decide FOR EACH QUESTION whether to use the browser or the terminal. The test: **would the user understand this better by seeing it than reading it?**
+<HARD-GATE>
+**Per-question decision:** Even after the user accepts, decide FOR EACH QUESTION whether to use the browser or the terminal. Before EVERY browser write, answer this out loud: "Am I showing a visual artifact (mockup, wireframe, diagram, layout comparison) that cannot be communicated as text?" If the answer is no, use the terminal. Approach comparisons, tradeoff lists, A/B/C choices described in words, and clarifying questions are NEVER visual — even when the topic is UI.
 
-- **Use the browser** for content that IS visual — mockups, wireframes, layout comparisons, architecture diagrams, side-by-side visual designs
-- **Use the terminal** for content that is text — requirements questions, conceptual choices, tradeoff lists, A/B/C/D text options, scope decisions
+- **Use the browser** ONLY for content that IS visual — rendered mockups, wireframes, layout comparisons, architecture diagrams, side-by-side visual designs
+- **Use the terminal** for everything else — requirements questions, conceptual choices, tradeoff lists, A/B/C/D text options, scope decisions, pros/cons
 
-A question about a UI topic is not automatically a visual question. "What does personality mean in this context?" is a conceptual question — use the terminal. "Which wizard layout works better?" is a visual question — use the browser.
+A question *about* a UI topic is not automatically a visual question. "What kind of wizard do you want?" is conceptual — use the terminal. "Which of these two rendered wizard layouts feels right?" is visual — use the browser.
+</HARD-GATE>
 
 If they agree to the companion, read the detailed guide before proceeding:
 `skills/brainstorming/visual-companion.md`


### PR DESCRIPTION
## Problem

The visual companion guidelines already say to use the terminal for text content (tradeoff lists, A/B choices, clarifying questions), but LLMs routinely ignore this soft guidance and render HTML pages for content that is purely textual — wasting tokens and user time.

Real-world example: when brainstorming a TOTP wizard redesign, the LLM rendered a full HTML page just to show two text-based approach descriptions with pros/cons. This could have been a simple terminal message.

## Fix

Wraps the per-question decision section in a `<HARD-GATE>` tag (already used elsewhere in the skill for the no-implementation gate), adds a verbalization requirement before each browser write, and strengthens the language with ONLY/NEVER qualifiers.

The key addition is requiring the LLM to answer out loud: *"Am I showing a visual artifact that cannot be communicated as text?"* — forcing a conscious decision before each browser write.

## Changes

- `skills/brainstorming/SKILL.md` — 1 section changed (6 lines added, 4 removed)