### PR TITLE
feat: add jj (Jujutsu) VCS support alongside git

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Thanks!
 
 ## Installation
 
-**Note:** Installation differs by platform. Claude Code or Cursor have built-in plugin marketplaces. Codex and OpenCode require manual setup.
+**Note:** Installation differs by platform. Claude Code or Cursor have built-in plugin marketplaces. Codex and OpenCode require manual setup. Superpowers supports both **git** and **jj** (Jujutsu) version control — set your preference in `~/.config/superpowers/config.json`.
 
 ### Claude Code Official Marketplace
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Start a new session in your chosen platform and ask for something that should tr
 
 1. **brainstorming** - Activates before writing code. Refines rough ideas through questions, explores alternatives, presents design in sections for validation. Saves design document.
 
-2. **using-git-worktrees** - Activates after design approval. Creates isolated workspace on new branch, runs project setup, verifies clean test baseline.
+2. **using-workspaces** - Activates after design approval. Creates isolated workspace, runs project setup, verifies clean test baseline.
 
 3. **writing-plans** - Activates with approved design. Breaks work into bite-sized tasks (2-5 minutes each). Every task has exact file paths, complete code, verification steps.
 
@@ -119,7 +119,7 @@ Start a new session in your chosen platform and ask for something that should tr
 
 6. **requesting-code-review** - Activates between tasks. Reviews against plan, reports issues by severity. Critical issues block progress.
 
-7. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
+7. **finishing-development-work** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up workspace.
 
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
 
@@ -141,8 +141,8 @@ Start a new session in your chosen platform and ask for something that should tr
 - **dispatching-parallel-agents** - Concurrent subagent workflows
 - **requesting-code-review** - Pre-review checklist
 - **receiving-code-review** - Responding to feedback
-- **using-git-worktrees** - Parallel development branches
-- **finishing-a-development-branch** - Merge/PR decision workflow
+- **using-workspaces** - Isolated development workspaces
+- **finishing-development-work** - Merge/PR decision workflow
 - **subagent-driven-development** - Fast iteration with two-stage review (spec compliance, then code quality)
 
 **Meta**

--- a/docs/superpowers/plans/2026-04-11-vcs-abstraction.md
+++ b/docs/superpowers/plans/2026-04-11-vcs-abstraction.md
@@ -1,0 +1,1030 @@
+# VCS Abstraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let superpowers users choose git or jj as their VCS via a user-level config, with skills referencing a VCS operations mapping doc instead of hardcoding git commands.
+
+**Architecture:** User config at `~/.config/superpowers/config.json` is read by the session-start hook and injected into context. Skills use abstract language for VCS operations; a reference doc (`references/vcs-operations.md`) maps abstract operations to concrete commands per VCS. Two skills are renamed to VCS-neutral names.
+
+**Tech Stack:** Bash (hooks), Markdown (skills, reference doc)
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|---------------|--------|
+| `skills/using-superpowers/references/vcs-operations.md` | Maps abstract VCS operations to git/jj commands | Create |
+| `hooks/session-start` | Session bootstrap, now also injects VCS preference | Modify |
+| `tests/claude-code/test-session-start-vcs.sh` | Tests VCS config reading in session-start hook | Create |
+| `skills/using-workspaces/SKILL.md` | Workspace isolation skill (replaces using-git-worktrees) | Create (rename + rewrite) |
+| `skills/finishing-development-work/SKILL.md` | Development completion skill (replaces finishing-a-development-branch) | Create (rename + rewrite) |
+| `skills/requesting-code-review/SKILL.md` | Code review dispatch | Modify |
+| `skills/requesting-code-review/code-reviewer.md` | Code reviewer template | Modify |
+| `skills/writing-plans/SKILL.md` | Plan writing skill | Modify |
+| `skills/subagent-driven-development/SKILL.md` | Subagent orchestration | Modify |
+| `skills/subagent-driven-development/code-quality-reviewer-prompt.md` | Code quality reviewer template | Modify |
+| `skills/executing-plans/SKILL.md` | Plan execution skill | Modify |
+| `skills/using-superpowers/references/codex-tools.md` | Codex platform mapping | Modify |
+| `README.md` | Project overview | Modify |
+
+---
+
+### Task 1: Create VCS Operations Reference Doc
+
+**Files:**
+- Create: `skills/using-superpowers/references/vcs-operations.md`
+
+- [ ] **Step 1: Create the reference doc**
+
+```markdown
+# VCS Operations Reference
+
+Skills describe VCS operations abstractly. Use the column matching your VCS (injected as `VCS: git` or `VCS: jj` in session context) for concrete commands.
+
+## Key Conceptual Differences
+
+Before using the command table, understand how the two VCS models differ:
+
+- **No staging area in jj.** The working copy is automatically tracked. `jj describe` sets the commit message for the current change; `jj new` starts a new change. This replaces git's add/commit workflow.
+- **Bookmarks, not branches.** jj "bookmarks" map to git branches on push, but they're optional — jj works with anonymous revisions by default. You only need a bookmark when pushing to a remote.
+- **Change IDs, not SHAs.** jj identifies revisions by change ID (a stable identifier that survives rewrites). Review commands use revision expressions (`@` for current, `trunk()` for main branch, change IDs) rather than SHA ranges.
+- **Workspaces don't auto-create named refs.** Unlike git worktrees (which require a branch), jj workspaces create a new working copy at a revision. Create a bookmark explicitly if you want a named ref.
+
+## Operation Mapping
+
+| Operation | git | jj |
+|-----------|-----|-----|
+| **Workspace isolation** | | |
+| Detect project root | `git rev-parse --show-toplevel` | `jj root` |
+| Create isolated workspace | `git worktree add "$path" -b "$BRANCH"` | `jj workspace add "$path"` |
+| Remove workspace | `git worktree remove "$path"` | `jj workspace forget "$name" && rm -rf "$path"` |
+| List workspaces | `git worktree list` | `jj workspace list` |
+| Check if in linked workspace | `GIT_DIR=$(cd "$(git rev-parse --git-dir)" && pwd -P)` / `GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)` / compare: `GIT_DIR != GIT_COMMON` | `jj workspace list` shows more than one entry |
+| **Branching & bookmarks** | | |
+| Create named ref | `git checkout -b "$name"` | `jj bookmark create "$name"` |
+| Current ref name | `git branch --show-current` | `jj bookmark list --all` (look for bookmark pointing at `@`) |
+| Determine base | `git merge-base HEAD main` | `jj log -r 'trunk()' --no-graph -T 'change_id ++ "\n"' \| head -1` |
+| **History & review** | | |
+| Show diff for range | `git diff $BASE..$HEAD` | `jj diff -r "$rev"` |
+| Diff stats for range | `git diff --stat $BASE..$HEAD` | `jj diff --stat -r "$rev"` |
+| Log recent history | `git log --oneline` | `jj log --no-graph` |
+| Current revision identifier | `git rev-parse HEAD` | `jj log -r @ --no-graph -T 'change_id ++ "\n"' \| head -1` |
+| **Committing** | | |
+| Stage and commit | `git add <files> && git commit -m "msg"` | `jj describe -m "msg" && jj new` |
+| **Integration** | | |
+| Merge to base | `git checkout $base && git merge $feature` | `jj new $base_rev $feature_rev` (creates merge commit) |
+| Push to remote | `git push -u origin "$branch"` | `jj git push -b "$bookmark"` |
+| **Safety** | | |
+| Check if directory is ignored | `git check-ignore -q "$dir"` | `git check-ignore -q "$dir"` (jj uses .gitignore) |
+| Discard work | `git branch -D "$name"` | `jj abandon "$rev"` |
+```
+
+- [ ] **Step 2: Verify the file is in the right location**
+
+Run: `ls skills/using-superpowers/references/`
+Expected: `codex-tools.md  vcs-operations.md`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/using-superpowers/references/vcs-operations.md
+git commit -m "feat: add VCS operations reference doc for git/jj command mapping"
+```
+
+---
+
+### Task 2: Add VCS Config Reading to Session-Start Hook
+
+**Files:**
+- Create: `tests/claude-code/test-session-start-vcs.sh`
+- Modify: `hooks/session-start:1-57`
+
+- [ ] **Step 1: Write the test script**
+
+Create `tests/claude-code/test-session-start-vcs.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Tests for VCS config reading in session-start hook
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$(cd "$SCRIPT_DIR/../../hooks" && pwd)/session-start"
+FAILURES=0
+
+pass() { echo "  [PASS] $1"; }
+fail() { echo "  [FAIL] $1"; FAILURES=$((FAILURES + 1)); }
+
+echo "=== Session-start VCS config tests ==="
+
+# --- Test 1: Default VCS is git when no config file ---
+echo "Test 1: Default VCS is git when no config exists"
+TMPDIR_T=$(mktemp -d)
+HOME_ORIG="$HOME"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: git'; then
+    pass "default is git"
+else
+    fail "default is git — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+# --- Test 2: VCS reads jj from config ---
+echo "Test 2: VCS reads jj from config"
+TMPDIR_T=$(mktemp -d)
+mkdir -p "$TMPDIR_T/.config/superpowers"
+echo '{"vcs": "jj"}' > "$TMPDIR_T/.config/superpowers/config.json"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: jj'; then
+    pass "reads jj from config"
+else
+    fail "reads jj from config — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+# --- Test 3: VCS reads git from config ---
+echo "Test 3: VCS reads explicit git from config"
+TMPDIR_T=$(mktemp -d)
+mkdir -p "$TMPDIR_T/.config/superpowers"
+echo '{"vcs": "git"}' > "$TMPDIR_T/.config/superpowers/config.json"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: git'; then
+    pass "reads git from config"
+else
+    fail "reads git from config — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+# --- Test 4: Invalid VCS value falls back to git ---
+echo "Test 4: Invalid VCS value falls back to git"
+TMPDIR_T=$(mktemp -d)
+mkdir -p "$TMPDIR_T/.config/superpowers"
+echo '{"vcs": "svn"}' > "$TMPDIR_T/.config/superpowers/config.json"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: git'; then
+    pass "invalid value falls back to git"
+else
+    fail "invalid value falls back to git — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+# --- Test 5: Missing vcs key falls back to git ---
+echo "Test 5: Config exists but no vcs key"
+TMPDIR_T=$(mktemp -d)
+mkdir -p "$TMPDIR_T/.config/superpowers"
+echo '{"other": "value"}' > "$TMPDIR_T/.config/superpowers/config.json"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: git'; then
+    pass "missing key falls back to git"
+else
+    fail "missing key falls back to git — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo "All tests passed."
+    exit 0
+else
+    echo "$FAILURES test(s) failed."
+    exit 1
+fi
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash tests/claude-code/test-session-start-vcs.sh`
+Expected: Tests 1-5 all FAIL (hook doesn't emit VCS line yet)
+
+- [ ] **Step 3: Add VCS config reading to hooks/session-start**
+
+In `hooks/session-start`, after the `PLUGIN_ROOT` line (line 8) and before the legacy skills check (line 11), add the VCS config reading block:
+
+```bash
+# Read VCS preference from user config (default: git)
+VCS="git"
+SUPERPOWERS_CONFIG="${HOME}/.config/superpowers/config.json"
+if [ -f "$SUPERPOWERS_CONFIG" ]; then
+    vcs_detected=$(grep -o '"vcs"[[:space:]]*:[[:space:]]*"[^"]*"' "$SUPERPOWERS_CONFIG" 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"' || true)
+    if [ "$vcs_detected" = "git" ] || [ "$vcs_detected" = "jj" ]; then
+        VCS="$vcs_detected"
+    fi
+fi
+```
+
+Then modify the `session_context` line (currently line 35) to append the VCS context. Change:
+
+```bash
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+```
+
+To:
+
+```bash
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n\nVCS: ${VCS}\n\nYour user uses ${VCS} for version control. When skills reference VCS operations, use the ${VCS} column from references/vcs-operations.md for concrete commands.\n</EXTREMELY_IMPORTANT>"
+```
+
+Note: No separate variable or `escape_for_json` needed — `$VCS` is just "git" or "jj" (no special characters), and `session_context` uses literal `\n` sequences like the rest of the string.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bash tests/claude-code/test-session-start-vcs.sh`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/claude-code/test-session-start-vcs.sh hooks/session-start
+git commit -m "feat: session-start hook reads VCS preference from user config
+
+Reads ~/.config/superpowers/config.json for vcs setting (git or jj).
+Injects VCS context into session so all skills see the preference.
+Defaults to git. Invalid values fall back to git."
+```
+
+---
+
+### Task 3: Rename and Rewrite using-workspaces Skill
+
+**Files:**
+- Delete: `skills/using-git-worktrees/SKILL.md`
+- Create: `skills/using-workspaces/SKILL.md`
+
+- [ ] **Step 1: Rename the skill directory**
+
+```bash
+git mv skills/using-git-worktrees skills/using-workspaces
+```
+
+- [ ] **Step 2: Rewrite SKILL.md with VCS-abstract content**
+
+Replace the entire content of `skills/using-workspaces/SKILL.md` with:
+
+```markdown
+---
+name: using-workspaces
+description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated workspaces with smart directory selection and safety verification
+---
+
+# Using Workspaces
+
+## Overview
+
+Isolated workspaces let you work on multiple tasks simultaneously without interference, sharing the same repository.
+
+**Core principle:** Systematic directory selection + safety verification = reliable isolation.
+
+**Announce at start:** "I'm using the using-workspaces skill to set up an isolated workspace."
+
+**VCS commands:** All VCS operations below use abstract names. See `references/vcs-operations.md` for the concrete command matching your user's VCS (injected as `VCS: git` or `VCS: jj` in session context).
+
+## Directory Selection Process
+
+Follow this priority order:
+
+### 1. Check Existing Directories
+
+```bash
+# Check in priority order
+ls -d .worktrees 2>/dev/null     # Preferred (hidden)
+ls -d worktrees 2>/dev/null      # Alternative
+```
+
+**If found:** Use that directory. If both exist, `.worktrees` wins.
+
+### 2. Check CLAUDE.md
+
+```bash
+grep -i "worktree.*director\|workspace.*director" CLAUDE.md 2>/dev/null
+```
+
+**If preference specified:** Use it without asking.
+
+### 3. Ask User
+
+If no directory exists and no CLAUDE.md preference:
+
+```
+No workspace directory found. Where should I create workspaces?
+
+1. .worktrees/ (project-local, hidden)
+2. ~/.config/superpowers/worktrees/<project-name>/ (global location)
+
+Which would you prefer?
+```
+
+## Safety Verification
+
+### For Project-Local Directories (.worktrees or worktrees)
+
+**MUST verify directory is ignored before creating workspace:**
+
+Use the "Check if directory is ignored" operation from `references/vcs-operations.md`.
+
+**If NOT ignored:**
+
+Per Jesse's rule "Fix broken things immediately":
+1. Add appropriate line to .gitignore
+2. Commit the change
+3. Proceed with workspace creation
+
+**Why critical:** Prevents accidentally committing workspace contents to repository.
+
+### For Global Directory (~/.config/superpowers/worktrees)
+
+No .gitignore verification needed - outside project entirely.
+
+## Creation Steps
+
+### 1. Detect Project Name
+
+Use the "Detect project root" operation from `references/vcs-operations.md`, then extract the directory name.
+
+### 2. Create Workspace
+
+```bash
+# Determine full path
+case $LOCATION in
+  .worktrees|worktrees)
+    path="$LOCATION/$WORKSPACE_NAME"
+    ;;
+  ~/.config/superpowers/worktrees/*)
+    path="~/.config/superpowers/worktrees/$project/$WORKSPACE_NAME"
+    ;;
+esac
+```
+
+Use the "Create isolated workspace" operation from `references/vcs-operations.md` with the path and workspace name.
+
+**jj note:** jj workspaces don't automatically create a named ref. If the user wants a named ref (needed for pushing/PRs later), use the "Create named ref" operation to create a bookmark after workspace creation.
+
+### 3. Run Project Setup
+
+Auto-detect and run appropriate setup:
+
+```bash
+# Node.js
+if [ -f package.json ]; then npm install; fi
+
+# Rust
+if [ -f Cargo.toml ]; then cargo build; fi
+
+# Python
+if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+if [ -f pyproject.toml ]; then poetry install; fi
+
+# Go
+if [ -f go.mod ]; then go mod download; fi
+```
+
+### 4. Verify Clean Baseline
+
+Run tests to ensure workspace starts clean:
+
+```bash
+# Examples - use project-appropriate command
+npm test
+cargo test
+pytest
+go test ./...
+```
+
+**If tests fail:** Report failures, ask whether to proceed or investigate.
+
+**If tests pass:** Report ready.
+
+### 5. Report Location
+
+```
+Workspace ready at <full-path>
+Tests passing (<N> tests, 0 failures)
+Ready to implement <feature-name>
+```
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| `.worktrees/` exists | Use it (verify ignored) |
+| `worktrees/` exists | Use it (verify ignored) |
+| Both exist | Use `.worktrees/` |
+| Neither exists | Check CLAUDE.md → Ask user |
+| Directory not ignored | Add to .gitignore + commit |
+| Tests fail during baseline | Report failures + ask |
+| No package.json/Cargo.toml | Skip dependency install |
+
+## Common Mistakes
+
+### Skipping ignore verification
+
+- **Problem:** Workspace contents get tracked, pollute status
+- **Fix:** Always verify directory is ignored before creating project-local workspace
+
+### Assuming directory location
+
+- **Problem:** Creates inconsistency, violates project conventions
+- **Fix:** Follow priority: existing > CLAUDE.md > ask
+
+### Proceeding with failing tests
+
+- **Problem:** Can't distinguish new bugs from pre-existing issues
+- **Fix:** Report failures, get explicit permission to proceed
+
+### Hardcoding setup commands
+
+- **Problem:** Breaks on projects using different tools
+- **Fix:** Auto-detect from project files (package.json, etc.)
+
+## Example Workflow
+
+```
+You: I'm using the using-workspaces skill to set up an isolated workspace.
+
+[Check .worktrees/ - exists]
+[Verify ignored - confirmed .worktrees/ is ignored]
+[Create workspace using "Create isolated workspace" operation from vcs-operations.md]
+[Run npm install]
+[Run npm test - 47 passing]
+
+Workspace ready at /Users/jesse/myproject/.worktrees/auth
+Tests passing (47 tests, 0 failures)
+Ready to implement auth feature
+```
+
+## Red Flags
+
+**Never:**
+- Create workspace without verifying it's ignored (project-local)
+- Skip baseline test verification
+- Proceed with failing tests without asking
+- Assume directory location when ambiguous
+- Skip CLAUDE.md check
+
+**Always:**
+- Follow directory priority: existing > CLAUDE.md > ask
+- Verify directory is ignored for project-local
+- Auto-detect and run project setup
+- Verify clean test baseline
+
+## Integration
+
+**Called by:**
+- **brainstorming** (Phase 4) - REQUIRED when design is approved and implementation follows
+- **subagent-driven-development** - REQUIRED before executing any tasks
+- **executing-plans** - REQUIRED before executing any tasks
+- Any skill needing isolated workspace
+
+**Pairs with:**
+- **finishing-development-work** - REQUIRED for cleanup after work complete
+```
+
+- [ ] **Step 3: Verify no stale references within the file**
+
+Run: `grep -n "git worktree\|git branch\|git checkout\|git rev-parse" skills/using-workspaces/SKILL.md`
+Expected: No matches (all git commands removed from skill, moved to reference doc)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/using-git-worktrees skills/using-workspaces
+git commit -m "feat: rename using-git-worktrees to using-workspaces, abstract VCS commands
+
+Skill now uses abstract VCS operation names and references
+vcs-operations.md for concrete commands. Workflow logic unchanged.
+Adds jj-specific callout for bookmark creation."
+```
+
+---
+
+### Task 4: Rename and Rewrite finishing-development-work Skill
+
+**Files:**
+- Delete: `skills/finishing-a-development-branch/SKILL.md`
+- Create: `skills/finishing-development-work/SKILL.md`
+
+- [ ] **Step 1: Rename the skill directory**
+
+```bash
+git mv skills/finishing-a-development-branch skills/finishing-development-work
+```
+
+- [ ] **Step 2: Rewrite SKILL.md with VCS-abstract content**
+
+Replace the entire content of `skills/finishing-development-work/SKILL.md` with:
+
+```markdown
+---
+name: finishing-development-work
+description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+---
+
+# Finishing Development Work
+
+## Overview
+
+Guide completion of development work by presenting clear options and handling chosen workflow.
+
+**Core principle:** Verify tests → Present options → Execute choice → Clean up.
+
+**Announce at start:** "I'm using the finishing-development-work skill to complete this work."
+
+**VCS commands:** All VCS operations below use abstract names. See `references/vcs-operations.md` for the concrete command matching your user's VCS (injected as `VCS: git` or `VCS: jj` in session context).
+
+## The Process
+
+### Step 1: Verify Tests
+
+**Before presenting options, verify tests pass:**
+
+```bash
+# Run project's test suite
+npm test / cargo test / pytest / go test ./...
+```
+
+**If tests fail:**
+```
+Tests failing (<N> failures). Must fix before completing:
+
+[Show failures]
+
+Cannot proceed with merge/PR until tests pass.
+```
+
+Stop. Don't proceed to Step 2.
+
+**If tests pass:** Continue to Step 2.
+
+### Step 2: Determine Base
+
+Use the "Determine base" operation from `references/vcs-operations.md` to find the base revision.
+
+Or ask: "This work started from main - is that correct?"
+
+### Step 3: Present Options
+
+Present exactly these 4 options:
+
+```
+Implementation complete. What would you like to do?
+
+1. Merge back to <base> locally
+2. Push and create a Pull Request
+3. Keep the work as-is (I'll handle it later)
+4. Discard this work
+
+Which option?
+```
+
+**Don't add explanation** - keep options concise.
+
+### Step 4: Execute Choice
+
+#### Option 1: Merge Locally
+
+Use the "Merge to base" operation from `references/vcs-operations.md`.
+
+Then verify tests on the merged result:
+```bash
+<test command>
+```
+
+If tests pass, the feature ref/branch can be cleaned up.
+
+Then: Cleanup workspace (Step 5)
+
+#### Option 2: Push and Create PR
+
+Use the "Push to remote" operation from `references/vcs-operations.md`.
+
+**jj note:** Ensure a bookmark exists before pushing. If no bookmark was created during workspace setup, use the "Create named ref" operation first.
+
+Then create PR:
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<2-3 bullets of what changed>
+
+## Test Plan
+- [ ] <verification steps>
+EOF
+)"
+```
+
+Then: Cleanup workspace (Step 5)
+
+#### Option 3: Keep As-Is
+
+Report: "Keeping work in current state. Workspace preserved at <path>."
+
+**Don't cleanup workspace.**
+
+#### Option 4: Discard
+
+**Confirm first:**
+```
+This will permanently delete:
+- All work in this workspace
+- Revision(s): <revision-list>
+- Workspace at <path>
+
+Type 'discard' to confirm.
+```
+
+Wait for exact confirmation.
+
+If confirmed, use the "Discard work" operation from `references/vcs-operations.md`.
+
+Then: Cleanup workspace (Step 5)
+
+### Step 5: Cleanup Workspace
+
+**For Options 1, 2, 4:**
+
+Check if in a linked workspace using the "Check if in linked workspace" operation from `references/vcs-operations.md`.
+
+If yes, use the "Remove workspace" operation to clean up.
+
+**For Option 3:** Keep workspace.
+
+## Quick Reference
+
+| Option | Merge | Push | Keep Workspace | Cleanup Ref |
+|--------|-------|------|----------------|-------------|
+| 1. Merge locally | yes | - | - | yes |
+| 2. Create PR | - | yes | yes | - |
+| 3. Keep as-is | - | - | yes | - |
+| 4. Discard | - | - | - | yes (force) |
+
+## Common Mistakes
+
+**Skipping test verification**
+- **Problem:** Merge broken code, create failing PR
+- **Fix:** Always verify tests before offering options
+
+**Open-ended questions**
+- **Problem:** "What should I do next?" → ambiguous
+- **Fix:** Present exactly 4 structured options
+
+**Automatic workspace cleanup**
+- **Problem:** Remove workspace when might need it (Option 2, 3)
+- **Fix:** Only cleanup for Options 1 and 4
+
+**No confirmation for discard**
+- **Problem:** Accidentally delete work
+- **Fix:** Require typed "discard" confirmation
+
+## Red Flags
+
+**Never:**
+- Proceed with failing tests
+- Merge without verifying tests on result
+- Delete work without confirmation
+- Force-push without explicit request
+
+**Always:**
+- Verify tests before offering options
+- Present exactly 4 options
+- Get typed confirmation for Option 4
+- Clean up workspace for Options 1 & 4 only
+
+## Integration
+
+**Called by:**
+- **subagent-driven-development** (Step 7) - After all tasks complete
+- **executing-plans** (Step 5) - After all batches complete
+
+**Pairs with:**
+- **using-workspaces** - Cleans up workspace created by that skill
+```
+
+- [ ] **Step 3: Verify no stale references within the file**
+
+Run: `grep -n "git merge\|git checkout\|git push\|git branch\|git worktree\|worktree" skills/finishing-development-work/SKILL.md`
+Expected: No matches (all git commands and "worktree" references removed)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/finishing-a-development-branch skills/finishing-development-work
+git commit -m "feat: rename finishing-a-development-branch to finishing-development-work, abstract VCS commands
+
+Skill now uses abstract VCS operation names and references
+vcs-operations.md for concrete commands. Workflow and 4-option
+menu unchanged. Adds jj-specific callout for bookmark creation
+before pushing."
+```
+
+---
+
+### Task 5: Update requesting-code-review Skill and Template
+
+**Files:**
+- Modify: `skills/requesting-code-review/SKILL.md:27-63`
+- Modify: `skills/requesting-code-review/code-reviewer.md:22-27`
+
+- [ ] **Step 1: Update SKILL.md — abstract VCS commands and rename placeholders**
+
+In `skills/requesting-code-review/SKILL.md`, replace the section at lines 27-40:
+
+```markdown
+**1. Get revision identifiers:**
+
+Use the "Current revision identifier" operation from `references/vcs-operations.md` to get the base and head revisions.
+
+**2. Dispatch code-reviewer subagent:**
+
+Use Task tool with superpowers:code-reviewer type, fill template at `code-reviewer.md`
+
+**Placeholders:**
+- `{WHAT_WAS_IMPLEMENTED}` - What you just built
+- `{PLAN_OR_REQUIREMENTS}` - What it should do
+- `{BASE_REV}` - Starting revision
+- `{HEAD_REV}` - Ending revision
+- `{DESCRIPTION}` - Brief summary
+```
+
+Replace the example section at lines 52-63:
+
+```markdown
+```
+[Just completed Task 2: Add verification function]
+
+You: Let me request code review before proceeding.
+
+[Get base revision using "Current revision identifier" from vcs-operations.md]
+[Get head revision]
+
+[Dispatch superpowers:code-reviewer subagent]
+  WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
+  PLAN_OR_REQUIREMENTS: Task 2 from docs/superpowers/plans/deployment-plan.md
+  BASE_REV: <base-revision-identifier>
+  HEAD_REV: <head-revision-identifier>
+  DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
+```
+```
+
+- [ ] **Step 2: Update code-reviewer.md — abstract VCS commands and rename placeholders**
+
+In `skills/requesting-code-review/code-reviewer.md`, replace lines 22-27:
+
+```markdown
+**Base:** {BASE_REV}
+**Head:** {HEAD_REV}
+
+Use the "Show diff for range" and "Diff stats for range" operations from `references/vcs-operations.md` to review the changes between BASE_REV and HEAD_REV.
+```
+
+- [ ] **Step 3: Verify no stale SHA references**
+
+Run: `grep -n "BASE_SHA\|HEAD_SHA\|git diff\|git log\|git rev-parse" skills/requesting-code-review/`
+Expected: No matches
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/requesting-code-review/SKILL.md skills/requesting-code-review/code-reviewer.md
+git commit -m "feat: abstract VCS commands in requesting-code-review skill
+
+Rename BASE_SHA/HEAD_SHA to BASE_REV/HEAD_REV. Replace hardcoded
+git commands with references to vcs-operations.md."
+```
+
+---
+
+### Task 6: Update writing-plans Skill
+
+**Files:**
+- Modify: `skills/writing-plans/SKILL.md:99-103`
+
+- [ ] **Step 1: Replace the commit step example**
+
+In `skills/writing-plans/SKILL.md`, replace lines 99-103 (the commit step in the task structure example):
+
+```markdown
+- [ ] **Step 5: Commit**
+
+Use the "Stage and commit" operation from `references/vcs-operations.md`:
+- Stage the test file and implementation file
+- Commit with message: "feat: add specific feature"
+```
+
+- [ ] **Step 2: Verify no stale git commands in the example**
+
+Run: `grep -n "git add\|git commit" skills/writing-plans/SKILL.md`
+Expected: No matches
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/writing-plans/SKILL.md
+git commit -m "feat: abstract VCS commands in writing-plans skill commit example"
+```
+
+---
+
+### Task 7: Update subagent-driven-development Skill and Template
+
+**Files:**
+- Modify: `skills/subagent-driven-development/SKILL.md:64,83,268,271`
+- Modify: `skills/subagent-driven-development/code-quality-reviewer-prompt.md:15-16`
+
+- [ ] **Step 1: Update SKILL.md — replace old skill name references**
+
+In `skills/subagent-driven-development/SKILL.md`:
+
+Replace all instances of `superpowers:finishing-a-development-branch` with `superpowers:finishing-development-work` (appears in the dot graph at lines 64, 83 and in Integration at line 271).
+
+Replace all instances of `superpowers:using-git-worktrees` with `superpowers:using-workspaces` (appears in Integration at line 268).
+
+Replace the label text `"Use superpowers:finishing-a-development-branch"` in the dot graph with `"Use superpowers:finishing-development-work"`.
+
+- [ ] **Step 2: Update code-quality-reviewer-prompt.md — rename placeholders**
+
+In `skills/subagent-driven-development/code-quality-reviewer-prompt.md`, replace lines 15-16:
+
+```markdown
+  BASE_REV: [revision before task]
+  HEAD_REV: [current revision]
+```
+
+- [ ] **Step 3: Verify no stale references**
+
+Run: `grep -n "using-git-worktrees\|finishing-a-development-branch\|BASE_SHA\|HEAD_SHA" skills/subagent-driven-development/`
+Expected: No matches
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/subagent-driven-development/SKILL.md skills/subagent-driven-development/code-quality-reviewer-prompt.md
+git commit -m "feat: update subagent-driven-development to use renamed skills and REV placeholders"
+```
+
+---
+
+### Task 8: Update executing-plans Skill
+
+**Files:**
+- Modify: `skills/executing-plans/SKILL.md:35-36,68,70`
+
+- [ ] **Step 1: Update skill name references**
+
+In `skills/executing-plans/SKILL.md`:
+
+Replace line 35:
+```markdown
+- Announce: "I'm using the finishing-development-work skill to complete this work."
+```
+
+Replace line 36:
+```markdown
+- **REQUIRED SUB-SKILL:** Use superpowers:finishing-development-work
+```
+
+Replace line 68:
+```markdown
+- **superpowers:using-workspaces** - REQUIRED: Set up isolated workspace before starting
+```
+
+Replace line 70:
+```markdown
+- **superpowers:finishing-development-work** - Complete development after all tasks
+```
+
+- [ ] **Step 2: Verify no stale references**
+
+Run: `grep -n "using-git-worktrees\|finishing-a-development-branch" skills/executing-plans/SKILL.md`
+Expected: No matches
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/executing-plans/SKILL.md
+git commit -m "feat: update executing-plans to reference renamed skills"
+```
+
+---
+
+### Task 9: Update codex-tools.md Reference
+
+**Files:**
+- Modify: `skills/using-superpowers/references/codex-tools.md:38,76-99`
+
+- [ ] **Step 1: Update placeholder reference**
+
+In `skills/using-superpowers/references/codex-tools.md`, replace `{BASE_SHA}` on line 38 with `{BASE_REV}`:
+
+```markdown
+3. Fill any template placeholders (`{BASE_REV}`, `{WHAT_WAS_IMPLEMENTED}`, etc.)
+```
+
+- [ ] **Step 2: Update Environment Detection section**
+
+Replace lines 76-99 (the Environment Detection and Codex App Finishing sections) with:
+
+```markdown
+## Environment Detection
+
+Skills that create workspaces or finish development work should detect their
+environment before proceeding. The approach depends on the user's VCS
+(injected as `VCS: git` or `VCS: jj` in session context).
+
+**For git users:**
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+BRANCH=$(git branch --show-current)
+```
+
+- `GIT_DIR != GIT_COMMON` → already in a linked worktree (skip creation)
+- `BRANCH` empty → detached HEAD (cannot branch/push/PR from sandbox)
+
+**For jj users:**
+
+```bash
+jj workspace list 2>/dev/null
+```
+
+- More than one workspace listed → already in a linked workspace (skip creation)
+- Check if current workspace has a bookmark: `jj bookmark list --all`
+
+See `using-workspaces` and `finishing-development-work`
+for how each skill uses these signals.
+
+## Codex App Finishing
+
+When the sandbox blocks branch/push operations (detached HEAD in an
+externally managed worktree), the agent commits all work and informs
+the user to use the App's native controls:
+
+- **"Create branch"** — names the branch, then commit/push/PR via App UI
+- **"Hand off to local"** — transfers work to the user's local checkout
+
+The agent can still run tests, stage files, and output suggested branch
+names, commit messages, and PR descriptions for the user to copy.
+```
+
+- [ ] **Step 3: Verify no stale references**
+
+Run: `grep -n "using-git-worktrees\|finishing-a-development-branch" skills/using-superpowers/references/codex-tools.md`
+Expected: No matches
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/using-superpowers/references/codex-tools.md
+git commit -m "feat: update codex-tools.md with VCS-conditional environment detection"
+```
+
+---
+
+### Task 10: Update README.md
+
+**Files:**
+- Modify: `README.md:112,122,144-145`
+
+- [ ] **Step 1: Update Basic Workflow section**
+
+In `README.md`, replace line 112:
+
+```markdown
+2. **using-workspaces** - Activates after design approval. Creates isolated workspace, runs project setup, verifies clean test baseline.
+```
+
+Replace line 122:
+
+```markdown
+7. **finishing-development-work** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up workspace.
+```
+
+- [ ] **Step 2: Update Skills Library section**
+
+In `README.md`, replace lines 144-145:
+
+```markdown
+- **using-workspaces** - Isolated development workspaces
+- **finishing-development-work** - Merge/PR decision workflow
+```
+
+- [ ] **Step 3: Verify no stale references**
+
+Run: `grep -n "using-git-worktrees\|finishing-a-development-branch" README.md`
+Expected: No matches
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: update README with renamed skill names"
+```

--- a/docs/superpowers/specs/2026-04-11-vcs-abstraction-design.md
+++ b/docs/superpowers/specs/2026-04-11-vcs-abstraction-design.md
@@ -1,0 +1,179 @@
+# VCS Abstraction Design — git/jj Support
+
+## Goal
+
+Let superpowers users choose their version control system (git or jj) as a user-level preference. Skills describe *what* to do; a reference doc maps operations to concrete commands per VCS.
+
+## Motivation
+
+Superpowers skills currently hardcode git commands throughout. Users of jj (Jujutsu) — which can operate on git repos transparently — cannot use superpowers idiomatically. Different contributors to the same project may use different VCS tools, so this must be a user-level choice, not a project-level setting.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scope | User-level preference | Different people on same project may use different VCS |
+| Config location | `~/.config/superpowers/config.json` | User-scoped, survives plugin updates, path already referenced in codebase |
+| Default | `git` | Zero breakage for existing users |
+| Injection mechanism | Session-start hook | Already runs every session, context visible to all skills before they fire |
+| Command mapping | Single reference doc | Skills stay readable, single source of truth, easy to extend |
+| Skill naming | VCS-neutral renames | `using-workspaces`, `finishing-development-work` |
+| jj workspace isolation | `jj workspace add` | Native jj equivalent to git worktrees |
+
+## Architecture
+
+### 1. User Configuration
+
+File: `~/.config/superpowers/config.json`
+
+```json
+{
+  "vcs": "jj"
+}
+```
+
+- Default: `"git"` if file missing or key absent
+- Accepted values: `"git"`, `"jj"`. Anything else falls back to `"git"` with a warning in context.
+
+### 2. Session-Start Hook Changes
+
+File: `hooks/session-start`
+
+The hook reads the config file and injects the VCS preference into the session context alongside the existing superpowers bootstrap.
+
+```bash
+VCS="git"  # default
+CONFIG_FILE="${HOME}/.config/superpowers/config.json"
+if [ -f "$CONFIG_FILE" ]; then
+    detected=$(grep -o '"vcs"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" | grep -o '"[^"]*"$' | tr -d '"')
+    if [ -n "$detected" ]; then
+        VCS="$detected"
+    fi
+fi
+```
+
+Appended to `session_context`:
+
+```
+VCS: ${VCS}
+
+Your user uses ${VCS} for version control. When skills reference VCS operations, use the ${VCS} column from references/vcs-operations.md for concrete commands.
+```
+
+No new dependencies. Pure bash, grep-based JSON parsing. Matches hook's zero-dependency approach.
+
+Validation: only `git` or `jj` accepted. Anything else falls back to `git` with warning.
+
+### 3. VCS Operations Reference Doc
+
+New file: `skills/using-superpowers/references/vcs-operations.md`
+
+Sits alongside existing `codex-tools.md` — same pattern (reference doc mapping), different axis (VCS instead of harness).
+
+#### Operation Mapping
+
+| Operation | git | jj |
+|-----------|-----|-----|
+| **Workspace isolation** | | |
+| Detect project root | `git rev-parse --show-toplevel` | `jj root` |
+| Create isolated workspace | `git worktree add "$path" -b "$BRANCH"` | `jj workspace add "$path"` |
+| Remove workspace | `git worktree remove "$path"` | `jj workspace forget "$name"` + rm |
+| List workspaces | `git worktree list` | `jj workspace list` |
+| Check if in workspace | `GIT_DIR != GIT_COMMON` | `jj workspace list` shows multiple |
+| **Branching & bookmarks** | | |
+| Create named ref | `git checkout -b "$name"` | `jj bookmark create "$name"` |
+| Current ref name | `git branch --show-current` | `jj bookmark list` (active) |
+| Determine base | `git merge-base HEAD main` | `jj log -r 'trunk()'` |
+| **History & review** | | |
+| Show diff | `git diff A..B` | `jj diff -r "$rev"` |
+| Diff stats | `git diff --stat A..B` | `jj diff --stat -r "$rev"` |
+| Log | `git log --oneline` | `jj log --no-graph` |
+| Current revision | `git rev-parse HEAD` | `jj log -r @ --no-graph -T 'change_id'` |
+| **Committing** | | |
+| Stage + commit | `git add . && git commit -m "msg"` | `jj describe -m "msg" && jj new` |
+| **Integration** | | |
+| Merge to base | `git checkout base && git merge feat` | `jj new trunk() feat-rev` |
+| Push | `git push -u origin "$branch"` | `jj git push -b "$bookmark"` |
+| **Safety** | | |
+| Check ignore | `git check-ignore -q "$dir"` | Check `.gitignore` (jj respects it) |
+| Discard workspace | `git branch -D "$name"` | `jj abandon "$rev"` |
+
+#### Key Conceptual Differences
+
+The reference doc must call out these differences so the agent understands the mental model, not just the command mapping:
+
+- **No staging area in jj.** `jj describe` + `jj new` replaces add/commit. The working copy is automatically tracked.
+- **Bookmarks, not branches.** jj "bookmarks" map to git branches on push, but they're optional — jj works with anonymous revisions by default.
+- **Change IDs, not SHAs.** jj identifies revisions by change ID. Review commands use revision expressions (`@`, `trunk()`, change IDs) rather than SHA ranges.
+- **Workspaces don't auto-create named refs.** Unlike git worktrees (which require a branch), jj workspaces just create a new working copy at a revision. The skill should prompt to create a bookmark if the user wants a named ref.
+
+### 4. Skill Renames
+
+| Current name | New name |
+|-------------|----------|
+| `using-git-worktrees` | `using-workspaces` |
+| `finishing-a-development-branch` | `finishing-development-work` |
+
+Renamed because: "worktrees" and "branch" are git-specific concepts. jj users think in workspaces, revisions, and bookmarks.
+
+### 5. Skill Content Changes
+
+#### `using-workspaces` (heavy rewrite)
+
+- All git commands replaced with abstract descriptions: "create isolated workspace", "verify directory is ignored", "detect project root"
+- Each operation references `references/vcs-operations.md` for concrete commands
+- Workflow stays identical: directory selection → safety verification → creation → setup → test baseline
+- One jj-specific callout: jj workspaces don't auto-create a named ref, so the skill prompts to create a bookmark if the user wants one
+
+#### `finishing-development-work` (moderate rewrite)
+
+- "Determine Base Branch" becomes "Determine Base" — git: `merge-base`, jj: `trunk()`
+- Option 1 "Merge locally" — abstract merge operation
+- Option 2 "Push and create PR" — abstract push, `gh pr create` stays identical (both VCS push to git remotes)
+- Option 4 "Discard" — `abandon` vs `branch -D`
+- Worktree cleanup becomes workspace cleanup
+
+#### `requesting-code-review` + `code-reviewer.md` (light rewrite)
+
+- SHA extraction becomes "get current revision identifier"
+- `git diff` becomes "show diff for revision range"
+- Template placeholders renamed: `{BASE_SHA}` → `{BASE_REV}`, `{HEAD_SHA}` → `{HEAD_REV}` (generic term covering both git SHAs and jj change IDs)
+- Commands reference vcs-operations doc
+
+#### `writing-plans` (light touch)
+
+- Commit step example shows abstract "stage and commit" with reference to vcs-operations
+- Rest of skill is VCS-agnostic already
+
+#### `subagent-driven-development` + `executing-plans` (minimal)
+
+- Replace `using-git-worktrees` references with `using-workspaces`
+- Replace `finishing-a-development-branch` with `finishing-development-work`
+- Integration sections updated
+
+#### `codex-tools.md` (moderate)
+
+- Environment detection section gets VCS-conditional logic
+- jj equivalent: `jj root` instead of `git rev-parse --show-toplevel`, `jj workspace list` instead of GIT_DIR/GIT_COMMON comparison
+
+#### Test scaffolds (`tests/`)
+
+- Keep as git. Test scaffolds create throwaway repos to exercise superpowers skill behavior — they're test infrastructure, not user-facing workflow. Adding VCS-conditional logic here adds complexity with no user benefit. If jj-specific test scaffolds are needed later, add them then.
+
+### 6. What Doesn't Change
+
+- **Skill workflow logic** — directory selection priority, safety verification, test baseline, review stages, 4-option finish menu. Identical.
+- **brainstorming, test-driven-development, systematic-debugging, verification-before-completion, dispatching-parallel-agents, writing-skills, receiving-code-review** — no VCS references, untouched.
+- **Installation docs** — `git clone` for installing superpowers itself stays git. That's the plugin distribution mechanism, not the user's project VCS.
+- **`gh pr create`** — both git and jj users push to git remotes for PRs. PR creation step is identical.
+- **Plugin manifest** — skill renames require updating any skill references in manifest / plugin.json.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| jj command mapping wrong or incomplete | Validate against jj docs during implementation; keep reference doc easy to update |
+| Skills lose clarity from abstraction | Each skill still describes the workflow in full; only the concrete commands move to reference doc |
+| Existing users confused by renames | Default is `git`, renames use intuitive generic terms, old names mentioned in commit messages |
+| Agent ignores VCS context | Injected at session start before any skill fires, same mechanism that already works for superpowers bootstrap |
+| jj workspace model divergence | Callout boxes in skills where workflow genuinely differs (e.g., bookmark creation) |

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -9,11 +9,15 @@ PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Read VCS preference from user config (default: git)
 VCS="git"
+VCS_WARNING=""
 SUPERPOWERS_CONFIG="${HOME}/.config/superpowers/config.json"
 if [ -f "$SUPERPOWERS_CONFIG" ]; then
     vcs_detected=$(grep -o '"vcs"[[:space:]]*:[[:space:]]*"[^"]*"' "$SUPERPOWERS_CONFIG" 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"' || true)
     if [ "$vcs_detected" = "git" ] || [ "$vcs_detected" = "jj" ]; then
         VCS="$vcs_detected"
+    elif [ -n "$vcs_detected" ]; then
+        VCS="git"
+        VCS_WARNING="Warning: Unrecognized VCS value '${vcs_detected}' in ~/.config/superpowers/config.json. Falling back to git. Accepted values: git, jj."
     fi
 fi
 
@@ -42,7 +46,7 @@ escape_for_json() {
 
 using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
 warning_escaped=$(escape_for_json "$warning_message")
-session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n\nVCS: ${VCS}\n\nYour user uses ${VCS} for version control. When skills reference VCS operations, use the ${VCS} column from references/vcs-operations.md for concrete commands.\n</EXTREMELY_IMPORTANT>"
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n\nVCS: ${VCS}\n\nYour user uses ${VCS} for version control. When skills reference VCS operations, use the ${VCS} column from references/vcs-operations.md for concrete commands.${VCS_WARNING:+\n\n${VCS_WARNING}}\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
 # Cursor hooks expect additional_context (snake_case).

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -7,6 +7,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# Read VCS preference from user config (default: git)
+VCS="git"
+SUPERPOWERS_CONFIG="${HOME}/.config/superpowers/config.json"
+if [ -f "$SUPERPOWERS_CONFIG" ]; then
+    vcs_detected=$(grep -o '"vcs"[[:space:]]*:[[:space:]]*"[^"]*"' "$SUPERPOWERS_CONFIG" 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"' || true)
+    if [ "$vcs_detected" = "git" ] || [ "$vcs_detected" = "jj" ]; then
+        VCS="$vcs_detected"
+    fi
+fi
+
 # Check if legacy skills directory exists and build warning
 warning_message=""
 legacy_skills_dir="${HOME}/.config/superpowers/skills"
@@ -32,7 +42,7 @@ escape_for_json() {
 
 using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
 warning_escaped=$(escape_for_json "$warning_message")
-session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n\nVCS: ${VCS}\n\nYour user uses ${VCS} for version control. When skills reference VCS operations, use the ${VCS} column from references/vcs-operations.md for concrete commands.\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
 # Cursor hooks expect additional_context (snake_case).

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -17,7 +17,7 @@ if [ -f "$SUPERPOWERS_CONFIG" ]; then
         VCS="$vcs_detected"
     elif [ -n "$vcs_detected" ]; then
         VCS="git"
-        VCS_WARNING="Warning: Unrecognized VCS value '${vcs_detected}' in ~/.config/superpowers/config.json. Falling back to git. Accepted values: git, jj."
+        VCS_WARNING="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER:⚠️ **Unsupported VCS '${vcs_detected}' in ~/.config/superpowers/config.json.** Falling back to git. Accepted values: git, jj. Fix your config to silence this warning.</important-reminder>"
     fi
 fi
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -111,7 +111,7 @@ digraph brainstorming {
 - Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
-- Commit the design document to git
+- Commit the design document
 
 **Spec Self-Review:**
 After writing the spec document, look at it with fresh eyes:

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -32,8 +32,8 @@ For each task:
 ### Step 3: Complete Development
 
 After all tasks complete and verified:
-- Announce: "I'm using the finishing-a-development-branch skill to complete this work."
-- **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
+- Announce: "I'm using the finishing-development-work skill to complete this work."
+- **REQUIRED SUB-SKILL:** Use superpowers:finishing-development-work
 - Follow that skill to verify tests, present options, execute choice
 
 ## When to Stop and Ask for Help
@@ -65,6 +65,6 @@ After all tasks complete and verified:
 ## Integration
 
 **Required workflow skills:**
-- **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
+- **superpowers:using-workspaces** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
-- **superpowers:finishing-a-development-branch** - Complete development after all tasks
+- **superpowers:finishing-development-work** - Complete development after all tasks

--- a/skills/finishing-development-work/SKILL.md
+++ b/skills/finishing-development-work/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: finishing-a-development-branch
+name: finishing-development-work
 description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
 ---
 
-# Finishing a Development Branch
+# Finishing Development Work
 
 ## Overview
 
@@ -11,7 +11,9 @@ Guide completion of development work by presenting clear options and handling ch
 
 **Core principle:** Verify tests → Present options → Execute choice → Clean up.
 
-**Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
+**Announce at start:** "I'm using the finishing-development-work skill to complete this work."
+
+**VCS commands:** All VCS operations below use abstract names. See `references/vcs-operations.md` for the concrete command matching your user's VCS (injected as `VCS: git` or `VCS: jj` in session context).
 
 ## The Process
 
@@ -37,14 +39,11 @@ Stop. Don't proceed to Step 2.
 
 **If tests pass:** Continue to Step 2.
 
-### Step 2: Determine Base Branch
+### Step 2: Determine Base
 
-```bash
-# Try common base branches
-git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
-```
+Use the "Determine base" operation from `references/vcs-operations.md` to find the base revision.
 
-Or ask: "This branch split from main - is that correct?"
+Or ask: "This work started from main - is that correct?"
 
 ### Step 3: Present Options
 
@@ -53,9 +52,9 @@ Present exactly these 4 options:
 ```
 Implementation complete. What would you like to do?
 
-1. Merge back to <base-branch> locally
+1. Merge back to <base> locally
 2. Push and create a Pull Request
-3. Keep the branch as-is (I'll handle it later)
+3. Keep the work as-is (I'll handle it later)
 4. Discard this work
 
 Which option?
@@ -67,32 +66,25 @@ Which option?
 
 #### Option 1: Merge Locally
 
+Use the "Merge to base" operation from `references/vcs-operations.md`.
+
+Then verify tests on the merged result:
 ```bash
-# Switch to base branch
-git checkout <base-branch>
-
-# Pull latest
-git pull
-
-# Merge feature branch
-git merge <feature-branch>
-
-# Verify tests on merged result
 <test command>
-
-# If tests pass
-git branch -d <feature-branch>
 ```
 
-Then: Cleanup worktree (Step 5)
+If tests pass, the feature ref/branch can be cleaned up.
+
+Then: Cleanup workspace (Step 5)
 
 #### Option 2: Push and Create PR
 
-```bash
-# Push branch
-git push -u origin <feature-branch>
+Use the "Push to remote" operation from `references/vcs-operations.md`.
 
-# Create PR
+**jj note:** Ensure a bookmark exists before pushing. If no bookmark was created during workspace setup, use the "Create named ref" operation first.
+
+Then create PR:
+```bash
 gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Summary
 <2-3 bullets of what changed>
@@ -103,60 +95,50 @@ EOF
 )"
 ```
 
-Then: Cleanup worktree (Step 5)
+Then: Cleanup workspace (Step 5)
 
 #### Option 3: Keep As-Is
 
-Report: "Keeping branch <name>. Worktree preserved at <path>."
+Report: "Keeping work in current state. Workspace preserved at <path>."
 
-**Don't cleanup worktree.**
+**Don't cleanup workspace.**
 
 #### Option 4: Discard
 
 **Confirm first:**
 ```
 This will permanently delete:
-- Branch <name>
-- All commits: <commit-list>
-- Worktree at <path>
+- All work in this workspace
+- Revision(s): <revision-list>
+- Workspace at <path>
 
 Type 'discard' to confirm.
 ```
 
 Wait for exact confirmation.
 
-If confirmed:
-```bash
-git checkout <base-branch>
-git branch -D <feature-branch>
-```
+If confirmed, use the "Discard feature work" operation from `references/vcs-operations.md`.
 
-Then: Cleanup worktree (Step 5)
+Then: Cleanup workspace (Step 5)
 
-### Step 5: Cleanup Worktree
+### Step 5: Cleanup Workspace
 
 **For Options 1, 2, 4:**
 
-Check if in worktree:
-```bash
-git worktree list | grep $(git branch --show-current)
-```
+Check if in a linked workspace using the "Check if in linked workspace" operation from `references/vcs-operations.md`.
 
-If yes:
-```bash
-git worktree remove <worktree-path>
-```
+If yes, use the "Remove workspace" operation to clean up.
 
-**For Option 3:** Keep worktree.
+**For Option 3:** Keep workspace.
 
 ## Quick Reference
 
-| Option | Merge | Push | Keep Worktree | Cleanup Branch |
-|--------|-------|------|---------------|----------------|
-| 1. Merge locally | ✓ | - | - | ✓ |
-| 2. Create PR | - | ✓ | ✓ | - |
-| 3. Keep as-is | - | - | ✓ | - |
-| 4. Discard | - | - | - | ✓ (force) |
+| Option | Merge | Push | Keep Workspace | Cleanup Ref |
+|--------|-------|------|----------------|-------------|
+| 1. Merge locally | yes | - | - | yes |
+| 2. Create PR | - | yes | yes | - |
+| 3. Keep as-is | - | - | yes | - |
+| 4. Discard | - | - | - | yes (force) |
 
 ## Common Mistakes
 
@@ -168,8 +150,8 @@ git worktree remove <worktree-path>
 - **Problem:** "What should I do next?" → ambiguous
 - **Fix:** Present exactly 4 structured options
 
-**Automatic worktree cleanup**
-- **Problem:** Remove worktree when might need it (Option 2, 3)
+**Automatic workspace cleanup**
+- **Problem:** Remove workspace when might need it (Option 2, 3)
 - **Fix:** Only cleanup for Options 1 and 4
 
 **No confirmation for discard**
@@ -188,7 +170,7 @@ git worktree remove <worktree-path>
 - Verify tests before offering options
 - Present exactly 4 options
 - Get typed confirmation for Option 4
-- Clean up worktree for Options 1 & 4 only
+- Clean up workspace for Options 1 & 4 only
 
 ## Integration
 
@@ -197,4 +179,4 @@ git worktree remove <worktree-path>
 - **executing-plans** (Step 5) - After all batches complete
 
 **Pairs with:**
-- **using-git-worktrees** - Cleans up worktree created by that skill
+- **using-workspaces** - Cleans up workspace created by that skill

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -23,11 +23,9 @@ Dispatch superpowers:code-reviewer subagent to catch issues before they cascade.
 
 ## How to Request
 
-**1. Get git SHAs:**
-```bash
-BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
-HEAD_SHA=$(git rev-parse HEAD)
-```
+**1. Get revision identifiers:**
+
+Use the "Current revision identifier" operation from `references/vcs-operations.md` to get the base and head revisions.
 
 **2. Dispatch code-reviewer subagent:**
 
@@ -36,8 +34,8 @@ Use Task tool with superpowers:code-reviewer type, fill template at `code-review
 **Placeholders:**
 - `{WHAT_WAS_IMPLEMENTED}` - What you just built
 - `{PLAN_OR_REQUIREMENTS}` - What it should do
-- `{BASE_SHA}` - Starting commit
-- `{HEAD_SHA}` - Ending commit
+- `{BASE_REV}` - Starting revision
+- `{HEAD_REV}` - Ending revision
 - `{DESCRIPTION}` - Brief summary
 
 **3. Act on feedback:**
@@ -53,14 +51,14 @@ Use Task tool with superpowers:code-reviewer type, fill template at `code-review
 
 You: Let me request code review before proceeding.
 
-BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk '{print $1}')
-HEAD_SHA=$(git rev-parse HEAD)
+[Get base revision using "Current revision identifier" from vcs-operations.md]
+[Get head revision]
 
 [Dispatch superpowers:code-reviewer subagent]
   WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
   PLAN_OR_REQUIREMENTS: Task 2 from docs/superpowers/plans/deployment-plan.md
-  BASE_SHA: a7981ec
-  HEAD_SHA: 3df7661
+  BASE_REV: <base-revision-identifier>
+  HEAD_REV: <head-revision-identifier>
   DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
 
 [Subagent returns]:

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -37,6 +37,7 @@ Use Task tool with superpowers:code-reviewer type, fill template at `code-review
 - `{BASE_REV}` - Starting revision
 - `{HEAD_REV}` - Ending revision
 - `{DESCRIPTION}` - Brief summary
+- `{VCS_CONTEXT}` - VCS commands for diff/log (include if user's VCS is not git — the reviewer subagent won't inherit your session context)
 
 **3. Act on feedback:**
 - Fix Critical issues immediately

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -37,7 +37,7 @@ Use Task tool with superpowers:code-reviewer type, fill template at `code-review
 - `{BASE_REV}` - Starting revision
 - `{HEAD_REV}` - Ending revision
 - `{DESCRIPTION}` - Brief summary
-- `{VCS_CONTEXT}` - VCS commands for diff/log (include if user's VCS is not git — the reviewer subagent won't inherit your session context)
+- `{VCS_CONTEXT}` - VCS commands for diff/log (always include — the reviewer subagent won't inherit your session context; see `references/vcs-operations.md` for commands matching user's VCS)
 
 **3. Act on feedback:**
 - Fix Critical issues immediately

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -37,7 +37,7 @@ Use Task tool with superpowers:code-reviewer type, fill template at `code-review
 - `{BASE_REV}` - Starting revision
 - `{HEAD_REV}` - Ending revision
 - `{DESCRIPTION}` - Brief summary
-- `{VCS_CONTEXT}` - VCS commands for diff/log (always include — the reviewer subagent won't inherit your session context; see `references/vcs-operations.md` for commands matching user's VCS)
+- `{VCS_CONTEXT}` - VCS commands for diff/log (required if user's VCS is not git — reviewer defaults to git when VCS_CONTEXT is empty; see `references/vcs-operations.md`)
 
 **3. Act on feedback:**
 - Fix Critical issues immediately

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -24,7 +24,7 @@ You are reviewing code changes for production readiness.
 
 {VCS_CONTEXT}
 
-Use the diff commands from VCS_CONTEXT to review the changes. If VCS_CONTEXT is empty or missing, default to git (`git diff --stat {BASE_REV}..{HEAD_REV}` / `git diff {BASE_REV}..{HEAD_REV}`). Do not attempt to auto-detect the VCS — non-git VCS requires explicit configuration.
+Use the diff commands from VCS_CONTEXT to review the changes. If VCS_CONTEXT is empty or missing, default to git (`git diff --stat {BASE_REV}..{HEAD_REV}` / `git diff {BASE_REV}..{HEAD_REV}`). **Superpowers only supports git and jj.** If VCS_CONTEXT specifies any other VCS, ignore it and use git commands instead. Do not attempt to auto-detect the VCS — non-git VCS requires explicit configuration.
 
 ## Review Checklist
 

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -24,7 +24,7 @@ You are reviewing code changes for production readiness.
 
 {VCS_CONTEXT}
 
-Use the diff commands from VCS_CONTEXT to review the changes. **VCS_CONTEXT must be provided by the calling skill.** If it is empty or missing, you cannot review — report the error to the orchestrator and request VCS context.
+Use the diff commands from VCS_CONTEXT to review the changes. If VCS_CONTEXT is empty or missing, default to git (`git diff --stat {BASE_REV}..{HEAD_REV}` / `git diff {BASE_REV}..{HEAD_REV}`). Do not attempt to auto-detect the VCS — non-git VCS requires explicit configuration.
 
 ## Review Checklist
 
@@ -108,7 +108,7 @@ Use the diff commands from VCS_CONTEXT to review the changes. **VCS_CONTEXT must
 
 ## Example Output
 
-> **Note:** The diff commands in the review below came from VCS_CONTEXT, filled by the calling skill. For git users this includes `git diff`; for jj users, `jj diff`. The reviewer should never hard-code VCS commands.
+> **Note:** The reviewer defaults to git commands when VCS_CONTEXT is empty. For non-git users (e.g., jj), the calling skill must fill VCS_CONTEXT with the correct commands. Do not auto-detect VCS — it requires explicit configuration.
 
 ```
 ### Strengths

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -17,7 +17,7 @@ You are reviewing code changes for production readiness.
 
 {PLAN_REFERENCE}
 
-## Git Range to Review
+## Revision Range to Review
 
 **Base:** {BASE_REV}
 **Head:** {HEAD_REV}

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -19,13 +19,10 @@ You are reviewing code changes for production readiness.
 
 ## Git Range to Review
 
-**Base:** {BASE_SHA}
-**Head:** {HEAD_SHA}
+**Base:** {BASE_REV}
+**Head:** {HEAD_REV}
 
-```bash
-git diff --stat {BASE_SHA}..{HEAD_SHA}
-git diff {BASE_SHA}..{HEAD_SHA}
-```
+Use the "Show diff for range" and "Diff stats for range" operations from `references/vcs-operations.md` to review the changes between BASE_REV and HEAD_REV.
 
 ## Review Checklist
 

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -24,7 +24,7 @@ You are reviewing code changes for production readiness.
 
 {VCS_CONTEXT}
 
-Use the diff commands from VCS_CONTEXT (or `git diff --stat {BASE_REV}..{HEAD_REV}` / `git diff {BASE_REV}..{HEAD_REV}` if no VCS_CONTEXT provided) to review the changes.
+Use the diff commands from VCS_CONTEXT to review the changes. **VCS_CONTEXT must be provided by the calling skill.** If it is empty or missing, you cannot review — report the error to the orchestrator and request VCS context.
 
 ## Review Checklist
 
@@ -107,6 +107,8 @@ Use the diff commands from VCS_CONTEXT (or `git diff --stat {BASE_REV}..{HEAD_RE
 - Avoid giving a clear verdict
 
 ## Example Output
+
+> **Note:** The diff commands in the review below came from VCS_CONTEXT, filled by the calling skill. For git users this includes `git diff`; for jj users, `jj diff`. The reviewer should never hard-code VCS commands.
 
 ```
 ### Strengths

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -22,7 +22,9 @@ You are reviewing code changes for production readiness.
 **Base:** {BASE_REV}
 **Head:** {HEAD_REV}
 
-Use the "Show diff for range" and "Diff stats for range" operations from `references/vcs-operations.md` to review the changes between BASE_REV and HEAD_REV.
+{VCS_CONTEXT}
+
+Use the diff commands from VCS_CONTEXT (or `git diff --stat {BASE_REV}..{HEAD_REV}` / `git diff {BASE_REV}..{HEAD_REV}` if no VCS_CONTEXT provided) to review the changes.
 
 ## Review Checklist
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -117,6 +117,33 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 
 **Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
 
+## VCS Context Propagation
+
+Subagents don't inherit your session context. They will NOT see the `VCS: jj` or `VCS: git` setting. You MUST propagate VCS context to every subagent you dispatch.
+
+**At the start of SDD execution:**
+1. Check the session context for `VCS: git` or `VCS: jj`
+2. If VCS is not git, read `references/vcs-operations.md` once
+3. Extract the commands your subagents will need (commit, diff, current revision at minimum)
+
+**When dispatching any subagent**, fill the `{VCS_CONTEXT}` placeholder in the prompt template with the relevant VCS commands. For git users, this can be empty (git is the default assumption). For jj users, include at minimum:
+
+```
+## VCS
+
+This project uses jj (not git). Key commands:
+- Commit: `jj describe -m "msg" && jj new` (no staging area — working copy is auto-tracked)
+- Current revision: `jj log -r @ --no-graph -T 'change_id ++ "\n"' | head -1`
+- Diff: `jj diff -r "$rev"`
+- Diff stats: `jj diff --stat -r "$rev"`
+- Log: `jj log --no-graph`
+- Push: `jj git push -b "$bookmark"`
+
+Do NOT use git commands. Use jj equivalents above.
+```
+
+**This is not optional.** If the session VCS is jj and you dispatch a subagent without VCS context, it will use git commands and fail or corrupt state.
+
 ## Prompt Templates
 
 - `./implementer-prompt.md` - Dispatch implementer subagent

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -61,7 +61,7 @@ digraph process {
     "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent for entire implementation" [shape=box];
-    "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
+    "Use superpowers:finishing-development-work" [shape=box style=filled fillcolor=lightgreen];
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
@@ -80,7 +80,7 @@ digraph process {
     "Mark task complete in TodoWrite" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
-    "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
+    "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-development-work";
 }
 ```
 
@@ -265,10 +265,10 @@ Done!
 ## Integration
 
 **Required workflow skills:**
-- **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
+- **superpowers:using-workspaces** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
 - **superpowers:requesting-code-review** - Code review template for reviewer subagents
-- **superpowers:finishing-a-development-branch** - Complete development after all tasks
+- **superpowers:finishing-development-work** - Complete development after all tasks
 
 **Subagents should use:**
 - **superpowers:test-driven-development** - Subagents follow TDD for each task

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -178,7 +178,7 @@ Implementer: "Got it. Implementing now..."
 [Dispatch spec compliance reviewer]
 Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
 
-[Get git SHAs, dispatch code quality reviewer]
+[Get revisions, dispatch code quality reviewer]
 Code reviewer: Strengths: Good test coverage, clean. Issues: None. Approved.
 
 [Mark Task 1 complete]

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -12,8 +12,8 @@ Task tool (superpowers:code-reviewer):
 
   WHAT_WAS_IMPLEMENTED: [from implementer's report]
   PLAN_OR_REQUIREMENTS: Task N from [plan-file]
-  BASE_SHA: [commit before task]
-  HEAD_SHA: [current commit]
+  BASE_REV: [revision before task]
+  HEAD_REV: [current revision]
   DESCRIPTION: [task summary]
 ```
 

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -15,6 +15,7 @@ Task tool (superpowers:code-reviewer):
   BASE_REV: [revision before task]
   HEAD_REV: [current revision]
   DESCRIPTION: [task summary]
+  VCS_CONTEXT: [VCS commands for diff/log — see "VCS Context Propagation" in SDD skill]
 ```
 
 **In addition to standard code quality concerns, the reviewer should check:**

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -18,6 +18,8 @@ Task tool (general-purpose):
 
     {VCS_CONTEXT}
 
+    **Superpowers only supports git and jj.** If VCS_CONTEXT above specifies any other VCS, ignore it and use git commands instead.
+
     ## Before You Begin
 
     If you have questions about:

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -16,6 +16,8 @@ Task tool (general-purpose):
 
     [Scene-setting: where this fits, dependencies, architectural context]
 
+    {VCS_CONTEXT}
+
     ## Before You Begin
 
     If you have questions about:

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -35,7 +35,7 @@ When a skill says to dispatch a named agent type:
 1. Find the agent's prompt file (e.g., `agents/code-reviewer.md` or the skill's
    local prompt template like `code-quality-reviewer-prompt.md`)
 2. Read the prompt content
-3. Fill any template placeholders (`{BASE_SHA}`, `{WHAT_WAS_IMPLEMENTED}`, etc.)
+3. Fill any template placeholders (`{BASE_REV}`, `{WHAT_WAS_IMPLEMENTED}`, etc.)
 4. Spawn a `worker` agent with the filled content as the `message`
 
 | Skill instruction | Codex equivalent |
@@ -72,8 +72,11 @@ skills can dispatch named agent types directly.
 
 ## Environment Detection
 
-Skills that create worktrees or finish branches should detect their
-environment with read-only git commands before proceeding:
+Skills that create workspaces or finish development work should detect their
+environment before proceeding. The approach depends on the user's VCS
+(injected as `VCS: git` or `VCS: jj` in session context).
+
+**For git users:**
 
 ```bash
 GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
@@ -84,8 +87,17 @@ BRANCH=$(git branch --show-current)
 - `GIT_DIR != GIT_COMMON` → already in a linked worktree (skip creation)
 - `BRANCH` empty → detached HEAD (cannot branch/push/PR from sandbox)
 
-See `using-git-worktrees` Step 0 and `finishing-a-development-branch`
-Step 1 for how each skill uses these signals.
+**For jj users:**
+
+```bash
+jj workspace list 2>/dev/null
+```
+
+- More than one workspace listed → already in a linked workspace (skip creation)
+- Check if current workspace has a bookmark: `jj bookmark list`
+
+See `using-workspaces` and `finishing-development-work`
+for how each skill uses these signals.
 
 ## Codex App Finishing
 

--- a/skills/using-superpowers/references/vcs-operations.md
+++ b/skills/using-superpowers/references/vcs-operations.md
@@ -1,0 +1,40 @@
+# VCS Operations Reference
+
+Skills describe VCS operations abstractly. Use the column matching your VCS (injected as `VCS: git` or `VCS: jj` in session context) for concrete commands.
+
+## Key Conceptual Differences
+
+Before using the command table, understand how the two VCS models differ:
+
+- **No staging area in jj.** The working copy is automatically tracked. `jj describe` sets the commit message for the current change; `jj new` starts a new change. This replaces git's add/commit workflow.
+- **Bookmarks, not branches.** jj "bookmarks" map to git branches on push, but they're optional — jj works with anonymous revisions by default. You only need a bookmark when pushing to a remote.
+- **Change IDs, not SHAs.** jj identifies revisions by change ID (a stable identifier that survives rewrites). Review commands use revision expressions (`@` for current, `trunk()` for main branch, change IDs) rather than SHA ranges.
+- **Workspaces don't auto-create named refs.** Unlike git worktrees (which require a branch), jj workspaces create a new working copy at a revision. Create a bookmark explicitly if you want a named ref.
+
+## Operation Mapping
+
+| Operation | git | jj |
+|-----------|-----|-----|
+| **Workspace isolation** | | |
+| Detect project root | `git rev-parse --show-toplevel` | `jj root` |
+| Create isolated workspace | `git worktree add "$path" -b "$BRANCH"` | `jj workspace add "$path"` |
+| Remove workspace | `git worktree remove "$path"` | `jj workspace forget "$workspace_name" && rm -rf "$path"` |
+| List workspaces | `git worktree list` | `jj workspace list` |
+| Check if in linked workspace | `GIT_DIR=$(cd "$(git rev-parse --git-dir)" && pwd -P)` / `GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)` / compare: `GIT_DIR != GIT_COMMON` | `jj workspace list` — if current directory's workspace name is not `default`, you are in a linked workspace |
+| **Branching & bookmarks** | | |
+| Create named ref | `git checkout -b "$name"` | `jj bookmark create "$name"` |
+| Current ref name | `git branch --show-current` | `jj bookmark list` (look for bookmark at current revision) |
+| Determine base | `git merge-base HEAD main` | `jj log -r 'trunk()' --no-graph -T 'change_id ++ "\n"' \| head -1` |
+| **History & review** | | |
+| Show diff for range | `git diff $BASE..$HEAD` | `jj diff -r "$rev"` |
+| Diff stats for range | `git diff --stat $BASE..$HEAD` | `jj diff --stat -r "$rev"` |
+| Log recent history | `git log --oneline` | `jj log --no-graph` |
+| Current revision identifier | `git rev-parse HEAD` | `jj log -r @ --no-graph -T 'change_id ++ "\n"' \| head -1` |
+| **Committing** | | |
+| Stage and commit | `git add <files> && git commit -m "msg"` | `jj describe -m "msg" && jj new` |
+| **Integration** | | |
+| Merge to base | `git checkout $base && git merge $feature` | `jj new $base_rev $feature_rev` (creates merge commit) |
+| Push to remote | `git push -u origin "$branch"` | `jj git push -b "$bookmark"` |
+| **Safety** | | |
+| Check if directory is ignored | `git check-ignore -q "$dir"` | `git check-ignore -q "$dir"` (jj uses .gitignore) |
+| Discard feature work | `git branch -D "$name"` | `jj abandon "$rev"` |

--- a/skills/using-workspaces/SKILL.md
+++ b/skills/using-workspaces/SKILL.md
@@ -1,17 +1,19 @@
 ---
-name: using-git-worktrees
-description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification
+name: using-workspaces
+description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated workspaces with smart directory selection and safety verification
 ---
 
-# Using Git Worktrees
+# Using Workspaces
 
 ## Overview
 
-Git worktrees create isolated workspaces sharing the same repository, allowing work on multiple branches simultaneously without switching.
+Isolated workspaces let you work on multiple tasks simultaneously without interference, sharing the same repository.
 
 **Core principle:** Systematic directory selection + safety verification = reliable isolation.
 
-**Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
+**Announce at start:** "I'm using the using-workspaces skill to set up an isolated workspace."
+
+**VCS commands:** All VCS operations below use abstract names. See `references/vcs-operations.md` for the concrete command matching your user's VCS (injected as `VCS: git` or `VCS: jj` in session context).
 
 ## Directory Selection Process
 
@@ -30,7 +32,7 @@ ls -d worktrees 2>/dev/null      # Alternative
 ### 2. Check CLAUDE.md
 
 ```bash
-grep -i "worktree.*director" CLAUDE.md 2>/dev/null
+grep -i "worktree.*director\|workspace.*director" CLAUDE.md 2>/dev/null
 ```
 
 **If preference specified:** Use it without asking.
@@ -40,7 +42,7 @@ grep -i "worktree.*director" CLAUDE.md 2>/dev/null
 If no directory exists and no CLAUDE.md preference:
 
 ```
-No worktree directory found. Where should I create worktrees?
+No workspace directory found. Where should I create workspaces?
 
 1. .worktrees/ (project-local, hidden)
 2. ~/.config/superpowers/worktrees/<project-name>/ (global location)
@@ -52,21 +54,18 @@ Which would you prefer?
 
 ### For Project-Local Directories (.worktrees or worktrees)
 
-**MUST verify directory is ignored before creating worktree:**
+**MUST verify directory is ignored before creating workspace:**
 
-```bash
-# Check if directory is ignored (respects local, global, and system gitignore)
-git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/dev/null
-```
+Use the "Check if directory is ignored" operation from `references/vcs-operations.md`.
 
 **If NOT ignored:**
 
 Per Jesse's rule "Fix broken things immediately":
 1. Add appropriate line to .gitignore
 2. Commit the change
-3. Proceed with worktree creation
+3. Proceed with workspace creation
 
-**Why critical:** Prevents accidentally committing worktree contents to repository.
+**Why critical:** Prevents accidentally committing workspace contents to repository.
 
 ### For Global Directory (~/.config/superpowers/worktrees)
 
@@ -76,27 +75,25 @@ No .gitignore verification needed - outside project entirely.
 
 ### 1. Detect Project Name
 
-```bash
-project=$(basename "$(git rev-parse --show-toplevel)")
-```
+Use the "Detect project root" operation from `references/vcs-operations.md`, then extract the directory name.
 
-### 2. Create Worktree
+### 2. Create Workspace
 
 ```bash
 # Determine full path
 case $LOCATION in
   .worktrees|worktrees)
-    path="$LOCATION/$BRANCH_NAME"
+    path="$LOCATION/$WORKSPACE_NAME"
     ;;
   ~/.config/superpowers/worktrees/*)
-    path="~/.config/superpowers/worktrees/$project/$BRANCH_NAME"
+    path="~/.config/superpowers/worktrees/$project/$WORKSPACE_NAME"
     ;;
 esac
-
-# Create worktree with new branch
-git worktree add "$path" -b "$BRANCH_NAME"
-cd "$path"
 ```
+
+Use the "Create isolated workspace" operation from `references/vcs-operations.md` with the path and workspace name.
+
+**jj note:** jj workspaces don't automatically create a named ref. If the user wants a named ref (needed for pushing/PRs later), use the "Create named ref" operation to create a bookmark after workspace creation.
 
 ### 3. Run Project Setup
 
@@ -119,7 +116,7 @@ if [ -f go.mod ]; then go mod download; fi
 
 ### 4. Verify Clean Baseline
 
-Run tests to ensure worktree starts clean:
+Run tests to ensure workspace starts clean:
 
 ```bash
 # Examples - use project-appropriate command
@@ -136,7 +133,7 @@ go test ./...
 ### 5. Report Location
 
 ```
-Worktree ready at <full-path>
+Workspace ready at <full-path>
 Tests passing (<N> tests, 0 failures)
 Ready to implement <feature-name>
 ```
@@ -157,8 +154,8 @@ Ready to implement <feature-name>
 
 ### Skipping ignore verification
 
-- **Problem:** Worktree contents get tracked, pollute git status
-- **Fix:** Always use `git check-ignore` before creating project-local worktree
+- **Problem:** Workspace contents get tracked, pollute status
+- **Fix:** Always verify directory is ignored before creating project-local workspace
 
 ### Assuming directory location
 
@@ -178,15 +175,15 @@ Ready to implement <feature-name>
 ## Example Workflow
 
 ```
-You: I'm using the using-git-worktrees skill to set up an isolated workspace.
+You: I'm using the using-workspaces skill to set up an isolated workspace.
 
 [Check .worktrees/ - exists]
-[Verify ignored - git check-ignore confirms .worktrees/ is ignored]
-[Create worktree: git worktree add .worktrees/auth -b feature/auth]
+[Verify ignored - confirmed .worktrees/ is ignored]
+[Create workspace using "Create isolated workspace" operation from vcs-operations.md]
 [Run npm install]
 [Run npm test - 47 passing]
 
-Worktree ready at /Users/jesse/myproject/.worktrees/auth
+Workspace ready at /Users/jesse/myproject/.worktrees/auth
 Tests passing (47 tests, 0 failures)
 Ready to implement auth feature
 ```
@@ -194,7 +191,7 @@ Ready to implement auth feature
 ## Red Flags
 
 **Never:**
-- Create worktree without verifying it's ignored (project-local)
+- Create workspace without verifying it's ignored (project-local)
 - Skip baseline test verification
 - Proceed with failing tests without asking
 - Assume directory location when ambiguous
@@ -215,4 +212,4 @@ Ready to implement auth feature
 - Any skill needing isolated workspace
 
 **Pairs with:**
-- **finishing-a-development-branch** - REQUIRED for cleanup after work complete
+- **finishing-development-work** - REQUIRED for cleanup after work complete

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -13,7 +13,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
 
-**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+**Context:** This should be run in a dedicated workspace (created by brainstorming skill).
 
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -97,9 +97,9 @@ Expected: PASS
 
 - [ ] **Step 5: Commit**
 
-Use the "Stage and commit" operation from `references/vcs-operations.md`:
-- Stage the test file and implementation file
-- Commit with message: "feat: add specific feature"
+Stage and commit the changes with message: "feat: add specific feature"
+
+**Important:** Write the actual VCS commands in your plan based on the user's VCS (from session context). Plans are executed by subagents that won't have access to `references/vcs-operations.md`. For git: `git add <files> && git commit -m "msg"`. For jj: `jj describe -m "msg" && jj new`.
 ````
 
 ## No Placeholders

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -97,10 +97,9 @@ Expected: PASS
 
 - [ ] **Step 5: Commit**
 
-```bash
-git add tests/path/test.py src/path/file.py
-git commit -m "feat: add specific feature"
-```
+Use the "Stage and commit" operation from `references/vcs-operations.md`:
+- Stage the test file and implementation file
+- Commit with message: "feat: add specific feature"
 ````
 
 ## No Placeholders

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -629,7 +629,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 - [ ] Supporting files only for tools or heavy reference
 
 **Deployment:**
-- [ ] Commit skill to git and push to your fork (if configured)
+- [ ] Commit skill and push to your fork (if configured)
 - [ ] Consider contributing back via PR (if broadly useful)
 
 ## Discovery Workflow

--- a/tests/claude-code/test-session-start-vcs.sh
+++ b/tests/claude-code/test-session-start-vcs.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tests for VCS config reading in session-start hook
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$(cd "$SCRIPT_DIR/../../hooks" && pwd)/session-start"
+FAILURES=0
+
+pass() { echo "  [PASS] $1"; }
+fail() { echo "  [FAIL] $1"; FAILURES=$((FAILURES + 1)); }
+
+echo "=== Session-start VCS config tests ==="
+
+# --- Test 1: Default VCS is git when no config file ---
+echo "Test 1: Default VCS is git when no config exists"
+TMPDIR_T=$(mktemp -d)
+HOME_ORIG="$HOME"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: git'; then
+    pass "default is git"
+else
+    fail "default is git — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+# --- Test 2: VCS reads jj from config ---
+echo "Test 2: VCS reads jj from config"
+TMPDIR_T=$(mktemp -d)
+mkdir -p "$TMPDIR_T/.config/superpowers"
+echo '{"vcs": "jj"}' > "$TMPDIR_T/.config/superpowers/config.json"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: jj'; then
+    pass "reads jj from config"
+else
+    fail "reads jj from config — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+# --- Test 3: VCS reads git from config ---
+echo "Test 3: VCS reads explicit git from config"
+TMPDIR_T=$(mktemp -d)
+mkdir -p "$TMPDIR_T/.config/superpowers"
+echo '{"vcs": "git"}' > "$TMPDIR_T/.config/superpowers/config.json"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: git'; then
+    pass "reads git from config"
+else
+    fail "reads git from config — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+# --- Test 4: Invalid VCS value falls back to git ---
+echo "Test 4: Invalid VCS value falls back to git"
+TMPDIR_T=$(mktemp -d)
+mkdir -p "$TMPDIR_T/.config/superpowers"
+echo '{"vcs": "svn"}' > "$TMPDIR_T/.config/superpowers/config.json"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: git'; then
+    pass "invalid value falls back to git"
+else
+    fail "invalid value falls back to git — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+# --- Test 5: Missing vcs key falls back to git ---
+echo "Test 5: Config exists but no vcs key"
+TMPDIR_T=$(mktemp -d)
+mkdir -p "$TMPDIR_T/.config/superpowers"
+echo '{"other": "value"}' > "$TMPDIR_T/.config/superpowers/config.json"
+export HOME="$TMPDIR_T"
+output=$(bash "$HOOK" 2>&1) || true
+if echo "$output" | grep -q 'VCS: git'; then
+    pass "missing key falls back to git"
+else
+    fail "missing key falls back to git — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
+fi
+export HOME="$HOME_ORIG"
+rm -rf "$TMPDIR_T"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo "All tests passed."
+    exit 0
+else
+    echo "$FAILURES test(s) failed."
+    exit 1
+fi

--- a/tests/claude-code/test-session-start-vcs.sh
+++ b/tests/claude-code/test-session-start-vcs.sh
@@ -67,6 +67,11 @@ if echo "$output" | grep -q 'VCS: git'; then
 else
     fail "invalid value falls back to git — got: $(echo "$output" | grep 'VCS:' || echo 'no VCS line')"
 fi
+if echo "$output" | grep -q 'important-reminder.*Unsupported VCS'; then
+    pass "invalid value emits visible warning"
+else
+    fail "invalid value emits visible warning — no important-reminder found"
+fi
 export HOME="$HOME_ORIG"
 rm -rf "$TMPDIR_T"
 

--- a/tests/claude-code/test-subagent-driven-development.sh
+++ b/tests/claude-code/test-subagent-driven-development.sh
@@ -141,7 +141,7 @@ echo "Test 8: Worktree requirement..."
 
 output=$(run_claude "What workflow skills are required before using subagent-driven-development? List any prerequisites or required skills." 30)
 
-if assert_contains "$output" "using-git-worktrees\|worktree" "Mentions worktree requirement"; then
+if assert_contains "$output" "using-workspaces\|workspace" "Mentions workspace requirement"; then
     : # pass
 else
     exit 1


### PR DESCRIPTION
## What problem are you trying to solve?

Superpowers hardcodes git commands and git-specific terminology throughout its skills. Users who use jj (Jujutsu) — which operates on top of git repos — cannot use skills like worktree creation, branch finishing, commit workflows, or code review without mentally translating every git command to its jj equivalent. Since skills are meant to be followed literally by agents, this translation fails silently: agents execute git commands that either error or produce unexpected results in a jj workflow.

Specific failure modes observed:
- `using-git-worktrees` tells agents to run `git worktree add` — jj users need `jj workspace add`
- `finishing-a-development-branch` references branches and merge — jj uses bookmarks and different merge semantics
- Subagent prompt templates assume git for diff/log — jj agents get wrong commands
- Code reviewer template falls back to `git diff` when VCS_CONTEXT is missing — silent failure for jj users

## What does this PR change?

Adds VCS abstraction across the entire skill set so both git and jj users are supported transparently. Renames git-specific skills to VCS-neutral names (`using-git-worktrees` → `using-workspaces`, `finishing-a-development-branch` → `finishing-development-work`). Adds a VCS operations reference doc mapping abstract operations to concrete git/jj commands. Session-start hook reads user VCS preference from `~/.config/superpowers/config.json` and injects it into session context. Subagent prompt templates accept a `{VCS_CONTEXT}` placeholder so dispatched agents get correct commands. Unsupported VCS values in config fall back to git with a visible warning.

## Is this change appropriate for the core library?

Yes. VCS is foundational infrastructure — every user of every project type uses version control. jj is gaining adoption as a git-compatible alternative (it operates on git repos, so teams can mix git and jj users on the same codebase). This is not a domain-specific or tool-specific change; it makes Superpowers work correctly for a growing segment of users regardless of what they're building.

## What alternatives did you consider?

1. **Separate jj plugin.** Rejected — would require duplicating every skill that mentions VCS commands. Maintenance nightmare, guaranteed drift.
2. **Auto-detect VCS from repo state.** Considered — jj repos contain a `.jj/` directory. Rejected as primary mechanism because different developers on the same repo may use different VCS tools (jj is git-compatible). User preference is the right signal, with auto-detection as possible future enhancement.
3. **Only abstract the worktree skill.** Rejected — VCS commands appear across brainstorming (commit spec), writing-plans (commit steps), code review (diff commands), finishing work (merge/push). Partial abstraction would leave jj users broken in most workflows.

## Does this PR contain multiple unrelated changes?

No. Single concern: VCS abstraction for git/jj support. All changes serve this goal:
- Design spec and implementation plan (docs)
- VCS operations reference doc (new reference)
- Session-start hook VCS detection (infrastructure)
- Skill renames and content updates (skill changes)
- Subagent prompt template updates (skill changes)
- Test coverage for VCS hook behavior (testing)

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1073, #1063, #1092, #639

**#1073** (open, chernistry) makes `using-git-worktrees` platform-neutral by checking multiple agent config files (CLAUDE.md, AGENTS.md, GEMINI.md). Orthogonal concern — that PR addresses which config file to read for worktree directory preferences; this PR addresses VCS command abstraction across all skills. Both changes are complementary; #1073's config detection loop would work within the renamed `using-workspaces` skill.

**#1063** (open, funsaized) also addresses platform-neutral worktrees, similar scope to #1073.

**#1092** (open, RaviTharuma) auto-creates `.worktrees/` directory. Orthogonal to VCS abstraction.

**#639** (open, stablegenius49) defaults to global worktree location. Orthogonal.

No existing PR addresses jj/Jujutsu support or VCS abstraction across the skill set.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code CLI                     | 1.0.33          | Claude | claude-opus-4-6 |

## Evaluation
- Audited all skill files for remaining git-specific language. Found and fixed 7 instances where git-specific terminology or fallback behavior remained after the main abstraction work.
- VCS hook test (`test-session-start-vcs.sh`) covers: no config, git config, jj config, invalid config (with warning assertion), missing file scenarios. All 6 assertions pass.

### Subagent Pressure Testing

Three pressure tests dispatched to verify VCS behavior end-to-end:

| Test | Scenario | Result | What it validates |
|------|----------|--------|-------------------|
| **1. Implementer + jj** | Subagent given jj VCS_CONTEXT, asked to implement feature | **PASS** — used jj commands exclusively (jj describe, jj diff, jj log). Zero git commands. | VCS_CONTEXT propagation works correctly for supported VCS |
| **2. Reviewer + empty VCS_CONTEXT** | Code reviewer subagent dispatched without VCS_CONTEXT filled | **PASS** (after fix) — initially auto-detected .jj dir and used jj commands. After updating template to default to git, correctly used git. | Missing VCS_CONTEXT defaults to git, no auto-detection |
| **3. Implementer + unsupported VCS** | Subagent given Mercurial (hg) commands in VCS_CONTEXT | **PASS** — read template guard ("Superpowers only supports git and jj"), ignored hg, used git throughout. Zero hg commands attempted. | Unsupported VCS in VCS_CONTEXT falls back to git |

**Test 2 drove a fix:** Initial code-reviewer.md wording let the agent work around missing VCS_CONTEXT by auto-detecting .jj. Updated to explicitly default to git and forbid auto-detection.

**Test 3 drove a fix:** Added guard to implementer-prompt.md and code-reviewer.md: "Superpowers only supports git and jj. If VCS_CONTEXT specifies any other VCS, ignore it and use git commands instead." Verified guard works from template alone.

**Defense in depth for unsupported VCS:**

| Layer | What happens | Tested by |
|-------|-------------|-----------|
| **Hook** (config validation) | Unsupported VCS in config → falls back to git + visible warning to user | test-session-start-vcs.sh test 4 |
| **Orchestrator** (SDD) | VCS is git → empty VCS_CONTEXT → subagents default to git | Pressure test 2 |
| **Subagent templates** | VCS_CONTEXT has unsupported VCS → ignores it, uses git | Pressure test 3 |

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

Pressure testing followed the writing-skills methodology: dispatched subagents with realistic scenarios under pressure (correct VCS, missing VCS, unsupported VCS). Two tests drove fixes before they were checked in. No behavior-shaping content (Red Flags tables, rationalization lists, workflow enforcement) was modified — only VCS command references and terminology were abstracted.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission