### PR TITLE
fix: correct cleanup sequence in finishing-a-development-branch

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -79,12 +79,15 @@ git merge <feature-branch>
 
 # Verify tests on merged result
 <test command>
+```
 
-# If tests pass
+Then: Cleanup worktree (Step 5), then delete the feature branch:
+
+```bash
 git branch -d <feature-branch>
 ```
 
-Then: Cleanup worktree (Step 5)
+**Note:** The branch must be deleted AFTER worktree removal — git refuses to delete a branch that a worktree has checked out.
 
 #### Option 2: Push and Create PR
 
@@ -103,7 +106,7 @@ EOF
 )"
 ```
 
-Then: Cleanup worktree (Step 5)
+Worktree preserved — you may need it for PR review changes.
 
 #### Option 3: Keep As-Is
 
@@ -135,7 +138,7 @@ Then: Cleanup worktree (Step 5)
 
 ### Step 5: Cleanup Worktree
 
-**For Options 1, 2, 4:**
+**For Options 1 and 4:**
 
 Check if in worktree:
 ```bash


### PR DESCRIPTION
Fixes #999

## Summary
- **Bug 1:** Moved `git branch -d` to after worktree removal in Option 1 — git refuses to delete a branch that a worktree has checked out
- **Bug 2:** Changed Step 5 from "Options 1, 2, 4" to "Options 1 and 4" — Option 2 (Create PR) should keep the worktree for review changes, matching the Quick Reference table

## Context
Option 1 (Merge Locally) ran `git branch -d <feature-branch>` while the worktree still had the branch checked out, causing: `error: cannot delete branch 'feature-branch' used by worktree`.

Additionally, Step 5 contradicted the Quick Reference table about Option 2 — the table correctly shows the worktree should be preserved (PRs may need changes), but Step 5 included Option 2 in the cleanup list.

## Test plan
- [ ] Walk through Option 1 flow: verify branch delete happens after worktree removal
- [ ] Walk through Option 2 flow: verify worktree is preserved
- [ ] Verify Quick Reference table matches Step 5 behavior