### PR TITLE
feat: add multi-repo worktree guidance (#710)

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -168,7 +168,7 @@ Ready to implement <feature-name>
 | Permission error on create | Sandbox fallback, work in place |
 | Tests fail during baseline | Report failures + ask |
 | No package.json/Cargo.toml | Skip dependency install |
-| Plan touches multiple repos | Create a worktree in each repo (same Step 0→1a→1b flow, matching branch names) |
+| Plan touches multiple repos | Create a matching worktree in each repo, same branch name |
 
 ## Common Mistakes
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -168,6 +168,7 @@ Ready to implement <feature-name>
 | Permission error on create | Sandbox fallback, work in place |
 | Tests fail during baseline | Report failures + ask |
 | No package.json/Cargo.toml | Skip dependency install |
+| Plan touches multiple repos | Create a worktree in each repo (same Step 0→1a→1b flow, matching branch names) |
 
 ## Common Mistakes
 


### PR DESCRIPTION
## What problem are you trying to solve?

The worktree skill had no guidance for plans that span multiple repositories. Agents encountering multi-repo plans either created a worktree in only the first repo or skipped worktree creation entirely for secondary repos, leading to inconsistent isolation.

## What does this PR change?

Adds a row to the Edge Cases table in `using-git-worktrees/SKILL.md` instructing agents to create a worktree in each repo when a plan touches multiple repos, using the same flow with matching branch names.

## Is this change appropriate for the core library?

Yes — multi-repo projects are common, and the worktree skill is a core skill. This fills a gap in existing edge case documentation.

## What alternatives did you consider?

1. A separate multi-repo worktree skill — overkill for a single edge case row.
2. Adding a full new section — the edge case table is the right place since this is a conditional behavior, not a new workflow.

## Does this PR contain multiple unrelated changes?

No. Single line addition to one file.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #710 (the issue this addresses)

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | latest | Claude Opus 4.6 | claude-opus-4-6 |

## Evaluation
- Tested with multi-repo implementation plans to verify agents create worktrees in each repo
- Before: agents only created worktree in primary repo
- After: agents create matching worktrees across all repos referenced in the plan

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission