### PR TITLE
fix(brainstorming): require explicit (Recommended) label when presenting approaches

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -80,8 +80,22 @@ digraph brainstorming {
 **Exploring approaches:**
 
 - Propose 2-3 different approaches with trade-offs
-- Present options conversationally with your recommendation and reasoning
-- Lead with your recommended option and explain why
+- **Always mark your recommendation explicitly** using `**(Recommended)**` next to the option label
+- Present your recommended option first, then alternatives
+- State clearly why you recommend it (1-2 sentences of reasoning, not just "it's simpler")
+
+Example format:
+```
+**Option A — [name] (Recommended)**
+[description and trade-offs]
+→ Why recommended: [specific reasoning]
+
+**Option B — [name]**
+[description and trade-offs]
+
+**Option C — [name]**
+[description and trade-offs]
+```
 
 **Presenting the design:**
 


### PR DESCRIPTION
## What problem are you trying to solve?

When brainstorming presents 2–3 approaches, the recommended option is only implied through word order or phrasing like "I'd lean toward option A." In practice, users have to re-read the options to identify which one Claude actually prefers — especially when all options are described with similar depth. This creates unnecessary friction at a decision point that should be fast.

Observed failure: after a brainstorming session presenting three approaches, the user had to ask a follow-up question to confirm which option was recommended, because the preference was buried in prose rather than marked explicitly.

## What does this PR change?

Updates the "Exploring approaches" section of the brainstorming skill to:

- Require an explicit `**(Recommended)**` marker next to the recommended option label
- Present the recommended option first
- Require a "Why recommended:" line with specific reasoning (not just "it's simpler")
- Add a concrete example format block so the instruction is unambiguous

Single file changed: `skills/brainstorming/SKILL.md`

## Is this change appropriate for the core library?

Yes. Clear recommendation labeling in design proposals benefits all users regardless of project type. It is not domain-specific or workflow-specific.

## What alternatives did you consider?

- **Leave as-is:** "Lead with your recommended option" works sometimes but the recommendation gets lost when options are described with similar depth. Explicit markup is more reliable.
- **Separate "My recommendation" section after all options:** Rejected — splits reasoning from the option description, making side-by-side comparison harder.

## Does this PR contain multiple unrelated changes?

No. Single file, single behavior change.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code CLI | latest | Claude Sonnet | aws/claude-sonnet-4-6 |

## Evaluation

**Sessions run after the change:** 3 brainstorming sessions on unrelated tasks (API design, CLI feature, config refactor).

**Before:** Recommendation implied through prose. In 2 of 3 sessions, a follow-up "which do you actually recommend?" was needed.

**After:** Every session produced a clearly marked `(Recommended)` label on the first option with a co-located "Why recommended:" line. No follow-up clarification needed in any session.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language)

The change only touches the "Exploring approaches" paragraph and adds an example format block. HARD-GATE, flow graph, Red Flags, and all other behavior-shaping content are untouched.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission