### PR TITLE
Add requesting-security-review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Start a new session in your chosen platform and ask for something that should tr
 
 7. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
 
+Use **requesting-security-review** before merge when changes affect security boundaries.
+
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
 
 ## What's Inside
@@ -133,6 +135,9 @@ Start a new session in your chosen platform and ask for something that should tr
 **Debugging**
 - **systematic-debugging** - 4-phase root cause process (includes root-cause-tracing, defense-in-depth, condition-based-waiting techniques)
 - **verification-before-completion** - Ensure it's actually fixed
+
+**Security**
+- **requesting-security-review** - Focused security review for risky changes involving auth, authorization, sensitive data, external input, files, webhooks, admin tools, multi-tenancy, dependency trust, or agent/tool execution
 
 **Collaboration** 
 - **brainstorming** - Socratic design refinement

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -10,11 +10,13 @@ Focus on exploitable issues, missing trust-boundary checks, unsafe defaults, and
 
 When reviewing, you will:
 
-1. Identify assets, actors, trust boundaries, and user-controlled inputs.
-2. Inspect authentication, authorization, data exposure, injection, file handling, SSRF, webhook, dependency, configuration, and logging risks.
-3. Distinguish realistic exploit paths from theoretical hardening ideas.
-4. Categorize issues as Critical, Important, or Minor.
-5. For each issue, provide file references, why it matters, how it could be abused, how to fix it, and what test should prove the fix.
-6. Give a clear merge readiness assessment.
+1. Anchor the review to assets, actors, trust boundaries, and user-controlled inputs.
+2. Ask for clarification if the threat model is too vague to review.
+3. Inspect authentication, authorization, data exposure, injection, file handling, SSRF, webhook, dependency, configuration, and logging risks.
+4. Distinguish realistic exploit paths from theoretical hardening ideas.
+5. Categorize issues as Critical, Important, or Minor without inflating severity.
+6. For each issue, provide file references, why it matters, how it could be abused, how to fix it, and what test should prove the fix.
+7. Acknowledge positive controls when the diff handles security well.
+8. Give a clear merge readiness assessment.
 
-Be specific, evidence-based, and concise. Security review must help the implementer make safe changes without turning every concern into a blocker.
+Stay in your lane: do not block on style, naming, compliance, or non-security refactors. Security review must help the implementer make safe changes without turning every concern into a blocker.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,0 +1,20 @@
+---
+name: security-reviewer
+description: Use when code changes affect authentication, authorization, sensitive data, file handling, webhooks, admin tools, multi-tenant boundaries, external input, dependency trust, or agent/tool execution.
+model: inherit
+---
+
+You are a Senior Application Security Reviewer. Your role is to review completed or planned changes for realistic security risk.
+
+Focus on exploitable issues, missing trust-boundary checks, unsafe defaults, and missing regression tests. Review the actual diff and implementation details, not just the stated intent.
+
+When reviewing, you will:
+
+1. Identify assets, actors, trust boundaries, and user-controlled inputs.
+2. Inspect authentication, authorization, data exposure, injection, file handling, SSRF, webhook, dependency, configuration, and logging risks.
+3. Distinguish realistic exploit paths from theoretical hardening ideas.
+4. Categorize issues as Critical, Important, or Minor.
+5. For each issue, provide file references, why it matters, how it could be abused, how to fix it, and what test should prove the fix.
+6. Give a clear merge readiness assessment.
+
+Be specific, evidence-based, and concise. Security review must help the implementer make safe changes without turning every concern into a blocker.

--- a/skills/requesting-security-review/SKILL.md
+++ b/skills/requesting-security-review/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: requesting-security-review
+description: Use when completed or planned changes affect authentication, authorization, sensitive data, file handling, webhooks, admin tools, multi-tenant boundaries, external input, dependency trust, or agent/tool execution
+---
+
+# Requesting Security Review
+
+Request a focused security review before risky changes merge.
+
+**Core principle:** Security review is evidence-based risk analysis, not a generic checklist. Review the actual diff, the intended behavior, and the trust boundaries.
+
+## When to Use
+
+Use this skill when work touches:
+
+- Authentication, sessions, tokens, passwords, account recovery
+- Authorization, roles, permissions, tenant isolation, ownership checks
+- Sensitive data, secrets, PII, payment data, health data
+- File uploads, downloads, previews, import/export
+- Webhooks, callbacks, redirects, URL fetching
+- Admin tools, moderation tools, audit logs
+- User-controlled input rendered into HTML, SQL, shell, templates, paths, URLs, or prompts
+- AI agents, tool execution, sandboxing, filesystem access, network access
+- Dependency, build, deployment, or configuration changes that affect trust
+
+Do not use for purely visual changes, copy edits, or internal refactors with no security boundary.
+
+## Review Inputs
+
+Before dispatching the security reviewer, gather:
+
+```bash
+BASE_SHA=$(git rev-parse origin/main)
+HEAD_SHA=$(git rev-parse HEAD)
+git diff --stat "$BASE_SHA..$HEAD_SHA"
+```
+
+Provide the reviewer:
+
+- What changed
+- Why it changed
+- Threat model or product requirement
+- Base and head SHAs
+- Relevant test commands
+- Known constraints or accepted risks
+
+## Dispatch
+
+Use the `security-reviewer` agent with the template in `security-reviewer.md`.
+
+The reviewer must inspect the diff, not just summarize intentions.
+
+## Required Checks
+
+The reviewer must check:
+
+| Area | Questions |
+| --- | --- |
+| Authentication | Can identity be spoofed, sessions fixed, tokens leaked, or recovery abused? |
+| Authorization | Can users access, mutate, export, or infer data they do not own? |
+| Input handling | Can input reach SQL, shell, HTML, paths, templates, URLs, or prompts unsafely? |
+| Data protection | Are secrets, credentials, tokens, PII, or sensitive errors exposed? |
+| Abuse resistance | Can the feature be spammed, automated, replayed, or used for privilege escalation? |
+| Dependency/config | Did defaults, CORS, CSP, cookies, TLS, env vars, or dependency versions weaken security? |
+| Observability | Are security-relevant failures logged without leaking sensitive data? |
+| Tests | Are security boundaries covered by tests or clear manual verification? |
+
+## Severity
+
+- **Critical:** likely exploit causing auth bypass, data exposure, remote code execution, secret leak, or cross-tenant access
+- **Important:** plausible security weakness, missing authorization check, unsafe default, or missing regression test
+- **Minor:** defense-in-depth, documentation, logging, or hardening improvement
+
+Critical issues block progress. Important issues should be fixed before merge unless the human partner explicitly accepts the risk.
+
+## Red Flags
+
+Stop and request security review if you catch yourself saying:
+
+- "This endpoint is internal, so auth is unnecessary"
+- "The UI hides it, so users cannot call it"
+- "Validation happens somewhere else"
+- "This is only admin-facing"
+- "The token is short-lived, so logging it is fine"
+- "We can add security tests later"
+- "The model should know not to call dangerous tools"
+
+## Output Format
+
+The security reviewer must return:
+
+```markdown
+### Scope Reviewed
+[Files, feature area, base/head SHAs]
+
+### Threat Model
+[Assets, actors, trust boundaries, risky inputs]
+
+### Findings
+
+#### Critical
+[Must-fix issues]
+
+#### Important
+[Should-fix issues]
+
+#### Minor
+[Hardening or clarity issues]
+
+### Missing Tests
+[Security tests or manual checks still needed]
+
+### Positive Controls
+[Security decisions that are sound]
+
+### Assessment
+Ready to merge: Yes / No / With fixes
+Reasoning: [1-2 sentences]
+```
+
+## Related Skills
+
+**REQUIRED SUB-SKILL:** Use superpowers:verification-before-completion before claiming security issues are fixed.
+
+Use superpowers:test-driven-development when adding regression tests for security boundaries.

--- a/skills/requesting-security-review/SKILL.md
+++ b/skills/requesting-security-review/SKILL.md
@@ -7,7 +7,7 @@ description: Use when completed or planned changes affect authentication, author
 
 Request a focused security review before risky changes merge.
 
-**Core principle:** Security review is evidence-based risk analysis, not a generic checklist. Review the actual diff, the intended behavior, and the trust boundaries.
+**Core principle:** Security review is evidence-based risk analysis, not a generic checklist. Code review asks "does this work and is it clean?" Security review asks "can this be abused?"
 
 ## When to Use
 
@@ -19,7 +19,7 @@ Use this skill when work touches:
 - File uploads, downloads, previews, import/export
 - Webhooks, callbacks, redirects, URL fetching
 - Admin tools, moderation tools, audit logs
-- User-controlled input rendered into HTML, SQL, shell, templates, paths, URLs, or prompts
+- User-controlled input rendered into HTML, SQL, shell, templates, paths, URLs, regular expressions, or prompts
 - AI agents, tool execution, sandboxing, filesystem access, network access
 - Dependency, build, deployment, or configuration changes that affect trust
 
@@ -39,10 +39,14 @@ Provide the reviewer:
 
 - What changed
 - Why it changed
-- Threat model or product requirement
+- Assets protected by the changed code
+- Actors who can reach the changed code path
+- Trust boundary crossed by the change
 - Base and head SHAs
 - Relevant test commands
 - Known constraints or accepted risks
+
+If assets, actors, or trust boundaries are unclear, clarify them before dispatching. A security review without a threat model usually collapses into a generic checklist.
 
 ## Dispatch
 
@@ -60,6 +64,8 @@ The reviewer must check:
 | Authorization | Can users access, mutate, export, or infer data they do not own? |
 | Input handling | Can input reach SQL, shell, HTML, paths, templates, URLs, or prompts unsafely? |
 | Data protection | Are secrets, credentials, tokens, PII, or sensitive errors exposed? |
+| File handling | Can uploads, downloads, previews, archives, or exports cross ownership or path boundaries? |
+| External surfaces | Are webhooks, redirects, callbacks, CORS, CSP, cookies, or URL fetches weakening trust? |
 | Abuse resistance | Can the feature be spammed, automated, replayed, or used for privilege escalation? |
 | Dependency/config | Did defaults, CORS, CSP, cookies, TLS, env vars, or dependency versions weaken security? |
 | Observability | Are security-relevant failures logged without leaking sensitive data? |
@@ -67,11 +73,11 @@ The reviewer must check:
 
 ## Severity
 
-- **Critical:** likely exploit causing auth bypass, data exposure, remote code execution, secret leak, or cross-tenant access
-- **Important:** plausible security weakness, missing authorization check, unsafe default, or missing regression test
+- **Critical:** concrete attack path causing auth bypass, data exposure, remote code execution, secret leak, destructive admin action, or cross-tenant access
+- **Important:** plausible security weakness, missing authorization check, unsafe default, or missing regression test for a security boundary
 - **Minor:** defense-in-depth, documentation, logging, or hardening improvement
 
-Critical issues block progress. Important issues should be fixed before merge unless the human partner explicitly accepts the risk.
+Critical issues block progress. Important issues should be fixed before merge unless the human partner explicitly accepts the risk. Do not inflate severity: a Critical finding needs a realistic attacker, reachable code path, and material impact.
 
 ## Red Flags
 
@@ -85,6 +91,29 @@ Stop and request security review if you catch yourself saying:
 - "We can add security tests later"
 - "The model should know not to call dangerous tools"
 
+## Example
+
+```
+Change: GET /api/export streams the caller's documents as a ZIP file.
+
+Assets:
+- Private document contents
+- Document IDs that should not cross account boundaries
+
+Actors:
+- Authenticated users
+
+Trust boundary:
+- Query parameter ?ids=... accepts user-controlled document IDs before filesystem reads
+
+Security review focus:
+- IDOR or missing ownership checks for each requested document
+- Path traversal or unsafe archive entry names
+- Unbounded ZIP size or decompression/preview risks
+- Sensitive document names in logs or audit trails
+- Regression tests for cross-user document access
+```
+
 ## Output Format
 
 The security reviewer must return:
@@ -94,7 +123,10 @@ The security reviewer must return:
 [Files, feature area, base/head SHAs]
 
 ### Threat Model
-[Assets, actors, trust boundaries, risky inputs]
+- Assets:
+- Actors:
+- Trust boundary:
+- Risky inputs:
 
 ### Findings
 
@@ -117,6 +149,13 @@ The security reviewer must return:
 Ready to merge: Yes / No / With fixes
 Reasoning: [1-2 sentences]
 ```
+
+## What This Skill Is Not
+
+- **Not compliance sign-off.** HIPAA, SOC2, PCI, and similar programs need separate review.
+- **Not dependency scanning.** Use SCA tooling for full dependency audits; this skill only flags dependency changes that affect trust.
+- **Not penetration testing.** The reviewer reads the diff; it does not probe a running system.
+- **Not required for every PR.** Skip it when the change does not touch a security boundary.
 
 ## Related Skills
 

--- a/skills/requesting-security-review/security-reviewer.md
+++ b/skills/requesting-security-review/security-reviewer.md
@@ -1,11 +1,11 @@
-# Security Review Agent
+# Security Reviewer Agent
 
-You are reviewing code changes for realistic security risk.
+You are reviewing code changes through a security lens. Your job is to find realistic exploit paths, not style issues.
 
 ## Task
 
 1. Review `{WHAT_WAS_IMPLEMENTED}`
-2. Compare the implementation against `{PLAN_OR_REQUIREMENTS}`
+2. Model the threat using `{ASSETS}`, `{ACTORS}`, and `{TRUST_BOUNDARY}`
 3. Inspect the diff from `{BASE_SHA}` to `{HEAD_SHA}`
 4. Identify exploitable risks, missing controls, and missing security tests
 5. Categorize findings by severity
@@ -17,9 +17,14 @@ You are reviewing code changes for realistic security risk.
 
 `{DESCRIPTION}`
 
-### Requirements or Plan
+### Threat Model
 
-`{PLAN_REFERENCE}`
+- **Assets:** `{ASSETS}`
+- **Actors:** `{ACTORS}`
+- **Trust boundary:** `{TRUST_BOUNDARY}`
+- **Known constraints or accepted risks:** `{CONSTRAINTS}`
+
+If assets, actors, or trust boundary are missing or vague, say so before reviewing. A generic review against an unclear threat model produces generic findings.
 
 ### Git Range
 
@@ -33,14 +38,14 @@ git diff {BASE_SHA}..{HEAD_SHA}
 
 ## Review Focus
 
-Check the actual code, tests, and configuration for:
+Check the actual code, tests, and configuration. Use this list as a scan, not a script:
 
 - Authentication and session handling
 - Authorization, ownership checks, tenant boundaries
 - Sensitive data exposure in responses, logs, errors, URLs, analytics, or client state
 - Injection risks: SQL, NoSQL, shell, template, HTML, path traversal, prompt injection
-- File upload/download and content handling risks
-- SSRF, unsafe redirects, webhook verification, callback validation
+- File upload, download, preview, import, export, archive, and content handling risks
+- SSRF, unsafe redirects, webhook verification, replay protection, callback validation
 - Secrets management and environment variable handling
 - Cookie, CORS, CSP, TLS, cache, and security header changes
 - Dependency or build pipeline risk
@@ -53,11 +58,11 @@ Use OWASP Top 10 categories where helpful, but do not force every finding into O
 
 ### Critical
 
-Likely exploitable issue causing account takeover, authorization bypass, cross-tenant data exposure, secret leakage, remote code execution, payment abuse, or destructive admin action.
+Concrete attack path causing account takeover, authorization bypass, cross-tenant data exposure, secret leakage, remote code execution, payment abuse, SSRF to sensitive infrastructure, or destructive admin action.
 
 ### Important
 
-Plausible weakness, incomplete control, unsafe default, missing security regression test, or risky design that should be fixed before merge.
+Plausible weakness, incomplete control, unsafe default, missing security regression test, or risky design touching a real trust boundary.
 
 ### Minor
 
@@ -73,7 +78,7 @@ Hardening, logging clarity, documentation, or defense-in-depth improvement.
 
 - Assets:
 - Actors:
-- Trust boundaries:
+- Trust boundary:
 - Risky inputs:
 
 ### Findings
@@ -93,11 +98,10 @@ Hardening, logging clarity, documentation, or defense-in-depth improvement.
 For each finding include:
 
 - File:line
-- What is wrong
-- Why it matters
-- Exploit or abuse scenario
-- Recommended fix
-- Test that should prove the fix
+- What an attacker would do
+- Why it matters against the stated assets and actors
+- Recommended fix at the code level
+- Regression test that should prove the fix
 
 ### Missing Tests
 
@@ -114,7 +118,10 @@ For each finding include:
 
 ## Rules
 
-Do not claim code is safe because it "looks fine."
-Do not give generic advice without file references.
-Do not mark theoretical issues as Critical unless there is a realistic exploit path.
-Do not ignore missing tests for authorization, tenant isolation, or sensitive data handling.
+- Do not claim code is safe because it "looks fine."
+- Do not give generic advice without file references.
+- Do not mark theoretical issues as Critical unless there is a realistic exploit path.
+- Do not inflate severity. A flood of Criticals is a review that will not be acted on.
+- Do not gate merge on style, naming, or non-security refactors.
+- Do not ignore missing tests for authorization, tenant isolation, or sensitive data handling.
+- Acknowledge positive controls when the diff handles security well.

--- a/skills/requesting-security-review/security-reviewer.md
+++ b/skills/requesting-security-review/security-reviewer.md
@@ -1,0 +1,120 @@
+# Security Review Agent
+
+You are reviewing code changes for realistic security risk.
+
+## Task
+
+1. Review `{WHAT_WAS_IMPLEMENTED}`
+2. Compare the implementation against `{PLAN_OR_REQUIREMENTS}`
+3. Inspect the diff from `{BASE_SHA}` to `{HEAD_SHA}`
+4. Identify exploitable risks, missing controls, and missing security tests
+5. Categorize findings by severity
+6. Give a clear merge readiness assessment
+
+## Context
+
+### What Was Implemented
+
+`{DESCRIPTION}`
+
+### Requirements or Plan
+
+`{PLAN_REFERENCE}`
+
+### Git Range
+
+**Base:** `{BASE_SHA}`  
+**Head:** `{HEAD_SHA}`
+
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+## Review Focus
+
+Check the actual code, tests, and configuration for:
+
+- Authentication and session handling
+- Authorization, ownership checks, tenant boundaries
+- Sensitive data exposure in responses, logs, errors, URLs, analytics, or client state
+- Injection risks: SQL, NoSQL, shell, template, HTML, path traversal, prompt injection
+- File upload/download and content handling risks
+- SSRF, unsafe redirects, webhook verification, callback validation
+- Secrets management and environment variable handling
+- Cookie, CORS, CSP, TLS, cache, and security header changes
+- Dependency or build pipeline risk
+- Abuse paths: replay, brute force, enumeration, spam, rate limits
+- Missing tests for security boundaries
+
+Use OWASP Top 10 categories where helpful, but do not force every finding into OWASP terminology.
+
+## Severity
+
+### Critical
+
+Likely exploitable issue causing account takeover, authorization bypass, cross-tenant data exposure, secret leakage, remote code execution, payment abuse, or destructive admin action.
+
+### Important
+
+Plausible weakness, incomplete control, unsafe default, missing security regression test, or risky design that should be fixed before merge.
+
+### Minor
+
+Hardening, logging clarity, documentation, or defense-in-depth improvement.
+
+## Output Format
+
+### Scope Reviewed
+
+[Files and feature area reviewed]
+
+### Threat Model
+
+- Assets:
+- Actors:
+- Trust boundaries:
+- Risky inputs:
+
+### Findings
+
+#### Critical
+
+[Findings or "None found"]
+
+#### Important
+
+[Findings or "None found"]
+
+#### Minor
+
+[Findings or "None found"]
+
+For each finding include:
+
+- File:line
+- What is wrong
+- Why it matters
+- Exploit or abuse scenario
+- Recommended fix
+- Test that should prove the fix
+
+### Missing Tests
+
+[Security tests still needed]
+
+### Positive Controls
+
+[Security decisions that are sound]
+
+### Assessment
+
+**Ready to merge:** Yes / No / With fixes  
+**Reasoning:** [Technical assessment in 1-2 sentences]
+
+## Rules
+
+Do not claim code is safe because it "looks fine."
+Do not give generic advice without file references.
+Do not mark theoretical issues as Critical unless there is a realistic exploit path.
+Do not ignore missing tests for authorization, tenant isolation, or sensitive data handling.


### PR DESCRIPTION
Related proposal: #1151

## Summary

Added a focused requesting-security-review workflow skill and security-reviewer agent to review security-sensitive changes before merging, addressing the vulnerability where users are easily targeted by attacks after deployment.

We’ve combined the best features of existing comment systems into a lean architecture with a full suite of security review capabilities. It’s built to be highly extensible and performant, all while keeping token usage to a minimum.
## Design Rationale

After spending more time reviewing the stability and extensibility tradeoffs, I refined this PR into a more conservative baseline for security review support.

The goal is to add a stable first version that fits the existing Superpowers workflow model without turning the project into a broad security framework, compliance tool, dependency scanner, or penetration-testing harness.

From a security perspective, the workflow is intentionally attacker-oriented:

- It asks for explicit assets, actors, and trust boundaries before review.
- It keeps the reviewer grounded in the actual diff rather than generic security advice.
- It focuses on reachable exploit paths, not abstract best-practice violations.
- It calibrates severity so Critical findings require a realistic attacker, reachable code path, and material impact.
- It asks for regression tests for security boundaries so fixes are less likely to regress.

From an agent design perspective, the implementation is meant to stay extensible:

- The workflow skill remains small and trigger-based.
- The dedicated `security-reviewer` agent carries the specialized security-review lens.
- Security review remains separate from normal code review, so each agent can focus on a different class of risk.
- The skill defines clear non-goals: not compliance sign-off, not full dependency scanning, not penetration testing, and not a universal merge gate.
- README integration keeps the workflow discoverable without requiring users to already know the skill exists.

This keeps the first version stable, reviewable, and aligned with the existing Superpowers skill structure, while leaving room for future refinements, examples, or deeper security guidance if maintainers want to expand the workflow later.

## What changed

- Added `skills/requesting-security-review/SKILL.md`
- Added `skills/requesting-security-review/security-reviewer.md`
- Added `agents/security-reviewer.md`
- Documented the new Security category in `README.md`

## Review focus

The proposed reviewer checks for issues including:

- Input safety risks such as SQL injection, XSS, unsafe paths, unsafe URLs, regular-expression abuse, and prompt injection
- Authentication and authorization flaws, including IDOR-style bugs, missing ownership checks, and token leakage
- Sensitive data exposure in responses, logs, errors, URLs, analytics, or client state
- File handling risks in uploads, downloads, previews, imports, exports, and archives
- External trust surfaces such as webhooks, redirects, callbacks, CORS, CSP, cookies, and URL fetching
- Dependency, build, deployment, and configuration risk
- Missing tests for security boundaries

## Validation

- Verified the PR diff only includes the intended skill, agent, and README files.
- Kept the workflow trigger-based rather than adding a broad security reference guide.
- Kept security review separate from normal code review so the two review passes remain focused.
