### PR TITLE
brainstorm-server: validate websocket origin before upgrade

### DIFF
--- a/skills/brainstorming/scripts/server.cjs
+++ b/skills/brainstorming/scripts/server.cjs
@@ -124,6 +124,22 @@ function getNewestScreen() {
   return files.length > 0 ? files[0].path : null;
 }
 
+function isLoopbackHost(hostname) {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === HOST || hostname === URL_HOST;
+}
+
+function isTrustedWebSocketOrigin(originHeader) {
+  if (!originHeader) return true;
+
+  try {
+    const origin = new URL(originHeader);
+    const expectedPort = String(PORT);
+    return isLoopbackHost(origin.hostname) && origin.port === expectedPort;
+  } catch (error) {
+    return false;
+  }
+}
+
 // ========== HTTP Request Handler ==========
 
 function handleRequest(req, res) {
@@ -167,6 +183,12 @@ const clients = new Set();
 function handleUpgrade(req, socket) {
   const key = req.headers['sec-websocket-key'];
   if (!key) { socket.destroy(); return; }
+
+  const origin = req.headers.origin;
+  if (!isTrustedWebSocketOrigin(origin)) {
+    socket.destroy();
+    return;
+  }
 
   const accept = computeAcceptKey(key);
   socket.write(
@@ -351,4 +373,10 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };
+module.exports = {
+  computeAcceptKey,
+  encodeFrame,
+  decodeFrame,
+  OPCODES,
+  isTrustedWebSocketOrigin
+};

--- a/tests/brainstorm-server/server.test.js
+++ b/tests/brainstorm-server/server.test.js
@@ -45,6 +45,23 @@ async function fetch(url) {
   });
 }
 
+async function expectWebSocketOpen(url, options = {}) {
+  const ws = new WebSocket(url, options);
+  await new Promise((resolve, reject) => {
+    ws.on('open', resolve);
+    ws.on('error', reject);
+  });
+  return ws;
+}
+
+async function expectWebSocketReject(url, options = {}) {
+  const ws = new WebSocket(url, options);
+  await new Promise((resolve, reject) => {
+    ws.on('open', () => reject(new Error('WebSocket should have been rejected')));
+    ws.on('error', resolve);
+  });
+}
+
 function startServer() {
   return spawn('node', [SERVER_PATH], {
     env: { ...process.env, BRAINSTORM_PORT: TEST_PORT, BRAINSTORM_DIR: TEST_DIR }
@@ -188,11 +205,25 @@ async function runTests() {
     console.log('\n--- WebSocket Communication ---');
 
     await test('accepts WebSocket upgrade on /', async () => {
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
-      await new Promise((resolve, reject) => {
-        ws.on('open', resolve);
-        ws.on('error', reject);
+      const ws = await expectWebSocketOpen(`ws://localhost:${TEST_PORT}`);
+      ws.close();
+    });
+
+    await test('accepts localhost Origin on /', async () => {
+      const ws = await expectWebSocketOpen(`ws://localhost:${TEST_PORT}`, {
+        headers: { Origin: `http://localhost:${TEST_PORT}` }
       });
+      ws.close();
+    });
+
+    await test('rejects foreign Origin on /', async () => {
+      await expectWebSocketReject(`ws://localhost:${TEST_PORT}`, {
+        headers: { Origin: 'https://evil.example' }
+      });
+    });
+
+    await test('still accepts clients without Origin header', async () => {
+      const ws = await expectWebSocketOpen(`ws://localhost:${TEST_PORT}`);
       ws.close();
     });
 


### PR DESCRIPTION
## What problem are you trying to solve?
`obra/superpowers#1014` reports that the brainstorm companion server accepts WebSocket upgrades from arbitrary origins while also serving `/files/*` from the local brainstorm content directory.

That means an unrelated webpage visited during an active brainstorm session can attempt to connect to the localhost server, send crafted events, and interact with local brainstorm state even though the companion is intended to be loopback-only.

## What does this PR change?
This PR adds a narrow origin gate before the brainstorm WebSocket upgrade completes.

It introduces `isTrustedWebSocketOrigin()` in `skills/brainstorming/scripts/server.cjs`, rejects non-loopback origins before returning `101 Switching Protocols`, and adds focused harness coverage for localhost allow, foreign-origin reject, and no-origin compatibility in `tests/brainstorm-server/server.test.js`.

## Is this change appropriate for the core library?
Yes. This is a core localhost safety boundary in an existing first-party skill server, not a project-specific integration or workflow tweak.

## What alternatives did you consider?
I considered a session token or explicit per-session secret handshake, but that is a broader design change than the public issue asks for.

I also considered validating only against `sec-websocket-key`, but that does not address the cross-origin localhost browser case described in the issue.

A loopback/self-origin allowlist keeps the fix aligned with the current companion-server model while staying narrow.

## Does this PR contain multiple unrelated changes?
No. The change stays on one seam: WebSocket origin validation for the brainstorm server plus focused tests for that behavior.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex in Clio World workspace | browser + local shell workflow | GPT-5.4 | GPT-5.4 |

## Evaluation
- Initial prompt/session goal: investigate `obra/superpowers#1014` and verify whether the brainstorm localhost companion accepted cross-origin WebSocket upgrades without origin validation.
- Eval sessions run after the change: 2 focused harness reruns on the narrow brainstorm-server test surface.
- Outcome change compared to before:
  - before: the harness only proved generic WebSocket upgrade acceptance and had no regression coverage for origin trust boundaries.
  - after: the harness still accepts the expected loopback flow, still accepts clients without an `Origin` header, and now explicitly rejects a foreign origin (`https://evil.example`).

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Adversarial coverage here is on the server trust boundary rather than prose: the new tests cover localhost allow, foreign-origin reject, and no-origin compatibility.

Focused verification run:
- `cd tests/brainstorm-server && npm test -- --runInBand`
- result: `28 passed, 0 failed`

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

I am leaving this unchecked intentionally rather than claiming a human diff review that did not happen in this run.