### PR TITLE
feat: add Gemini CLI subagent support (fixes #1045)

### DIFF
--- a/skills/using-superpowers/references/gemini-tools.md
+++ b/skills/using-superpowers/references/gemini-tools.md
@@ -14,11 +14,29 @@ Skills use Claude Code tool names. When you encounter these in a skill, use your
 | `Skill` tool (invoke a skill) | `activate_skill` |
 | `WebSearch` | `google_web_search` |
 | `WebFetch` | `web_fetch` |
-| `Task` tool (dispatch subagent) | No equivalent — Gemini CLI does not support subagents |
+| `Task` tool (dispatch subagent) | `@agent-name` (see [Subagent support](#subagent-support)) |
 
-## No subagent support
+## Subagent support
 
-Gemini CLI has no equivalent to Claude Code's `Task` tool. Skills that rely on subagent dispatch (`subagent-driven-development`, `dispatching-parallel-agents`) will fall back to single-session execution via `executing-plans`.
+Gemini CLI supports subagents natively via the `@` syntax. Use the built-in `@generalist` agent to dispatch any task — it has access to all tools and follows the prompt you provide.
+
+When a skill says to dispatch a named agent type, use `@generalist` with the full prompt from the skill's prompt template:
+
+| Skill instruction | Gemini CLI equivalent |
+|-------------------|----------------------|
+| `Task tool (superpowers:implementer)` | `@generalist` with the filled `implementer-prompt.md` template |
+| `Task tool (superpowers:spec-reviewer)` | `@generalist` with the filled `spec-reviewer-prompt.md` template |
+| `Task tool (superpowers:code-reviewer)` | `@code-reviewer` (bundled agent) or `@generalist` with the filled review prompt |
+| `Task tool (superpowers:code-quality-reviewer)` | `@generalist` with the filled `code-quality-reviewer-prompt.md` template |
+| `Task tool (general-purpose)` with inline prompt | `@generalist` with your inline prompt |
+
+### Prompt filling
+
+Skills provide prompt templates with placeholders like `{WHAT_WAS_IMPLEMENTED}` or `[FULL TEXT of task]`. Fill all placeholders and pass the complete prompt as the message to `@generalist`. The prompt template itself contains the agent's role, review criteria, and expected output format — `@generalist` will follow it.
+
+### Sequential execution
+
+Gemini CLI runs subagents sequentially. While you can dispatch multiple tasks, the CLI processes them one at a time. This satisfies the requirements of `subagent-driven-development` while maintaining a clear, serial history.
 
 ## Additional Gemini CLI tools
 

--- a/skills/using-superpowers/references/gemini-tools.md
+++ b/skills/using-superpowers/references/gemini-tools.md
@@ -34,9 +34,9 @@ When a skill says to dispatch a named agent type, use `@generalist` with the ful
 
 Skills provide prompt templates with placeholders like `{WHAT_WAS_IMPLEMENTED}` or `[FULL TEXT of task]`. Fill all placeholders and pass the complete prompt as the message to `@generalist`. The prompt template itself contains the agent's role, review criteria, and expected output format — `@generalist` will follow it.
 
-### Sequential execution
+### Parallel dispatch
 
-Gemini CLI runs subagents sequentially. While you can dispatch multiple tasks, the CLI processes them one at a time. This satisfies the requirements of `subagent-driven-development` while maintaining a clear, serial history.
+Gemini CLI supports parallel subagent dispatch. When a skill asks you to dispatch multiple independent subagent tasks in parallel, request all of those `@generalist` or named subagent tasks together in the same prompt. Keep dependent tasks sequential, but do not serialize independent subagent tasks just to preserve a simpler history.
 
 ## Additional Gemini CLI tools
 


### PR DESCRIPTION
## What problem are you trying to solve?

I use Gemini CLI daily and noticed the superpowers `gemini-tools.md` says "No equivalent — Gemini CLI does not support subagents." But Gemini CLI has supported subagents since v0.36 — the built-in `@generalist` agent has all tools and runs in its own context, which is exactly what Claude Code's `Task tool` does.

Skills like `subagent-driven-development` and `dispatching-parallel-agents` couldn't work on Gemini at all because the docs said subagents don't exist.

## What does this PR change?

Updates `gemini-tools.md` to document how to use Gemini CLI's built-in `@generalist` agent for subagent dispatch. Maps all `Task tool` skill instructions to `@generalist` with the appropriate prompt template content. Includes message framing guidance (matching the Codex approach in `codex-tools.md`).

One file changed. No new agent files — uses the existing `@generalist` built-in instead.

## Is this change appropriate for the core library?

Yes — this is platform parity documentation. `codex-tools.md` already documents how Codex dispatches subagents using `spawn_agent` with prompt content. This does the same for Gemini CLI using `@generalist`.

## What alternatives did you consider?

- **Custom agent files in `agents/`** — my first approach (initial commit). Created dedicated agent definitions with YAML frontmatter. Maintainer correctly pointed out this is unnecessary when `@generalist` + prompt content works fine. Reverted to simpler approach.
- **PR #941** — maps only Gemini's built-in agents without showing how to use them for subagent-driven-development prompt templates.

## Does this PR contain multiple unrelated changes?

No. Single file change — documentation update for Gemini CLI subagent support.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #941 (open, different approach — lists built-in agents but doesn't map skill dispatch instructions)

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Gemini CLI                          | v0.36+          | Gemini 3.1 Pro | gemini-3.1-pro-preview |

## Evaluation

- Tested in Gemini CLI: dispatched `@generalist` with implementer prompt content, verified it follows the role instructions and reports back with correct status format.
- Before: gemini-tools.md said "No equivalent — no subagents." Skills referencing Task tool had no Gemini mapping.
- After: clear mapping from every Task tool instruction to `@generalist` with the right prompt template.

## Rigor

- [x] If this is a skills change: N/A — no skill content was modified. Documentation-only change to gemini-tools.md.
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

This PR modifies only `gemini-tools.md` (tool mapping documentation). No skill content, agent files, or behavior-shaping content was touched.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission