### PR TITLE
feat: add keep-coding-instructions: true to all skill frontmatters

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: brainstorming
 description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+keep-coding-instructions: true
 ---
 
 # Brainstorming Ideas Into Designs

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dispatching-parallel-agents
 description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
+keep-coding-instructions: true
 ---
 
 # Dispatching Parallel Agents

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: executing-plans
 description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
+keep-coding-instructions: true
 ---
 
 # Executing Plans

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: finishing-a-development-branch
 description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+keep-coding-instructions: true
 ---
 
 # Finishing a Development Branch

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: receiving-code-review
 description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+keep-coding-instructions: true
 ---
 
 # Code Review Reception

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: requesting-code-review
 description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+keep-coding-instructions: true
 ---
 
 # Requesting Code Review

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: subagent-driven-development
 description: Use when executing implementation plans with independent tasks in the current session
+keep-coding-instructions: true
 ---
 
 # Subagent-Driven Development

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: systematic-debugging
 description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+keep-coding-instructions: true
 ---
 
 # Systematic Debugging

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-driven-development
 description: Use when implementing any feature or bugfix, before writing implementation code
+keep-coding-instructions: true
 ---
 
 # Test-Driven Development (TDD)

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: using-git-worktrees
 description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification
+keep-coding-instructions: true
 ---
 
 # Using Git Worktrees

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: using-superpowers
 description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+keep-coding-instructions: true
 ---
 
 <SUBAGENT-STOP>

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verification-before-completion
 description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+keep-coding-instructions: true
 ---
 
 # Verification Before Completion

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: writing-plans
 description: Use when you have a spec or requirements for a multi-step task, before touching code
+keep-coding-instructions: true
 ---
 
 # Writing Plans

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: writing-skills
 description: Use when creating new skills, editing existing skills, or verifying skills work before deployment
+keep-coding-instructions: true
 ---
 
 # Writing Skills


### PR DESCRIPTION
## Summary

- Adds `keep-coding-instructions: true` to the frontmatter of all 14 SKILL.md files
- Prevents skills from replacing the user's CLAUDE.md coding instructions when invoked
- Uses the `keep-coding-instructions` frontmatter field introduced in Claude Code 2.1.94

Closes #1090

## Details

When a superpowers skill is invoked, Claude Code replaces the active coding instructions with the skill's prompt. This discards any rules defined in the user's CLAUDE.md (coding style, comment language, security constraints, etc.).

This one-line-per-file change ensures all superpowers skills preserve the user's project conventions alongside the skill prompt.

## Test plan

- [ ] Invoke any skill (e.g. `brainstorming`) with a CLAUDE.md that has custom rules
- [ ] Verify the custom rules are still active alongside the skill prompt
- [ ] Confirm all 14 SKILL.md files have the new frontmatter field