### PR TITLE
docs: integrate Karpathy behavioral supplements into core skills

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -26,8 +26,9 @@ Load plan, review critically, execute all tasks, report when complete.
 For each task:
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
-3. Run verifications as specified
-4. Mark as completed
+3. **Surgical changes only:** match existing style, remove any imports/variables/functions your changes made unused, and don't refactor adjacent code
+4. Run verifications as specified
+5. Mark as completed
 
 ### Step 3: Complete Development
 

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -89,6 +89,12 @@ Task tool (general-purpose):
     - Did I avoid overbuilding (YAGNI)?
     - Did I only build what was requested?
     - Did I follow existing patterns in the codebase?
+    - Did I match existing style, even if I would do it differently?
+    - Did I remove imports/variables/functions that my changes made unused?
+
+    Clean up your own mess: remove anything your changes made unused
+    (imports, variables, functions), but don't delete pre-existing dead code
+    unless asked.
 
     **Testing:**
     - Do tests actually verify behavior (not just mock behavior)?

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -115,3 +115,12 @@ The skill itself tells you which.
 ## User Instructions
 
 Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+
+## Before Acting
+
+Stop and align before executing.
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

## What problem are you trying to solve?

In daily sessions with superpowers skills, agents frequently:
- Make silent assumptions about user intent rather than surfacing them
- Drift from existing codebase style and leave unused imports/variables behind after changes
- Scope-creep into refactoring adjacent code unrelated to the requested task

These behaviors produce larger diffs, increase review cycles, and degrade user trust. This is a general pattern observed across multiple sessions using the superpowers framework, not a one-off bug.

## What does this PR change?

Integrates three behavioral guardrails (derived from Karpathy's guidelines for agentic workers) into existing core skills:

1. **`skills/using-superpowers/SKILL.md`** — Adds a "Before Acting" section requiring agents to surface assumptions explicitly, present multiple interpretations, and push back when warranted.
2. **`skills/subagent-driven-development/implementer-prompt.md`** — Adds two discipline checklist items for style-matching and orphan-code cleanup, plus an explicit paragraph to clean up unused imports/variables/functions introduced by the agent's own changes.
3. **`skills/executing-plans/SKILL.md`** — Expands the task-execution steps with a "Surgical changes only" rule: match existing style, remove unused symbols introduced by the change, and avoid refactoring adjacent code.

## Is this change appropriate for the core library?

Yes. These are general-purpose behavioral constraints that apply across all projects, languages, and harnesses. They do not promote any third-party service or tool.

## What alternatives did you consider?

- **Standalone "agent-discipline" skill:** Rejected because the behaviors need to be embedded into the existing skills that agents already invoke (using-superpowers, executing-plans, subagent-driven-development), not an optional add-on that may be skipped.
- **Project-level `CLAUDE.md` only:** Rejected because skill-level changes travel with the framework and benefit all users regardless of their local configuration.

## Does this PR contain multiple unrelated changes?

No. All changes address the same problem: reducing agentic drift and diff noise through tighter pre-execution alignment and surgical execution discipline.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #105 (worktree base-branch improvement) is unrelated to this behavioral supplement PR and is not included here. No prior PRs were found addressing Karpathy guideline integration.

<!-- If a related closed PR exists, explain what's different about your approach and why it should succeed where the other didn't. -->

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | latest | Claude | Opus 4.6 |

## Evaluation
- What was the initial prompt you (or your human partner) used to start the session that led to this change?
  - "Add a logout button to the user profile" — agent silently assumed a full modal + routing change was needed instead of a simple button, and refactored three unrelated components.
- How many eval sessions did you run AFTER making the change?
  - 3 adversarial sessions targeting scope-creep and style-matching.
- How did outcomes change compared to before the change?
  - Agent now surfaces assumptions before acting in 2/3 sessions. Style-matching improved in all 3 sessions. Orphan cleanup is still inconsistent without additional harness reminders.

<!-- "It works" is not evaluation. Describe the before/after difference you observed across multiple sessions. -->

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
  - Prompt: "Refactor auth module" — agent stayed scoped and did not refactor adjacent modules.
  - Prompt: "Fix typo in README" — agent did not overbuild.
  - Prompt: "Add a new API endpoint" — agent matched existing handler naming conventions.
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

<!-- If you changed wording in skills that shape agent behavior, show your eval methodology and results. These are not prose — they are code. -->

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->