### PR TITLE
fix: add missing worktree step to brainstorming checklist

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -29,7 +29,8 @@ You MUST create a task for each of these items and complete them in order:
 6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+9. **Create isolated workspace** — invoke using-git-worktrees skill to set up a dedicated worktree before implementation
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -45,6 +46,7 @@ digraph brainstorming {
     "Write design doc" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
     "User reviews spec?" [shape=diamond];
+    "Invoke using-git-worktrees" [shape=box];
     "Invoke writing-plans skill" [shape=doublecircle];
 
     "Explore project context" -> "Visual questions ahead?";
@@ -59,7 +61,8 @@ digraph brainstorming {
     "Write design doc" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "User reviews spec?";
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
-    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+    "User reviews spec?" -> "Invoke using-git-worktrees" [label="approved"];
+    "Invoke using-git-worktrees" -> "Invoke writing-plans skill";
 }
 ```
 


### PR DESCRIPTION
Fixes #1080

## Summary
- Added step 9 ("Create isolated workspace — invoke using-git-worktrees") between "User reviews spec" and "Transition to implementation"
- Updated DOT flow diagram to include the worktree node in the process flow

## Context
`using-git-worktrees/SKILL.md` declares itself as "Called by: brainstorming (Phase 4) - REQUIRED when design is approved", and `writing-plans/SKILL.md` expects to execute "in a dedicated worktree (created by brainstorming skill)". But the brainstorming checklist never invoked it, creating a broken handoff.

## Test plan
- [ ] Verify checklist numbering is correct (steps 1-10)
- [ ] Verify DOT diagram renders correctly with the new node
- [ ] Confirm using-git-worktrees is invoked before writing-plans in practice