### PR TITLE
feat(writing-plans): add model directive support for automatic model switching

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -42,6 +42,22 @@ This structure informs the task decomposition. Each task should produce self-con
 - "Run the tests and make sure they pass" - step
 - "Commit" - step
 
+## Model Directives (optional)
+
+If the user has a `plan-model-switch` hook installed, adding `<!-- model: xxx -->` directives before each step group enables automatic model switching as the agent works through the plan. Use the lowest-cost model sufficient for each step type:
+
+| Step type | Directive | Why |
+|-----------|-----------|-----|
+| Write tests, write implementation, refactor | `<!-- model: sonnet -->` | Needs codebase understanding |
+| Run commands, commit, install deps, mechanical steps | `<!-- model: haiku -->` | No reasoning needed — just execute |
+| Architecture decisions, hard debugging, design | `<!-- model: opus -->` | Deep reasoning required |
+
+**How it works:** The hook fires when the plan file is read. It finds the first unchecked task (`- [ ]`) and looks upward for the nearest `<!-- model: xxx -->` directive. As tasks complete and get checked off, re-reading the plan automatically advances to the next phase's model.
+
+**Opt-in:** Plans without directives behave exactly as before. Only add directives if the user has the hook installed or wants to annotate plans for cost awareness.
+
+**Split at model boundaries:** Don't mix step types under one directive. Give `haiku` steps (run/commit) their own group with their own directive.
+
 ## Plan Document Header
 
 **Every plan MUST start with this header:**
@@ -70,6 +86,7 @@ This structure informs the task decomposition. Each task should produce self-con
 - Modify: `exact/path/to/existing.py:123-145`
 - Test: `tests/exact/path/to/test.py`
 
+<!-- model: sonnet -->
 - [ ] **Step 1: Write the failing test**
 
 ```python
@@ -78,11 +95,13 @@ def test_specific_behavior():
     assert result == expected
 ```
 
+<!-- model: haiku -->
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `pytest tests/path/test.py::test_name -v`
 Expected: FAIL with "function not defined"
 
+<!-- model: sonnet -->
 - [ ] **Step 3: Write minimal implementation**
 
 ```python
@@ -90,6 +109,7 @@ def function(input):
     return expected
 ```
 
+<!-- model: haiku -->
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `pytest tests/path/test.py::test_name -v`
@@ -102,6 +122,8 @@ git add tests/path/test.py src/path/file.py
 git commit -m "feat: add specific feature"
 ```
 ````
+
+**Note:** The `<!-- model: xxx -->` directives are optional. Omit them if the user hasn't configured model switching. When present, they must immediately precede the `- [ ]` step(s) they apply to.
 
 ## No Placeholders
 


### PR DESCRIPTION
## Summary

Adds `<!-- model: xxx -->` directive support to the `writing-plans` skill so that generated plans embed explicit model hints at each phase boundary. A companion PostToolUse hook (installed separately in `~/.claude/settings.json`) reads these directives and auto-switches the active Claude model as the plan is executed.

### How it works

Plans generated by `writing-plans` now include directives immediately before task checklists:

```markdown
<!-- model: sonnet -->
- [ ] Write the failing test
- [ ] Implement the minimal code

<!-- model: haiku -->
- [ ] Run: `pytest tests/path/test.py -v`
- [ ] Commit
```

A hook registered in `~/.claude/settings.json` fires on every `Read` tool call. When it reads a `.md` file that contains both `<!-- model: -->` directives and unchecked `- [ ]` tasks, it finds the directive for the current phase (the one above the first unchecked task) and writes the resolved model ID to `~/.claude/settings.local.json`. Claude Code picks this up immediately.

### Model assignment rules

| Task type | Model | Why |
|-----------|-------|-----|
| Architecture, design decisions, hard debugging | `opus` | Deep reasoning required |
| Writing tests, writing implementation, refactoring | `sonnet` | Needs codebase understanding |
| Running commands, committing, installing deps | `haiku` | No reasoning needed |

### Hook setup (companion config)

```json
// ~/.claude/settings.json — PostToolUse section
{
  "PostToolUse": [
    {
      "matcher": "Read",
      "hooks": [
        {
          "type": "command",
          "command": "$HOME/.claude/hooks/plan-model-switch.sh"
        }
      ]
    }
  ]
}
```

```bash
#!/usr/bin/env bash
# ~/.claude/hooks/plan-model-switch.sh
trap 'exit 0' ERR
SETTINGS_FILE="$HOME/.claude/settings.local.json"
INPUT=$(cat)
TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
[ "$TOOL_NAME" != "Read" ] && exit 0
FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
echo "$FILE_PATH" | grep -qE '\.md$' || exit 0
CONTENT=$(echo "$INPUT" | jq -r '
  if (.tool_response | type) == "string" then .tool_response
  elif (.tool_response.content | type) == "string" then .tool_response.content
  else empty
  end
' 2>/dev/null)
[ -z "$CONTENT" ] && exit 0
echo "$CONTENT" | grep -q '^- \[ \]' || exit 0
MODEL=$(echo "$CONTENT" | awk '
  /<!-- model:/ {
    m = $0; gsub(/.*<!-- model: */, "", m); gsub(/ *-->.*/, "", m)
    gsub(/^[ \t]+|[ \t]+$/, "", m); current = m
  }
  /^- \[ \]/ { if (current != "") { print current }; exit }
')
[ -z "$MODEL" ] && exit 0
case "$(echo "$MODEL" | tr '[:upper:]' '[:lower:]')" in
  opus*|claude-opus*)     FULL_MODEL="claude-opus-4-6" ;;
  sonnet*|claude-sonnet*) FULL_MODEL="claude-sonnet-4-6" ;;
  haiku*|claude-haiku*)   FULL_MODEL="claude-haiku-4-5-20251001" ;;
  *) exit 0 ;;
esac
CURRENT=$(jq -r '.model // empty' "$SETTINGS_FILE" 2>/dev/null)
[ "$CURRENT" = "$FULL_MODEL" ] && exit 0
[ ! -f "$SETTINGS_FILE" ] && echo '{}' > "$SETTINGS_FILE"
jq --arg m "$FULL_MODEL" '.model = $m' "$SETTINGS_FILE" > /tmp/plan-model-tmp.json \
  && mv /tmp/plan-model-tmp.json "$SETTINGS_FILE"
```

### Changes

- `skills/writing-plans/SKILL.md`: Added **Model Directives** section with 3-tier model table, updated Task Structure template to include directives at step boundaries, added rule about splitting tasks at model boundaries

### Notes

- Directives are **opt-in** — plans without them behave exactly as before
- The hook fires globally on all `.md` reads, not just plan files — it only acts when both a directive and unchecked tasks are present
- Works with any skill or plan file, not just `writing-plans` output
- Closes #1115