### PR TITLE
fix(brainstorming): make assumptions and unknowns explicit before spec handoff

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -25,11 +25,12 @@ You MUST create a task for each of these items and complete them in order:
 2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+5. **Capture assumptions and unknowns** — list current assumptions, unresolved unknowns, and 1-3 concrete validation questions/checks
+6. **Present design** — in sections scaled to their complexity, get user approval after each section
+7. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+8. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+9. **User reviews written spec** — ask user to review the spec file before proceeding
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -40,6 +41,7 @@ digraph brainstorming {
     "Offer Visual Companion\n(own message, no other content)" [shape=box];
     "Ask clarifying questions" [shape=box];
     "Propose 2-3 approaches" [shape=box];
+    "Capture assumptions/unknowns" [shape=box];
     "Present design sections" [shape=box];
     "User approves design?" [shape=diamond];
     "Write design doc" [shape=box];
@@ -52,7 +54,8 @@ digraph brainstorming {
     "Visual questions ahead?" -> "Ask clarifying questions" [label="no"];
     "Offer Visual Companion\n(own message, no other content)" -> "Ask clarifying questions";
     "Ask clarifying questions" -> "Propose 2-3 approaches";
-    "Propose 2-3 approaches" -> "Present design sections";
+    "Propose 2-3 approaches" -> "Capture assumptions/unknowns";
+    "Capture assumptions/unknowns" -> "Present design sections";
     "Present design sections" -> "User approves design?";
     "User approves design?" -> "Present design sections" [label="no, revise"];
     "User approves design?" -> "Write design doc" [label="yes"];
@@ -82,6 +85,12 @@ digraph brainstorming {
 - Propose 2-3 different approaches with trade-offs
 - Present options conversationally with your recommendation and reasoning
 - Lead with your recommended option and explain why
+
+**Capturing assumptions and unknowns:**
+
+- Before design approval, explicitly list current assumptions and unresolved unknowns.
+- Include 1-3 concrete validation questions/checks when uncertainty remains.
+- Keep this section lightweight but explicit so uncertainty does not silently harden into scope.
 
 **Presenting the design:**
 
@@ -120,6 +129,7 @@ After writing the spec document, look at it with fresh eyes:
 2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
 3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
 4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+5. **Assumptions/unknowns check:** Are assumptions and unresolved unknowns still explicit in the written spec?
 
 Fix any issues inline. No need to re-review — just fix and move on.
 


### PR DESCRIPTION
## Summary
- add an explicit checklist step for assumptions/unknowns before design approval
- update the brainstorming flow graph to include this step between approaches and design presentation
- add lightweight guidance for listing assumptions, unknowns, and validation checks
- extend spec self-review with an assumptions/unknowns check

## Why
Issue #1098 requests a clear uncertainty-capture step so speculative choices do not silently harden into implementation scope.

## Validation
- manual content review of `skills/brainstorming/SKILL.md`
- verified checklist numbering, flow transitions, and self-review list consistency

Closes #1098