### PR TITLE
Add security-reviewer skill

### DIFF
--- a/docs/testing/security-reviewer-test-report.md
+++ b/docs/testing/security-reviewer-test-report.md
@@ -1,0 +1,110 @@
+# Test Report: security-reviewer
+
+## Goal
+
+Verify that a specialized security review skill pushes the reviewer toward evidence-backed security findings, explicit source-to-sink reasoning, and regression detection instead of generic code review comments.
+
+## RED Phase Baseline Scenarios
+
+These scenarios are designed to expose how a generic reviewer can miss security-relevant changes by focusing on style, architecture, or tests instead of trust boundaries and security regressions.
+
+### Scenario 1: Authorization check moved after data access
+
+**Pressure:** Clean refactor appearance, passing tests, tempting to call it harmless.
+
+**Prompt:**
+
+```markdown
+IMPORTANT: This is a real review scenario. You must review the change and decide if it is security-ready.
+
+A pull request refactors an endpoint handler. Before the change, ownership was checked before loading a billing record. After the change, the handler loads the billing record by ID first, then checks ownership against a field on the loaded object.
+
+Diff summary:
+- old: `requireAccountAccess(req.user, accountId)` before `loadInvoice(invoiceId)`
+- new: `invoice = loadInvoice(invoiceId)` then `requireAccountAccess(req.user, invoice.accountId)`
+- tests still pass
+- reviewer notes say "nice cleanup, less parameter threading"
+
+What do you do? Provide your review.
+```
+
+**Expected baseline failure patterns:**
+- praises refactor cleanliness without examining IDOR risk
+- assumes post-load check is equivalent without tracing trust boundary
+- focuses on tests, style, or maintainability only
+
+### Scenario 2: Validation narrowed during parser refactor
+
+**Pressure:** Validation still exists, code looks cleaner, change seems low-risk.
+
+**Prompt:**
+
+```markdown
+IMPORTANT: This is a real review scenario. You must review the change and decide if it is security-ready.
+
+A PR refactors webhook verification.
+
+Before:
+- Rejects requests missing `x-signature`
+- Rejects duplicate headers
+- Canonicalizes header casing
+- Verifies HMAC over raw body bytes
+
+After:
+- Reads the first `x-signature` value if present
+- Uses parsed JSON body instead of raw bytes
+- Leaves the rest of the verification flow intact
+- Existing unit tests still pass
+
+Review this change for merge readiness.
+```
+
+**Expected baseline failure patterns:**
+- says verification still exists so change is fine
+- misses canonicalization / duplicate-header regression
+- misses raw-body versus parsed-body trust change
+
+### Scenario 3: SSRF guard bypass through nearby sibling path
+
+**Pressure:** Original fix exists, diff only adds a new helper path, easy to miss sibling issue.
+
+**Prompt:**
+
+```markdown
+IMPORTANT: This is a real review scenario. You must review the change and decide if it is security-ready.
+
+A previous SSRF fix introduced `fetchWithHostnameBlocklist(url)` and replaced direct fetches in most import paths.
+
+This PR adds a new preview feature:
+- `previewRemoteImage(url)`
+- implementation calls raw `fetch(url)` directly
+- author says it is safe because it only fetches images and does not reuse credentials
+- the earlier SSRF bug was considered fixed already
+
+Review the change.
+```
+
+**Expected baseline failure patterns:**
+- accepts the author’s safety claim without tracing network trust boundary
+- misses sibling pattern despite prior SSRF fix
+- treats it as a generic code consistency issue, not security regression risk
+
+## GREEN Expectations
+
+With the `security-reviewer` skill loaded, the reviewer should:
+- identify the relevant trust boundary in each scenario
+- trace source → propagation → sink or broken control
+- explicitly call out regression risk where prior defenses were weakened or bypassed
+- avoid padding with generic style feedback
+- give a clear merge-readiness assessment tied to security evidence
+
+## REFACTOR Targets
+
+If the reviewer still fails after the skill, capture rationalizations such as:
+- "tests pass so behavior is probably equivalent"
+- "there is still an auth check, so not a security issue"
+- "this is more of a code quality concern than security"
+- "the old fix still exists elsewhere"
+- "it only affects images / internal tools / background jobs"
+
+Then tighten the skill against those exact shortcuts.

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -21,6 +21,15 @@ Dispatch superpowers:code-reviewer subagent to catch issues before they cascade.
 - Before refactoring (baseline check)
 - After fixing complex bug
 
+## When to Use a Specialized Reviewer
+
+Use a specialized reviewer instead of, or in addition to, the generic code reviewer when the completed change has a dominant risk area.
+
+Examples:
+- Use `superpowers:security-reviewer` when the diff touches trust boundaries, attacker-controlled input, authentication, authorization, secrets, dangerous sinks, or recent security fixes that might regress.
+
+If a change is both generally complex and security-sensitive, do both reviews: security review first, then generic code review.
+
 ## How to Request
 
 **1. Get git SHAs:**
@@ -29,9 +38,13 @@ BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
 HEAD_SHA=$(git rev-parse HEAD)
 ```
 
-**2. Dispatch code-reviewer subagent:**
+**2. Dispatch the right reviewer subagent:**
 
-Use Task tool with superpowers:code-reviewer type, fill template at `code-reviewer.md`
+Default: use Task tool with `superpowers:code-reviewer`, fill template at `code-reviewer.md`
+
+Security-sensitive changes: use Task tool with `superpowers:security-reviewer`, fill the specialized template at `../security-reviewer/security-reviewer.md`
+
+For mixed-risk changes, run the security reviewer first, then the generic code reviewer.
 
 **Placeholders:**
 - `{WHAT_WAS_IMPLEMENTED}` - What you just built
@@ -80,14 +93,17 @@ You: [Fix progress indicators]
 - Review after EACH task
 - Catch issues before they compound
 - Fix before moving to next task
+- If task is security-sensitive, dispatch `superpowers:security-reviewer` before the generic review
 
 **Executing Plans:**
 - Review after each batch (3 tasks)
 - Get feedback, apply, continue
+- Add specialized security review when the batch changes trust boundaries or security controls
 
 **Ad-Hoc Development:**
 - Review before merge
 - Review when stuck
+- Use specialized review for security-sensitive diffs
 
 ## Red Flags
 

--- a/skills/security-reviewer/SKILL.md
+++ b/skills/security-reviewer/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: security-reviewer
+description: Use when reviewing code changes, completed tasks, or pull requests that touch trust boundaries, attacker-controlled input, authentication, authorization, secrets, dangerous sinks, or security-sensitive data flows.
+---
+
+# Security Reviewer
+
+Review code changes for real security risk, not generic code quality.
+
+**Core principle:** Prove the path. Report only issues you can trace from attacker control to a meaningful sink, broken boundary, or unsafe assumption.
+
+## When to Use
+
+Use this after implementation when the diff includes any of:
+- input parsing, deserialization, templating, file handling, redirects, fetches, command execution
+- authn, authz, session, tenancy, access control, role checks
+- secrets, tokens, crypto, signing, trust decisions
+- webhooks, background jobs, callbacks, integration boundaries
+- new endpoints, middleware, security checks, validation, or bypass-prone conditionals
+
+Do not use for purely stylistic review, dependency update sweeps, or generic architecture review with no security-sensitive change.
+
+## Review Process
+
+1. Read the diff first.
+2. Mark the trust boundary that changed.
+3. Identify attacker-controlled or externally-influenced inputs.
+4. Trace source → propagation → sink.
+5. Verify the actual guard: validation, auth check, canonicalization, invariant, or policy decision.
+6. Compare the intended control with the real code path.
+7. Check whether the change introduces a security regression by weakening, removing, reordering, or bypassing an existing control.
+8. Check nearby changed code for the first sibling pattern with the same weakness.
+9. Report only evidence-backed findings.
+
+## What Counts as a Real Finding
+
+A real finding has all of:
+- a controllable or influenceable source
+- a reachable path through changed or affected code
+- a meaningful sink, trust break, or missing security invariant
+- a clear reason the current guard is absent, bypassable, or incorrectly scoped
+
+If you cannot explain the path, downgrade it to a question or omit it.
+
+## Security Checklist
+
+Treat regressions as first-class findings. A change can be security-relevant even when it does not introduce a brand new bug, if it re-opens a previously closed path or weakens an established defense.
+
+Check these areas when relevant:
+- **Input handling:** validation, normalization, canonicalization, parser assumptions
+- **Authn/Authz:** missing checks, wrong object scope, tenant mix-ups, stale trust in caller-supplied identity
+- **Data flow:** untrusted input reaching templates, queries, filesystem, URLs, shells, interpreters, redirects, or dynamic loaders
+- **State transitions:** privilege changes, account linking, workflow bypasses, idempotency and replay assumptions
+- **Secrets/Crypto:** token exposure, weak trust decisions, incorrect verification, dangerous fallback behavior
+- **Defense boundaries:** middleware order, allowlist/blocklist gaps, internal-only assumptions, unsafe defaults
+
+## Severity Rules
+
+A regression that reintroduces a previously fixed serious issue should be treated at the severity of the re-opened impact, not downgraded just because the code existed before in a different form.
+
+**Critical**
+- Credible path to RCE, auth bypass, privilege escalation, tenant breakout, arbitrary file access, sensitive secret exposure, or meaningful integrity loss
+
+**Important**
+- Reachable security weakness with constrained impact, incomplete guard, or strong regression risk that should be fixed before merge
+
+**Minor**
+- Hardening gaps, suspicious assumptions, or defense-in-depth improvements without a demonstrated exploit path
+
+## Output Format
+
+### Strengths
+[Security controls or design choices that are actually sound]
+
+### Issues
+
+#### Critical (Must Fix)
+#### Important (Should Fix)
+#### Minor (Nice to Have)
+
+For each issue include:
+- File:line
+- Source
+- Sink / broken boundary
+- Regression note (if applicable)
+- Why the current guard fails
+- Why it matters
+- Suggested fix direction
+
+### Assessment
+
+**Security ready to merge?** [Yes/No/With fixes]
+
+**Reasoning:** [1-2 sentences]
+
+## Red Flags
+
+Never:
+- report a theoretical issue without a path
+- assume attacker control without showing where it comes from
+- confuse generic code quality problems with security findings
+- call something auth bypass unless you traced the authorization boundary
+- list many weak suspicions instead of the few strongest issues
+
+## Companion template
+
+When dispatching a specialized reviewer, use `security-reviewer/security-reviewer.md`.
+
+## Review Heuristic
+
+Prefer one strong, well-traced security finding over five vague warnings.

--- a/skills/security-reviewer/security-reviewer.md
+++ b/skills/security-reviewer/security-reviewer.md
@@ -1,0 +1,118 @@
+# Security Review Agent
+
+You are reviewing code changes for security regressions and newly introduced security weaknesses.
+
+**Your task:**
+1. Review the changed code and surrounding context
+2. Identify trust boundaries touched by the diff
+3. Trace attacker-controlled or externally influenced input to meaningful sinks
+4. Detect missing, bypassable, or regressed security controls
+5. Check whether the change reintroduces a previously-known bug pattern or weakens an existing guard
+6. Categorize findings by severity
+7. Assess whether the change is security-ready to merge
+
+## What Was Implemented
+
+{DESCRIPTION}
+
+## Requirements / Plan
+
+{PLAN_REFERENCE}
+
+## Git Range to Review
+
+**Base:** {BASE_SHA}
+**Head:** {HEAD_SHA}
+
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+## Core Review Standard
+
+Only report issues you can support with a concrete code path, broken security boundary, or credible regression in an existing control.
+
+Prefer a small number of strong findings over many vague warnings.
+
+## Review Checklist
+
+**Trust boundaries**
+- What external or lower-trust inputs cross into a higher-trust context?
+- Did the diff weaken an existing trust boundary?
+- Did a previous explicit guard become implicit, optional, reordered, or removed?
+
+**Security regressions**
+- Does the change undo or narrow a prior fix?
+- Does a refactor move validation or authorization later in the flow?
+- Does a new code path bypass existing checks?
+- Does changed middleware, routing, caching, or object mapping re-open a previously closed issue?
+
+**Input to sink tracing**
+- Source: where can attacker-controlled or externally-influenced data enter?
+- Propagation: how does that data move through the code?
+- Sink: where does it reach a dangerous operation, trust decision, or sensitive object?
+- Guard: what validation, canonicalization, auth check, or invariant is supposed to stop abuse?
+
+**High-signal security areas**
+- Authentication and authorization
+- Multi-tenant scoping and object ownership
+- Deserialization and parser assumptions
+- Templating and injection surfaces
+- SSRF, redirects, fetches, callbacks, webhooks
+- Filesystem and path handling
+- Secrets, tokens, signing, crypto verification
+- Background jobs, async retries, state transitions, replay assumptions
+
+**Regression-oriented checks**
+- Nearby sibling code with the same pattern still present?
+- Previously centralized check now duplicated inconsistently?
+- Old safe default replaced with caller-controlled behavior?
+- Error handling changed in a way that leaks sensitive data or changes authorization outcomes?
+
+## Output Format
+
+### Strengths
+[Security-relevant choices that are sound and worth preserving]
+
+### Issues
+
+#### Critical (Must Fix)
+[Credible path to serious impact such as auth bypass, privilege escalation, secret exposure, RCE, arbitrary file access, or tenant breakout]
+
+#### Important (Should Fix)
+[Reachable weakness, incomplete fix, or realistic security regression that should be addressed before merge]
+
+#### Minor (Nice to Have)
+[Hardening gaps or defense-in-depth improvements without a demonstrated high-impact path]
+
+**For each issue include:**
+- File:line
+- Source
+- Sink or broken boundary
+- Regression note (if applicable)
+- Why the current guard fails
+- Why it matters
+- Suggested fix direction
+
+### Assessment
+
+**Security ready to merge?** [Yes/No/With fixes]
+
+**Reasoning:** [1-2 sentences]
+
+## Critical Rules
+
+**DO:**
+- Read the diff before forming conclusions
+- Trace the full path for each serious finding
+- Call out regressions explicitly when a prior control was weakened or bypassed
+- Distinguish newly introduced issues from pre-existing ones when possible
+- Acknowledge sound security decisions in the change
+
+**DON'T:**
+- Report theoretical findings without attacker path evidence
+- Assume user control without showing where it enters
+- Treat generic style or maintainability comments as security issues
+- Inflate severity for weak or speculative concerns
+- Ignore regressions just because the code looks cleaner after refactor


### PR DESCRIPTION
## Summary

This PR adds a new `security-reviewer` skill for security-focused review of code changes.

The goal is to complement the existing generic review flow with a specialized reviewer for changes that touch trust boundaries, attacker-controlled input, authentication, authorization, secrets, dangerous sinks, and security-sensitive data flows.

The skill is designed to push review toward:
- evidence-backed findings
- explicit source → propagation → sink reasoning
- trust-boundary analysis
- security regression detection
- clear merge-readiness assessment

It also integrates the specialized reviewer into the existing `requesting-code-review` workflow for security-sensitive diffs.

## Included

- `skills/security-reviewer/SKILL.md`
- `skills/security-reviewer/security-reviewer.md`
- `docs/testing/security-reviewer-test-report.md`
- update to `skills/requesting-code-review/SKILL.md` to route security-sensitive changes to the specialized reviewer

## Why

Generic code review can miss:
- weakened existing guards
- auth/authz regressions
- reintroduced bug patterns after refactors
- unsafe source-to-sink paths
- sibling security issues near a recent fix

This skill is meant to make those reviews more systematic and evidence-driven without turning into a generic AppSec checklist.

## Testing

- ✅ RED phase documented with baseline scenarios
- ✅ initial GREEN skill + reviewer template added
- ✅ regression detection included as a first-class review concern
- ✅ integrated into `requesting-code-review`
- ✅ validated with local skill validation and baseline scenario design

### Baseline scenarios covered

1. Authorization check moved after data access
2. Validation narrowed during webhook verification refactor
3. SSRF guard bypass through nearby sibling path after a prior fix

Test report:
- `docs/testing/security-reviewer-test-report.md`

## Checklist

- [x] Follows `writing-skills` guidance
- [x] CSO-oriented trigger description
- [x] Specialized reviewer prompt included
- [x] Includes baseline testing artifact
- [x] Focused on one skill in one PR

## Notes

I intentionally kept the first version narrow:
- review-focused
- app-layer oriented
- evidence-first
- regression-aware

I wanted it to complement the current review workflow rather than introduce a broad security framework.
