### PR TITLE
fix: distinguish Skills from Agent types in subagent-driven-development Integration section

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -264,14 +264,11 @@ Done!
 
 ## Integration
 
-**Workflow skills (invoke via Skill tool):**
+**Required workflow skills:**
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
-- **superpowers:requesting-code-review** - Review workflow guide (how to prepare context and act on feedback). This is a Skill, not an Agent — do NOT dispatch it via the Agent/Task tool
+- **superpowers:requesting-code-review** - Review workflow guide — prepares context and acts on feedback from reviewers (not an agent to dispatch)
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks
-
-**Agent types (dispatch via Task tool):**
-- **superpowers:code-reviewer** - Dispatched for code quality reviews and final review (see `./code-quality-reviewer-prompt.md`)
 
 **Subagents should use:**
 - **superpowers:test-driven-development** - Subagents follow TDD for each task

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -264,11 +264,14 @@ Done!
 
 ## Integration
 
-**Required workflow skills:**
+**Workflow skills (invoke via Skill tool):**
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
-- **superpowers:requesting-code-review** - Code review template for reviewer subagents
+- **superpowers:requesting-code-review** - Review workflow guide (how to prepare context and act on feedback). This is a Skill, not an Agent — do NOT dispatch it via the Agent/Task tool
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks
+
+**Agent types (dispatch via Task tool):**
+- **superpowers:code-reviewer** - Dispatched for code quality reviews and final review (see `./code-quality-reviewer-prompt.md`)
 
 **Subagents should use:**
 - **superpowers:test-driven-development** - Subagents follow TDD for each task


### PR DESCRIPTION
## Summary

Fixes https://github.com/obra/superpowers/issues/1077

The `subagent-driven-development` skill's Integration section listed `superpowers:requesting-code-review` without clarifying it was a workflow guide, causing Claude to attempt dispatching it as an agent type.

## Changes

Minimal fix:
- Revert section name to "Required workflow skills" (no tool-specific terms)
- Clarify `requesting-code-review` as a workflow guide "(not an agent to dispatch)"
- Remove the "Agent types" section (the existing `[Dispatch final code-reviewer]` reference in the skill is sufficient)

## Testing

Markdown-only change to skill documentation. No test suite affected.