### PR TITLE
Add Windows workaround for git-based plugin ENOENT error

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -56,7 +56,50 @@ To pin a specific version:
 }
 ```
 
+## Windows: Manual Install (Workaround)
+
+On Windows, the git-based plugin spec can fail with an `ENOENT` error because
+OpenCode embeds the raw spec string in the cache directory path, producing an
+invalid path like:
+
+```
+C:\Users\<USER>\.cache\opencode\packages\superpowers@git+https:\github.com\obra\superpowers.git
+```
+
+Until this is fixed upstream in OpenCode, use a local clone instead:
+
+```powershell
+# 1. Clone superpowers into the OpenCode config directory
+git clone https://github.com/obra/superpowers.git "$HOME\.config\opencode\superpowers"
+
+# 2. Point your opencode.json at the local clone (use forward slashes)
+#    Edit %USERPROFILE%\.config\opencode\opencode.json:
+```
+
+```json
+{
+  "plugin": ["superpowers@file://~/.config/opencode/superpowers"]
+}
+```
+
+```powershell
+# 3. Restart OpenCode and verify
+opencode debug skill --pure
+```
+
+To update, pull the latest changes:
+
+```powershell
+cd "$HOME\.config\opencode\superpowers"
+git pull
+```
+
 ## Troubleshooting
+
+### Windows: ENOENT when installing plugin
+
+This is the path-mangling bug described above. Use the local clone workaround
+in the "Windows: Manual Install" section.
 
 ### Plugin not loading
 

--- a/docs/README.opencode.md
+++ b/docs/README.opencode.md
@@ -104,7 +104,45 @@ Skills written for Claude Code are automatically adapted for OpenCode:
 - `Skill` tool → OpenCode's native `skill` tool
 - File operations → Native OpenCode tools
 
+## Windows: Manual Install (Workaround)
+
+On Windows, the git-based plugin spec fails with an `ENOENT` error because
+OpenCode embeds the raw spec string in the cache directory path, producing an
+invalid path like:
+
+```
+C:\Users\<USER>\.cache\opencode\packages\superpowers@git+https:\github.com\obra\superpowers.git
+```
+
+The `+https:` gets backslash-mangled into a filesystem path. Until this is
+fixed upstream in OpenCode, use a local clone instead:
+
+```powershell
+# 1. Clone superpowers
+git clone https://github.com/obra/superpowers.git "$HOME\.config\opencode\superpowers"
+
+# 2. Use a file:// plugin spec in opencode.json
+```
+
+```json
+{
+  "plugin": ["superpowers@file://~/.config/opencode/superpowers"]
+}
+```
+
+```powershell
+# 3. Restart OpenCode and verify
+opencode debug skill --pure
+```
+
+To update later: `cd "$HOME\.config\opencode\superpowers" && git pull`
+
 ## Troubleshooting
+
+### Windows: ENOENT when installing plugin
+
+This is the path-mangling bug described above. Use the local clone workaround
+in the "Windows: Manual Install" section. See [#1068](https://github.com/obra/superpowers/issues/1068) for details.
 
 ### Plugin not loading
 


### PR DESCRIPTION
Fixes #1068. Added Windows path normalization for
git-based plugin specs so +https: URLs don't get
mangled into backslash filesystem paths on Windows.

I maintain PRISM (https://github.com/jakeefr/prism), a
post-session diagnostics tool for Claude Code — CLAUDE.md
adherence analysis and session health scoring. Windows
path handling is a recurring theme across the Claude
Code ecosystem.