### PR TITLE
docs: add YAML frontmatter quoting guidance to writing-skills

### DIFF
--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -101,6 +101,13 @@ skills/
   - Include specific symptoms, situations, and contexts
   - **NEVER summarize the skill's process or workflow** (see CSO section for why)
   - Keep under 500 characters if possible
+  - **Always wrap in double quotes.** Unquoted values containing `: ` (colon + space) break YAML parsing silently — the skill won't be detected by `npx skills add` with no error message.
+    ```yaml
+    # BAD — silently breaks if description contains ": "
+    description: Use when configuring X for production applications: tuning and sizing
+    # GOOD
+    description: "Use when configuring X for production applications: tuning and sizing"
+    ```
 
 ```markdown
 ---


### PR DESCRIPTION
Fixes #955. Added YAML frontmatter quoting guidance to writing-skills SKILL.md — description values containing colons or special characters must be quoted or they'll break YAML parsing silently.

Includes a bad/good example showing the exact failure mode (`npx skills add` reports 0 skills with no error).
