### PR TITLE
[brainstorm] Implement token-based access control

### DIFF
--- a/skills/brainstorming/scripts/helper.js
+++ b/skills/brainstorming/scripts/helper.js
@@ -1,5 +1,7 @@
 (function() {
-  const WS_URL = 'ws://' + window.location.host;
+  const authMeta = document.querySelector('meta[name="auth-token"]');
+  const authToken = authMeta ? authMeta.getAttribute('content') : '';
+  const WS_URL = 'ws://' + window.location.host + '/?token=' + encodeURIComponent(authToken);
   let ws = null;
   let eventQueue = [];
 

--- a/skills/brainstorming/scripts/server.cjs
+++ b/skills/brainstorming/scripts/server.cjs
@@ -81,6 +81,25 @@ const CONTENT_DIR = path.join(SESSION_DIR, 'content');
 const STATE_DIR = path.join(SESSION_DIR, 'state');
 let ownerPid = process.env.BRAINSTORM_OWNER_PID ? Number(process.env.BRAINSTORM_OWNER_PID) : null;
 
+const AUTH_TOKEN = crypto.randomBytes(32).toString('hex');
+
+function validateToken(provided) {
+  if (!provided || typeof provided !== 'string') return false;
+  const a = Buffer.from(AUTH_TOKEN, 'utf-8');
+  const b = Buffer.from(provided, 'utf-8');
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+function extractToken(req) {
+  const url = new URL(req.url, 'http://localhost');
+  const fromQuery = url.searchParams.get('token');
+  if (fromQuery) return fromQuery;
+  const auth = req.headers['authorization'] || '';
+  if (auth.startsWith('Bearer ')) return auth.slice(7);
+  return null;
+}
+
 const MIME_TYPES = {
   '.html': 'text/html', '.css': 'text/css', '.js': 'application/javascript',
   '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg',
@@ -127,12 +146,28 @@ function getNewestScreen() {
 // ========== HTTP Request Handler ==========
 
 function handleRequest(req, res) {
+  const token = extractToken(req);
+  if (!validateToken(token)) {
+    res.writeHead(401, { 'Content-Type': 'text/plain' });
+    res.end('Unauthorized');
+    return;
+  }
   touchActivity();
-  if (req.method === 'GET' && req.url === '/') {
+  const urlPath = new URL(req.url, 'http://localhost').pathname;
+  if (req.method === 'GET' && urlPath === '/') {
     const screenFile = getNewestScreen();
     let html = screenFile
       ? (raw => isFullDocument(raw) ? raw : wrapInFrame(raw))(fs.readFileSync(screenFile, 'utf-8'))
       : WAITING_PAGE;
+
+    const metaTag = `<meta name="auth-token" content="${AUTH_TOKEN}">`;
+    if (html.includes('</head>')) {
+      html = html.replace('</head>', metaTag + '\n</head>');
+    } else if (html.includes('<head>')) {
+      html = html.replace('<head>', '<head>\n' + metaTag);
+    } else {
+      html = metaTag + '\n' + html;
+    }
 
     if (html.includes('</body>')) {
       html = html.replace('</body>', helperInjection + '\n</body>');
@@ -142,8 +177,8 @@ function handleRequest(req, res) {
 
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
     res.end(html);
-  } else if (req.method === 'GET' && req.url.startsWith('/files/')) {
-    const fileName = req.url.slice(7);
+  } else if (req.method === 'GET' && urlPath.startsWith('/files/')) {
+    const fileName = urlPath.slice(7);
     const filePath = path.join(CONTENT_DIR, path.basename(fileName));
     if (!fs.existsSync(filePath)) {
       res.writeHead(404);
@@ -165,6 +200,12 @@ function handleRequest(req, res) {
 const clients = new Set();
 
 function handleUpgrade(req, socket) {
+  const token = extractToken(req);
+  if (!validateToken(token)) {
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    socket.destroy();
+    return;
+  }
   const key = req.headers['sec-websocket-key'];
   if (!key) { socket.destroy(); return; }
 
@@ -340,7 +381,8 @@ function startServer() {
     const info = JSON.stringify({
       type: 'server-started', port: Number(PORT), host: HOST,
       url_host: URL_HOST, url: 'http://' + URL_HOST + ':' + PORT,
-      screen_dir: CONTENT_DIR, state_dir: STATE_DIR
+      screen_dir: CONTENT_DIR, state_dir: STATE_DIR,
+      token: AUTH_TOKEN
     });
     console.log(info);
     fs.writeFileSync(path.join(STATE_DIR, 'server-info'), info + '\n');
@@ -351,4 +393,4 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };
+module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES, AUTH_TOKEN, validateToken, extractToken };

--- a/tests/brainstorm-server/server.test.js
+++ b/tests/brainstorm-server/server.test.js
@@ -144,20 +144,20 @@ async function runTests() {
     console.log('\n--- HTTP Serving ---');
 
     await test('serves waiting page when no screens exist', async () => {
-      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
       assert.strictEqual(res.status, 200);
       assert(res.body.includes('Waiting for the agent'), 'Should show waiting message');
     });
 
     await test('injects helper.js into waiting page', async () => {
-      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
       assert(res.body.includes('WebSocket'), 'Should have helper.js injected');
       assert(res.body.includes('toggleSelect'), 'Should have toggleSelect from helper');
       assert(res.body.includes('brainstorm'), 'Should have brainstorm API from helper');
     });
 
     await test('returns Content-Type text/html', async () => {
-      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
       assert(res.headers['content-type'].includes('text/html'), 'Should be text/html');
     });
 
@@ -166,7 +166,7 @@ async function runTests() {
       fs.writeFileSync(path.join(CONTENT_DIR, 'full-doc.html'), fullDoc);
       await sleep(300);
 
-      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
       assert(res.body.includes('<h1>Custom Page</h1>'), 'Should contain original content');
       assert(res.body.includes('WebSocket'), 'Should still inject helper.js');
       assert(!res.body.includes('indicator-bar'), 'Should NOT wrap in frame template');
@@ -177,7 +177,7 @@ async function runTests() {
       fs.writeFileSync(path.join(CONTENT_DIR, 'fragment.html'), fragment);
       await sleep(300);
 
-      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
       assert(res.body.includes('indicator-bar'), 'Fragment should get indicator bar');
       assert(!res.body.includes('<!-- CONTENT -->'), 'Placeholder should be replaced');
       assert(res.body.includes('Pick a layout'), 'Fragment content should be present');
@@ -190,7 +190,7 @@ async function runTests() {
       fs.writeFileSync(path.join(CONTENT_DIR, 'newer.html'), '<h2>Newer</h2>');
       await sleep(300);
 
-      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
       assert(res.body.includes('Newer'), 'Should serve newest file');
     });
 
@@ -199,13 +199,13 @@ async function runTests() {
       fs.writeFileSync(path.join(CONTENT_DIR, 'data.json'), '{"not": "html"}');
       await sleep(300);
 
-      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
       assert(res.body.includes('Newer'), 'Should still serve newest HTML');
       assert(!res.body.includes('"not"'), 'Should not serve JSON');
     });
 
     await test('returns 404 for non-root paths', async () => {
-      const res = await fetch(`http://localhost:${TEST_PORT}/other`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/other?token=${token}`);
       assert.strictEqual(res.status, 404);
     });
 
@@ -292,7 +292,7 @@ async function runTests() {
     console.log('\n--- WebSocket Communication ---');
 
     await test('accepts WebSocket upgrade on /', async () => {
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise((resolve, reject) => {
         ws.on('open', resolve);
         ws.on('error', reject);
@@ -302,7 +302,7 @@ async function runTests() {
 
     await test('relays user events to stdout with source field', async () => {
       stdoutAccum = '';
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise(resolve => ws.on('open', resolve));
 
       ws.send(JSON.stringify({ type: 'click', text: 'Test Button' }));
@@ -318,7 +318,7 @@ async function runTests() {
       const eventsFile = path.join(STATE_DIR, 'events');
       if (fs.existsSync(eventsFile)) fs.unlinkSync(eventsFile);
 
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise(resolve => ws.on('open', resolve));
 
       ws.send(JSON.stringify({ type: 'click', choice: 'b', text: 'Option B' }));
@@ -336,7 +336,7 @@ async function runTests() {
       const eventsFile = path.join(STATE_DIR, 'events');
       if (fs.existsSync(eventsFile)) fs.unlinkSync(eventsFile);
 
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise(resolve => ws.on('open', resolve));
 
       ws.send(JSON.stringify({ type: 'hover', text: 'Something' }));
@@ -348,8 +348,8 @@ async function runTests() {
     });
 
     await test('handles multiple concurrent WebSocket clients', async () => {
-      const ws1 = new WebSocket(`ws://localhost:${TEST_PORT}`);
-      const ws2 = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws1 = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
+      const ws2 = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await Promise.all([
         new Promise(resolve => ws1.on('open', resolve)),
         new Promise(resolve => ws2.on('open', resolve))
@@ -374,7 +374,7 @@ async function runTests() {
     });
 
     await test('cleans up closed clients from broadcast list', async () => {
-      const ws1 = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws1 = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise(resolve => ws1.on('open', resolve));
       ws1.close();
       await sleep(100);
@@ -386,7 +386,7 @@ async function runTests() {
     });
 
     await test('handles malformed JSON from client gracefully', async () => {
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise(resolve => ws.on('open', resolve));
 
       // Send invalid JSON — server should not crash
@@ -394,7 +394,7 @@ async function runTests() {
       await sleep(300);
 
       // Verify server is still responsive
-      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
       assert.strictEqual(res.status, 200, 'Server should still be running');
       ws.close();
     });
@@ -403,7 +403,7 @@ async function runTests() {
     console.log('\n--- File Watching ---');
 
     await test('sends reload on new .html file', async () => {
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise(resolve => ws.on('open', resolve));
 
       let gotReload = false;
@@ -423,7 +423,7 @@ async function runTests() {
       fs.writeFileSync(filePath, '<h2>Original</h2>');
       await sleep(500);
 
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise(resolve => ws.on('open', resolve));
 
       let gotReload = false;
@@ -439,7 +439,7 @@ async function runTests() {
     });
 
     await test('does NOT send reload for non-.html files', async () => {
-      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
       await new Promise(resolve => ws.on('open', resolve));
 
       let gotReload = false;

--- a/tests/brainstorm-server/server.test.js
+++ b/tests/brainstorm-server/server.test.js
@@ -45,6 +45,26 @@ async function fetch(url) {
   });
 }
 
+async function fetchWithHeaders(url, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    http.get({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
+      headers
+    }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        headers: res.headers,
+        body: data
+      }));
+    }).on('error', reject);
+  });
+}
+
 function startServer() {
   return spawn('node', [SERVER_PATH], {
     env: { ...process.env, BRAINSTORM_PORT: TEST_PORT, BRAINSTORM_DIR: TEST_DIR }
@@ -77,6 +97,11 @@ async function runTests() {
   server.stdout.on('data', (data) => { stdoutAccum += data.toString(); });
 
   const { stdout: initialStdout } = await waitForServer(server);
+
+  // Read auth token from server-info (will be undefined until auth is implemented)
+  const serverInfo = JSON.parse(fs.readFileSync(path.join(STATE_DIR, 'server-info'), 'utf-8').trim());
+  const token = serverInfo.token;
+
   let passed = 0;
   let failed = 0;
 
@@ -182,6 +207,85 @@ async function runTests() {
     await test('returns 404 for non-root paths', async () => {
       const res = await fetch(`http://localhost:${TEST_PORT}/other`);
       assert.strictEqual(res.status, 404);
+    });
+
+    // ========== Token Authentication ==========
+    console.log('\n--- Token Authentication ---');
+
+    await test('server-info contains token field (64-char hex)', async () => {
+      assert(token, 'server-info should contain a token field');
+      assert.strictEqual(typeof token, 'string', 'token should be a string');
+      assert.strictEqual(token.length, 64, 'token should be 64 characters (32 bytes hex)');
+      assert(/^[0-9a-f]{64}$/.test(token), 'token should be a hex string');
+    });
+
+    await test('returns 401 for HTTP request without token', async () => {
+      const res = await fetch(`http://localhost:${TEST_PORT}/`);
+      assert.strictEqual(res.status, 401, 'Should return 401 without token');
+    });
+
+    await test('returns 401 for HTTP request with invalid token', async () => {
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=invalid-token-value`);
+      assert.strictEqual(res.status, 401, 'Should return 401 with invalid token');
+    });
+
+    await test('returns 200 for HTTP request with valid token via query param', async () => {
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
+      assert.strictEqual(res.status, 200, 'Should return 200 with valid token');
+    });
+
+    await test('returns 200 for HTTP request with valid token via Authorization header', async () => {
+      const res = await fetchWithHeaders(`http://localhost:${TEST_PORT}/`, {
+        'Authorization': `Bearer ${token}`
+      });
+      assert.strictEqual(res.status, 200, 'Should return 200 with Bearer token');
+    });
+
+    await test('returns 401 for /files/ without token', async () => {
+      const testFile = path.join(CONTENT_DIR, 'auth-test.png');
+      fs.writeFileSync(testFile, 'fake-image-data');
+      const res = await fetch(`http://localhost:${TEST_PORT}/files/auth-test.png`);
+      assert.strictEqual(res.status, 401, 'Should return 401 for /files/ without token');
+    });
+
+    await test('rejects WebSocket upgrade without token', async () => {
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}`);
+      await new Promise((resolve, reject) => {
+        ws.on('open', () => reject(new Error('Should not connect without token')));
+        ws.on('unexpected-response', (req, res) => {
+          assert.strictEqual(res.statusCode, 401, 'Should return 401 for WS without token');
+          resolve();
+        });
+        ws.on('error', () => resolve()); // Connection refused is also acceptable
+      });
+    });
+
+    await test('rejects WebSocket upgrade with invalid token', async () => {
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=bad-token`);
+      await new Promise((resolve, reject) => {
+        ws.on('open', () => reject(new Error('Should not connect with invalid token')));
+        ws.on('unexpected-response', (req, res) => {
+          assert.strictEqual(res.statusCode, 401, 'Should return 401 for WS with invalid token');
+          resolve();
+        });
+        ws.on('error', () => resolve());
+      });
+    });
+
+    await test('accepts WebSocket upgrade with valid token', async () => {
+      const ws = new WebSocket(`ws://localhost:${TEST_PORT}/?token=${token}`);
+      await new Promise((resolve, reject) => {
+        ws.on('open', resolve);
+        ws.on('error', reject);
+      });
+      ws.close();
+    });
+
+    await test('injects auth-token meta tag into served HTML', async () => {
+      const res = await fetch(`http://localhost:${TEST_PORT}/?token=${token}`);
+      assert.strictEqual(res.status, 200);
+      assert(res.body.includes('<meta name="auth-token"'), 'Should contain auth-token meta tag');
+      assert(res.body.includes(`content="${token}"`), 'Meta tag should contain the server token');
     });
 
     // ========== WebSocket Communication ==========


### PR DESCRIPTION
## Summary
- Generate random auth token at startup using `crypto.randomBytes(32)`
- Validate tokens via query param (`?token=`) or `Authorization: Bearer` header with constant-time comparison (`crypto.timingSafeEqual`)
- Reject unauthenticated HTTP requests (401) and WebSocket upgrades (401) before any processing
- Switch URL routing from `req.url` exact match to parsed `pathname` (required since `?token=` breaks direct string matching)
- Inject `<meta name="auth-token">` into served HTML so the frontend can read it
- Update `helper.js` to read token from meta tag and include in WebSocket URL
- Write token to `server-info` file for test/client consumption
- Update all existing tests to pass tokens in requests

## Test plan
- [x] All 35 tests pass (existing + 10 new auth tests)
- [x] Zero new dependencies
- [x] ~70 lines of new/modified code across 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)