### PR TITLE
fix: make using-git-worktrees platform-neutral (fixes #1049)

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -27,17 +27,22 @@ ls -d worktrees 2>/dev/null      # Alternative
 
 **If found:** Use that directory. If both exist, `.worktrees` wins.
 
-### 2. Check CLAUDE.md
+### 2. Check Agent Configuration
+
+Check the platform's agent-instruction file for a worktree directory preference:
 
 ```bash
-grep -i "worktree.*director" CLAUDE.md 2>/dev/null
+# Check known agent config files (Claude Code, Codex, Gemini CLI, Cursor)
+for config in CLAUDE.md AGENTS.md GEMINI.md .cursorrules; do
+  grep -i "worktree.*director" "$config" 2>/dev/null && break
+done
 ```
 
 **If preference specified:** Use it without asking.
 
 ### 3. Ask User
 
-If no directory exists and no CLAUDE.md preference:
+If no directory exists and no agent-configuration preference:
 
 ```
 No worktree directory found. Where should I create worktrees?
@@ -148,7 +153,7 @@ Ready to implement <feature-name>
 | `.worktrees/` exists | Use it (verify ignored) |
 | `worktrees/` exists | Use it (verify ignored) |
 | Both exist | Use `.worktrees/` |
-| Neither exists | Check CLAUDE.md → Ask user |
+| Neither exists | Check agent config → Ask user |
 | Directory not ignored | Add to .gitignore + commit |
 | Tests fail during baseline | Report failures + ask |
 | No package.json/Cargo.toml | Skip dependency install |
@@ -163,7 +168,7 @@ Ready to implement <feature-name>
 ### Assuming directory location
 
 - **Problem:** Creates inconsistency, violates project conventions
-- **Fix:** Follow priority: existing > CLAUDE.md > ask
+- **Fix:** Follow priority: existing > agent config > ask
 
 ### Proceeding with failing tests
 
@@ -198,10 +203,10 @@ Ready to implement auth feature
 - Skip baseline test verification
 - Proceed with failing tests without asking
 - Assume directory location when ambiguous
-- Skip CLAUDE.md check
+- Skip agent configuration check
 
 **Always:**
-- Follow directory priority: existing > CLAUDE.md > ask
+- Follow directory priority: existing > agent config > ask
 - Verify directory is ignored for project-local
 - Auto-detect and run project setup
 - Verify clean test baseline


### PR DESCRIPTION
## What problem are you trying to solve?

The `using-git-worktrees` skill hardcodes `CLAUDE.md` as the only agent-instruction file to check for worktree directory preferences. This makes the skill Claude-specific, even though Superpowers targets multiple platforms (Claude Code, Codex, Gemini CLI, Cursor, Copilot CLI, OpenCode).

I hit this while running the worktree skill from Codex -- step 2 of the directory selection process greps `CLAUDE.md`, which does not exist in a Codex-only project. The skill should check whatever config file the current platform uses, the same way `using-superpowers/SKILL.md` already lists `CLAUDE.md, GEMINI.md, AGENTS.md` as equivalent instruction sources.

## What does this PR change?

Replaces the hardcoded `grep ... CLAUDE.md` step with a for-loop that checks `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, and `.cursorrules` in priority order. Updates all downstream prose references from "CLAUDE.md" to "agent config" / "agent configuration."

## Is this change appropriate for the core library?

Yes. `using-git-worktrees` is listed as part of the basic workflow and is called by `brainstorming`, `subagent-driven-development`, and `executing-plans`. Making it work across platforms is a correctness fix, not a new feature. The `using-superpowers` skill already treats these config files as equivalent (line 22: "User's explicit instructions (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests)"), so the worktree skill should too.

## What alternatives did you consider?

1. **Check only `CLAUDE.md` and document that other platforms should adapt.** Rejected because the skill is meant to be followed literally, and telling non-Claude users to mentally translate is error-prone.
2. **Use a single generic filename like `AGENT_CONFIG`.** Rejected because it does not match any real platform's convention. The for-loop approach checks actual files that exist in real projects.
3. **Add every possible config file (including `.opencode`, `.aider.conf`, etc.).** Rejected -- keeping the list to the four platforms that Superpowers actively documents avoids noise. Easy to extend later.

## Does this PR contain multiple unrelated changes?

No. Single concern: replace hardcoded CLAUDE.md references with platform-neutral config detection.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1063, #639, #599

PR #1063 addresses the same issue but includes `CODEX.md` in its config file list, which is not a real Codex config file (Codex uses `AGENTS.md`). This PR uses the correct config filenames matching each platform's actual convention.

PR #639 is a separate concern (defaulting to global worktree location to avoid CLAUDE.md double-loading). Orthogonal to this change.

PR #599 (closed) bundled worktree isolation with dead code removal and hook hardening -- too broad, correctly rejected.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 1.0.33 | Claude | claude-opus-4-6 |

## Evaluation

- The change was motivated by running the worktree skill across multiple CLI agents (Claude Code, Codex, Gemini CLI) while working on a multi-agent orchestration system (Bernstein). The CLAUDE.md-only check silently skips config on non-Claude platforms.
- After the change: the for-loop correctly picks up `AGENTS.md` on Codex projects and `GEMINI.md` on Gemini CLI projects where those files contain worktree directory preferences.
- Verified the only remaining `CLAUDE.md` reference in the file is inside the for-loop config list, which is correct (it should still check CLAUDE.md for Claude Code users).

## Rigor

- [x] If this is a skills change: the change is minimal (prose + one bash block), follows the existing pattern from `using-superpowers/SKILL.md` which already lists these config files as equivalent
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission