### PR TITLE
feat: add feature-ship skill for release gate checklist

### DIFF
--- a/skills/feature-ship/SKILL.md
+++ b/skills/feature-ship/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: feature-ship
+description: Use before deploying to production, merging to a release branch, or shipping any user-facing change — runs a structured release gate checklist and blocks deployment when any gate fails
+---
+
+# Feature Ship
+
+## Overview
+
+Most production incidents come from features that were done but not ready. Done means the code works. Ready means the system is prepared for what happens next.
+
+**Core principle:** A feature isn't shipped until every gate passes. Not mostly. Not "close enough." Every gate.
+
+**Announce at start:** "I'm using the feature-ship skill to run the release gate checklist."
+
+## The Iron Law
+
+```
+DO NOT DEPLOY UNTIL EVERY GATE PASSES.
+FAILING GATES ARE NOT JUDGMENT CALLS.
+```
+
+A failing gate means the feature is not ready to ship. If a gate cannot pass, the deployment does not happen. Bring the failing gate to your human partner — don't negotiate with the checklist.
+
+## The Gates
+
+Run each gate in order. A gate must pass before the next is checked.
+
+---
+
+### Gate 1: Tests
+
+**Evidence required:** Run the full test suite. Show the output.
+
+```bash
+# Run your project's full test suite
+npm test / pytest / cargo test / go test ./... / bundle exec rspec
+```
+
+**Pass when:**
+- Exit code is 0
+- Zero failing tests
+- Coverage has not regressed below the project threshold (if tracked)
+
+**Block on:**
+- Any failing test
+- Tests newly marked as skipped since the last passing build
+- Coverage below threshold
+
+Stop here if tests fail. Fix them before checking any other gate.
+
+---
+
+### Gate 2: Acceptance Criteria
+
+**Evidence required:** Verify each AC from the feature spec one by one.
+
+```
+AC-1: [name] — PASS / FAIL / N/A
+AC-2: [name] — PASS / FAIL / N/A
+...
+```
+
+If no ACs exist: invoke `superpowers:acceptance-criteria` to write them retroactively, verify them, then continue.
+
+**Pass when:** Every AC is marked PASS or N/A with a documented reason.
+
+**Block on:** Any AC marked FAIL.
+
+---
+
+### Gate 3: Documentation
+
+Verify documentation reflects the shipped feature:
+
+- [ ] CHANGELOG or release notes entry written
+- [ ] Public API changes documented (if applicable)
+- [ ] README updated if behavior visible to users or developers changed
+- [ ] Inline code comments reflect current behavior, not previous behavior
+- [ ] Runbooks or operational docs updated (if applicable)
+
+**Pass when:** All applicable items are checked.
+
+**Block on:** Missing CHANGELOG entry. Undocumented public API changes.
+
+---
+
+### Gate 4: Breaking Changes
+
+Identify and explicitly account for any breaking changes:
+
+- [ ] No public APIs removed without a deprecation period (or removal documented)
+- [ ] No schema changes that would break existing data (or migration provided and tested)
+- [ ] No environment variable renames without backward compatibility (or documented)
+- [ ] Downstream consumers notified (if applicable)
+
+**Pass when:** No breaking changes exist, OR all breaking changes are explicitly documented and accepted by your human partner.
+
+**Block on:** Undocumented breaking changes. Breaking changes not explicitly reviewed.
+
+---
+
+### Gate 5: Rollback Plan
+
+Answer these four questions before deploying — with specifics, not intentions:
+
+1. **How do you detect a bad deploy?** (Which metric, error rate, or user signal tells you something is wrong?)
+2. **How do you roll back?** (The exact commands or steps — not "revert the PR")
+3. **What breaks if you roll back?** (Data mutations, schema changes, emails sent, webhooks fired)
+4. **How long does rollback take?** (Is this acceptable given the blast radius?)
+
+**Pass when:** All four questions are answered with specific, actionable answers.
+
+**Block on:** "We'll figure it out if something goes wrong." Vague rollback steps. Unanswered questions.
+
+---
+
+### Gate 6: Observability
+
+Verify the feature's behavior will be visible in production:
+
+- [ ] New code paths have appropriate logging at the right level
+- [ ] Key operations emit metrics or traces (if the project uses them)
+- [ ] Error conditions are logged — not swallowed silently
+- [ ] Alerts cover any new SLO-critical paths (or existing alerts are confirmed to cover them)
+
+**Pass when:** All applicable items are checked. No new errors fail silently.
+
+**Block on:** Critical errors swallowed without logging. New SLO-critical path with no alert coverage.
+
+---
+
+### Gate 7: Security
+
+Verify no security regressions:
+
+- [ ] No new inputs accepted without validation and sanitization
+- [ ] No authorization levels changed without explicit review (public ↔ authenticated ↔ admin)
+- [ ] No secrets introduced in code, logs, or error messages
+- [ ] No new dependencies with known vulnerabilities (`npm audit` / `cargo audit` / equivalent)
+- [ ] No new admin or privileged functionality without authorization checks
+
+**Pass when:** All items checked or marked N/A with a documented reason.
+
+**Block on:** Unvalidated input. Incorrect authorization. Exposed secrets.
+
+---
+
+### Gate 8: Human Partner Sign-Off
+
+Present the gate summary and wait for explicit approval:
+
+> "All gates passed. Here's the summary:
+>
+> - Tests: [N/N passing]
+> - ACs: [N/N verified]
+> - Docs: [updated / N/A]
+> - Breaking changes: [none / documented and accepted]
+> - Rollback: [detect via X, roll back with Y, takes Z minutes]
+> - Observability: [in place / N/A]
+> - Security: [verified / N/A]
+>
+> Ready to deploy to [environment]?"
+
+Wait for an explicit "yes" or equivalent. Do not deploy on implied consent, silence, or "sounds good."
+
+---
+
+## Gate Summary Report
+
+After running all gates, produce a summary and save it:
+
+```markdown
+## Feature Ship Report — [Feature Name]
+
+**Date:** YYYY-MM-DD
+**Environment:** [staging / production / etc.]
+**Deploying:** [what is being shipped]
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| 1. Tests | ✅ PASS | 142/142 passing |
+| 2. Acceptance Criteria | ✅ PASS | 7/7 verified |
+| 3. Documentation | ✅ PASS | CHANGELOG updated |
+| 4. Breaking Changes | ✅ PASS | None |
+| 5. Rollback Plan | ✅ PASS | Revert deploy + run migration-rollback |
+| 6. Observability | ✅ PASS | Metrics added, alert threshold updated |
+| 7. Security | ✅ PASS | No new inputs; deps clean |
+| 8. Human Sign-Off | ✅ PASS | Approved by [name] at [time] |
+
+**Overall: READY TO DEPLOY**
+```
+
+Save to `docs/superpowers/ships/YYYY-MM-DD-[feature-name].md` before deploying. Commit it.
+
+---
+
+## When a Gate Fails
+
+1. **Stop.** Do not check the next gate. Do not deploy.
+2. **Report clearly:** "Gate [N] — [gate name] — FAIL: [specific reason]."
+3. **Present options to your human partner:** fix the issue, accept the risk explicitly, or postpone deployment.
+4. **Do not proceed without explicit direction.** No gate failure is automatically acceptable.
+
+## Red Flags — STOP
+
+- Deploying before all gates pass ("it's close enough")
+- Skipping gates because the change is "small" (small changes cause small incidents — or large ones)
+- Running gates after deployment instead of before
+- Treating a FAIL result as a judgment call rather than a stop
+- Producing gate results without actually running the gate ("tests should pass")
+- Skipping human sign-off on urgent deploys ("no time")
+- Answering rollback questions with intentions instead of specifics
+- Counting passing tests as passing all gates
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "The tests pass, we're good" | Tests are Gate 1 of 8. |
+| "It's a small change, no need for the full checklist" | Small changes cause small incidents. Or large ones. Run the checklist. |
+| "We need to ship now, we'll document after" | "Document later" means "document never." |
+| "The rollback is obvious" | Obvious rollback plans fail under pressure. Write them down now. |
+| "No breaking changes in this PR" | What about the migration? The config key rename? The webhook shape change? Run the gate. |
+| "We don't have observability for this" | Add it. Or accept that you're flying blind in production. |
+| "Security review is for big features" | Bugs don't check feature size. |
+| "My human partner knows we're shipping" | Implied consent is not consent. Wait for "yes." |
+| "This gate doesn't apply to us" | Document why explicitly. Don't silently skip it. |
+
+## Quick Reference
+
+| Gate | Evidence Required | Common Block |
+|------|------------------|--------------|
+| 1. Tests | Test output: exit 0, 0 failures | Failing tests |
+| 2. Acceptance Criteria | Per-AC PASS / FAIL / N/A | Any AC marked FAIL |
+| 3. Documentation | Checklist complete | Missing CHANGELOG entry |
+| 4. Breaking Changes | None or documented + accepted | Undocumented API or schema break |
+| 5. Rollback Plan | 4 questions answered specifically | Vague "revert the PR" answer |
+| 6. Observability | Checklist complete | Silent error paths; uncovered SLO |
+| 7. Security | Checklist complete | Unvalidated input; wrong auth level |
+| 8. Sign-Off | Explicit "yes" from human partner | No response; implied consent |
+
+## Integration
+
+**Runs before:**
+- Any deployment to production
+- Merging to the main or release branch when that triggers a deploy
+- Publishing a library or package version
+
+**Called after:**
+- **superpowers:finishing-a-development-branch** — that skill handles git integration; this skill gates the deploy that follows
+
+**Pairs with:**
+- **superpowers:acceptance-criteria** — ACs written there become Gate 2 here
+- **superpowers:verification-before-completion** — verification covers code correctness; feature-ship covers deployment readiness
+- **superpowers:test-driven-development** — passing Gate 1 is the payoff of having followed TDD throughout

--- a/skills/feature-ship/SKILL.md
+++ b/skills/feature-ship/SKILL.md
@@ -11,6 +11,8 @@ Most production incidents come from features that were done but not ready. Done 
 
 **Core principle:** A feature isn't shipped until every gate passes. Not mostly. Not "close enough." Every gate.
 
+**Relationship to existing skills:** `verification-before-completion` covers code correctness (does it work?). `finishing-a-development-branch` covers git integration (merge, PR, worktree). This skill covers the gap between them and production: the eight questions every team must answer before deploying, regardless of language, platform, or domain.
+
 **Announce at start:** "I'm using the feature-ship skill to run the release gate checklist."
 
 ## The Iron Law
@@ -220,6 +222,7 @@ Save to `docs/superpowers/ships/YYYY-MM-DD-[feature-name].md` before deploying. 
 | "The tests pass, we're good" | Tests are Gate 1 of 8. |
 | "It's a small change, no need for the full checklist" | Small changes cause small incidents. Or large ones. Run the checklist. |
 | "We need to ship now, we'll document after" | "Document later" means "document never." |
+| "It's a hotfix — no time for the full checklist" | Hotfixes go to production too. A 5-minute checklist is faster than a 2-hour rollback. Run Gates 1, 5, and 8 at minimum. |
 | "The rollback is obvious" | Obvious rollback plans fail under pressure. Write them down now. |
 | "No breaking changes in this PR" | What about the migration? The config key rename? The webhook shape change? Run the gate. |
 | "We don't have observability for this" | Add it. Or accept that you're flying blind in production. |


### PR DESCRIPTION
## What problem does this solve?

**Specific failure mode:** A feature's code works — tests pass, branch is merged — but the deploy fails or causes a production incident because questions that weren't about code correctness weren't answered before shipping. Tests weren't run against production config. Rollback hadn't been thought through. A silent error path wasn't wired to observability. An API shape changed without consumers being notified.

The gap is between "done" and "ready." The existing skills cover both ends of a feature's life — `verification-before-completion` covers code correctness; `finishing-a-development-branch` covers git integration. Neither covers the deploy decision itself.

**Failure pattern I encountered:** Treating "tests pass, PR merged" as deployment readiness. In practice: no CHANGELOG entry, no rollback plan, newly introduced unvalidated input, no alert for the new code path. Each is a separate category of incident risk that tests can't catch.

## What does this change do?

Adds `skills/feature-ship/SKILL.md` — a discipline skill with an Iron Law and 8 sequential gates that must all pass before any deployment.

**The 8 gates:**
1. Tests — run full suite, exit 0, zero failures
2. Acceptance Criteria — verify per-AC against spec (invokes `acceptance-criteria` skill if ACs don't exist)
3. Documentation — CHANGELOG, API docs, README, inline comments
4. Breaking Changes — no undocumented API/schema/env breaks
5. Rollback Plan — four specific questions answered (how to detect, how to roll back, what breaks, how long)
6. Observability — logging, metrics, alerts for new code paths
7. Security — input validation, authorization, secrets, deps
8. Human Partner Sign-Off — explicit "yes," no implied consent

**Gate format:** each gate defines exactly what evidence passes it and exactly what blocks it. No judgment calls — a failing gate is a stop, not a negotiation.

**Gate Summary Report:** saved to `docs/superpowers/ships/YYYY-MM-DD-[feature].md` and committed before deploying.

## What does this NOT overlap with?

The overview explicitly documents the boundary:

> `verification-before-completion` covers code correctness (does it work?). `finishing-a-development-branch` covers git integration (merge, PR, worktree). This skill covers the gap between them and production: the eight questions every team must answer before deploying, regardless of language, platform, or domain.

None of the 8 gates duplicate what `verification-before-completion` checks. Gate 1 uses the same evidence standard (run the command, read the output), but the gate structure applies that standard to a deployment decision rather than a code claim.

## Prior art: PR #424

PR #424 ("feat: add pre-deployment checklist") was closed with the comment that it was domain-specific (CI/CD pipeline focused) and contained iOS App Store and Web3-specific steps.

**What is different here:**

- No platform-specific steps. All 8 gates are language and platform agnostic.
- No CI/CD pipeline configuration. The skill is about the deployment decision, not the deployment mechanism.
- No iOS, App Store, Web3, or toolchain-specific content.
- The 8 gates use generic commands (`npm test / pytest / cargo test / go test ./... / bundle exec rspec`) as examples, not prescriptions.
- Integrates with the existing skill graph (`acceptance-criteria`, `finishing-a-development-branch`, `verification-before-completion`) rather than standing alone.

The core question from the PR #424 closure — "is this general-purpose?" — is answered by the gate structure: every gate asks a question that every deploy must answer, regardless of stack.

## What alternatives did you consider?

1. **Extending `finishing-a-development-branch`** — that skill ends at "merge the PR." Adding deployment gates to it would conflate two distinct decisions (git integration and deploy readiness). Rejected in favor of a separate skill that explicitly calls out the handoff.

2. **Extending `verification-before-completion`** — VBC covers code claims; deploy readiness covers a broader surface (rollback, observability, docs, breaking changes). Rejected because they answer different questions.

3. **Single "done checklist"** combining VBC + git + deploy — a monolithic checklist that runs at the end of everything. Rejected because it would eliminate the useful modularity between code verification, branch completion, and deployment.

## Have you searched for existing PRs?

Searched open and closed PRs for: "ship", "deploy", "release", "checklist", "gate", "production", "pre-deploy", "rollback".

- **PR #424** (closed): "feat: add pre-deployment checklist" — addressed above.
- No other open or closed PRs targeting deploy readiness found.
- No conflicts with open PRs.

## Does this belong in core?

Yes. The 8-gate structure represents decisions every team must make before deploying, regardless of domain, language, or infrastructure. No gate references any third-party tool, service, or platform. The rollback questions, observability checklist, and security checklist are intentionally written to work for a CLI tool, a web service, a library, or a mobile app.

## Environment

| Harness | Version | Tested |
|---------|---------|--------|
| Claude Code | claude-sonnet-4-5 | ✅ |

## Evaluation

**Without the skill (RED baseline):**

"Tests pass, PR merged — ship it." Deploy goes out. New error path swallows exceptions silently. No rollback plan when an edge case triggers in production. 45-minute incident, manual rollback by reading git history under pressure.

**With the skill (GREEN):**

Gate 6 (Observability): new error path identified, logging added before deploy. Gate 5 (Rollback Plan): rollback steps documented before deploy. If incident occurs, rollback is the command already written in the ship report, not improvised under pressure.

**Adversarial scenarios tested:**

1. **"Tests pass, we're good"** — Gate 1 passes, gates 2–8 still run. Red Flag: "Counting passing tests as passing all gates."

2. **"It's a hotfix, no time"** — Rationalization table: "Hotfixes go to production too. A 5-minute checklist is faster than a 2-hour rollback. Run Gates 1, 5, and 8 at minimum."

3. **"Small change, skip the checklist"** — Red Flag: "Skipping gates because the change is 'small'." Rationalization: "Small changes cause small incidents. Or large ones."

4. **"My human partner knows we're shipping"** — Gate 8 requires explicit "yes." Rationalization: "Implied consent is not consent. Wait for 'yes.'"

5. **"The rollback is obvious"** — Gate 5 blocks on vague rollback steps. Rationalization: "Obvious rollback plans fail under pressure. Write them down now."

## Rigor

- [x] Adversarial pressure testing: 5+ scenarios designed and reasoned through; loopholes closed in Red Flags and Rationalizations
- [x] Iron Law established with explicit block behavior
- [x] Each gate defines evidence required and specific block conditions — no judgment calls
- [x] Explicitly addresses prior art (PR #424) and documents what is different
- [x] No platform-specific steps anywhere in the skill
- [x] No third-party dependencies added
- [x] One skill per PR (this PR: feature-ship only)
- [x] Human review: human partner approved this submission