### PR TITLE
fix: close sibling-worktree loophole in already-inside path

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -30,7 +30,11 @@ BRANCH=$(git branch --show-current)
 git rev-parse --show-superproject-working-tree 2>/dev/null
 ```
 
-**If `GIT_DIR != GIT_COMMON` (and not a submodule):** You are already in a linked worktree. Skip to Step 4 (Project Setup). Do NOT create another worktree.
+**If `GIT_DIR != GIT_COMMON` (and not a submodule):** You are already in a linked worktree. The current workspace is your working environment — use it for whatever the user is asking about. Skip to Step 4 (Project Setup).
+
+**Do not offer alternatives, and do not create another worktree — not here as a nested one, not as a sibling from the main repo, and not anywhere else.** If the user's request mentions "isolation" or "a worktree" explicitly, the current worktree already satisfies that need. Explain this and work in place.
+
+**If the user insists on different isolation for unrelated work:** stop and ask them to exit this workspace and re-invoke the skill from the main repo. Do not create siblings on their behalf.
 
 Report with branch state:
 - On a branch: "Already in isolated workspace at `<path>` on branch `<name>`."


### PR DESCRIPTION
## What problem are you trying to solve?

The `using-git-worktrees` skill's "already in a linked worktree" detection branch had a subtle loophole: agents would correctly refuse to *nest* a new worktree, but would then offer alternatives to the user — including "exit to the main repo and create a sibling worktree for signup there" — and execute the sibling option when the user accepted.

Drill scenario `worktree-already-inside-spec-aware` intermittently surfaced this (1 failure in 5 recent runs). Session log from the failing run:

> Agent (turn 3): *"GIT_DIR != GIT_COMMON and not a submodule — I'm already in a linked worktree. Per the skill, I must skip worktree creation and not nest another one. [...] You have three options: 1. Build signup here on existing-feature, 2. Build signup here on a new branch, 3. Create a sibling worktree — exit to the main repo and create a separate worktree for signup there. Which do you want?"*
>
> Agent (turn 4): executes option 3 — `git -C "$MAIN" worktree add .worktrees/signup -b signup`. Reports "Worktree ready at `.worktrees/signup` on branch signup."

The original directive *"Do NOT create another worktree"* was being read as *"don't NEST another worktree."* A sibling worktree created from the main repo is technically not nesting, so the agent considered itself compliant with the directive.

## What does this PR change?

Tightens the already-inside-worktree block in `using-git-worktrees/SKILL.md` to be unambiguous about creation:

- Current workspace is your working environment — use it for whatever the user asked about
- No alternatives, no creation: not as nested, not as sibling, not anywhere else
- If the user *does* insist on different isolation for unrelated work, the agent must stop and ask the user to exit this workspace and re-invoke the skill from the main repo themselves — not create siblings on their behalf

## Is this change appropriate for the core library?

Yes. This is a correctness fix to a core workflow skill. The loophole exists in the original `using-git-worktrees` text and persists through the `add-worktree-consent-step` (#1124) rewrite, so it applies regardless of which design iteration ships.

## What alternatives did you consider?

1. **A softer rewrite allowing sibling creation with explicit consent** — rejected. Allowing siblings creates the loophole again in a different form.
2. **Fixing this on #1124 as a 4th commit** — rejected because it would muddy #1124's "consent inversion" review narrative. This fix is a separate concern stacked above #1124.
3. **Filing as an issue and deferring** — rejected because the fix is small, targeted, and the evidence was fresh.

## Does this PR contain multiple unrelated changes?

No. Single-paragraph edit to one block in one file, +5/-1.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related: #1080 / #1097 (brainstorming → using-git-worktrees auto-invocation gap) — different failure mode, different fix

## Environment tested

| Harness | Harness version | Model | Model version/ID |
| --- | --- | --- | --- |
| Claude Code | latest | Claude Opus 4.6 | `claude-opus-4-6` |

## Evaluation

Drill harness validation on the two `already-inside` scenarios, 3 runs each:

| Scenario | Pre-fix | Post-fix |
| --- | --- | --- |
| `worktree-already-inside` | baseline PASS | ✅ 3/3 PASS |
| `worktree-already-inside-spec-aware` | 4/5 (80% — loophole triggered 1 time) | ✅ 3/3 PASS |

**6 runs, 18/18 criteria passed.** One post-fix run observed the agent still offering options, but the sibling-worktree option was gone — replaced by "exit and re-invoke from main repo" (the correct behavior per the new wording). Scenario passed because no worktree was created.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (drill harness)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review

- [ ] A human has reviewed the COMPLETE proposed diff before submission