### PR TITLE
fix(brainstorming): add section overview and explicit section progress

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -25,7 +25,7 @@ You MUST create a task for each of these items and complete them in order:
 2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
+5. **Present design** — start with a section overview, then present sections scaled to their complexity and get user approval after each section
 6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
@@ -86,6 +86,8 @@ digraph brainstorming {
 **Presenting the design:**
 
 - Once you believe you understand what you're building, present the design
+- Before diving into details, show a compact section overview (index + one-line summary for each section)
+- When presenting sections, use `Section X of N` labels so progress is explicit
 - Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
 - Ask after each section whether it looks right so far
 - Cover: architecture, components, data flow, error handling, testing


### PR DESCRIPTION
## Summary
- update design-presentation checklist text to require an upfront section overview
- add guidance to show a compact section index before details
- require `Section X of N` labels during section walkthroughs

## Why
Issue #1132 asks for visibility into how many design sections are coming and how far along the review has progressed.

## Validation
- manual review of `skills/brainstorming/SKILL.md` for wording consistency
- verified the new guidance appears in both checklist and process instructions

Closes #1132