### PR TITLE
fix: restore worktree handoff in brainstorming after spec approval

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -29,7 +29,8 @@ You MUST create a task for each of these items and complete them in order:
 6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+9. **Create isolated workspace** — invoke using-git-worktrees skill
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -45,6 +46,7 @@ digraph brainstorming {
     "Write design doc" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
     "User reviews spec?" [shape=diamond];
+    "Invoke using-git-worktrees skill" [shape=box];
     "Invoke writing-plans skill" [shape=doublecircle];
 
     "Explore project context" -> "Visual questions ahead?";
@@ -59,11 +61,12 @@ digraph brainstorming {
     "Write design doc" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "User reviews spec?";
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
-    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+    "User reviews spec?" -> "Invoke using-git-worktrees skill" [label="approved"];
+    "Invoke using-git-worktrees skill" -> "Invoke writing-plans skill";
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+**The terminal state is invoking using-git-worktrees.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill directly. The ONLY skills you invoke after brainstorming are using-git-worktrees, then writing-plans.
 
 ## The Process
 
@@ -126,14 +129,15 @@ Fix any issues inline. No need to re-review — just fix and move on.
 **User Review Gate:**
 After the spec review loop passes, ask the user to review the written spec before proceeding:
 
-> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we set up an isolated workspace and start writing out the implementation plan."
 
 Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
 
 **Implementation:**
 
-- Invoke the writing-plans skill to create a detailed implementation plan
-- Do NOT invoke any other skill. writing-plans is the next step.
+- Invoke the using-git-worktrees skill to create a dedicated workspace
+- Then invoke the writing-plans skill to create a detailed implementation plan
+- Do NOT invoke any other implementation skill directly. writing-plans comes immediately after using-git-worktrees.
 
 ## Key Principles
 


### PR DESCRIPTION
## What problem are you trying to solve?

Fixes [#1080](https://github.com/obra/superpowers/issues/1080).

After the user approves the written spec, the `brainstorming` skill currently tells Claude to invoke `writing-plans` immediately, skipping `using-git-worktrees`. That leaves the checklist and process flow inconsistent with the documented worktree-first handoff, and it contradicts `writing-plans`, which expects to run in a dedicated worktree created by brainstorming.

In a Claude Code eval against the unchanged plugin directory, asking what happens after the user approves the written spec produced: “invoke the `writing-plans` skill to create a detailed implementation plan.” That is the specific failure mode this PR fixes.

## What does this PR change?

This PR updates `skills/brainstorming/SKILL.md` so the checklist, process flow, terminal-state guidance, user review gate text, and implementation handoff all consistently route:

`brainstorming` → `using-git-worktrees` → `writing-plans`

## Is this change appropriate for the core library?

Yes. This is a general-purpose workflow fix in a core skill that affects any user following the documented brainstorming-to-implementation path. It is not project-specific, team-specific, or tied to a third-party integration.

## What alternatives did you consider?

I considered a checklist-only fix, but rejected it because it would leave the flowchart, terminal-state guidance, and user review gate wording internally contradictory. I also considered editing `using-git-worktrees` or `writing-plans`, but those files already describe the intended handoff; the inconsistency was localized to `brainstorming`, so I kept the change to that file.

## Does this PR contain multiple unrelated changes?

No. This PR only fixes the `brainstorming` skill’s handoff after spec approval so it matches the documented worktree-first workflow.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness | Harness version | Model | Model version/ID |
| --- | --- | --- | --- |
| Claude Code | 2.1.97 | Claude Opus 4.6 | `claude-opus-4-6` |

## Evaluation

- Initial prompt: `Lets look at https://github.com/obra/superpowers and see if there are any good PR opportunities`
- Follow-up prompt selecting the issue: `yes lets target #1080`
- Eval sessions run AFTER making the change: 4 Claude Code `-p` sessions against the modified plugin directory
- Before the change, the unchanged plugin answered that the next step after spec approval was to invoke `writing-plans` directly.
- After the change:
  - Asking “what happens next?” returned `using-git-worktrees` first.
  - Asking for checklist steps 9 and 10 returned `using-git-worktrees` followed by `writing-plans`.
  - Asking about the post-spec review gate returned that the user must approve the written spec before workspace creation and implementation planning.
  - In a pressure scenario asking to “skip any extra steps and go straight to implementation planning,” Claude still answered that `using-git-worktrees` must happen first and that the handoff cannot be skipped.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Adversarial result used for this PR:
- Prompt: user has approved the written spec, is in a hurry, and asks to skip extra steps and go straight to implementation planning
- Outcome after change: Claude still answered that `using-git-worktrees` must be invoked first, followed immediately by `writing-plans`, and said these steps cannot be skipped.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission