### PR TITLE
feat: add disableGit mode to skip git worktree usage (fix #1140)

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -9,13 +9,35 @@ description: Use when implementation is complete, all tests pass, and you need t
 
 Guide completion of development work by presenting clear options and handling chosen workflow.
 
+## Git Disable Mode
+
+If disableGit is true:
+- DO NOT run any git commands
+- DO NOT merge branches
+- DO NOT create pull requests
+- DO NOT push code
+- DO NOT delete or manage branches/worktrees
+- Simply verify tests and mark work as complete
+
+This overrides all instructions in this file.
+
 **Core principle:** Verify tests → Present options → Execute choice → Clean up.
 
-**Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
+**Announce at start:** 
+If disableGit is false:
+"I'm using the finishing-a-development-branch skill to complete this work."
+
+If disableGit is true:
+"Git mode disabled. Skipping branch finalization and working without VCS."
 
 ## The Process
 
 ### Step 1: Verify Tests
+
+If disableGit is true:
+- Run tests as usual
+- If tests pass, report completion and STOP
+- Do NOT proceed to further steps
 
 **Before presenting options, verify tests pass:**
 
@@ -39,6 +61,9 @@ Stop. Don't proceed to Step 2.
 
 ### Step 2: Determine Base Branch
 
+If disableGit is true:
+Skip this step.
+
 ```bash
 # Try common base branches
 git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
@@ -47,6 +72,11 @@ git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
 Or ask: "This branch split from main - is that correct?"
 
 ### Step 3: Present Options
+
+If disableGit is true:
+Do NOT present any options.
+Instead respond:
+"Work completed successfully. Git operations are disabled, so no merge or PR actions were performed."
 
 Present exactly these 4 options:
 
@@ -64,6 +94,9 @@ Which option?
 **Don't add explanation** - keep options concise.
 
 ### Step 4: Execute Choice
+
+If disableGit is true:
+Skip this entire section.
 
 #### Option 1: Merge Locally
 
@@ -107,7 +140,11 @@ Then: Cleanup worktree (Step 5)
 
 #### Option 3: Keep As-Is
 
+If disableGit is false:
 Report: "Keeping branch <name>. Worktree preserved at <path>."
+
+If disableGit is true:
+Report: "Work completed. No git operations performed."
 
 **Don't cleanup worktree.**
 
@@ -134,6 +171,9 @@ git branch -D <feature-branch>
 Then: Cleanup worktree (Step 5)
 
 ### Step 5: Cleanup Worktree
+
+If disableGit is true:
+Do NOT perform any cleanup.
 
 **For Options 1, 2, 4:**
 
@@ -183,6 +223,7 @@ git worktree remove <worktree-path>
 - Merge without verifying tests on result
 - Delete work without confirmation
 - Force-push without explicit request
+- Execute git operations when disableGit is true
 
 **Always:**
 - Verify tests before offering options

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -39,6 +39,18 @@ digraph when_to_use {
 
 ## The Process
 
+## Git Disable Mode
+
+If disableGit is true:
+- DO NOT start or assume any git-based workflow
+- DO NOT create branches, commits, or worktrees
+- Subagents should NOT commit code
+- Execute tasks directly in the current workspace
+- Skip any steps involving version control
+- At completion, do NOT call finishing-a-development-branch
+
+This overrides all git-related behavior in this file.
+
 ```dot
 digraph process {
     rankdir=TB;
@@ -61,14 +73,21 @@ digraph process {
     "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent for entire implementation" [shape=box];
-    "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
+    If disableGit is false:
+    Use superpowers:finishing-a-development-branch
+    If disableGit is true:
+    Skip this step and report completion directly [shape=box style=filled fillcolor=lightgreen];
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
     "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
     "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Implementer subagent asks questions?" -> "Implementer subagent implements, tests, commits, self-reviews" [label="no"];
-    "Implementer subagent implements, tests, commits, self-reviews" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)";
+    Implementer subagent implements, tests, self-reviews
+    If disableGit is false:
+    - Commit changes
+    If disableGit is true:
+    - Do NOT commit changes -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)";
     "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" -> "Spec reviewer subagent confirms code matches spec?";
     "Spec reviewer subagent confirms code matches spec?" -> "Implementer subagent fixes spec gaps" [label="no"];
     "Implementer subagent fixes spec gaps" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [label="re-review"];
@@ -246,6 +265,7 @@ Done!
 - Let implementer self-review replace actual review (both are needed)
 - **Start code quality review before spec compliance is ✅** (wrong order)
 - Move to next task while either review has open issues
+- Perform commits or git operations when disableGit is true
 
 **If subagent asks questions:**
 - Answer clearly and completely
@@ -265,10 +285,10 @@ Done!
 ## Integration
 
 **Required workflow skills:**
-- **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
+- **superpowers:using-git-worktrees** - REQUIRED only if disableGit is false
 - **superpowers:writing-plans** - Creates the plan this skill executes
 - **superpowers:requesting-code-review** - Code review template for reviewer subagents
-- **superpowers:finishing-a-development-branch** - Complete development after all tasks
+- **superpowers:finishing-a-development-branch** - Only if disableGit is false
 
 **Subagents should use:**
 - **superpowers:test-driven-development** - Subagents follow TDD for each task

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -9,13 +9,33 @@ description: Use when starting feature work that needs isolation from current wo
 
 Git worktrees create isolated workspaces sharing the same repository, allowing work on multiple branches simultaneously without switching.
 
+## Git Disable Mode
+
+If disableGit is true:
+- DO NOT create git worktrees
+- DO NOT create branches
+- DO NOT run any git commands
+- Work in the current directory only
+- Skip directory selection and safety verification steps entirely
+- Proceed directly to implementation
+
+This overrides all instructions in this file.
+
 **Core principle:** Systematic directory selection + safety verification = reliable isolation.
 
-**Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
+**Announce at start:** 
+If disableGit is false:
+"I'm using the using-git-worktrees skill to set up an isolated workspace."
+
+If disableGit is true:
+"Git mode disabled. Working in current directory without worktrees."
 
 ## Directory Selection Process
 
 Follow this priority order:
+
+If disableGit is true:
+Skip this entire section.
 
 ### 1. Check Existing Directories
 
@@ -73,6 +93,12 @@ Per Jesse's rule "Fix broken things immediately":
 No .gitignore verification needed - outside project entirely.
 
 ## Creation Steps
+
+If disableGit is true:
+- Do NOT run any commands in this section
+- Do NOT create worktrees or branches
+- Stay in current directory
+- Continue with project setup if needed
 
 ### 1. Detect Project Name
 
@@ -136,7 +162,11 @@ go test ./...
 ### 5. Report Location
 
 ```
+If disableGit is false:
 Worktree ready at <full-path>
+
+If disableGit is true:
+Working in current directory (git disabled)
 Tests passing (<N> tests, 0 failures)
 Ready to implement <feature-name>
 ```
@@ -199,6 +229,7 @@ Ready to implement auth feature
 - Proceed with failing tests without asking
 - Assume directory location when ambiguous
 - Skip CLAUDE.md check
+- Run git commands when disableGit is true
 
 **Always:**
 - Follow directory priority: existing > CLAUDE.md > ask


### PR DESCRIPTION
## What problem are you trying to solve?
Fixes #1140

Users currently cannot opt out of git-based workflows (worktrees, commits, PR flow), which interrupts workflows for those who prefer manual control or are not using git.

---

## What does this PR change?
- Adds a `disableGit` mode to bypass all git/VCS operations
- Updates `using-git-worktrees` to skip worktree creation
- Updates `finishing-a-development-branch` to skip merge/PR/branch logic
- Updates `subagent-driven-development` to prevent commits and git assumptions

---

## Is this change appropriate for the core library?
Yes. This change adds flexibility without breaking existing workflows. Default behavior remains unchanged unless `disableGit` is enabled.

---

## What alternatives did you consider?
- Blocking git via permissions (caused interruptions)
- Ignoring git failures (not clean and breaks flow)

---

## Does this PR contain multiple unrelated changes?
No. All changes are focused on enabling a no-git workflow.

---

## Existing PRs
- No related PRs found
