### PR TITLE
fix: detect Python package manager before installing in worktree setup

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -109,9 +109,20 @@ if [ -f package.json ]; then npm install; fi
 # Rust
 if [ -f Cargo.toml ]; then cargo build; fi
 
-# Python
-if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-if [ -f pyproject.toml ]; then poetry install; fi
+# Python - detect package manager before installing
+if [ -f pyproject.toml ]; then
+  if grep -q '\[tool\.poetry\]' pyproject.toml; then
+    poetry install
+  elif [ -f uv.lock ]; then
+    uv sync
+  elif [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+  else
+    pip install -e .
+  fi
+elif [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi
 
 # Go
 if [ -f go.mod ]; then go mod download; fi


### PR DESCRIPTION
Closes #1108

## Problem

The `using-git-worktrees` skill unconditionally ran `poetry install` for any project containing a `pyproject.toml`:

```bash
# Old code
if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
if [ -f pyproject.toml ]; then poetry install; fi
```

`pyproject.toml` is now the standard Python project metadata file — it is used by `uv`, `pip`, `hatch`, `pdm`, `setuptools`, and many other tools, the vast majority of which are **not** Poetry. Running `poetry install` on these projects either fails outright (if Poetry is not installed) or produces an incorrect environment.

## Fix

Detect the actual package manager by inspecting file contents and lock files:

```bash
# New code
if [ -f pyproject.toml ]; then
  if grep -q '\[tool\.poetry\]' pyproject.toml; then
    poetry install
  elif [ -f uv.lock ]; then
    uv sync
  elif [ -f requirements.txt ]; then
    pip install -r requirements.txt
  else
    pip install -e .
  fi
elif [ -f requirements.txt ]; then
  pip install -r requirements.txt
fi
```

**Detection heuristic:**
| Signal | Action |
|--------|--------|
| `[tool.poetry]` in `pyproject.toml` | `poetry install` |
| `uv.lock` present | `uv sync` |
| `requirements.txt` present | `pip install -r requirements.txt` |
| Generic `pyproject.toml` | `pip install -e .` |
| Only `requirements.txt` | `pip install -r requirements.txt` |

Poetry projects are still handled correctly. Non-Poetry projects now get an appropriate install command instead of a Poetry error.

## Changed Files

- `skills/using-git-worktrees/SKILL.md`: updated "Run Project Setup" section
