### PR TITLE
fix(hooks): avoid SessionStart path split on Windows home paths with spaces

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start\"",
             "async": false
           }
         ]


### PR DESCRIPTION
## Summary
- replace `run-hook.cmd` invocation in `hooks/hooks.json` with direct bash call to `hooks/session-start`
- keep the command quoted around `${CLAUDE_PLUGIN_ROOT}` so Windows paths containing spaces are preserved

## Why
Issue #1142 reports `SessionStart` failures when the Windows username/home path contains spaces. The current command loses path quoting after expansion and bash splits the path.

## Validation
- parsed `hooks/hooks.json` as JSON
- verified the command string is exactly:
  - `bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start`

Closes #1142