### PR TITLE
fix: remove redundant instructions in dispatching-parallel-agents

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -123,13 +123,6 @@ Return: Summary of what you found and what you fixed.
 **❌ Vague output:** "Fix it" - you don't know what changed
 **✅ Specific:** "Return summary of root cause and changes"
 
-## When NOT to Use
-
-**Related failures:** Fixing one might fix others - investigate together first
-**Need full context:** Understanding requires seeing entire system
-**Exploratory debugging:** You don't know what's broken yet
-**Shared state:** Agents would interfere (editing same files, using same resources)
-
 ## Real Example from Session
 
 **Scenario:** 6 test failures across 3 files after major refactoring
@@ -154,8 +147,6 @@ Agent 3 → Fix tool-approval-race-conditions.test.ts
 - Agent 3: Added wait for async tool execution to complete
 
 **Integration:** All fixes independent, no conflicts, full suite green
-
-**Time saved:** 3 problems solved in parallel vs sequentially
 
 ## Key Benefits
 


### PR DESCRIPTION
Fixes #1017

## Summary
- Removed "When NOT to Use" section — duplicated the "Don't use when" list verbatim
- Removed "Time saved" line from Real Example — duplicated Key Benefits "Speed" point

## Context
Two pairs of content said the same thing in different sections:
1. "Failures are related (fix one might fix others)" appeared in both "Don't use when" (line 44) and "When NOT to Use" (line 128)
2. "3 problems solved in parallel vs sequentially" (line 158) restated "3 problems solved in time of 1" (line 165)

## Test plan
- [ ] Verify no unique information was lost (all concepts still present in remaining sections)
- [ ] Verify markdown renders correctly