### PR TITLE
feat: context provider convention for sub-agent protocols

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -81,6 +81,12 @@ When agents return:
 - Run full test suite
 - Integrate all changes
 
+## Domain Context
+
+Before constructing agent prompts, check for `*_get_context` MCP tools (e.g., `dave_get_context`). These are domain context providers that return lists of protocol skills to inject.
+
+Call them with the task description for each agent you're dispatching. Include the returned protocol content in each agent's prompt. Different agents may receive different protocols depending on their task domain — an agent doing analog SPICE work gets different protocols than one writing unit tests.
+
 ## Agent Prompt Structure
 
 Good agent prompts are:

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -117,6 +117,20 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 
 **Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
 
+## Domain Context Injection
+
+Before dispatching any subagent, check if MCP tools matching `*_get_context` are available (e.g., `dave_get_context`, `bio_get_context`). These are **domain context providers** — plugins that supply domain-specific protocols for sub-agent work.
+
+If any are available:
+1. Call each `*_get_context` tool with the task description
+2. Each returns a list of skill names to load
+3. Load each returned skill via the Skill tool
+4. Include the loaded skill content in the sub-agent prompt under a "Domain Protocols" section
+
+These protocols are mandatory for the sub-agent to follow — they exist because sub-agents without domain-specific guardrails reliably produce bad work (e.g., brute-forcing simulations instead of computing analytically, debugging by guessing instead of observing).
+
+If no `*_get_context` tools are available, proceed normally.
+
 ## Prompt Templates
 
 - `./implementer-prompt.md` - Dispatch implementer subagent

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -16,6 +16,15 @@ Task tool (general-purpose):
 
     [Scene-setting: where this fits, dependencies, architectural context]
 
+    ## Domain Protocols
+
+    {domain_protocols}
+
+    If domain protocols are present above, they are mandatory. Follow them exactly.
+    If a protocol conflicts with your task instructions, the protocol wins — it exists
+    because agents without it reliably produce bad work. If no protocols are listed,
+    proceed normally.
+
     ## Before You Begin
 
     If you have questions about:


### PR DESCRIPTION
## Summary

- Adds a convention where MCP tools matching `*_get_context` serve as domain context providers
- Coordinators check for these tools before dispatching sub-agents and inject returned protocols
- Three small text additions to dispatch templates — zero code changes

Closes #1128

## Changes

1. **`subagent-driven-development/SKILL.md`** — new "Domain Context Injection" section telling coordinators to check for `*_get_context` tools before dispatch
2. **`subagent-driven-development/implementer-prompt.md`** — new "Domain Protocols" placeholder section in the prompt template
3. **`dispatching-parallel-agents/SKILL.md`** — new "Domain Context" section in prompt construction guidance

## Motivation

Sub-agents dispatched by superpowers start with zero domain context. A hardware design plugin can enforce "compute before simulate" on the main agent, but sub-agents launched by superpowers never see these rules. This convention lets any domain plugin inject protocols into sub-agent prompts through a simple naming convention.

## Test plan

- [ ] Verify existing dispatch behavior unchanged when no `*_get_context` tools are present
- [ ] Test with a `*_get_context` tool that returns skill names — coordinator should load and inject them
- [ ] Verify different agents can receive different domain protocols based on their task