### PR TITLE
feat: add delegated-brainstorming skill

### DIFF
--- a/skills/delegated-brainstorming/SKILL.md
+++ b/skills/delegated-brainstorming/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: delegated-brainstorming
+description: Use when designing features, APIs, or architecture in existing codebases where design decisions need validation against actual code. Alternative to single-agent brainstorming that splits design exploration from codebase review.
+---
+
+# Delegated Brainstorming
+
+Split brainstorming into two roles: a **design subagent** explores requirements and proposes solutions, while you (the **coordinator**) review every output against the real codebase.
+
+**Why:** Single-agent brainstorming forces one context to hold both design exploration AND codebase details. Splitting roles lets the designer focus on design thinking while the coordinator catches technical inaccuracies — producing better designs with fewer errors.
+
+**Core principle:** Design subagent proposes, coordinator validates against code, user decides.
+
+<HARD-GATE>
+Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented the complete design and the user has approved it. The coordinator writes the final spec — never the subagent.
+</HARD-GATE>
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Feature touches existing code?" [shape=diamond];
+    "Design has codebase constraints\n(schemas, patterns, conventions)?" [shape=diamond];
+    "delegated-brainstorming" [shape=box];
+    "superpowers:brainstorming\n(single-agent)" [shape=box];
+
+    "Feature touches existing code?" -> "Design has codebase constraints\n(schemas, patterns, conventions)?" [label="yes"];
+    "Feature touches existing code?" -> "superpowers:brainstorming\n(single-agent)" [label="no (greenfield)"];
+    "Design has codebase constraints\n(schemas, patterns, conventions)?" -> "delegated-brainstorming" [label="yes"];
+    "Design has codebase constraints\n(schemas, patterns, conventions)?" -> "superpowers:brainstorming\n(single-agent)" [label="no (trivial)"];
+}
+```
+
+**Use this when:** Design decisions need validation against actual DB schemas, service patterns, naming conventions, or architectural constraints.
+
+**Use superpowers:brainstorming instead when:** Greenfield projects, trivial changes, or when codebase context isn't critical.
+
+## Checklist
+
+You MUST create a task for each of these items and complete them in order:
+
+1. **Explore codebase** — read relevant schemas, services, patterns; build curated summary
+2. **Dispatch design subagent** — with codebase summary + user request (see `./designer-prompt.md`)
+3. **Review loop** — for each subagent output: validate against code → present to user with review notes → relay answer back to subagent
+4. **Write spec yourself** — coordinator writes the final spec (you have codebase context)
+5. **Spec self-review** — check for placeholders, contradictions, ambiguity
+6. **User reviews spec** — wait for approval before proceeding
+7. **Transition to implementation** — invoke writing-plans skill
+
+## Process
+
+```dot
+digraph delegated_brainstorming {
+    rankdir=TB;
+
+    subgraph cluster_setup {
+        label="Setup (coordinator only)";
+        "Explore codebase" [shape=box];
+        "Build curated summary\n(schemas, patterns, conventions)" [shape=box];
+    }
+
+    subgraph cluster_loop {
+        label="Design Loop (coordinator + subagent + user)";
+        "Dispatch design subagent\n(./designer-prompt.md)" [shape=box];
+        "Subagent returns output\n(QUESTION / APPROACH / DESIGN_SECTION)" [shape=box];
+        "Review against codebase\n(validate types, names, patterns)" [shape=box];
+        "Issues found?" [shape=diamond];
+        "Present to user as-is" [shape=box];
+        "Present to user\nwith corrections" [shape=box];
+        "User responds" [shape=box];
+        "SendMessage to subagent\n(answer + coordinator guidance)" [shape=box];
+        "Design complete?" [shape=diamond];
+    }
+
+    subgraph cluster_finish {
+        label="Finish (coordinator only)";
+        "Write spec\n(coordinator has full codebase context)" [shape=box];
+        "Spec self-review" [shape=box];
+        "User reviews spec" [shape=box];
+        "Invoke writing-plans" [shape=doublecircle];
+    }
+
+    "Explore codebase" -> "Build curated summary\n(schemas, patterns, conventions)";
+    "Build curated summary\n(schemas, patterns, conventions)" -> "Dispatch design subagent\n(./designer-prompt.md)";
+    "Dispatch design subagent\n(./designer-prompt.md)" -> "Subagent returns output\n(QUESTION / APPROACH / DESIGN_SECTION)";
+    "Subagent returns output\n(QUESTION / APPROACH / DESIGN_SECTION)" -> "Review against codebase\n(validate types, names, patterns)";
+    "Review against codebase\n(validate types, names, patterns)" -> "Issues found?";
+    "Issues found?" -> "Present to user as-is" [label="no"];
+    "Issues found?" -> "Present to user\nwith corrections" [label="yes"];
+    "Present to user as-is" -> "User responds";
+    "Present to user\nwith corrections" -> "User responds";
+    "User responds" -> "SendMessage to subagent\n(answer + coordinator guidance)";
+    "SendMessage to subagent\n(answer + coordinator guidance)" -> "Subagent returns output\n(QUESTION / APPROACH / DESIGN_SECTION)";
+    "Subagent returns output\n(QUESTION / APPROACH / DESIGN_SECTION)" -> "Design complete?" [style=dashed];
+    "Design complete?" -> "Review against codebase\n(validate types, names, patterns)" [label="no"];
+    "Design complete?" -> "Write spec\n(coordinator has full codebase context)" [label="yes"];
+    "Write spec\n(coordinator has full codebase context)" -> "Spec self-review";
+    "Spec self-review" -> "User reviews spec";
+    "User reviews spec" -> "Invoke writing-plans" [label="approved"];
+    "User reviews spec" -> "Write spec\n(coordinator has full codebase context)" [label="changes requested"];
+}
+```
+
+**The terminal state is invoking writing-plans.** Do NOT invoke any implementation skill directly.
+
+## Step 1: Explore Codebase
+
+Before dispatching the subagent, YOU read the codebase and build a curated summary:
+
+- **DB schemas** — table names, column types, relationships, JSONB shapes
+- **Service patterns** — how similar features are implemented (CRUD conventions, error handling)
+- **API conventions** — route structure, middleware chain, auth/RLS patterns
+- **Shared types** — enums, Zod schemas, naming conventions
+- **Recent changes** — relevant commits, in-progress work
+
+**This is the coordinator's unique value.** The subagent gets a curated summary, not raw file dumps. Include enough detail for accurate design decisions, but don't overwhelm.
+
+## Step 2: Dispatch Design Subagent
+
+Use the Agent tool with the template in `./designer-prompt.md`. The prompt includes:
+
+1. Your **codebase summary** (from Step 1)
+2. The **user's request** (what they want to build)
+3. **Role instructions** with labeled output format
+
+Use `SendMessage` to continue the same subagent across the design loop — don't dispatch a new one each round.
+
+## Step 3: Review Loop
+
+For each subagent output:
+
+1. **Read the output** — question, approach proposal, or design section
+2. **Validate against codebase:**
+   - Are field types correct? (e.g., uuid not text for FK fields)
+   - Do proposed names match existing conventions?
+   - Would the approach conflict with existing patterns?
+   - Are there constraints the subagent doesn't know about?
+3. **Present to user:**
+   - If accurate: relay as-is
+   - If issues found: add your corrections (e.g., "Note: `createdBy` should be uuid, not text — matching existing tables")
+4. **Relay back:** SendMessage to subagent with user's answer + your technical guidance
+
+## Step 4: Write Spec
+
+When design is complete, **you** write the spec (not the subagent), because:
+- You have full codebase context for accurate file paths and code references
+- You can cross-check every detail against actual code
+- The spec needs to be implementation-ready, not conceptual
+
+Save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` (user preferences override).
+
+**Spec Self-Review:**
+1. **Placeholder scan:** Any "TBD", "TODO", vague requirements? Fix them.
+2. **Internal consistency:** Do sections contradict each other?
+3. **Scope check:** Focused enough for a single implementation plan?
+4. **Ambiguity check:** Could any requirement be read two ways?
+
+**User Review Gate:**
+> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+
+Wait for approval before proceeding.
+
+## Key Principles
+
+- **Coordinator never delegates understanding** — you must understand every design decision, not just relay
+- **Subagent never guesses about codebase** — if it needs info not in the summary, it asks
+- **Review is mandatory** — every subagent output gets checked against real code before reaching the user
+- **Spec is written by coordinator** — the agent with codebase context writes the final document
+- **One question at a time** — subagent asks one question per round (same as brainstorming)
+- **Multiple choice preferred** — easier for user to answer
+- **YAGNI ruthlessly** — remove unnecessary features from all designs
+
+## Red Flags
+
+**Never:**
+- Let the subagent write the final spec (it lacks codebase context)
+- Relay subagent output without reviewing against actual code
+- Give subagent raw file dumps instead of curated summaries
+- Skip codebase exploration in Step 1
+- Start implementation before spec is approved
+- Dispatch a new subagent each round (use SendMessage to continue)
+
+**If subagent proposes something that conflicts with codebase:**
+- Don't silently fix it — tell the user what the subagent proposed AND what the codebase actually requires
+- This transparency builds trust and helps the user understand constraints
+
+## Integration
+
+**Alternative workflow:**
+- **superpowers:brainstorming** — Single-agent brainstorming for greenfield or simple projects
+
+**Next step after design:**
+- **superpowers:writing-plans** — REQUIRED: Create implementation plan from approved spec
+
+**Implementation options after plan:**
+- **superpowers:subagent-driven-development** — Execute plan with subagents in current session
+- **superpowers:executing-plans** — Execute plan in parallel session

--- a/skills/delegated-brainstorming/SKILL.md
+++ b/skills/delegated-brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: delegated-brainstorming
-description: Use when designing features, APIs, or architecture in existing codebases where design decisions need validation against actual code. Alternative to single-agent brainstorming that splits design exploration from codebase review.
+description: Use when designing features, APIs, or architecture in existing codebases where design decisions need validation against actual DB schemas, service patterns, or architectural constraints.
 ---
 
 # Delegated Brainstorming
@@ -125,6 +125,8 @@ Use the Agent tool with the template in `./designer-prompt.md`. The prompt inclu
 
 Use `SendMessage` to continue the same subagent across the design loop — don't dispatch a new one each round.
 
+**Model selection:** Design work requires judgment — use the most capable available model for the design subagent.
+
 ## Step 3: Review Loop
 
 For each subagent output:
@@ -175,6 +177,7 @@ Wait for approval before proceeding.
 **Never:**
 - Let the subagent write the final spec (it lacks codebase context)
 - Relay subagent output without reviewing against actual code
+- Become a passive relay — if you're just forwarding messages without adding value, you're not coordinating
 - Give subagent raw file dumps instead of curated summaries
 - Skip codebase exploration in Step 1
 - Start implementation before spec is approved
@@ -183,6 +186,11 @@ Wait for approval before proceeding.
 **If subagent proposes something that conflicts with codebase:**
 - Don't silently fix it — tell the user what the subagent proposed AND what the codebase actually requires
 - This transparency builds trust and helps the user understand constraints
+
+**If subagent recommends scope decomposition:**
+- Agree with the decomposition — present sub-projects to user for prioritization
+- Brainstorm the first sub-project through the normal design loop
+- Each sub-project gets its own spec → plan → implementation cycle
 
 ## Integration
 

--- a/skills/delegated-brainstorming/designer-prompt.md
+++ b/skills/delegated-brainstorming/designer-prompt.md
@@ -37,6 +37,13 @@ Agent tool (general-purpose):
     - YAGNI ruthlessly — remove unnecessary features from proposals
     - Assess scope first: if too large for one spec, recommend decomposition
 
+    ## Design Quality
+
+    - Break the system into smaller units with one clear purpose each
+    - Each unit should have a well-defined interface — can someone use it without reading its internals?
+    - Units that change together should live together
+    - Prefer smaller, focused components over large ones that do too much
+
     ## Output Labels
 
     Label every output with exactly one of these tags:

--- a/skills/delegated-brainstorming/designer-prompt.md
+++ b/skills/delegated-brainstorming/designer-prompt.md
@@ -1,0 +1,91 @@
+# Design Subagent Prompt Template
+
+Use this template when dispatching the design subagent. Continue the same subagent with SendMessage for subsequent rounds.
+
+## Initial Dispatch
+
+```
+Agent tool (general-purpose):
+  description: "Design: [feature name]"
+  prompt: |
+    You are a design specialist. Your job is to explore requirements and propose
+    solutions through structured Q&A, then present a design in sections.
+
+    ## User's Request
+
+    [What the user wants to build]
+
+    ## Codebase Summary
+
+    [Coordinator's curated summary — DB schemas, service patterns, conventions,
+    recent changes. Include enough for accurate design, not raw file dumps.]
+
+    ## Your Process
+
+    1. Ask clarifying questions ONE AT A TIME (prefer multiple choice)
+    2. After enough context, propose 2-3 approaches with trade-offs and your recommendation
+    3. Present design in sections, scaled to complexity
+    4. For each section, wait for approval before moving to next
+
+    ## Rules
+
+    - Your codebase knowledge comes ONLY from the summary above — don't guess
+    - If you need info not in the summary, ask for it (the coordinator will provide)
+    - Focus on WHAT and WHY, not implementation details
+    - One question per round — if a topic needs more, break into multiple rounds
+    - Prefer multiple choice questions when possible
+    - YAGNI ruthlessly — remove unnecessary features from proposals
+    - Assess scope first: if too large for one spec, recommend decomposition
+
+    ## Output Labels
+
+    Label every output with exactly one of these tags:
+
+    QUESTION: [Your question with options A/B/C if applicable]
+
+    APPROACH: [2-3 options with trade-offs and your recommendation]
+
+    DESIGN_SECTION: [Section title]
+    [Section content]
+
+    NEEDS_INFO: [What codebase detail you need that isn't in the summary]
+
+    DESIGN_COMPLETE: [All sections approved, ready for spec writing]
+
+    Always use exactly one label per response. The coordinator uses these
+    to route your output correctly.
+```
+
+## Continuing the Conversation
+
+```
+SendMessage:
+  to: [subagent ID from initial dispatch]
+  message: |
+    ## User's Answer
+
+    [What the user said]
+
+    ## Coordinator Notes
+
+    [Technical corrections, additional codebase context, or guidance.
+    Examples:
+    - "Note: the field should be uuid, not text — matching existing FK pattern"
+    - "Additional context: this table already has RLS via app.current_org_id"
+    - "The user agreed with your recommendation. Proceed to next section."
+    Leave empty if no corrections needed.]
+```
+
+## When Subagent Reports NEEDS_INFO
+
+The coordinator should:
+1. Read the requested codebase detail
+2. Provide it via SendMessage in the "Coordinator Notes" section
+3. Don't make the user answer codebase questions — that's the coordinator's job
+
+## When Subagent Reports DESIGN_COMPLETE
+
+The coordinator takes over:
+1. Thank the subagent (conversation ends)
+2. Write the spec yourself using full codebase context
+3. Follow the spec self-review and user review process from SKILL.md


### PR DESCRIPTION
## Summary

Adds a new `delegated-brainstorming` skill that splits the brainstorming process into two roles:

- **Design subagent** — explores requirements, asks questions, proposes approaches
- **Coordinator** (parent agent) — validates every output against actual codebase, catches technical inaccuracies

This addresses a pain point with single-agent brainstorming: when designing features in existing codebases, one agent struggles to hold both design exploration AND codebase details in context. Splitting roles produces better designs with fewer technical errors.

## What's included

- `skills/delegated-brainstorming/SKILL.md` — Full skill with process flowchart, checklist, and integration with existing superpowers workflow (writing-plans, subagent-driven-development)
- `skills/delegated-brainstorming/designer-prompt.md` — Prompt template for dispatching the design subagent, with labeled output format (QUESTION / APPROACH / DESIGN_SECTION / NEEDS_INFO / DESIGN_COMPLETE)

## How it works

1. Coordinator explores codebase, builds curated summary
2. Dispatches design subagent with summary + user request
3. Subagent returns questions/proposals → Coordinator reviews against code → Presents to user (with corrections if needed)
4. User answers → Coordinator relays back via SendMessage
5. Repeat until design complete
6. Coordinator writes the final spec (not the subagent — coordinator has full codebase context)
7. Transitions to writing-plans

## Relationship to existing skills

- **Alternative to `superpowers:brainstorming`** for existing codebases with complex constraints
- **Feeds into `superpowers:writing-plans`** as the next step (same as brainstorming)
- Uses `SendMessage` pattern similar to `superpowers:subagent-driven-development`

## Origin

This pattern emerged from real usage — designing features for a legal assistant app where DB schemas, RLS policies, service patterns, and tool definitions all constrained design decisions. The coordinator caught issues like wrong FK types, missing fields, naming convention mismatches that a single-agent brainstormer missed.