### PR TITLE
Add smart rebasing and conflict resolution to the finishing skill

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -21,20 +21,117 @@ Every project goes through this process. A todo list, a single-function utility,
 
 You MUST create a task for each of these items and complete them in order:
 
-1. **Explore project context** — check files, docs, recent commits
-2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
-3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
-4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+1. **Determine base branch and base revision** — see the "Base branch and revision" section below
+2. **Explore project context** — check files, docs, recent commits
+3. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
+4. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
+5. **Propose 2-3 approaches** — with trade-offs and your recommendation
+6. **Present design** — in sections scaled to their complexity, get user approval after each section
+7. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+8. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+9. **User reviews written spec** — ask user to review the spec file before proceeding
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+
+## Base branch and revision
+
+Every spec must record the commit and branch it was written against. This information is used later by `finishing-a-development-branch` to detect drift on the base branch, safely rebase, and route to the right fix flow when drift is found.
+
+### If invoked with inherited context
+
+If another skill (typically `finishing-a-development-branch` for drift recovery) dispatched this brainstorming session and provided `base_branch` and `base_revision` values, use them verbatim and skip the detection below. The invoker knows what it's doing — do not re-ask the user which branch to merge to, do not second-guess the revision.
+
+### Otherwise, detect the base branch
+
+Check the current branch:
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+```
+
+**If the current branch is one of** `main`, `master`, `dev`, `develop`, `developer`, or `trunk`: use the current branch as the base branch. Do not ask the user — the intent is unambiguous.
+
+**Otherwise:** present the following numbered-list question (generate options 2..N-1 dynamically, one per default-ish branch that actually exists in the repo, as reported by `git for-each-ref refs/heads/`):
+
+```
+You're on branch `<CURRENT_BRANCH>`. Which best describes your situation?
+
+1. This is a long-term branch. Start a new feature branch from here,
+   and later merge the feature back to `<CURRENT_BRANCH>`.
+2. This is the feature branch for this work. Complete the work here
+   and later merge back to `<default-branch-1>`.
+<additional options per existing default-ish branch>
+N. Something else — let me specify the base branch name.
+```
+
+Interpret the user's choice:
+- **Option 1 ("long-term branch"):** base branch = `<CURRENT_BRANCH>`. The feature will be built from here and merged back here.
+- **Options 2..N-1 ("feature branch"):** base branch = the named default-ish branch.
+- **Option N ("something else"):** ask the user to type the base branch name. Verify the name refers to an existing branch; if not, ask again.
+
+**Do not create new branches yourself.** Brainstorming records the intended base branch; it does not modify the git state.
+
+### Record the base revision
+
+Once the base branch is known, capture its current HEAD:
+
+```bash
+BASE_REVISION=$(git rev-parse "$BASE_BRANCH")
+```
+
+Also record the current UTC timestamp in ISO 8601 format.
+
+### Write the header into the spec
+
+When you write the spec document (checklist step 7), include these lines near the top of the file, after the title and before any section headings:
+
+```markdown
+This spec was written against the following baseline:
+
+**Base revision:** `<BASE_REVISION>` on branch `<BASE_BRANCH>` (as of <ISO 8601 UTC timestamp>)
+```
+
+Example:
+
+```markdown
+# Add Lowercase Function
+
+This spec was written against the following baseline:
+
+**Base revision:** `9c107a3cafa81a3acb32d12d25495baf958a1846` on branch `main` (as of 2026-04-12T14:30:00Z)
+
+## Summary
+...
+```
+
+The `**Base revision:**` line is **required** for drift detection to work. Do not omit it. Do not reword its format — `finishing-a-development-branch` parses this line.
+
+### When updating an existing spec (drift recovery)
+
+If you are invoked to update an existing spec (via the `spec_update` routing from `finishing-a-development-branch`), the spec already has a `**Base revision:**` header. Preserve the original `created at` commit, but add (or update) a "later updated to reflect" clause with the passed-in `base_revision`:
+
+Before:
+```markdown
+This spec was written against the following baseline:
+
+**Base revision:** `9c107a3...` on branch `main` (as of 2026-04-11T10:00:00Z)
+```
+
+After:
+```markdown
+This spec was written against the following baseline:
+
+**Base revision:** `9c107a3...` on branch `main`, later updated to reflect `b43f566...` (as of 2026-04-12T14:30:00Z)
+```
+
+If the header already has a "later updated to reflect" clause from a previous update, **replace** the old `<new_revision>` value with the current one — do not accumulate a chain of updates. The header always carries at most two values: the original creation revision and the most recent update revision.
+
+The branch name does not change across updates.
 
 ## Process Flow
 
 ```dot
 digraph brainstorming {
+    "Determine base branch/revision" [shape=box];
     "Explore project context" [shape=box];
     "Visual questions ahead?" [shape=diamond];
     "Offer Visual Companion\n(own message, no other content)" [shape=box];
@@ -47,6 +144,7 @@ digraph brainstorming {
     "User reviews spec?" [shape=diamond];
     "Invoke writing-plans skill" [shape=doublecircle];
 
+    "Determine base branch/revision" -> "Explore project context";
     "Explore project context" -> "Visual questions ahead?";
     "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
     "Visual questions ahead?" -> "Ask clarifying questions" [label="no"];
@@ -110,6 +208,7 @@ digraph brainstorming {
 
 - Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
+- **Include the `**Base revision:**` header near the top of the spec** (see "Base branch and revision" section above). This is mandatory for drift detection.
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
 
@@ -120,6 +219,7 @@ After writing the spec document, look at it with fresh eyes:
 2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
 3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
 4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+5. **Base revision header:** Is the `**Base revision:**` line present and correctly formatted?
 
 Fix any issues inline. No need to re-review — just fix and move on.
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -9,7 +9,7 @@ description: Use when implementation is complete, all tests pass, and you need t
 
 Guide completion of development work by presenting clear options and handling chosen workflow.
 
-**Core principle:** Verify tests → Present options → Execute choice → Clean up.
+**Core principle:** Verify tests → Rebase onto base branch → Detect drift → Present options → Execute choice → Clean up.
 
 **Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
 
@@ -37,14 +37,183 @@ Stop. Don't proceed to Step 2.
 
 **If tests pass:** Continue to Step 2.
 
-### Step 2: Determine Base Branch
+### Step 2: Read base info from the spec header
+
+Find the most recent spec in `docs/superpowers/specs/`:
 
 ```bash
-# Try common base branches
-git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
+# Files are named YYYY-MM-DD-<topic>-design.md; sort by filename date
+most_recent_spec=$(ls -1 docs/superpowers/specs/*.md 2>/dev/null | sort -r | head -1)
 ```
 
-Or ask: "This branch split from main - is that correct?"
+Parse the `**Base revision:**` line in that spec:
+
+```
+**Base revision:** `<hash>` on branch `<branch>` (as of <timestamp>)
+```
+
+Or, if the spec has been updated:
+
+```
+**Base revision:** `<original-hash>` on branch `<branch>`, later updated to reflect `<new-hash>` (as of <timestamp>)
+```
+
+Extract:
+- `BASE_BRANCH` — the branch name from "on branch `<branch>`"
+- `BASE_REVISION` — the "later updated to reflect" value if present; otherwise the first hash
+
+**If the spec has no `**Base revision:**` header** (e.g., it was written by an older brainstorming session that predates drift detection), skip Step 2.5 entirely and continue to Step 3. This is the backward-compatibility path: old specs get the old behavior (no drift detection), exactly as they would have under earlier versions of this skill.
+
+**If no spec exists at all** (rare; your human partner ran finishing on a branch without going through brainstorming), skip Step 2.5 and continue to Step 3, also as the old behavior.
+
+### Step 2.5: Rebase and drift detection
+
+**Run this step whenever a base revision was found in Step 2.** A clean rebase is not proof that the merge is safe, and a missing rebase is not proof that the drift is cosmetic. Both must be checked.
+
+**Do not skip this step because tests pass or your human partner already reviewed the code.**
+
+#### A. Pre-check the rebase (read-only)
+
+Determine whether rebasing the feature branch onto `<BASE_BRANCH>` would succeed cleanly, without actually mutating any branch state:
+
+```bash
+# Simulate a merge of BASE_BRANCH into HEAD using git merge-tree.
+# Output contains conflict markers if the rebase would fail.
+conflict_output=$(git merge-tree --write-tree "$BASE_REVISION" HEAD "$BASE_BRANCH" 2>&1)
+```
+
+If `git merge-tree` is not available on the host's git version, fall back to the portable approach:
+
+```bash
+# Create a throwaway worktree of the feature branch, try the rebase there,
+# capture the result, then remove the worktree. Never touches the main checkout.
+tmp_wt=$(mktemp -d)
+git worktree add -q --detach "$tmp_wt" HEAD
+(cd "$tmp_wt" && git rebase "$BASE_BRANCH" >/dev/null 2>&1) && rebase_clean=1 || rebase_clean=0
+git worktree remove -f "$tmp_wt"
+```
+
+Three outcomes are possible:
+
+1. **Rebase is clean and `git diff "$BASE_REVISION".."$BASE_BRANCH"` is empty** → the base branch hasn't moved since we branched, nothing to analyze. Continue to Step 3 without further drift work.
+
+2. **Rebase is clean and the diff is non-empty** → the base branch has moved but without textual conflicts. Proceed to (B) "Actually rebase" and then (C) "Dispatch reviewer with clean-rebase input."
+
+3. **Rebase would conflict** → the base branch and feature branch touch overlapping regions. Do NOT rebase. Record the list of conflicting files and a snippet of each conflict region. Skip (B) and go directly to (C) "Dispatch reviewer with conflict input."
+
+#### B. Actually rebase (clean case only)
+
+```bash
+git rebase "$BASE_BRANCH"
+```
+
+The feature branch is now linearly on top of `<BASE_BRANCH>`. Any subsequent merge (Step 4 Option 1) will be a clean fast-forward.
+
+#### C. Dispatch the drift reviewer subagent
+
+Use the Task tool with the **most capable available model** (drift evaluation is judgment, not mechanics — a cheap model will mechanically approve merges that no longer make sense). Do not evaluate drift inline.
+
+The reviewer needs:
+- The diff: `git diff "$BASE_REVISION".."$BASE_BRANCH"` (or, after rebasing in B, `git diff "$BASE_REVISION"..HEAD` — equivalent because the branch is now rebased)
+- The spec document(s) under `docs/superpowers/specs/`
+- The plan document(s) under `docs/superpowers/plans/`
+- A list of files this branch added or modified
+- **If rebase had conflicts** (case 3 above): the list of conflicting files and the conflict regions. Label this explicitly as "Rebase conflict" in the reviewer's input.
+
+Reviewer prompt template at `./drift-reviewer.md`.
+
+#### D. Act on the reviewer's report
+
+The reviewer reports `NO_DRIFT` or `DRIFT_FOUND` with issues and a `RECOMMENDED_ACTION`.
+
+**On NO_DRIFT:**
+
+- If we were in case 2 (clean rebase, non-empty diff): continue to Step 3. The branch is rebased and safe.
+- If we were in case 3 (rebase conflict): this shouldn't happen — a reviewer presented with rebase conflicts should not return NO_DRIFT. If it does, the reviewer's report is defective; re-dispatch with explicit instruction to treat the conflict as drift.
+
+**On DRIFT_FOUND:**
+
+STOP. Present the reviewer's findings to your human partner verbatim, then present the routing menu below with the reviewer's `RECOMMENDED_ACTION` highlighted. Do not merge, do not route, and do not take any other action until your human partner chooses from the menu.
+
+### Routing menu
+
+Present the routing menu. The available options depend on whether rebase was clean or conflicted:
+
+**Case: clean rebase.** Present all 5 options:
+
+```
+Drift found. The reviewer recommends: <recommendation>.
+
+How would you like to proceed?
+
+1. Create a delta implementation plan addressing these issues
+2. Update the spec to reflect the new state, then re-plan
+3. Restart the brainstorming process from scratch
+4. Override and merge anyway
+5. Keep the branch as-is (I'll handle it later)
+```
+
+**Case: rebase conflict.** Present only options 2, 3, and 5:
+
+```
+Drift found (with rebase conflict). The reviewer recommends: <recommendation>.
+
+How would you like to proceed?
+
+2. Update the spec to reflect the new state, then re-plan
+3. Restart the brainstorming process from scratch
+5. Keep the branch as-is (I'll handle it later)
+
+(Options 1 and 4 are not available when the rebase would conflict — a delta
+plan can only be derived from a spec, and override-merge cannot safely
+merge an unrebasable branch.)
+```
+
+Where `<recommendation>` is derived from the reviewer's `RECOMMENDED_ACTION:` field:
+
+- `delta_plan` → "option 1 (delta implementation plan)"
+- `spec_update` → "option 2 (update the spec and re-plan)"
+- `restart_brainstorming` → "option 3 (restart brainstorming)"
+
+**Do not add your own recommendation.** Use only the reviewer's `RECOMMENDED_ACTION:` value. If the reviewer did not include a `RECOMMENDED_ACTION:` line, the reviewer's report is incomplete — re-dispatch the reviewer asking for the structured recommendation before presenting the menu.
+
+### Acting on your human partner's choice
+
+**Option 1 — delta implementation plan** (only available with clean rebase):
+Invoke `superpowers:writing-plans`. Provide it with:
+- The current spec path(s)
+- The drift findings verbatim
+- `base_branch` (from the spec header)
+- `base_revision` = `git rev-parse "$BASE_BRANCH"` (the current HEAD of the base branch, which is also the new branch point after rebase)
+- Context: this is a delta plan addressing known drift issues on the base branch, not a fresh feature plan. The feature branch has been rebased onto the current base.
+
+**Option 2 — update the spec and re-plan:**
+Invoke `superpowers:brainstorming` focused on updating the existing spec. Provide it with:
+- The current spec path(s)
+- The drift findings verbatim
+- `base_branch` (unchanged; inherited)
+- `base_revision` = `git rev-parse "$BASE_BRANCH"` (the current HEAD at the moment of routing — drift up to this point will be absorbed by the updated spec, so the new base revision is "now")
+- **If rebase had conflicts:** the conflict files and regions as additional context, plus this instruction: "The rebase from this feature branch onto `<base_branch>` fails because of conflicts in `<files>`. Your updated spec must describe how each conflict should be resolved (which side should win, or how the two sides should be combined). Where the resolution is ambiguous, ask your human partner clarifying questions. The implementation plan derived from your spec will include rebase + conflict resolution as early tasks."
+- Standard instruction: "The spec is partially invalidated by drift on the base branch. Review the findings against the current codebase and update the spec accordingly. Where the drift creates ambiguity about what to build — multiple plausible ways to accommodate the new base branch state — ask your human partner clarifying questions using the same approach as initial brainstorming (one question at a time, prefer multiple choice, focus on purpose and constraints). Do not unilaterally choose among ambiguous options."
+- Context: after the spec is updated, route to `superpowers:writing-plans` for a fresh implementation plan. The plan is derived from the spec — the spec itself must fully describe any needed rebase and conflict resolution work.
+
+Brainstorming will use the provided `base_branch` and `base_revision` values verbatim and skip its own detection logic. When updating the spec header, it will preserve the original "created at" revision and add/update the "later updated to reflect" clause with the new `base_revision`.
+
+**Option 3 — restart brainstorming:**
+Invoke `superpowers:brainstorming` from the beginning. Provide:
+- `base_branch` (inherited)
+- `base_revision` = `git rev-parse "$BASE_BRANCH"` (current HEAD)
+- **If rebase had conflicts:** the conflict files and regions, plus the same conflict-resolution instruction as Option 2
+- Context: "The base branch has drifted significantly since this session started. The previous spec and plan should be reviewed but not assumed valid. Start from scratch."
+- The drift findings as reference material
+
+Brainstorming will write a new spec file with a fresh `**Base revision:**` header using the provided values.
+
+**Option 4 — override and merge anyway** (only available with clean rebase):
+Continue to Step 3 (Present Options) and proceed as if NO_DRIFT had been reported. Your human partner has seen the findings and made an informed choice; do not ask for extra confirmation. The branch has already been rebased (in Step 2.5.B), so the merge in Step 4 will be clean.
+
+**Option 5 — keep as-is:**
+Report: "Keeping branch as-is with drift unresolved. Resume by invoking finishing-a-development-branch after addressing the drift." Do not clean up. Exit the skill.
 
 ### Step 3: Present Options
 
@@ -164,6 +333,30 @@ git worktree remove <worktree-path>
 - **Problem:** Merge broken code, create failing PR
 - **Fix:** Always verify tests before offering options
 
+**Skipping drift detection because tests pass**
+- **Problem:** A clean compile and a clean rebase do not prove the merge is meaningful. The base branch may have changed in ways that invalidate the spec, duplicate the work, or reference deleted files. Tests pass, the merge looks fine, the result is wrong.
+- **Fix:** Always run Step 2.5 when a base revision is found in the spec header. Always dispatch the drift reviewer when the rebase produces changes or conflicts. Do not evaluate drift inline.
+
+**Running drift evaluation on the current session model**
+- **Problem:** Drift evaluation is a judgment task. The current session may be running on a fast/cheap model that cannot reliably catch semantic drift. Inline evaluation produces false confidence.
+- **Fix:** Dispatch the reviewer subagent with the most capable available model. Do not skip the dispatch.
+
+**Reviewer returning NO_DRIFT after minimal investigation**
+- **Problem:** A reviewer that returns `NO_DRIFT` after a single tool call and a one-sentence rationale on a non-trivial diff has not actually done the check. Quick judgment calls miss documentation drift, stale references, and semantic invalidations that don't break the build.
+- **Fix:** If the reviewer's report is suspiciously brief relative to the diff size, do not act on it. Re-dispatch the reviewer with explicit instruction to walk through each file referenced by the spec and verify it against the base branch.
+
+**Presenting drift findings without routing options**
+- **Problem:** Presenting drift findings followed by an open-ended "How would you like to proceed?" leaves the human with a list of problems and no path forward. The human has to figure out which other superpowers skills apply to each kind of drift — even though the skill has exactly that information available.
+- **Fix:** Always present the routing menu after drift findings. Highlight the reviewer's `RECOMMENDED_ACTION` but let the human choose.
+
+**Skipping rebase because drift detection passed**
+- **Problem:** The drift reviewer says the spec is content-consistent with the current base branch state, but the feature branch's git ancestry still diverges from the base. A subsequent merge will fail or silently revert base-branch changes.
+- **Fix:** Always perform the actual rebase in Step 2.5.B when the pre-check reports a clean rebase. Do not rely on content equivalence to stand in for ancestry alignment.
+
+**Presenting option 1 or 4 when the rebase would conflict**
+- **Problem:** A delta plan can only be derived from a spec (writing-plans doesn't do side-channel rebases), and override-merge cannot cleanly merge an unrebasable branch. Offering these options in the conflict case produces incoherent outcomes.
+- **Fix:** In the rebase-conflict case, suppress options 1 and 4 from the routing menu. Only options 2, 3, and 5 are available.
+
 **Open-ended questions**
 - **Problem:** "What should I do next?" → ambiguous
 - **Fix:** Present exactly 4 structured options
@@ -181,11 +374,26 @@ git worktree remove <worktree-path>
 **Never:**
 - Proceed with failing tests
 - Merge without verifying tests on result
+- **Skip Step 2.5 (drift detection) because tests pass or the rebase is clean**
+- **Evaluate drift inline instead of dispatching the reviewer subagent**
+- **Use a fast/cheap model for the drift reviewer dispatch**
+- **Merge while the drift reviewer reports DRIFT_FOUND and your human partner has not confirmed how to proceed**
+- **Present drift findings without the routing menu — the human needs concrete options, not an open-ended question**
+- **Add your own action recommendation — use only the reviewer's `RECOMMENDED_ACTION:` field**
+- **Skip the actual rebase in Step 2.5.B when the pre-check reports clean**
+- **Offer options 1 (delta plan) or 4 (override merge) when the rebase would conflict**
+- **Rebase the feature branch when the pre-check reports conflicts — let the routed fix flow handle resolution via spec design**
 - Delete work without confirmation
 - Force-push without explicit request
 
 **Always:**
 - Verify tests before offering options
+- Run Step 2.5 before presenting options, whenever the spec has a base revision header
+- Read the base branch and revision from the spec header, not from guessed commands
+- Pre-check the rebase before actually rebasing or dispatching the reviewer
+- Dispatch the drift reviewer with the most capable available model
+- Present drift findings to your human partner verbatim and wait for their decision
+- Advance the base revision to current base HEAD when routing to brainstorming or writing-plans (drift up to routing time is absorbed by the updated spec/plan)
 - Present exactly 4 options
 - Get typed confirmation for Option 4
 - Clean up worktree for Options 1 & 4 only
@@ -197,4 +405,6 @@ git worktree remove <worktree-path>
 - **executing-plans** (Step 5) - After all batches complete
 
 **Pairs with:**
+- **brainstorming** - Writes the `**Base revision:**` spec header that Step 2 reads
+- **writing-plans** - Derives implementation plans from specs, including any rebase/conflict-resolution tasks the spec describes
 - **using-git-worktrees** - Cleans up worktree created by that skill

--- a/skills/finishing-a-development-branch/drift-reviewer.md
+++ b/skills/finishing-a-development-branch/drift-reviewer.md
@@ -1,0 +1,190 @@
+# Drift Reviewer Prompt Template
+
+Use this template when dispatching a drift reviewer subagent from Step 2.5 of the finishing-a-development-branch skill.
+
+```
+You are a drift reviewer. The codebase has changed on the base branch since
+this feature branch was created. Decide whether those changes affect the
+feature branch's spec, plan, or implementation.
+
+## Changes on base branch since branch point
+
+[paste full output of: git diff <base_revision>..<base_branch>]
+
+## Spec for the feature branch
+
+[paste full content of the spec document(s) under docs/superpowers/specs/]
+
+## Plan for the feature branch
+
+[paste full content of the plan document(s) under docs/superpowers/plans/]
+
+## Files this branch added or modified
+
+[list of paths]
+
+## Rebase conflict (if applicable)
+
+[If the dispatching skill pre-checked the rebase and found it would conflict,
+this section is included. Otherwise it is omitted.
+
+Example structure when present:
+
+### Conflict summary
+The rebase from this feature branch onto `<base_branch>` fails in the
+following files:
+- src/index.ts (lines X-Y)
+- src/config.ts (lines A-B)
+
+### Conflict regions
+<paste the conflict output from git merge-tree or equivalent, showing the
+conflicting hunks with their surrounding context>
+]
+
+## Your job
+
+Read the actual files independently — do not trust the diff alone. You
+must read each file referenced in the spec or plan and verify that what
+the spec describes still matches what is now in the base branch.
+
+**Do not shortcut.** A diff that "looks harmless" still requires the full
+check. The cost of an unnecessary verification is a few extra tool calls.
+The cost of missing drift is silently merging code whose spec or plan
+no longer describes the codebase truthfully.
+
+Look for:
+
+- Spec assumptions that are now false — for example, the spec references
+  a file that no longer exists, describes a sync API that is now async,
+  or names a function that has been renamed
+- Implementation patterns now inconsistent with the codebase — for
+  example, the spec says "mirror existing X" and X has been refactored
+  away or restructured
+- Duplication — the work this branch adds may already exist somewhere
+  else after the base branch changes
+- Documentation drift — the spec or plan describes the codebase in terms
+  that are no longer accurate, even if the code itself still compiles
+- Stated future-integration plans that are now impossible
+
+**Documentation drift counts as drift.** A spec that says "X exists in
+file Y" while X no longer exists in Y is drift, even if the deliverable
+this branch adds compiles fine on its own. The spec is now factually
+false; future readers will be confused; the merged state contains a
+contradiction. Flag it.
+
+## Handling rebase-conflict input
+
+If the context includes a "Rebase conflict" section, the feature branch
+cannot be cleanly rebased onto the base branch. The conflicting files
+and regions are provided as additional input.
+
+In this case:
+
+- Treat the rebase conflict as the most severe form of drift — it means
+  the two sides have made incompatible changes to overlapping code regions
+- Read the conflicting files on both sides (base branch and feature branch)
+  to understand what each side is trying to accomplish in those regions
+- Analyze each conflict in your findings and explicitly describe what the
+  two sides disagree about (e.g., "main renamed `foo` to `bar` in this
+  region; the feature branch added a call to `foo` in the same region
+  expecting the old name")
+- Your `RECOMMENDED_ACTION` in the conflict case should be `spec_update`
+  or `restart_brainstorming`, not `delta_plan`. A delta plan cannot be
+  derived from a spec that doesn't address conflict resolution, and
+  writing-plans doesn't inject side-channel rebase instructions — so the
+  spec itself has to describe how conflicts should be resolved.
+- Your `REASONING` should explain why spec_update is sufficient (the
+  original goal is still valid; the conflict can be resolved by updating
+  the spec to describe which side wins in each region and how the two
+  intents can coexist) or why restart_brainstorming is needed (the
+  conflict reveals that the feature's premise no longer holds and a
+  fresh design is required).
+
+## Minimum thoroughness
+
+Your investigation must include all of the following before reporting:
+
+1. Read the spec file(s) in full
+2. Read the plan file(s) in full
+3. For each file, function, or symbol the spec or plan names by reference,
+   verify it still exists with the same name and signature in the base
+   branch
+4. For each file this branch adds or modifies, check whether the base
+   branch already contains a similar or identical file
+5. If a "Rebase conflict" section is present, read both sides of each
+   conflicting file region and describe what each side is trying to do
+6. Provide reasoning that explicitly walks through what you checked
+
+A one-sentence verdict on a non-trivial diff is not acceptable. If your
+reasoning is shorter than the diff is long, you have not done the check.
+
+## Err on the side of caution
+
+When uncertain whether something constitutes drift, prefer `DRIFT_FOUND`.
+The cost of an unnecessary stop is one extra question to the human; they
+can always say "merge anyway." The cost of a missed drift is a confusing
+or wrong merged state that may not be caught until much later.
+
+If you find yourself reasoning "this technically doesn't break anything,
+so it's NO_DRIFT," check whether the spec or plan still describes the
+codebase truthfully. If the answer is no, the verdict is `DRIFT_FOUND`,
+even if the code compiles.
+
+When the context includes rebase conflict information, you may not return
+NO_DRIFT. The rebase conflict itself is drift — if the two sides couldn't
+be mechanically combined, that is evidence that the feature branch's code
+and the base branch's code disagree in ways that require human design
+judgment. Always return DRIFT_FOUND in this case.
+
+## Report
+
+Report exactly one of:
+
+- `NO_DRIFT` — base branch changes do not affect this work in any way:
+  the spec, the plan, and the implementation are all still consistent
+  with the current state of the base branch. Provide a short summary of
+  what you checked. (Not permitted when rebase conflict input is present.)
+- `DRIFT_FOUND` — base branch changes affect this work; list specific
+  issues with file:line references and a recommended action for each.
+
+Do not classify severity. Do not recommend whether to merge. Your job is
+to surface concrete problems for the human to decide on.
+
+### If DRIFT_FOUND: structured recommendation
+
+After listing the issues, end your report with a structured recommendation
+line in this exact format:
+
+```
+RECOMMENDED_ACTION: <delta_plan | spec_update | restart_brainstorming>
+REASONING: <1-2 sentence justification>
+```
+
+Where:
+
+- `delta_plan` — the spec is still correct, but the implementation needs
+  adjustment to match the current base branch state. The existing spec
+  is a valid specification; the fix is an implementation delta.
+  **Not available when rebase-conflict input is present.**
+
+- `spec_update` — the spec's assumptions are partially invalidated, but
+  the original problem the spec addresses is still valid. The fix
+  requires updating the spec to reflect the current base branch state.
+  Where the drift creates genuine ambiguity about what to build — for
+  example, main removed a mechanism the spec assumed was available and
+  there are several plausible replacements — the spec update should
+  include clarifying questions to the human before deciding. After the
+  spec is corrected, the implementation may need a small follow-up fix.
+  When conflict input is present, spec_update means the spec should be
+  updated to describe conflict resolution explicitly.
+
+- `restart_brainstorming` — the changes on the base branch undermine the
+  original problem statement or approach. The previous design premise
+  no longer holds; a fresh round of brainstorming is needed to decide
+  what to do given the new reality.
+
+Do not recommend "merge anyway" or "no action needed." Your job is to
+recommend a fix path for the drift you found. The human may choose to
+override and merge, but that is their decision to make from the menu of
+options the finishing skill will present, not yours.
+```


### PR DESCRIPTION
## What problem are you trying to solve?

The finishing skill has no mechanism to detect that the base branch has changed since the feature branch was created. When `main` (or any base branch) moves during a long implementation session — from another user pushing, a teammate merging, a submodule being updated elsewhere, or simply another shell doing work on the same repo — the finishing skill merges blindly. The result can be:

1. **Silently stale merges**: the spec's assumptions are invalidated (a function was renamed, a file was deleted, an API changed from sync to async), but the merge succeeds textually and tests pass. The merged state contains contradictions that aren't caught until much later.
2. **Merge conflicts with no structured guidance**: when the feature branch and base branch touch overlapping files, the conflict surfaces at `git merge` time with no context about what the two sides disagree about or how to resolve it.
3. **Wrong base branch**: the finishing skill hardcodes `git merge-base HEAD main`, so features branched from `develop` or other long-term branches are diffed against the wrong branch and merged to the wrong target.

All three failure modes were observed in end-to-end testing across 7 scenarios (details in Evaluation section).

## What does this PR change?

Three files:

- **`skills/brainstorming/SKILL.md`**: New step 1 detects the base branch (via default-branch list or interactive question) and records it plus the current HEAD commit in the spec as a `**Base revision:**` header. When invoked for drift recovery, inherits these values from the caller.
- **`skills/finishing-a-development-branch/SKILL.md`**: Step 2 reads base branch and revision from the spec header instead of guessing. New Step 2.5 pre-checks the rebase (read-only), actually rebases when clean, dispatches a drift reviewer subagent with conflict context when not clean, and presents a conflict-aware routing menu (options 1 and 4 suppressed when rebase would conflict).
- **`skills/finishing-a-development-branch/drift-reviewer.md`** (new file): Reviewer prompt template with a new section for handling rebase-conflict input — forced DRIFT_FOUND verdict, `delta_plan` not available, conflict analysis required.

## Is this change appropriate for the core library?

Yes. Base-branch drift affects any user working on a feature branch while the base branch moves — this is not project-specific or domain-specific. The change touches two existing core skills (brainstorming, finishing) and adds one supporting file (drift-reviewer prompt template).

## What alternatives did you consider?

1. **`.superpowers-session.json` metadata file** (PR #997's approach): a separate JSON file written by brainstorming, read by finishing. Rejected because it introduced a file lifecycle (create, read, update, cleanup) with its own failure modes (file not found, stale, cleanup missed), and required different handling for worktree vs non-worktree cases. Embedding the same information in the spec document that already exists eliminates the file lifecycle entirely.

2. **Inline 3-level numeric escalation** (PR #997's approach): the finishing skill evaluated drift inline using Level 0/1/2/3 categories. Rejected because drift evaluation is a judgment task that benefits from the most capable model; inline evaluation on a fast session model produced false negatives (scenario 4 in prior testing was classified Level 0 when it should have been Level 2). Subagent dispatch with the most capable model produces more reliable verdicts.

3. **Drift detection without rebase** (the intermediate approach tested during development): detect drift via `git diff merge-base..base-branch` and route to fix flows, but never rebase the feature branch. This catches semantic drift but leaves ancestry divergence unresolved. In testing, this caused: (a) wasted reviewer re-dispatches — after a fix flow updates the spec and code, the merge-base remains frozen at the pre-drift commit, so the next finishing invocation sees the same diff and dispatches the reviewer again to re-confirm what was already fixed; (b) infinite symptom-chasing — when drift involves file deletions/additions, each finishing invocation discovers one more ancestry issue, and content-level patching never converges; (c) in one scenario, the reviewer broke its own structured output format to recommend "just rebase the branch" because no available routing option could express the actual fix. Adding the rebase step resolved all three issues.

## Does this PR contain multiple unrelated changes?

No. All changes implement one capability: detect and handle base-branch drift during the finishing flow. The brainstorming change (recording base revision) exists solely to provide the data that finishing reads. The drift-reviewer change (conflict handling) exists solely to support the conflict path in finishing.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs:
  - **#997** (open, ours) — earlier attempt at the same problem. Used `.superpowers-session.json` and inline 3-level escalation. Closed by us for clean-room redesign after v5.0.6 introduced contributor guidelines and PR template requirements that the original submission did not follow.
  - **#1000** (closed, ours) — companion PR to #997 for brainstorming changes. Also closed for clean-room redesign.
  - **#989** (closed) — the original issue. Maintainer closed it reading the scope as "multiple agents in the same worktree." We posted a follow-up comment reframing as "base branch moves from any source during a long session" — no response yet.
  - **#1121** (open, arittr) — worktree rototill rewriting `finishing-a-development-branch` for environment detection and cleanup ordering (bugs #940, #999, #238, #991). Does NOT include drift detection. Our changes add Step 2 and Step 2.5 before the options menu; #1121 rewrites Steps 3-6 (options, execution, cleanup). The two PRs modify the same file but address orthogonal concerns. If #1121 lands first, this PR will need to be rebased and retested against the new baseline.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 1.0.33 | Claude Sonnet 4.6 (finishing skill) | claude-sonnet-4-6 |
| Claude Code | 1.0.33 | Claude Opus 4.6 (drift reviewer subagent) | claude-opus-4-6 |

## Evaluation

Development followed RED-GREEN-REFACTOR per `superpowers:writing-skills` across four iterations, using two test suites (6 scenarios in iterations 1-3, expanded to 7 in iteration 4).

### Iteration history

**Original RED baseline** (6 scenarios, current main v5.0.7, no drift detection):
- 0/5 drift scenarios detected. Agent merged blindly in all cases.
- 1/1 control scenario: merged cleanly (correct).

**Iteration 1 GREEN** — added Step 2.5 with drift-reviewer subagent dispatch:
- 4/5 drift scenarios detected. Scenario 4 (rename) missed — reviewer shortcutted with 1 tool call and a one-sentence verdict.
- Loophole identified: reviewer can return NO_DRIFT after minimal investigation.

**Iteration 2 GREEN** (REFACTOR) — hardened reviewer prompt with "err on caution," "minimum thoroughness" checklist, "documentation drift counts as drift":
- 5/5 drift scenarios detected. Scenario 4 now caught.
- Loophole identified: after DRIFT_FOUND, agent presented findings with open-ended "How would you like to proceed?" — no actionable routing.

**Iteration 3 GREEN** (REFACTOR) — added structured `RECOMMENDED_ACTION` and 5-option routing menu:
- 5/5 drift scenarios detected with correct routing. All three recommendation types (`delta_plan`, `spec_update`, `restart_brainstorming`) exercised.
- Loophole identified: the finishing skill never rebases the feature branch. After a routed fix flow completes, the merge-base is frozen at the pre-drift commit, causing wasted reviewer re-dispatches (scenarios 1, 2), infinite symptom-chasing (scenario 3 equivalent), and merge-time conflicts on overlapping files.

**Iteration 4** — this PR. Added rebase pre-check, actual rebase, spec-embedded base revision header, conflict-aware routing. Expanded test suite to 7 scenarios (added scenario 7 for rebase conflicts) and added Case 3 coverage (feature branched from `develop`, not `main`).

### Iteration 4 RED baseline (7 scenarios, iteration 3 skill with drift detection but no rebase):

| Scenario | Drift type | Base branch | Outcome |
|----------|-----------|-------------|---------|
| 1 | sync→async migration | main | 2 finishing invocations, wasted opus reviewer on 2nd pass |
| 2 | async→sync revert + no-async comment | main | 3 finishing invocations, reviewer broke structured format to recommend rebase |
| 3 | file deleted + inlined + new file | develop | Suspended after 3rd DRIFT_FOUND — infinite symptom-chasing loop. Also: base branch defaulted to main, required manual correction |
| 4 | function rename | main | 2 finishing invocations, wasted opus reviewer on 2nd pass |
| 5 | README only (control) | develop | Merged to wrong branch (main instead of develop) |
| 6 | feature already implemented | main | Correctly detected and discarded (1 invocation) |
| 7 | async→sync (overlapping files) | main | Merge conflict at `git merge` time in Step 4, no structured guidance |

### Iteration 4 GREEN (this PR):

| Scenario | Drift type | Base branch | Outcome |
|----------|-----------|-------------|---------|
| 1 | sync→async migration | main | Drift detected, spec updated, fast-forward merge |
| 2 | async→sync revert + no-async comment | main | Drift detected, brainstorming restarted, fast-forward merge |
| 3 | file deleted + inlined + new file | develop | Drift detected against correct base, brainstorming restarted, fast-forward merge to develop |
| 4 | function rename | main | Drift detected, spec updated, fast-forward merge |
| 5 | README only (control) | develop | NO_DRIFT against correct branch, merged to develop |
| 6 | feature already implemented | main | Duplication detected, branch discarded — no regression |
| 7 | async→sync (overlapping files) | main | Conflict detected at pre-check, reduced menu, spec-driven resolution, fast-forward merge |

### Cumulative improvement across all iterations

| Metric | Original RED | Iter 1 | Iter 2 | Iter 3 | Iter 4 (this PR) |
|--------|-------------|--------|--------|--------|------------------|
| Drift detected before merge | 0/5 | 4/5 | 5/5 | 5/5 | 6/6 + 1 conflict |
| False positive (control) | 0/1 | 0/1 | 0/1 | 0/1 | 0/1 |
| Correct routing after detection | n/a | n/a | n/a | 5/5 | 7/7 |
| Wasted reviewer re-dispatches | n/a | n/a | n/a | 3/6 | 0/7 |
| Wrong base branch | not tested | not tested | not tested | 2/7 | 0/7 |
| Merge-time conflict (no guidance) | not tested | not tested | not tested | 1/7 | 0/7 |
| Fast-forward merge | 0/6 | 0/6 | 0/6 | 0/6 | 6/6 (scenario 6 discarded) |

### Known limitations

- **No feature branch creation**: brainstorming records the base branch but does not create a feature branch. Work starting on `main` or `develop` will commit directly there. This is a pre-existing upstream issue (see #991, #675, #829, #1121) — not introduced or addressed by this PR. Our test harness works around it by creating the feature branch in the launch script.
- **Single harness tested**: only Claude Code. The skills are harness-agnostic (plain git commands), but we have not validated on Codex, Cursor, or Gemini CLI.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

**Methodology**: RED-GREEN-REFACTOR per `superpowers:writing-skills` across four iterations. Iterations 1-3 developed the drift-reviewer prompt and routing menu through three REFACTOR cycles (6 scenarios each, 18 total runs). Iteration 4 added the rebase step and spec header, validated against an expanded 7-scenario suite (7 RED + 7 GREEN runs). Total: 32 end-to-end scenario runs across all iterations.

All new Red Flags and Common Mistakes entries are grounded in observed failures, not hypothetical concerns. New "human partner" language was used consistently in all additions to the finishing skill. The drift-reviewer prompt template carries forward all iteration 1-3 additions (minimum thoroughness, err on caution, documentation drift) unchanged, adding only the conflict-handling section.

**Adversarial coverage**: scenario 7 exercises the conflict path (rebase pre-check fails, reduced menu, spec-driven conflict resolution). Scenario 3 exercises the most severe drift (file deletion + restructuring on a non-default base branch). Scenario 6 validates no regression on the duplication-detection path. Scenario 5 validates no false positive on the control case.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission