### PR TITLE
feat: add router-first default workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # Superpowers
 
-Superpowers is a complete software development workflow for your coding agents, built on top of a set of composable "skills" and some initial instructions that make sure your agent uses them.
+Superpowers is a software development workflow for coding agents, built on a set of composable skills and startup instructions that help the agent choose the right level of process for the task.
 
 ## How it works
 
-It starts from the moment you fire up your coding agent. As soon as it sees that you're building something, it *doesn't* just jump into trying to write code. Instead, it steps back and asks you what you're really trying to do. 
+By default, Superpowers now starts in a lightweight `router-first` mode. Instead of forcing every task through the full planning stack, the agent classifies the work and chooses the lightest safe path:
 
-Once it's teased a spec out of the conversation, it shows it to you in chunks short enough to actually read and digest. 
+- `small` -> inspect quickly, act directly, verify before claiming success
+- `medium` -> share a short execution plan, then execute
+- `large` -> explain the risk and ask whether to switch into the full heavy workflow
 
-After you've signed off on the design, your agent puts together an implementation plan that's clear enough for an enthusiastic junior engineer with poor taste, no judgement, no project context, and an aversion to testing to follow. It emphasizes true red/green TDD, YAGNI (You Aren't Gonna Need It), and DRY. 
+The original full Superpowers flow is still here when you want it: collaborative design, written specs, implementation plans, and subagent-driven execution. It just is no longer the default for every task.
 
-Next up, once you say "go", it launches a *subagent-driven-development* process, having agents work through each engineering task, inspecting and reviewing their work, and continuing forward. It's not uncommon for Claude to be able to work autonomously for a couple hours at a time without deviating from the plan you put together.
+That gives you both modes:
 
-There's a bunch more to it, but that's the core of the system. And because the skills trigger automatically, you don't need to do anything special. Your coding agent just has Superpowers.
+- `router-first` for fast, low-friction execution
+- `using-superpowers` for the complete heavy workflow
 
 
 ## Sponsorship
@@ -96,9 +99,29 @@ gemini extensions update superpowers
 
 ### Verify Installation
 
-Start a new session in your chosen platform and ask for something that should trigger a skill (for example, "help me plan this feature" or "let's debug this issue"). The agent should automatically invoke the relevant superpowers skill.
+Start a new session in your chosen platform and ask for something simple and concrete. The agent should default to the `router-first` mode, and only escalate into the heavy workflow when you explicitly ask for it or approve escalation for a high-risk task.
 
-## The Basic Workflow
+## Modes
+
+### `router-first` (default)
+
+Use this for everyday work. It keeps overhead low and only pulls in heavier skills when risk or ambiguity justifies it.
+
+- `small` -> inspect, act, verify
+- `medium` -> short plan, act, verify
+- `large` -> ask before entering heavy mode
+
+Always-on safeguards:
+- `verification-before-completion`
+
+Conditionally enforced:
+- `systematic-debugging` for bugs, test failures, flaky behavior, and unclear root causes
+
+### `using-superpowers` (heavy)
+
+Use this when you want the full planning and governance workflow up front, or when `router-first` flags a high-risk task and you approve escalation.
+
+## The Heavy Workflow
 
 1. **brainstorming** - Activates before writing code. Refines rough ideas through questions, explores alternatives, presents design in sections for validation. Saves design document.
 
@@ -114,7 +137,7 @@ Start a new session in your chosen platform and ask for something that should tr
 
 7. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
 
-**The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
+This heavy path remains available, but it is no longer the default for every task.
 
 ## What's Inside
 
@@ -128,6 +151,7 @@ Start a new session in your chosen platform and ask for something that should tr
 - **verification-before-completion** - Ensure it's actually fixed
 
 **Collaboration** 
+- **router-first** - Default entrypoint that chooses the lightest safe process
 - **brainstorming** - Socratic design refinement
 - **writing-plans** - Detailed implementation plans
 - **executing-plans** - Batch execution with checkpoints
@@ -140,11 +164,12 @@ Start a new session in your chosen platform and ask for something that should tr
 
 **Meta**
 - **writing-skills** - Create new skills following best practices (includes testing methodology)
-- **using-superpowers** - Introduction to the skills system
+- **using-superpowers** - Full heavy workflow entrypoint
 
 ## Philosophy
 
 - **Test-Driven Development** - Write tests first, always
+- **Right-sized process** - Use the lightest safe workflow for the task
 - **Systematic over ad-hoc** - Process over guessing
 - **Complexity reduction** - Simplicity as primary goal
 - **Evidence over claims** - Verify before declaring success

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -55,14 +55,20 @@ Codex has native skill discovery — it scans `~/.agents/skills/` at startup, pa
 ~/.agents/skills/superpowers/ → ~/.codex/superpowers/skills/
 ```
 
-The `using-superpowers` skill is discovered automatically and enforces skill usage discipline — no additional configuration needed.
+The `router-first` skill is the default Superpowers entrypoint for Codex. It routes tasks onto the lightest safe path:
+
+- `small` -> inspect, act, verify
+- `medium` -> share a short plan, then execute
+- `large` -> ask before escalating into the full heavy workflow
+
+The original `using-superpowers` skill remains available as the heavy workflow entrypoint when you explicitly want the full planning-and-governance path.
 
 ## Usage
 
 Skills are discovered automatically. Codex activates them when:
 - You mention a skill by name (e.g., "use brainstorming")
 - The task matches a skill's description
-- The `using-superpowers` skill directs Codex to use one
+- The `router-first` skill routes you to one
 
 ### Personal Skills
 

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -14,8 +14,8 @@ if [ -d "$legacy_skills_dir" ]; then
     warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER:⚠️ **WARNING:** Superpowers now uses Claude Code's skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
 fi
 
-# Read using-superpowers content
-using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
+# Read router-first content
+router_first_content=$(cat "${PLUGIN_ROOT}/skills/router-first/SKILL.md" 2>&1 || echo "Error reading router-first skill")
 
 # Escape string for JSON embedding using bash parameter substitution.
 # Each ${s//old/new} is a single C-level pass - orders of magnitude
@@ -30,9 +30,9 @@ escape_for_json() {
     printf '%s' "$s"
 }
 
-using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
+router_first_escaped=$(escape_for_json "$router_first_content")
 warning_escaped=$(escape_for_json "$warning_message")
-session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your default 'superpowers:router-first' skill - your default operating mode. For other skills, use the 'Skill' tool:**\n\n${router_first_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
 # Cursor hooks expect additional_context.

--- a/skills/router-first/SKILL.md
+++ b/skills/router-first/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: router-first
+description: Use when starting any conversation in Claude Code or Codex and you need to choose the lightest safe process for the task
+---
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
+
+# Router-First
+
+## Overview
+
+This is the default Superpowers entrypoint for Claude Code and Codex.
+
+Choose the lightest safe path for the task. Default to execution. Escalate only when risk or ambiguity justifies the overhead.
+
+**Core principle:** Skills are tools, not a constitution. Use only the process needed to complete the task safely.
+
+## Instruction Priority
+
+Superpowers skills override default system behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests)
+2. **Superpowers skills**
+3. **Default system prompt**
+
+If the user explicitly asks for the full heavy workflow, enter it. If the user explicitly asks to keep things light, do not escalate unless they approve.
+
+## The Routing Rule
+
+Before acting, classify the task only as much as needed to choose the lightest safe path:
+
+1. Check whether the task is `large`
+2. If not, check whether it is `medium`
+3. Otherwise treat it as `small`
+
+Do not turn simple work into process theater.
+
+## Task Sizes
+
+### `small`
+
+Use when the request is clear, bounded, and low-risk.
+
+Typical examples:
+- Small bugfixes
+- Small test additions
+- Copy, config, script, or tooling tweaks
+- A small, clearly specified feature slice
+- Local refactors that do not change architectural boundaries
+
+Default path:
+1. Inspect quickly
+2. Act directly
+3. Verify before claiming success
+
+Do not start brainstorming or write a formal plan for `small` tasks.
+
+### `medium`
+
+Use when the request is clear, but the work needs a few coordinated steps.
+
+Typical examples:
+- A modest feature addition touching a few related areas
+- A command or workflow change that also needs tests or docs
+- A fix that needs a short inspection pass before implementation
+
+Default path:
+1. Tell the user the short execution plan first
+2. Keep the plan light: 2-5 concrete steps
+3. Execute
+4. Verify before claiming success
+
+The short plan is not a spec and not a formal implementation document.
+
+### `large`
+
+Treat the task as `large` when ANY of these are true:
+- The requirements are unclear and need design work
+- The task will materially change product behavior and there are multiple reasonable approaches
+- The task crosses multiple independent subsystems
+- The task involves architecture changes, migrations, deletions, or compatibility strategy
+- The task involves security, permissions, payments, release flow, or data correctness risk
+- The task is likely to require long, multi-round coordination
+- You have already tried multiple times and still do not understand the root cause
+
+Default path:
+1. Explain why the task is high-risk
+2. Ask whether the user wants to switch to the heavy workflow
+3. Only enter the heavy workflow if the user explicitly agrees
+
+If the user declines, stop implementation. Offer advice, decomposition, or risk analysis only.
+
+## Heavy Workflow
+
+When the user explicitly asks for the full workflow, or approves escalation from a `large` task, switch into the existing heavy Superpowers path:
+
+1. `using-superpowers`
+2. `brainstorming`
+3. `writing-plans`
+4. Execution and review skills as needed
+
+Do not silently switch into heavy mode.
+
+## Skill Triggers
+
+### Always enforce
+
+- `verification-before-completion`
+  - Before claiming something is complete, fixed, or passing, run the relevant verification and check the result
+
+### Conditionally enforce
+
+- `systematic-debugging`
+  - Use when the task is a bug, test failure, flaky issue, unexpected behavior, or the root cause is unclear
+
+### Use only when needed
+
+- `brainstorming`
+  - Only after the user explicitly wants heavy mode or approves escalation for a `large` task
+- `writing-plans`
+  - Only after heavy mode is entered and a formal implementation plan is actually warranted
+- `test-driven-development`
+  - Recommended when it fits the task; not a top-level hard gate for every change
+- `requesting-code-review`
+  - Use for larger changes, merge prep, or when the user asks for review
+- `subagent-driven-development`
+  - Use only inside heavy execution flows
+- `using-git-worktrees`
+  - Use when isolation is useful, not by default
+
+## Communication Style
+
+- For `small` tasks, move quickly and keep preamble minimal
+- For `medium` tasks, share a short execution plan before acting
+- For `large` tasks, explain the risk briefly and ask whether to enter heavy mode
+
+Do not:
+- Force design discussions for simple work
+- Ask serial clarification questions when the task is already clear enough to execute
+- Turn a short plan into a formal design document
+- Silently escalate to heavy mode
+
+## Bottom Line
+
+Default to the lightest safe path:
+- `small` -> inspect, act, verify
+- `medium` -> short plan, act, verify
+- `large` -> ask before escalating to heavy

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-superpowers
-description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+description: Use when the human explicitly wants the full superpowers workflow, or agrees to switch into a heavy planning and execution process for a high-risk task
 ---
 
 <SUBAGENT-STOP>
@@ -38,6 +38,8 @@ If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "alw
 Skills use Claude Code tool names. Non-CC platforms: see `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
 
 # Using Skills
+
+This is the full heavy Superpowers workflow entrypoint. In installs that include `router-first`, this skill is no longer the default starting mode. Enter it when the human explicitly asks for the complete workflow, or after they approve escalation from a high-risk task.
 
 ## The Rule
 


### PR DESCRIPTION
## Summary
- add a new `router-first` skill as the default lightweight entrypoint
- document `router-first` as the default mode and `using-superpowers` as the heavy workflow
- switch the Claude session bootstrap and Codex docs to the new default entrypoint

## Motivation
The current default Superpowers flow is excellent for high-risk work, but it can feel too heavy for many day-to-day tasks in Codex and Claude. This change introduces a lighter default entrypoint so simple work can move faster without removing the existing heavy workflow.

## Behavior change
- new default entrypoint: `router-first`
- `using-superpowers` remains available as the full heavy workflow
- Claude session bootstrap now injects `router-first` by default
- Codex docs now describe `router-first` as the default mode

## Details
This keeps the original heavy Superpowers flow available, but makes the default behavior lighter:
- `small`: inspect, act, verify
- `medium`: share a short plan, then execute
- `large`: explain risk and ask before switching into the heavy workflow

It also preserves `verification-before-completion` as the always-on safeguard and keeps `systematic-debugging` as a conditional guardrail for debugging work.

## Compatibility
This does not remove the original heavy workflow. It preserves the existing planning-and-governance path and only changes the default entry behavior.

## Verification
- checked skill, docs, and bootstrap consistency
- ran `git diff --check`
- new Claude/Codex sessions are required for the new default mode to take effect
