### PR TITLE
feat: add reviewing-plans skill — mandatory gate between writing-plans and executing-plans

### DIFF
--- a/skills/reviewing-plans/SKILL.md
+++ b/skills/reviewing-plans/SKILL.md
@@ -38,7 +38,7 @@ Present two options:
 
 **A. Collaborative Walkthrough** — You and the user review the plan together, section by section. Best for important or complex plans where the user wants to understand and shape every decision.
 
-**B. Agent Review** — Dispatch architect agents (e.g., Whis) to review independently and produce a report. Best when the user trusts the design and wants a quality check.
+**B. Agent Review** — Dispatch a subagent to review independently and produce a report. Best when the user trusts the design and wants a quality check.
 
 ### Step 2: If Collaborative Walkthrough chosen
 

--- a/skills/reviewing-plans/SKILL.md
+++ b/skills/reviewing-plans/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: reviewing-plans
+description: Use after writing-plans completes and before executing-plans begins — mandatory gate before any plan is executed
+---
+
+# Reviewing Plans
+
+## Overview
+
+Mandatory review gate between writing-plans and executing-plans. Catches design flaws, missing edge cases, and incomplete specifications before implementation begins.
+
+**Core principle:** Never execute a plan you haven't reviewed. Implementing a flawed plan wastes more time than reviewing it.
+
+## When to Use
+
+```dot
+digraph trigger {
+  "writing-plans done?" [shape=diamond];
+  "Plan document exists" [shape=box];
+  "MUST invoke reviewing-plans" [shape=doublecircle];
+  "Then executing-plans" [shape=box];
+
+  "writing-plans done?" -> "Plan document exists" [label="yes"];
+  "Plan document exists" -> "MUST invoke reviewing-plans";
+  "MUST invoke reviewing-plans" -> "Then executing-plans";
+}
+```
+
+**Trigger:** A plan document has been written and is ready for execution.
+
+**This is NOT optional.** Every plan goes through review before execution — even "simple" ones. Simple plans are where unexamined assumptions cause the most waste.
+
+## Process
+
+### Step 1: Ask user to choose review mode
+
+Present two options:
+
+**A. Collaborative Walkthrough** — You and the user review the plan together, section by section. Best for important or complex plans where the user wants to understand and shape every decision.
+
+**B. Agent Review** — Dispatch architect agents (e.g., Whis) to review independently and produce a report. Best when the user trusts the design and wants a quality check.
+
+### Step 2: If Collaborative Walkthrough chosen
+
+**Ask user to choose granularity:**
+- **By Task** — review each task individually (thorough, slower)
+- **By Feature/Section** — group related tasks into blocks (balanced)
+- **Smart Grouping** — you identify which sections need deep analysis vs quick confirmation (fastest)
+
+**For each section, analyze across 5 dimensions:**
+
+| Dimension | What to evaluate |
+|-----------|-----------------|
+| **Reasonableness** | Is the logic sound? Are assumptions correct? |
+| **Completeness** | Missing edge cases, interactions, dependencies? |
+| **Best Practice** | Is this the best approach? Simpler alternatives? |
+| **Risk** | What could go wrong? Impact on existing code? |
+| **Test Sufficiency** | Do tests cover behavioral changes? Are assertions precise? |
+
+**For each section:**
+1. Present the section content
+2. Analyze across the 5 dimensions
+3. Flag any issues (tag as: Blocker / Should Fix / Suggestion)
+4. Confirm user understanding before moving to next section
+
+### Step 3: If Agent Review chosen
+
+Dispatch a subagent (via Agent tool) to independently review the plan. The agent should:
+- Read the plan document AND the actual source files it references
+- Analyze across the same 5 dimensions (Reasonableness, Completeness, Best Practice, Risk, Test Sufficiency)
+- Produce a structured report using the Issue Summary Table format
+
+Present the agent's report to the user for decision.
+
+### Step 4: Produce output
+
+After review (either mode), present:
+
+**A. Issue Summary Table** — All flagged issues, sorted by severity:
+- **Blocker** — Must fix before execution (design flaw, missing logic, incorrect assumption)
+- **Should Fix** — Important but not blocking (weak tests, missing docs, naming issues)
+- **Suggestion** — Nice to have (optimization, style, future consideration)
+
+**B. Decision Log** — Decisions made during review:
+- What was discussed and resolved
+- What was deferred and why
+- Any scope changes (features moved to future versions)
+
+**C. Next Step Options** — Ask user:
+- **Update plan** → apply fixes to the plan document, commit changes, then re-review only the changed sections
+- **Execute plan** → proceed to executing-plans
+- **Split plan** → move incomplete features to a separate future plan document, commit both files
+
+## Red Flags — STOP and Discuss
+
+If you catch yourself thinking any of these during review, the section needs deeper discussion:
+
+- "This implementation step is vague but probably fine" — ambiguity in a plan becomes a bug in code
+- "The test just checks `> 0` but that's enough" — weak assertions in a plan become weak assertions in code
+- "This only touches one file, should be simple" — unmentioned files = unplanned side effects
+- "These two features don't interact" — unspecified interactions are the #1 source of plan-stage design flaws
+- "I'll figure out the details during implementation" — if you can't specify it now, you can't implement it correctly later
+
+**ALL of these mean: STOP. Flag the section. Discuss with the user before proceeding.**
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Skipping review because "plan is simple" | Simple plans have unexamined assumptions. Review anyway. |
+| Reading sections without analyzing | Each section needs the 5-dimension analysis, not just a read-through. |
+| Not flagging weak test assertions | `> 0` in a plan will become `> 0` in code. Catch it now. |
+| Rubber-stamping agent review output | Read the agent report critically. Agents can miss things too. |
+| Not asking user for confirmation per section | The user may have context you don't. Check after each section. |


### PR DESCRIPTION
## What problem are you trying to solve?

The superpowers workflow chain is: `brainstorming → writing-plans → executing-plans → finishing-a-development-branch`. There is no review gate between writing-plans and executing-plans. Plans go directly from written to executed.

In a real project (Textric v2.1 — a pure JS text layout library), a plan with 3 features and 16 tasks was executed without review. Features 1 and 2 (10 tasks) executed fine. Feature 3 (6 tasks) had 5 design flaws that were visible in the plan document but only discovered during execution:

1. `nowrap` + `indent` interaction undefined (indent logic lives in `wrapParagraph`, which `nowrap` skips entirely)
2. `pre`/`nowrap` modes missing `maxLineWidth` calculation logic
3. Rich text path had zero `whiteSpace` support
4. `pre-wrap` trailing space behavior unspecified
5. Test assertions used `> 1` instead of precise values

All 5 were detectable by reading the plan — no code needed. Because there was no review step, the first 10 tasks were wasted work (Feature 3 was split to a separate plan after the flaws were found).

## What does this PR change?

Adds a `reviewing-plans` skill that inserts a mandatory review gate between `writing-plans` and `executing-plans`. The skill provides two review modes (collaborative walkthrough or agent review), a 5-dimension analysis framework, and structured output (issue table + decision log + next step options).

## Is this change appropriate for the core library?

Yes:
- Fills a gap in the existing workflow chain — every superpowers user who runs `writing-plans → executing-plans` benefits
- Naming follows the established convention (`writing-plans` → `reviewing-plans` → `executing-plans`)
- Technology-agnostic — works for any project type
- Follows superpowers design patterns: mandatory gate, Red Flags table, Common Mistakes table

## What alternatives did you consider?

1. **Add review steps inside `writing-plans`** — Rejected. writing-plans already has a clear scope (produce the plan). Adding review blurs its responsibility and makes it harder to skip review intentionally.
2. **Add review steps inside `executing-plans`** — Rejected. By then you're already executing. The whole point is catching flaws *before* implementation starts.
3. **Rely on `requesting-code-review` after execution** — This catches code issues, not plan issues. A flawed plan produces flawed code that passes flawed tests.
4. **Make it a standalone plugin** — Rejected. This is a workflow chain link, not a domain-specific tool. It needs to sit between two core skills and be discoverable in the same namespace.

## Does this PR contain multiple unrelated changes?

No. Single skill addition.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs:
  - #933 (CLOSED) — "opt-in adversarial review + TDD enforcement gates". Different: that PR adds review *during* execution (per-task code review). This PR adds review *before* execution (plan document review). Maintainer feedback was "build your own plugin" — but #933 was a large change modifying two existing skills. This PR adds one new skill without modifying any existing files.
  - #522 (MERGED) — "Scale process-oriented skills to task complexity". Related in spirit: both improve the writing-plans → executing-plans handoff. #522 added scaling and check-in. This PR adds the missing review step.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|----------------|-------|-----------------|
| Claude Code | 2.1.x | Claude Opus 4.6 | claude-opus-4-6 |

## Evaluation

**Initial prompt:** "We need a review gate between writing-plans and executing-plans. In Textric v2.1, 5 plan-level design flaws were only caught during execution, wasting work on 10 tasks."

**Baseline (without skill):** Textric v2.1 plan — 16 tasks, 3 features. Executed directly. 5 design flaws found during implementation of Feature 3. First 10 tasks wasted.

**Eval sessions run after writing skill: 3**

| Eval | Plan complexity | Issues found | Blockers | Compliance |
|------|----------------|-------------|----------|------------|
| Round 1 (baseline, no skill) | 16 task, 3 features | 5 flaws found *during execution* | — | N/A |
| Round 2 (with skill, defective plan) | 6 task, 2 features | 12 (6 Blocker, 4 Should Fix, 2 Suggestion) | 6 | Yes |
| Round 3 (with skill, trivial plan) | 2 task | 3 (1 Should Fix, 2 Suggestion) | 0 | Yes |

**Round 2 detail:** 6 defects were deliberately planted. Agent found all 6 (100% hit rate) plus 6 additional issues not planted. Agent quoted the skill's Red Flags and 5-dimension framework.

**Round 3 detail (pressure test):** Agent did NOT skip review on a trivial plan. Quoted the skill: "Simple plans have unexamined assumptions. Review anyway." Hard gate held.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content

Pressure testing: Round 2 tested detection capability (6/6 planted defects found). Round 3 tested hard gate under "too simple" pressure (gate held, agent did not skip).

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission