### PR TITLE
feat: establish plugin architecture and add tinystruct developer skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,16 @@
         "name": "Jesse Vincent",
         "email": "jesse@fsck.com"
       }
+    },
+    {
+      "name": "tinystruct-plugin",
+      "description": "Enterprise-grade Java backend development patterns using the tinystruct framework.",
+      "version": "1.0.0",
+      "source": "./plugins/tinystruct",
+      "author": {
+        "name": "James",
+        "email": "moverinfo@gmail.com"
+      }
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -18,7 +18,10 @@
     "best-practices",
     "workflows"
   ],
-  "skills": "./skills/",
+  "skills": [
+    "./skills/",
+    "./plugins/"
+  ],
   "agents": "./agents/",
   "commands": "./commands/",
   "hooks": "./hooks/hooks-cursor.json"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ Start a new session in your chosen platform and ask for something that should tr
 - **writing-skills** - Create new skills following best practices (includes testing methodology)
 - **using-superpowers** - Introduction to the skills system
 
+### Technology-Specific Plugins
+
+Superpowers separates **process skills** (how we work) from **technology skills** (what we use). Domain-specific expertise for languages, frameworks, or tools (e.g., Java, React, Infrastructure) lives in the `plugins/` directory. 
+
+This modular architecture allows the core to remain lean and methodology-focused, while allowing developers to plug in specialized knowledge as needed for their specific stack.
+
+
 ## Philosophy
 
 - **Test-Driven Development** - Write tests first, always

--- a/plugins/tinystruct/plugin.json
+++ b/plugins/tinystruct/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "tinystruct-plugin",
+  "description": "Enterprise-grade Java backend development patterns using the tinystruct framework.",
+  "version": "1.0.0",
+  "author": {
+    "name": "James",
+    "email": "moverinfo@gmail.com"
+  },
+  "keywords": [
+    "java",
+    "backend",
+    "tinystruct",
+    "routing",
+    "api",
+    "enterprise"
+  ]
+}

--- a/plugins/tinystruct/skills/developing-with-tinystruct/SKILL.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: developing-with-tinystruct
+description: Use when developing with the tinystruct Java framework or working on framework internals. Trigger when creating Application classes, mapping routes with @Action, handling JSON with Builder, or debugging CLI/HTTP dual-mode dispatching.
+---
+
+# tinystruct Framework Developer Skill
+
+This skill captures the architecture, conventions, and patterns of the **tinystruct** Java framework — a lightweight, high-performance framework that treats CLI and HTTP as equal citizens.
+
+## Core Principle
+
+**CLI and HTTP are equal citizens.** Every method annotated with `@Action` should ideally be runnable from both a terminal and a web browser without modification.
+
+---
+
+## Creating an Application
+
+Extend `AbstractApplication` for all modules:
+
+```java
+package com.example;
+
+import org.tinystruct.AbstractApplication;
+import org.tinystruct.system.annotation.Action;
+
+public class HelloApp extends AbstractApplication {
+
+    @Override
+    public void init() {
+        this.setTemplateRequired(false); // skip .view template lookup for APIs
+    }
+
+    @Override public String version() { return "1.0.0"; }
+
+    @Action("hello")
+    public String hello() {
+        return "Hello, tinystruct!";
+    }
+}
+```
+
+### `init()` Rules
+- Called once when `setConfiguration()` is executed.
+- Use for: DB setup, resource paths, calling `setTemplateRequired(false)`.
+- **Do not** call `setAction()` here — use `@Action` annotations.
+
+---
+
+## Red Flags - STOP and Review
+
+| Symptom | Reality |
+|---|---|
+| Using `Gson` or `Jackson` | **Violation.** Use `org.tinystruct.data.component.Builder` for native JSON. |
+| `template not found` error | **Missing setting.** Call `setTemplateRequired(false)` in `init()` for data-only apps. |
+| `@Action` on private method | **Ignored.** Actions MUST be `public` to be registered. |
+| Hardcoding `main()` method | **Anti-pattern.** Use `bin/dispatcher` for execution. |
+| Direct `ActionRegistry` usage | **Avoid.** Let the framework handle routing via annotations. |
+
+---
+
+## Common Pitfalls
+
+- **CLI Arg Visibility**: Pass args as `--key value`; access via `getContext().getAttribute("--key")`.
+- **Mode Disambiguation**: Use `mode = Mode.HTTP_POST` if a path handles different logic for GET vs POST.
+- **Path Params**: Ensure method parameter types match the expected path segments (String, int, etc.).
+
+---
+
+## Technical Reference
+
+Detailed guides are available in the `references/` directory:
+
+- [Architecture & Config](references/architecture.md) — Abstractions, Package Map, Properties
+- [Routing & @Action](references/routing.md) — Annotation details, Modes, Parameters
+- [Data Handling](references/data-handling.md) — Using the native `Builder` for JSON
+- [System & Usage](references/system-usage.md) — Context, Sessions, Events, CLI usage
+- [Testing Patterns](references/testing.md) — JUnit 5 integration and ActionRegistry testing
+
+---
+
+## Reference Source Files (Internal)
+
+- `src/main/java/org/tinystruct/AbstractApplication.java` — Core base class
+- `src/main/java/org/tinystruct/system/annotation/Action.java` — Annotation & Modes
+- `src/main/java/org/tinystruct/application/ActionRegistry.java` — Routing Engine

--- a/plugins/tinystruct/skills/developing-with-tinystruct/references/architecture.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/references/architecture.md
@@ -1,0 +1,82 @@
+# tinystruct Architecture and Configuration
+
+## Core Architecture
+
+### Key Abstractions
+
+| Class/Interface | Role |
+|---|---|
+| `AbstractApplication` | Base class for all tinystruct applications. Extend this. |
+| `@Action` annotation | Maps a method to a URI path (web) or command name (CLI). The single routing primitive. |
+| `ActionRegistry` | Singleton that maps URL patterns to `Action` objects via regex. Never instantiate directly. |
+| `Action` | Wraps a `MethodHandle` + regex pattern + priority + `Mode` for dispatch. |
+| `Context` | Per-request state store. Access via `getContext()`. Holds CLI args and HTTP request/response. |
+| `Dispatcher` | CLI entry point (`bin/dispatcher`). Reads `--import` to load applications. |
+| `HttpServer` | Built-in Netty-based HTTP server. Start with `bin/dispatcher start --import org.tinystruct.system.HttpServer`. |
+
+### Package Map
+
+```
+org.tinystruct/
+├── AbstractApplication.java      ← extend this
+├── Application.java              ← interface
+├── ApplicationException.java     ← checked exception
+├── ApplicationRuntimeException.java ← unchecked exception
+├── application/
+│   ├── Action.java               ← runtime action wrapper
+│   ├── ActionRegistry.java       ← singleton route registry
+│   └── Context.java              ← request context
+├── system/
+│   ├── annotation/Action.java    ← @Action annotation + Mode enum
+│   ├── Dispatcher.java           ← CLI dispatcher
+│   ├── HttpServer.java           ← built-in HTTP server
+│   ├── EventDispatcher.java      ← event bus
+│   └── Settings.java             ← reads application.properties
+├── data/component/Builder.java   ← JSON serialization (use instead of Gson/Jackson)
+└── http/                         ← Request, Response, Constants
+```
+
+## Templates
+
+If `templateRequired` is `true` (the default), `toString()` looks for a `.view` file:
+- Location: `src/main/resources/themes/<ClassName>.view` (on classpath)
+- Variables are interpolated using `[%variableName%]`
+
+```java
+// In your action method:
+setVariable("username", "James");
+setVariable("count", String.valueOf(42));
+// The template file uses: [%username%] and [%count%]
+```
+
+To skip templates and return data directly (e.g., for APIs):
+```java
+@Override
+public void init() {
+    this.setTemplateRequired(false);
+}
+```
+
+## Configuration (`application.properties`)
+
+Located at `src/main/resources/application.properties`:
+
+```properties
+# Database
+driver=org.h2.Driver
+database.url=jdbc:h2:~/mydb
+database.user=sa
+database.password=
+
+# Server
+default.home.page=hello        # default action for /?q= (root URL)
+server.port=8080
+
+# Locale
+default.language=en_US
+```
+
+Access config values in your application:
+```java
+String port = this.getConfiguration("server.port");
+```

--- a/plugins/tinystruct/skills/developing-with-tinystruct/references/data-handling.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/references/data-handling.md
@@ -1,0 +1,34 @@
+# tinystruct Data Handling (JSON)
+
+## JSON Handling (use `Builder`, not Gson/Jackson)
+
+The `org.tinystruct.data.component.Builder` class is the framework's native JSON library. It is lightweight and highly optimized for tinystruct's performance requirements.
+
+### Serialization
+```java
+import org.tinystruct.data.component.Builder;
+
+// Create and populate
+Builder response = new Builder();
+response.put("status", "success");
+response.put("count", 42);
+response.put("data", someList);
+
+return response.toString(); // {"status":"success","count":42,...}
+```
+
+### Parsing
+```java
+import org.tinystruct.data.component.Builder;
+
+// Parse a JSON string
+Builder parsed = new Builder();
+parsed.parse(jsonString);
+
+String status = parsed.get("status").toString();
+```
+
+### Why use Builder?
+- **Zero External Dependencies**: Keeps your application lean.
+- **Native Integration**: Works seamlessly with `AbstractApplication` result handling.
+- **Performance**: Optimized for the specific data structures used within the framework.

--- a/plugins/tinystruct/skills/developing-with-tinystruct/references/data-handling.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/references/data-handling.md
@@ -14,7 +14,7 @@ response.put("status", "success");
 response.put("count", 42);
 response.put("data", someList);
 
-return response.toString(); // {"status":"success","count":42,...}
+return response; // {"status":"success","count":42,...}
 ```
 
 ### Parsing

--- a/plugins/tinystruct/skills/developing-with-tinystruct/references/routing.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/references/routing.md
@@ -7,11 +7,8 @@
     value = "path/subpath",          // required: URI segment or CLI command
     description = "What it does",    // shown in --help output
     mode = Mode.HTTP_POST,           // default: Mode.DEFAULT (both CLI + HTTP)
-    arguments = {                    // optional: parameter metadata for CLI help
-        @Argument(key = "--id", description = "The item ID")
-    },
     options = {},                    // CLI option flags
-    example = "bin/dispatcher path/subpath --id 42"
+    example = "bin/dispatcher path/subpath/42"
 )
 public String myAction(int id) { ... }
 ```

--- a/plugins/tinystruct/skills/developing-with-tinystruct/references/routing.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/references/routing.md
@@ -1,0 +1,57 @@
+# tinystruct @Action Routing Reference
+
+## @Action Annotation
+
+```java
+@Action(
+    value = "path/subpath",          // required: URI segment or CLI command
+    description = "What it does",    // shown in --help output
+    mode = Mode.HTTP_POST,           // default: Mode.DEFAULT (both CLI + HTTP)
+    arguments = {                    // optional: parameter metadata for CLI help
+        @Argument(key = "--id", description = "The item ID")
+    },
+    options = {},                    // CLI option flags
+    example = "bin/dispatcher path/subpath --id 42"
+)
+public String myAction(int id) { ... }
+```
+
+### Mode Values
+| Mode | When it triggers |
+|---|---|
+| `DEFAULT` | Both CLI and HTTP (GET, POST, etc.) |
+| `CLI` | CLI dispatcher only |
+| `HTTP_GET` | HTTP GET only |
+| `HTTP_POST` | HTTP POST only |
+| `HTTP_PUT` | HTTP PUT only |
+| `HTTP_DELETE` | HTTP DELETE only |
+| `HTTP_PATCH` | HTTP PATCH only |
+
+### Path Parameters
+tinystruct automatically builds a regex from the method signature:
+
+```java
+@Action("user/{id}")
+public String getUser(int id) { ... }
+// → pattern: ^/?user/(-?\d+)$
+
+@Action("search")
+public String search(String query) { ... }
+// → pattern: ^/?search/([^/]+)$
+// → CLI: bin/dispatcher search/hello
+// → HTTP: /?q=search/hello
+```
+
+Supported parameter types: `String`, `int/Integer`, `long/Long`, `float/Float`, `double/Double`, `boolean/Boolean`, `char/Character`, `short/Short`, `byte/Byte`, `Date` (parsed as `yyyy-MM-dd HH:mm:ss`).
+
+### Accessing Request/Response
+
+Include `Request` and/or `Response` as parameters — ActionRegistry automatically injects them from `Context`:
+
+```java
+@Action(value = "upload", mode = Mode.HTTP_POST)
+public String upload(Request<?, ?> req, Response<?, ?> res) throws ApplicationException {
+    // req.getParameter("file"), res.setHeader(...), etc.
+    return "ok";
+}
+```

--- a/plugins/tinystruct/skills/developing-with-tinystruct/references/system-usage.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/references/system-usage.md
@@ -1,0 +1,72 @@
+# tinystruct System and Usage Reference
+
+## Context and CLI Arguments
+
+```java
+@Action("echo")
+public String echo() {
+    // CLI: bin/dispatcher echo --words "Hello World"
+    Object words = getContext().getAttribute("--words");
+    if (words != null) return words.toString();
+    return "No words provided";
+}
+```
+
+CLI flags passed as `--key value` are stored in `Context` as `"--key"` → value.
+
+## Session Management (Web Mode)
+
+```java
+@Action(value = "login", mode = Mode.HTTP_POST)
+public String login(Request request) {
+    request.getSession().setAttribute("userId", "42");
+    return "Logged in";
+}
+
+@Action("profile")
+public String profile(Request request) {
+    Object userId = request.getSession().getAttribute("userId");
+    if (userId == null) return "Not logged in";
+    return "User: " + userId;
+}
+```
+
+## Event System
+
+```java
+// 1. Define an event
+public class OrderCreatedEvent implements org.tinystruct.system.Event<Order> {
+    private final Order order;
+    public OrderCreatedEvent(Order order) { this.order = order; }
+
+    @Override public String getName() { return "order_created"; }
+    @Override public Order getPayload() { return order; }
+}
+
+// 2. Register a handler (typically in init())
+EventDispatcher.getInstance().registerHandler(OrderCreatedEvent.class, event -> {
+    CompletableFuture.runAsync(() -> sendConfirmationEmail(event.getPayload()));
+});
+
+// 3. Dispatch
+EventDispatcher.getInstance().dispatch(new OrderCreatedEvent(newOrder));
+```
+
+## Running the Application
+
+```bash
+# CLI mode
+bin/dispatcher hello
+bin/dispatcher greet/James
+bin/dispatcher echo --words "Hello" --import com.example.HelloApp
+
+# HTTP server (listens on :8080 by default)
+bin/dispatcher start --import org.tinystruct.system.HttpServer
+# Then: http://localhost:8080/?q=hello
+
+# Generate POJO from DB table
+bin/dispatcher generate --table users
+
+# Run SQL
+bin/dispatcher sql-query "SELECT * FROM users"
+```

--- a/plugins/tinystruct/skills/developing-with-tinystruct/references/testing.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/references/testing.md
@@ -1,0 +1,55 @@
+# tinystruct Testing Patterns
+
+Use JUnit 5 for testing tinystruct applications. Since `ActionRegistry` is a singleton, ensure fresh state is maintained between tests.
+
+## Unit Testing an Application
+
+```java
+import org.junit.jupiter.api.*;
+import org.tinystruct.application.ActionRegistry;
+import org.tinystruct.system.Settings;
+
+class MyAppTest {
+
+    private MyApp app;
+
+    @BeforeEach
+    void setUp() {
+        app = new MyApp();
+        // Set a minimal configuration to trigger init() and annotation processing
+        Settings config = new Settings();
+        app.setConfiguration(config);
+    }
+
+    @Test
+    void testHello() throws Exception {
+        // Direct invocation via the application object
+        Object result = app.invoke("hello");
+        Assertions.assertEquals("Hello, tinystruct!", result);
+    }
+
+    @Test
+    void testGreet() throws Exception {
+        // Invocation with arguments
+        Object result = app.invoke("greet", new Object[]{"James"});
+        Assertions.assertEquals("Hello, James!", result);
+    }
+}
+```
+
+## Testing via ActionRegistry
+
+If you need to test the routing logic itself:
+
+```java
+@Test
+void testRouting() {
+    ActionRegistry registry = ActionRegistry.getInstance();
+    // Verify a path matches an action
+    Action action = registry.getAction("greet/James");
+    Assertions.assertNotNull(action);
+}
+```
+
+For more complex `ActionRegistry` unit tests, follow the pattern in:
+`src/test/java/org/tinystruct/application/ActionRegistryTest.java`

--- a/plugins/tinystruct/skills/developing-with-tinystruct/references/testing.md
+++ b/plugins/tinystruct/skills/developing-with-tinystruct/references/testing.md
@@ -19,6 +19,7 @@ class MyAppTest {
         // Set a minimal configuration to trigger init() and annotation processing
         Settings config = new Settings();
         app.setConfiguration(config);
+        app.init();
     }
 
     @Test


### PR DESCRIPTION
## What problem are you trying to solve?
I wanted to add comprehensive developer expertise for the **tinystruct** Java framework to the repository. However, a "flat" one-file approach in the `skills/` directory was problematic because:
1.  **Clutter**: Domain-specific skills (like Java frameworks) mixed with core process skills (like TDD) make the library harder to navigate.
2.  **Inefficiency**: A single 370+ line document burns excessive context tokens and can cause models to "shortcut" the documentation.
3.  **Missing Pattern**: The project lacked a standardized location for technology-specific extensions.

## What does this PR change?
This PR introduces a **Modular Plugin Architecture** and adds the **Tinystruct Development Skill** as its first reference implementation:
*   **Infrastructure**: Created a `plugins/` directory and updated `.cursor-plugin/plugin.json` and `.claude-plugin/marketplace.json` to support auto-discovery of plugin-based skills.
*   **Modular Skill Design**: Instead of a "mega-file," the core `SKILL.md` is focused on triggers and high-level rules, while detailed technical guides (Routing, JSON, Testing) are contained in a `references/` subdirectory.
*   **Governance**: Established the architectural split in the `README.md`: `skills/` for methodology (Process) and `plugins/` for tech-stacks (Technology).

## Is this change appropriate for the core library?
Yes. It provides a scalable way to grow the library's technical expertise (Java, Backend, etc.) while keeping the Core Methodology clean and focused. It follows the guidance in `CLAUDE.md` that domain-specific skills belong in standalone structures.

## What alternatives did you consider?
*   **Adding `tinystruct-development.md` to `skills/`**: Rejected. It becomes too large to be effective and dilutes the core process-oriented focus of the `skills/` folder.
*   **Creating a separate repository**: Considered, but keeping the technology plugins alongside the core processes allows for tighter integration and easier maintenance for contributors.

## Does this PR contain multiple unrelated changes?
No. The infrastructural changes (Plugin folder) were created specifically to enable the scalable addition of the `tinystruct` skill.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: "none found"

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Gemini CLI | N/A | Gemini | 3 Flash |

## Evaluation
*   **Outcome**: By using the `references/` split, the agent only loads heavy technical documentation when explicitly mapping routes or handling JSON, saving ~300 lines of context per turn during general conversation.
*   **Discovery**: Verified that the new `plugins/` path is correctly recognized by the agent's skill activation tool.

## Rigor

- [x] I used `superpowers:writing-skills` patterns to ensure the new skill uses "Use when..." triggers.
- [x] Added "Red Flags" and "Pitfalls" tables to ensure the skill enforces framework-specific discipline (e.g., using the framework-native JSON `Builder`).

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
