### PR TITLE
sync-to-codex-plugin: seed interface.defaultPrompt

### DIFF
--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -127,6 +127,10 @@ generate_plugin_json() {
       "Read",
       "Write"
     ],
+    "defaultPrompt": [
+      "I've got an idea for something I'd like to build.",
+      "Let's add a feature to this project."
+    ],
     "brandColor": "#F59E0B",
     "composerIcon": "./assets/superpowers-small.svg",
     "logo": "./assets/app-icon.png",


### PR DESCRIPTION
## What problem are you trying to solve?
Codex plugins surface an `interface.defaultPrompt` array as suggested
prompts on the plugin's app page (see the figma plugin's `plugin.json`
for the canonical shape). The superpowers plugin generator in
`scripts/sync-to-codex-plugin.sh` omits that field entirely, so when
the generated `plugin.json` lands in the openai-codex-plugins mirror
the superpowers app card has no onboarding hints — users who open the
listing see an empty prompt-suggestion area.

## What does this PR change?
Adds `defaultPrompt` to the `interface` block of the heredoc in
`generate_plugin_json()`, seeded with two generic prompts. No other
fields change; the rest of the manifest is byte-identical.

## Is this change appropriate for the core library?
Yes. `sync-to-codex-plugin.sh` is core tooling (added in #1165) and
every sync run through it produces the manifest this edit shapes. The
two seed prompts are deliberately domain-neutral ("I've got an idea
for something I'd like to build." / "Let's add a feature to this
project.") so they apply to any user, any project.

## What alternatives did you consider?
Making the prompts configurable via a flag or env var. Rejected: the
rest of the heredoc (displayName, description, category, colors,
icons) is all hard-coded, so threading one field through a config
layer would be inconsistent and buy nothing — editing the script is
the same friction as editing an env var.

## Does this PR contain multiple unrelated changes?
No. One field added in one file.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness     | Harness version | Model     | Model version/ID      |
|-------------|-----------------|-----------|-----------------------|
| Claude Code | current         | Opus 4.6  | claude-opus-4-6[1m]   |

Verified by extracting `generate_plugin_json` and running it against
`/tmp/sp-plugin-test.json`, then parsing the result with
`python3 -m json.tool` — output is valid JSON and
`interface.defaultPrompt` contains both seed strings. Did not run the
full sync end-to-end (would push to a fork destination).

## Evaluation
Not a skills change — no behavior-shaping content touched. The change
is a pure additive manifest field; eval criterion is "generated JSON
still parses and contains the expected array," which it does.

## Rigor
- [ ] If this is a skills change: N/A
- [x] This change was tested adversarially, not just on the happy path
      (verified JSON validity after edit; confirmed apostrophes in the
      string literals survive the unquoted heredoc without shell
      interpolation)
- [x] I did not modify carefully-tuned content

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission