### PR TITLE
fix(subagent-driven-development): remove hardcoded task-count example

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -129,7 +129,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 You: I'm using Subagent-Driven Development to execute this plan.
 
 [Read plan file once: docs/superpowers/plans/feature-plan.md]
-[Extract all 5 tasks with full text and context]
+[Extract all tasks with full text and context]
 [Create TodoWrite with all tasks]
 
 Task 1: Hook installation script


### PR DESCRIPTION
## Summary

Removes a hardcoded numeric anchor from the `subagent-driven-development` example workflow.

Before:
- `Extract all 5 tasks with full text and context`

After:
- `Extract all tasks with full text and context`

Fixes #1058.

## Why

Hi! Basically for some reason whenever I run subagents it always stops at task 5 and I need to manually tell it to continue which is slightly annoying.

It might be because of the example? Not sure why else it stops at 5.

This does not change workflow semantics; it just makes the example task-count agnostic and aligns it with the surrounding guidance about extracting all tasks from the plan.