### PR TITLE
fix: add filesystem fallback for OpenCode skill discovery

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -2,7 +2,7 @@
  * Superpowers plugin for OpenCode.ai
  *
  * Injects superpowers bootstrap context via system prompt transform.
- * Auto-registers skills directory via config hook (no symlinks needed).
+ * Auto-registers skills directory via config hook, with filesystem symlink fallback.
  */
 
 import path from 'path';
@@ -81,6 +81,21 @@ ${toolMapping}
 </EXTREMELY_IMPORTANT>`;
   };
 
+
+  // Filesystem fallback: ensure skills are discoverable via OpenCode's
+  // default skills path, since the `config` hook may be silently ignored
+  // by some OpenCode versions (see #1087).
+  const ocSkillsTarget = path.join(configDir, 'skills', 'superpowers');
+  if (!fs.existsSync(ocSkillsTarget)) {
+    fs.mkdirSync(path.dirname(ocSkillsTarget), { recursive: true });
+    try {
+      // 'junction' works on Windows NTFS without admin privileges
+      fs.symlinkSync(superpowersSkillsDir, ocSkillsTarget, 'junction');
+    } catch {
+      // Fallback: copy directory if symlink/junction fails
+      fs.cpSync(superpowersSkillsDir, ocSkillsTarget, { recursive: true });
+    }
+  }
   return {
     // Inject skills path into live config so OpenCode discovers superpowers skills
     // without requiring manual symlinks or config file edits.


### PR DESCRIPTION
Fixes #1087

## Summary
- Added filesystem-based skill registration as fallback when the `config` hook is silently ignored
- Symlinks (junction on Windows) or copies the skills directory to `~/.config/opencode/skills/superpowers/`
- Uses `'junction'` type for Windows NTFS compatibility without admin privileges

## Context
The `config` hook injects the skills path, but OpenCode silently ignores unrecognized hook keys in some versions. This causes "Available skills: none" even though the plugin loads successfully. The bootstrap system prompt works (via `experimental.chat.messages.transform`), but skills aren't discoverable.

The fallback ensures skills are physically present at OpenCode's default discovery path regardless of whether the config hook is supported.

## Test plan
- [ ] Verify symlink/junction is created at `~/.config/opencode/skills/superpowers/`
- [ ] Verify skills are discoverable after plugin load
- [ ] Verify fallback to `fs.cpSync` works if symlink fails
- [ ] Verify no error if target already exists (idempotent)