### PR TITLE
Fix SessionStart hook execution on Windows

### DIFF
--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -1,9 +1,9 @@
-{
+﻿{
   "version": 1,
   "hooks": {
     "sessionStart": [
       {
-        "command": "./hooks/session-start"
+        "command": "./hooks/run-hook.cmd session-start"
       }
     ]
   }

--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": 1,
   "hooks": {
     "sessionStart": [


### PR DESCRIPTION
Fixes #871
## What problem are you trying to solve?

On Windows, Cursor loads `hooks/hooks-cursor.json` and runs `./hooks/session-start`. That script is intentionally extensionless (see comments in `run-hook.cmd`), but Windows does not treat it as an executable the way Unix does. In practice this can surface the system **“Open with”** dialog and the SessionStart hook does not run, so users never get the `additional_context` bootstrap from superpowers. This matches the report in #871.

## What does this PR change?

Updates `hooks/hooks-cursor.json` so the `sessionStart` hook invokes `./hooks/run-hook.cmd session-start` instead of `./hooks/session-start`, matching the existing Claude Code path in `hooks/hooks.json` that already routes through Git Bash.

## Is this change appropriate for the core library?

Yes. This is cross-cutting plugin infrastructure for anyone using superpowers with Cursor on Windows; it does not encode a specific project, team, or third-party product beyond the already-shipped `run-hook.cmd` helper.

## What alternatives did you consider?

- **Rename to `session-start.sh`**: Rejected for parity with the rest of the hook design; `run-hook.cmd` documents that extensionless names avoid Claude Code’s Windows behavior around `.sh`.
- **Document “use WSL only”**: Worse UX; the repo already ships `run-hook.cmd` specifically to support Git for Windows / bash on PATH.
- **Duplicate logic in a `.cmd` script**: Unnecessary; `session-start` already works when invoked under bash via the existing wrapper.

## Does this PR contain multiple unrelated changes?

No. Single-file, single-line behavioral change for the Cursor hook entrypoint.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #871 (issue describing the same failure mode and proposed fix); no merged PR found that updates `hooks-cursor.json` for this at time of submission.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Cursor | 3.0.12 | composer2 |  |

## Evaluation
- **Initial prompt / motivation:** Observed SessionStart / superpowers bootstrap not loading on Windows with Cursor; traced to extensionless hook invocation (see #871).
- **Eval sessions after change:** <!-- e.g. 1–2 --> new agent sessions after updating `hooks-cursor.json` locally.
- **Before / after:** Before: hook did not run reliably (e.g. “Open with” or no JSON context). After: `run-hook.cmd session-start` from the plugin root prints valid JSON with `additional_context` when `CURSOR_PLUGIN_ROOT` is set as in a real Cursor session.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path *(verified: no bash / wrong PATH would still fail — same as `hooks.json`; happy path is Git for Windows or bash on PATH)*
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

*N/A: This is not a skills/content change; only hook wiring.*

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission