### PR TITLE
review skills: enforce AGENTS.md checklist inline + new categories + severity floor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,14 +1,14 @@
 {
-  "name": "superpowers-dev",
-  "description": "Development marketplace for Superpowers core skills library",
+  "name": "vidably-superpowers",
+  "description": "Vidably fork of Superpowers core skills library",
   "owner": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"
   },
   "plugins": [
     {
-      "name": "superpowers",
-      "description": "Core skills library for Claude Code: TDD, debugging, collaboration patterns, and proven techniques",
+      "name": "vidably-superpowers",
+      "description": "Vidably fork: core skills library for Claude Code with Vidably-specific workflows",
       "version": "5.0.6",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
-  "name": "superpowers",
-  "description": "Core skills library for Claude Code: TDD, debugging, collaboration patterns, and proven techniques",
+  "name": "vidably-superpowers",
+  "description": "Vidably fork of superpowers: core skills library for Claude Code with Vidably-specific workflows",
   "version": "5.0.6",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"
   },
-  "homepage": "https://github.com/obra/superpowers",
-  "repository": "https://github.com/obra/superpowers",
+  "homepage": "https://github.com/Vidably/superpowers",
+  "repository": "https://github.com/Vidably/superpowers",
   "license": "MIT",
   "keywords": [
     "skills",
@@ -15,6 +15,7 @@
     "debugging",
     "collaboration",
     "best-practices",
-    "workflows"
+    "workflows",
+    "vidably"
   ]
 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/superpowers"]
-	path = tools/superpowers
-	url = https://github.com/Vidably/superpowers.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/superpowers"]
+	path = tools/superpowers
+	url = https://github.com/Vidably/superpowers.git

--- a/README.md
+++ b/README.md
@@ -1,28 +1,76 @@
+# Superpowers (Vidably Fork)
+
+> **This is [Vidably's](https://vidably.com) fork of [obra/superpowers](https://github.com/obra/superpowers).** We add custom skills on top of the excellent upstream workflow. Everything in the upstream 14-skill library works as-is — our additions are prefixed with `vidably-*` to avoid conflicts.
+
+## What Vidably Adds
+
+We build AI video evidence for e-commerce. Our engineering philosophy: **exhaustive research before decisions, multi-agent review for every plan and PR, and metrics to prove the process works.** These skills encode that philosophy.
+
+### Custom Skills
+
+| Skill                             | Status  | What It Does                                                                                                                                                                                                                                                                                                  |
+| --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vidably-exhaustive-research`     | Planned | Before any consequential decision (architecture, vendor choice, schema, services), search official docs and trusted sources, generate 4+ options with tradeoffs, rate on maintainability/complexity/extensibility/UX, present for approval. Type 1/Type 2 triage prevents over-triggering on trivial choices. |
+| `vidably-multi-agent-plan-review` | Planned | After writing a plan, dispatch it to multiple AI models (Claude, Codex, Gemini) in parallel. Collect findings, apply consensus scoring (unanimous = fix, majority = likely fix, split = judgment call). Prevents architectural gaps before any code is written.                                               |
+| `vidably-multi-agent-code-review` | Planned | Before opening a PR, dispatch the diff to multiple models. Same consensus scoring. Catches bugs across model blind spots (research shows 53% → 80% bug detection with multi-model debate).                                                                                                                    |
+
+### Supporting Infrastructure
+
+| Component            | Location   | What It Does                                                                                                                                                                         |
+| -------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Agent definitions    | `agents/`  | Shared prompt templates for plan review, code review, and consensus scoring. Reusable across local skills and CI.                                                                    |
+| Multi-model dispatch | `scripts/` | CLI runner that probes Codex/Gemini availability, handles input transport, timeouts, and output normalization. Gracefully degrades to Claude-only if external CLIs aren't available. |
+
+### How We Use This
+
+The fork is added to our app repo as a **git submodule** at `tools/superpowers/`. Custom skills are symlinked into `.claude/skills/` so Claude Code auto-discovers them with zero plugin installation. Edits to skills flow directly to this repo via git push.
+
+```
+our-app/
+  tools/superpowers/                    ← this repo (submodule)
+  .claude/skills/
+    vidably-exhaustive-research/        ← symlink → tools/superpowers/skills/vidably-exhaustive-research/
+    vidably-multi-agent-plan-review/    ← symlink → tools/superpowers/skills/vidably-multi-agent-plan-review/
+    vidably-multi-agent-code-review/    ← symlink → tools/superpowers/skills/vidably-multi-agent-code-review/
+```
+
+### Upstream Sync
+
+We sync with `obra/superpowers` monthly. Custom skills use the `vidably-*` prefix so merges are conflict-free:
+
+```bash
+git fetch upstream && git merge upstream/main
+```
+
+---
+
+## Original Superpowers README
+
+> Everything below is from the upstream [obra/superpowers](https://github.com/obra/superpowers) project by Jesse Vincent.
+
 # Superpowers
 
 Superpowers is a complete software development workflow for your coding agents, built on top of a set of composable "skills" and some initial instructions that make sure your agent uses them.
 
 ## How it works
 
-It starts from the moment you fire up your coding agent. As soon as it sees that you're building something, it *doesn't* just jump into trying to write code. Instead, it steps back and asks you what you're really trying to do. 
+It starts from the moment you fire up your coding agent. As soon as it sees that you're building something, it _doesn't_ just jump into trying to write code. Instead, it steps back and asks you what you're really trying to do.
 
-Once it's teased a spec out of the conversation, it shows it to you in chunks short enough to actually read and digest. 
+Once it's teased a spec out of the conversation, it shows it to you in chunks short enough to actually read and digest.
 
-After you've signed off on the design, your agent puts together an implementation plan that's clear enough for an enthusiastic junior engineer with poor taste, no judgement, no project context, and an aversion to testing to follow. It emphasizes true red/green TDD, YAGNI (You Aren't Gonna Need It), and DRY. 
+After you've signed off on the design, your agent puts together an implementation plan that's clear enough for an enthusiastic junior engineer with poor taste, no judgement, no project context, and an aversion to testing to follow. It emphasizes true red/green TDD, YAGNI (You Aren't Gonna Need It), and DRY.
 
-Next up, once you say "go", it launches a *subagent-driven-development* process, having agents work through each engineering task, inspecting and reviewing their work, and continuing forward. It's not uncommon for Claude to be able to work autonomously for a couple hours at a time without deviating from the plan you put together.
+Next up, once you say "go", it launches a _subagent-driven-development_ process, having agents work through each engineering task, inspecting and reviewing their work, and continuing forward. It's not uncommon for Claude to be able to work autonomously for a couple hours at a time without deviating from the plan you put together.
 
 There's a bunch more to it, but that's the core of the system. And because the skills trigger automatically, you don't need to do anything special. Your coding agent just has Superpowers.
-
 
 ## Sponsorship
 
 If Superpowers has helped you do stuff that makes money and you are so inclined, I'd greatly appreciate it if you'd consider [sponsoring my opensource work](https://github.com/sponsors/obra).
 
-Thanks! 
+Thanks!
 
 - Jesse
-
 
 ## Installation
 
@@ -121,13 +169,16 @@ Start a new session in your chosen platform and ask for something that should tr
 ### Skills Library
 
 **Testing**
+
 - **test-driven-development** - RED-GREEN-REFACTOR cycle (includes testing anti-patterns reference)
 
 **Debugging**
+
 - **systematic-debugging** - 4-phase root cause process (includes root-cause-tracing, defense-in-depth, condition-based-waiting techniques)
 - **verification-before-completion** - Ensure it's actually fixed
 
-**Collaboration** 
+**Collaboration**
+
 - **brainstorming** - Socratic design refinement
 - **writing-plans** - Detailed implementation plans
 - **executing-plans** - Batch execution with checkpoints
@@ -139,6 +190,7 @@ Start a new session in your chosen platform and ask for something that should tr
 - **subagent-driven-development** - Fast iteration with two-stage review (spec compliance, then code quality)
 
 **Meta**
+
 - **writing-skills** - Create new skills following best practices (includes testing methodology)
 - **using-superpowers** - Introduction to the skills system
 

--- a/docs/research-foundations.md
+++ b/docs/research-foundations.md
@@ -37,7 +37,15 @@ The Vidably custom skills are designed based on empirical research on multi-agen
 | Drift risk          | High — models optimize for agreement | Low — new code = fresh analysis                   |
 | Diminishing returns | After ~1.4 rounds                    | After 2-3 rounds (synthesis stops finding issues) |
 
-This is why local skills use 1 round (debate pattern) but the GH Action uses up to 3 rounds (re-review pattern). Round 2 catches issues introduced BY round 1 fixes. Round 3 uses a conservative policy ("only critical findings") to prevent diminishing returns.
+**Our decision:** We use up to 3 rounds everywhere — both local skills and GH Action — because both are re-review patterns (fresh content each round). We initially designed local skills with 1 round to be "fast," but realized that's optimizing for speed over quality with no research basis. A bad plan wastes more time than an extra review round.
+
+**Why not 1 round locally?** There's no quality argument for a different bar between local and CI. Both patterns review fresh content after fixes. The arXiv drift warning doesn't apply to re-review. If 3 rounds is the right number for CI quality, it's the right number for local quality.
+
+**Why not unlimited rounds?** Diminishing returns. Our data from PR #10 shows: round 1 found 5 issues, round 2 found 6 issues (in the fixed code), round 3 found 0 critical issues. The convergence signal is "zero accepted findings" — that's when we stop, regardless of round count. The 3-round cap prevents pathological cases.
+
+**Why the escalating policy (all → new-only → critical-only)?** Prevents the synthesis from endlessly polishing. Round 1 is the broad sweep. Round 2 catches issues introduced by round 1 fixes. Round 3 is a safety net for anything truly dangerous. This graduated approach matches our observed data: most value comes in rounds 1-2, round 3 is clean-up.
+
+**Why not the debate pattern (same content, multiple rounds)?** The arXiv paper is clear: debate performance degrades after ~1.4 rounds. Models start optimizing for agreement. We explicitly avoid this by ensuring each round reviews different content (the updated plan or diff after fixes). The skill instructions say "dispatch the UPDATED plan/diff" — never the same content twice.
 
 ### 4. Multi-model review catches 3-5x more bugs
 
@@ -92,13 +100,85 @@ This is why local skills use 1 round (debate pattern) but the GH Action uses up 
 
 **Implication:** Our exhaustive-research skill enforces research before decisions, but the Type 1/Type 2 triage ensures developers retain agency over when to apply the full process. The skill enhances human decision-making, not replaces it.
 
+## Design Decisions and Rejected Alternatives
+
+### Consensus scoring vs majority voting
+
+**Chosen:** Consensus scoring (Unanimous/Majority/Split/Solo tiers with severity × agreement weighting)
+
+**Rejected:** Simple majority voting (≥50% of models agree → accept)
+
+**Why:** The arXiv paper (2502.19130) shows consensus outperforms voting by +2.8% on knowledge tasks like code review. Voting treats all findings as equal; consensus allows a solo critical security finding to outrank a unanimous minor style issue. The calimero-network production system validates this — their `severity × agreement` formula dramatically reduced false positives vs flat lists.
+
+**Why not voting:** Voting is better for reasoning tasks (+13.2%), but code review is a knowledge task. Voting also creates a "tyranny of the majority" where a genuine insight from one model gets dismissed because the others missed it.
+
+### Independent dispatch vs shared context
+
+**Chosen:** Each model reviews independently with no access to other models' findings.
+
+**Rejected:** Sequential review where each model sees prior models' findings (debate/chain pattern).
+
+**Why:** The arXiv paper found independent initial drafts boost accuracy by +3.3%. Shared context causes premature convergence — models anchor on the first model's opinion rather than forming their own. The duh project specifically designed forced disagreement to counter this.
+
+**Why not shared context:** Sharing findings sounds efficient (avoid duplicates), but it introduces sycophantic agreement. Models seeing Claude's findings tend to agree with Claude rather than find new issues. The uncorrelated blind spots (Zylos) only work if models review independently.
+
+### Re-review pattern vs debate pattern
+
+**Chosen:** Up to 3 rounds of re-review (each round reviews UPDATED content after fixes)
+
+**Rejected:** Iterative debate (models discuss the same content back and forth)
+
+**Why:** The arXiv paper is unambiguous — debate performance degrades after ~1.4 rounds due to problem drift. But re-review doesn't suffer this because the content changes between rounds. Our PR #10 data confirms: round 1 found 5 issues, round 2 found 6 new issues in the fixed code. Round 2 was productive because it reviewed different code.
+
+**Why not debate:** Models optimizing for agreement is exactly the failure mode we want to avoid. Re-review avoids it structurally — there's nothing to "agree" on because the code changed.
+
+### Type 1/Type 2 triage vs always-on research
+
+**Chosen:** Triage gate — only Type 1 (consequential) decisions get the full exhaustive research treatment.
+
+**Rejected:** Apply exhaustive research to every decision regardless of impact.
+
+**Why:** The UCSD/Cornell study found professional developers "deploy explicit control strategies" — they need agency over when process is applied. Multiple review rounds (Gemini, Codex, our own experience) flagged that forcing 4+ options on trivial choices causes "skill fatigue" where developers learn to bypass the skill entirely. The triage gate channels the rigor where it matters.
+
+**Why not always-on:** A Type 2 decision (variable naming, UI spacing) has a reversal cost of minutes. Spending 5 minutes researching 4 options for it is a net time loss. The skill should amplify good judgment, not replace it with process.
+
+### Persona diversity fallback vs single-model review
+
+**Chosen:** When external CLIs aren't available, dispatch two Claude Code subagents with different system prompts (security-focused, maintainability-focused).
+
+**Rejected:** Just use one Claude Code review and accept the coverage gap.
+
+**Why:** The Zylos research shows different perspectives find different bugs. While two Claude subagents don't have truly uncorrelated architectures (same underlying model), persona prompting shifts attention and produces measurably different findings. The BryanHoo/superpowers-ccg project routes by domain (backend → Codex, frontend → Gemini) for the same reason.
+
+**Why not just one review:** The whole value proposition of multi-agent review is perspective diversity. Gracefully degrading to "one review" abandons the methodology entirely. Persona diversity is an imperfect substitute, but it's better than nothing.
+
+### File-based synthesis output vs PR comment posting
+
+**Chosen:** Synthesis agent writes `synthesis-summary.md`, workflow validates and posts it.
+
+**Rejected:** Synthesis agent posts PR comments directly via `gh pr comment`.
+
+**Why:** We discovered (the hard way, PR #10) that `claude-code-action` in agent mode silently denies write tool permissions — the agent tried 116 times to write/post and was denied every time. File-based output decouples creation from posting, allows the workflow to validate required sections exist, and posts a visible warning if the agent fails to produce the summary. The agent's job is analysis; the workflow's job is delivery.
+
+**Why not direct posting:** It worked conceptually but failed operationally. The action's permission model is designed for read-only review, not write operations. Even with `--allowedTools`, the file-based approach is more robust because it's verifiable before posting.
+
+### Anti-rationalization tables vs trust-the-model
+
+**Chosen:** Every skill includes an explicit table of "thoughts vs reality" for known failure modes.
+
+**Rejected:** Trust the model to follow instructions without listing escape hatches.
+
+**Why:** The obra/superpowers framework battle-tested this approach extensively. Their TDD skill has 12+ entries. In our own usage, the synthesis agent skipped writing the summary file twice — exactly the failure mode the anti-rationalization table was designed to prevent. These tables work because LLMs are excellent at rationalizing shortcuts; the tables pre-empt the specific rationalizations we've observed.
+
+**Why not trust the model:** We literally watched it happen. Two synthesis runs with "CRITICAL: you MUST write synthesis-summary.md" in the prompt, and the agent still didn't write it (partly due to permissions, partly due to rationalization). Anti-rationalization tables aren't paranoia — they're learned from real failure modes.
+
 ## How This Shaped Each Skill
 
-| Skill                               | Key Research Inputs                                                                                                                                |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **vidably-exhaustive-research**     | Research-first (Osmani), Type 1/Type 2 triage (UCSD/Cornell), multi-model perspective gathering (arXiv independent drafts)                         |
-| **vidably-multi-agent-plan-review** | Independent dispatch (arXiv +3.3%), consensus scoring (arXiv +2.8%), severity × agreement (calimero-network), 1-round limit (arXiv, problem drift) |
-| **vidably-multi-agent-code-review** | Uncorrelated blind spots (Zylos), 3-5x bug detection (Zylos), anti-sycophancy (duh), graceful degradation to persona diversity                     |
+| Skill                               | Key Research Inputs                                                                                                                                                            |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **vidably-exhaustive-research**     | Research-first (Osmani), Type 1/Type 2 triage (UCSD/Cornell), multi-model perspective gathering (arXiv independent drafts)                                                     |
+| **vidably-multi-agent-plan-review** | Independent dispatch (arXiv +3.3%), consensus scoring (arXiv +2.8%), severity × agreement (calimero-network), up to 3 re-review rounds (arXiv re-review vs debate distinction) |
+| **vidably-multi-agent-code-review** | Uncorrelated blind spots (Zylos), 3-5x bug detection (Zylos), anti-sycophancy (duh), graceful degradation to persona diversity, file-based synthesis output (PR #10 failure)   |
 
 ## Further Reading
 

--- a/docs/research-foundations.md
+++ b/docs/research-foundations.md
@@ -26,7 +26,18 @@ The Vidably custom skills are designed based on empirical research on multi-agen
 
 **Finding:** Adding more discussion rounds **reduces** performance due to "problem drift" — models start optimizing for agreement rather than accuracy. Consensus converges naturally in 1.42 rounds on average.
 
-**Implication:** Our skills use exactly 1 round of independent review + synthesis. No iterative debate. The GH Action uses max 3 rounds, but only because synthesis may push code changes that introduce new issues — each round reviews a new diff, not the same one repeatedly.
+**Implication:** Our local skills use exactly 1 round of independent review + synthesis. No iterative debate.
+
+**Important distinction: debate vs re-review.** The arXiv finding applies to _debate_ (same models discussing the same content repeatedly). Our GH Action uses _re-review_ (each round reviews a NEW diff after synthesis pushes fixes). These are different patterns:
+
+|                     | Debate (what research tested)        | Re-review (what our GH Action does)               |
+| ------------------- | ------------------------------------ | ------------------------------------------------- |
+| Context             | Same content, shared findings        | New diff each round                               |
+| Goal                | Converge on opinion                  | Catch new/remaining bugs                          |
+| Drift risk          | High — models optimize for agreement | Low — new code = fresh analysis                   |
+| Diminishing returns | After ~1.4 rounds                    | After 2-3 rounds (synthesis stops finding issues) |
+
+This is why local skills use 1 round (debate pattern) but the GH Action uses up to 3 rounds (re-review pattern). Round 2 catches issues introduced BY round 1 fixes. Round 3 uses a conservative policy ("only critical findings") to prevent diminishing returns.
 
 ### 4. Multi-model review catches 3-5x more bugs
 

--- a/docs/research-foundations.md
+++ b/docs/research-foundations.md
@@ -1,0 +1,97 @@
+# Research Foundations
+
+The Vidably custom skills are designed based on empirical research on multi-agent AI workflows, not intuition. This document cites the sources and explains how each finding shaped the skill design.
+
+## Key Research
+
+### 1. Consensus beats voting for code review
+
+**Source:** [Voting or Consensus? Decision-Making in Multi-Agent Debate](https://arxiv.org/html/2502.19130v4) (arXiv, 2025)
+
+**Finding:** On knowledge tasks (like code review), consensus-based approaches outperform voting by +2.8% accuracy. On reasoning tasks, voting is better (+13.2%).
+
+**Implication:** Code review is primarily a knowledge task ("does this code have a bug?"), so our skills use consensus scoring, not majority vote. The consensus map in our review skills reflects this — we track which models agreed and use that to weight confidence, not to count ballots.
+
+### 2. Independent initial drafts prevent groupthink
+
+**Source:** Same arXiv paper (2502.19130v4)
+
+**Finding:** "All-Agents Drafting" (each agent produces an independent analysis before seeing others) boosts accuracy by +3.3%. "Collective Improvement" (limited cross-agent communication) yields +7.4%.
+
+**Implication:** Our review skills dispatch to each model independently with no shared context. Each model reviews the code/plan in isolation, then we synthesize after collection. This is why the skills say "do not share one model's findings with another" during the dispatch phase.
+
+### 3. More debate rounds hurts performance
+
+**Source:** Same arXiv paper (2502.19130v4)
+
+**Finding:** Adding more discussion rounds **reduces** performance due to "problem drift" — models start optimizing for agreement rather than accuracy. Consensus converges naturally in 1.42 rounds on average.
+
+**Implication:** Our skills use exactly 1 round of independent review + synthesis. No iterative debate. The GH Action uses max 3 rounds, but only because synthesis may push code changes that introduce new issues — each round reviews a new diff, not the same one repeatedly.
+
+### 4. Multi-model review catches 3-5x more bugs
+
+**Source:** [Multi-Model AI Code Review: Iterative Consensus Ensemble](https://zylos.ai/research/2026-02-17-multi-model-ai-code-review) (Zylos Research, 2026)
+
+**Findings:**
+
+- 7-15 percentage point improvement over best single model
+- 3-5x more bugs found than single-pass review
+- Only 3 misclassifications across 24+ total rounds (very low false positive rate)
+- 60-70% of bugs discovered in the first half of rounds
+
+**Implication:** Multi-model review has a strong empirical basis. The low false-positive rate means the findings are actionable, not noisy. The first-round discovery rate justifies our 1-round design — most value comes immediately.
+
+### 5. Severity × agreement is the best scoring formula
+
+**Source:** [calimero-network/ai-code-reviewer](https://github.com/calimero-network/ai-code-reviewer) (production system, 2025)
+
+**Finding:** Ranking findings by `severity × agreement_count` dramatically reduces false positives compared to flat lists. The more models that independently flag the same issue, the higher confidence it's real.
+
+**Implication:** Our consensus map tiers (Unanimous/Majority/Split/Solo) are a categorical version of this scoring. Unanimous critical > Solo critical > Unanimous minor.
+
+### 6. Anti-sycophancy detection is essential
+
+**Source:** [msitarzewski/duh](https://github.com/msitarzewski/duh) (multi-model consensus engine, 2025)
+
+**Finding:** Models in debate tend toward sycophantic agreement. The duh project uses:
+
+- Forced disagreement in the Challenge phase
+- Jaccard similarity ≥ 0.7 for convergence detection
+- Epistemic confidence caps by domain (factual 95%, technical 90%, creative 85%)
+- Minority viewpoints preserved even after convergence
+
+**Implication:** Our code review skill includes an "anti-sycophancy check" — when all models agree, verify it's genuine agreement (references a specific line, explains a concrete consequence) rather than parroting the same training pattern.
+
+### 7. Different model architectures have uncorrelated blind spots
+
+**Source:** Zylos ICE research + Milvus research (referenced in our GH Action synthesis prompt)
+
+**Finding:** Claude, GPT, and Gemini find different categories of bugs. Claude tends to catch architectural and type safety issues. Codex catches logic errors and edge cases. Gemini catches consistency and documentation issues. Their blind spots don't overlap.
+
+**Implication:** This is the entire justification for multi-model review. If all models found the same bugs, there would be no reason to use multiple. The uncorrelated blind spots mean each additional model adds genuine coverage.
+
+### 8. Research-first workflows produce better decisions
+
+**Source:** [Addy Osmani's LLM Coding Workflow](https://addyosmani.com/blog/ai-coding-workflow/) (2025) + UC San Diego/Cornell study on developer agency (2025)
+
+**Findings:**
+
+- Osmani's "Waterfall in 15 Minutes" — collaborative spec → reasoning model plan → iterate until coherent — consistently produces better outcomes than "just start coding"
+- UCSD/Cornell found that professional developers "retain agency in software design, insist on fundamental software quality attributes, and deploy explicit control strategies"
+
+**Implication:** Our exhaustive-research skill enforces research before decisions, but the Type 1/Type 2 triage ensures developers retain agency over when to apply the full process. The skill enhances human decision-making, not replaces it.
+
+## How This Shaped Each Skill
+
+| Skill                               | Key Research Inputs                                                                                                                                |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **vidably-exhaustive-research**     | Research-first (Osmani), Type 1/Type 2 triage (UCSD/Cornell), multi-model perspective gathering (arXiv independent drafts)                         |
+| **vidably-multi-agent-plan-review** | Independent dispatch (arXiv +3.3%), consensus scoring (arXiv +2.8%), severity × agreement (calimero-network), 1-round limit (arXiv, problem drift) |
+| **vidably-multi-agent-code-review** | Uncorrelated blind spots (Zylos), 3-5x bug detection (Zylos), anti-sycophancy (duh), graceful degradation to persona diversity                     |
+
+## Further Reading
+
+- [obra/superpowers](https://github.com/obra/superpowers) — The upstream framework these skills extend
+- [BryanHoo/superpowers-ccg](https://github.com/BryanHoo/superpowers-ccg) — Multi-CLI integration via MCP routing
+- [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator) — Production multi-agent orchestration with git worktrees
+- [Virtua Cloud tutorial](https://www.virtua.cloud/learn/en/tutorials/ai-code-review-github-actions-vps) — Dual-model CI review with aggregation workflow

--- a/skills/diagnosing-failures/SKILL.md
+++ b/skills/diagnosing-failures/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: diagnosing-failures
+description: "Use when a tool, CLI, or process fails or produces unexpected results — BEFORE proposing any workaround. Forces exhaustive root cause analysis."
+---
+
+# Diagnosing Failures
+
+## Overview
+
+When something breaks, the natural instinct is to hypothesize a cause and build a workaround. This is wrong more often than you'd expect. This skill forces you to gather evidence and consider ALL possible causes before committing to a fix.
+
+**The iron law: you must list at least 3 possible root causes before proposing any fix.**
+
+If you can't think of 3, you don't understand the problem space well enough. The correct diagnosis is often not the first one that comes to mind.
+
+**Origin:** In PR #62, Codex CLI was killed by a 2-minute bash timeout while actively working. This was misdiagnosed as "hitting output limits." The same root cause (timeout) was independently misdiagnosed for Gemini CLI as "MCP initialization overhead." An entire API workaround was built for a problem that only required changing `timeout: 120000` to `timeout: 1200000`. The user had to ask "are we 100% certain?" three times before the actual output was read.
+
+## When to Use
+
+- A CLI tool "hangs" or produces no output
+- A process is "too slow"
+- An agent reports a tool "failed" or "hit a limit"
+- Something worked before and now doesn't
+- You're about to say "X is broken, let me build Y to work around it"
+
+**The trigger phrase in your own thinking: "I should build a workaround."** If you catch yourself thinking this, invoke this skill first.
+
+## Step 1: Gather Raw Evidence
+
+NOT summaries. NOT what an agent told you happened. The actual output.
+
+- **Full output:** Read the raw stdout/stderr. If an agent ran the command, find the agent's tool result and read it.
+- **Exit code:** Was it 0 (success), 1 (error), 137 (killed by signal), 143 (terminated)?
+- **Timing:** How long did it run? What was the timeout set to? Did elapsed time equal the timeout?
+- **Comparison:** Did similar tools/commands have the same issue? If two independent things "fail" the same way, suspect shared infrastructure (timeout, env, network), not the tools themselves.
+
+**If you don't have the raw output, you don't have evidence. Go get it.**
+
+## Step 2: List At Least 3 Root Causes
+
+For whatever you observed, write down at least 3 possible explanations. Force yourself past the obvious first guess.
+
+Example from the real incident:
+
+| #   | Possible Root Cause                    | What evidence would confirm it                                                      | What evidence would rule it out                                 |
+| --- | -------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| 1   | CLI hit an internal output/token limit | Output ends with a truncation message or the CLI's own error                        | Output ends mid-sentence at exactly the timeout boundary        |
+| 2   | Bash timeout killed the process        | Exit code 137, elapsed time equals timeout, output ends abruptly                    | Process exited on its own with exit code 0 or 1                 |
+| 3   | MCP server initialization is slow      | Startup logs show MCP connection attempts, most time spent before first real output | First output appears quickly, most time is spent on actual work |
+
+## Step 3: Check Evidence Against Each Hypothesis
+
+For each root cause, check the confirming and ruling-out evidence. Eliminate hypotheses that don't fit the data. Be honest — if the evidence is ambiguous, say so.
+
+**The correct diagnosis is the one the evidence supports, not the one that feels most plausible.**
+
+## Step 4: Propose Solutions (Exhaustive)
+
+Only after you have a confirmed root cause, list ALL possible solutions with tradeoffs. Don't jump to the first fix. The pattern:
+
+| Solution | Effort | Addresses Root Cause? | Tradeoffs |
+| -------- | ------ | --------------------- | --------- |
+| ...      | ...    | ...                   | ...       |
+
+Present to the user for decision unless the answer is obviously clear.
+
+## Step 5: Measure
+
+After applying the fix, confirm it actually worked. Add instrumentation so you'll know if the problem recurs. Log timing, exit codes, success/failure — whatever's relevant.
+
+## Anti-Patterns
+
+| Pattern                                                 | Why it's wrong                                                               |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| "Agent said it hit a limit"                             | Agents summarize — they can be wrong. Read the raw output.                   |
+| "It's too slow, let me build a faster alternative"      | Define "too slow" with numbers. Measure first.                               |
+| "Two tools are broken"                                  | Two tools failing the same way = one shared cause, not two independent bugs. |
+| "I'll build a workaround and we can switch back later"  | Workarounds become permanent. Fix the root cause.                            |
+| "The fix is obvious, I don't need to list alternatives" | The Gemini API workaround was "obvious" too. It was wrong.                   |

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -25,6 +25,7 @@ npm test / cargo test / pytest / go test ./...
 ```
 
 **If tests fail:**
+
 ```
 Tests failing (<N> failures). Must fix before completing:
 
@@ -114,6 +115,7 @@ Report: "Keeping branch <name>. Worktree preserved at <path>."
 #### Option 4: Discard
 
 **Confirm first:**
+
 ```
 This will permanently delete:
 - Branch <name>
@@ -126,6 +128,7 @@ Type 'discard' to confirm.
 Wait for exact confirmation.
 
 If confirmed:
+
 ```bash
 git checkout <base-branch>
 git branch -D <feature-branch>
@@ -138,53 +141,84 @@ Then: Cleanup worktree (Step 5)
 **For Options 1, 2, 4:**
 
 Check if in worktree:
+
 ```bash
 git worktree list | grep $(git branch --show-current)
 ```
 
 If yes:
+
 ```bash
 git worktree remove <worktree-path>
 ```
 
 **For Option 3:** Keep worktree.
 
+### Step 6: Workflow Metrics in PR Body
+
+Before creating the PR (Option 2), read `.claude/workflow-events.jsonl` for the current branch and embed a machine-readable metrics comment in the PR body:
+
+```bash
+BRANCH=$(git branch --show-current)
+EVENTS=$(grep "\"branch\":\"$BRANCH\"" .claude/workflow-events.jsonl 2>/dev/null || echo "")
+```
+
+Build a JSON summary from the events and include it as an HTML comment in the PR body:
+
+```html
+<!-- workflow-metrics: {"skills":["research","plan","plan-review","code-review"],"researchOptions":4,"planReviewModels":2,"planReviewFindings":3,"codeReviewModels":2,"codeReviewFindings":7,"totalDurationSec":18000} -->
+```
+
+This comment is machine-parseable by the weekly metrics GitHub Action. Include it at the end of the PR body, after the test plan section.
+
+Also append a PR creation event:
+
+```bash
+echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --show-current)\",\"event\":\"pr_created\",\"pr\":PR_NUMBER,\"sha\":\"$(git rev-parse --short HEAD)\"}" >> .claude/workflow-events.jsonl
+```
+
 ## Quick Reference
 
-| Option | Merge | Push | Keep Worktree | Cleanup Branch |
-|--------|-------|------|---------------|----------------|
-| 1. Merge locally | ✓ | - | - | ✓ |
-| 2. Create PR | - | ✓ | ✓ | - |
-| 3. Keep as-is | - | - | ✓ | - |
-| 4. Discard | - | - | - | ✓ (force) |
+| Option           | Merge | Push | Keep Worktree | Cleanup Branch |
+| ---------------- | ----- | ---- | ------------- | -------------- |
+| 1. Merge locally | ✓     | -    | -             | ✓              |
+| 2. Create PR     | -     | ✓    | ✓             | -              |
+| 3. Keep as-is    | -     | -    | ✓             | -              |
+| 4. Discard       | -     | -    | -             | ✓ (force)      |
 
 ## Common Mistakes
 
 **Skipping test verification**
+
 - **Problem:** Merge broken code, create failing PR
 - **Fix:** Always verify tests before offering options
 
 **Open-ended questions**
+
 - **Problem:** "What should I do next?" → ambiguous
 - **Fix:** Present exactly 4 structured options
 
 **Automatic worktree cleanup**
+
 - **Problem:** Remove worktree when might need it (Option 2, 3)
 - **Fix:** Only cleanup for Options 1 and 4
 
 **No confirmation for discard**
+
 - **Problem:** Accidentally delete work
 - **Fix:** Require typed "discard" confirmation
 
 ## Red Flags
 
 **Never:**
+
 - Proceed with failing tests
 - Merge without verifying tests on result
 - Delete work without confirmation
 - Force-push without explicit request
 
 **Always:**
+
 - Verify tests before offering options
 - Present exactly 4 options
 - Get typed confirmation for Option 4
@@ -193,8 +227,10 @@ git worktree remove <worktree-path>
 ## Integration
 
 **Called by:**
+
 - **subagent-driven-development** (Step 7) - After all tasks complete
 - **executing-plans** (Step 5) - After all batches complete
 
 **Pairs with:**
+
 - **using-git-worktrees** - Cleans up worktree created by that skill

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -27,11 +27,13 @@ WHEN receiving code review feedback:
 ## Forbidden Responses
 
 **NEVER:**
+
 - "You're absolutely right!" (explicit CLAUDE.md violation)
 - "Great point!" / "Excellent feedback!" (performative)
 - "Let me implement that now" (before verification)
 
 **INSTEAD:**
+
 - Restate the technical requirement
 - Ask clarifying questions
 - Push back with technical reasoning if wrong
@@ -48,6 +50,7 @@ WHY: Items may be related. Partial understanding = wrong implementation.
 ```
 
 **Example:**
+
 ```
 your human partner: "Fix 1-6"
 You understand 1,2,3,6. Unclear on 4,5.
@@ -59,12 +62,14 @@ You understand 1,2,3,6. Unclear on 4,5.
 ## Source-Specific Handling
 
 ### From your human partner
+
 - **Trusted** - implement after understanding
 - **Still ask** if scope unclear
 - **No performative agreement**
 - **Skip to action** or technical acknowledgment
 
 ### From External Reviewers
+
 ```
 BEFORE implementing:
   1. Check: Technically correct for THIS codebase?
@@ -113,6 +118,7 @@ FOR multi-item feedback:
 ## When To Push Back
 
 Push back when:
+
 - Suggestion breaks existing functionality
 - Reviewer lacks full context
 - Violates YAGNI (unused feature)
@@ -121,6 +127,7 @@ Push back when:
 - Conflicts with your human partner's architectural decisions
 
 **How to push back:**
+
 - Use technical reasoning, not defensiveness
 - Ask specific questions
 - Reference working tests/code
@@ -128,9 +135,30 @@ Push back when:
 
 **Signal if uncomfortable pushing back out loud:** "Strange things are afoot at the Circle K"
 
+### Verify authoritative source BEFORE rejecting
+
+Before writing a rejection, ground it in a specific source. The very act of writing confident rejection prose makes the position harder to revisit — avoid writing it until you have the citation.
+
+**Source precedence (highest first):**
+
+1. **Installed SDK / library types in `node_modules`.** Authoritative for the version actually in use. Grep them. There is almost always a typed docstring that settles the question in 10 seconds.
+2. **Current official API reference** (by specific URL, not marketing pages).
+3. **Your prior conviction is not a citation.** If you said something confidently earlier in the conversation without evidence, it does not become evidence by repetition. Writing the rejection paragraph hardens fiction into remembered fact.
+
+If you cannot ground the rejection in a specific SDK type, docstring, or versioned API URL, **do not reject**. Accept provisionally and let the fix be test-first.
+
+### Reviewer convergence requires a citation to dismiss
+
+When two or more independent reviewers (Codex, Gemini, Copilot, etc.) flag the same class of issue, **treat it as strong consensus signal, not "same misunderstanding."** They are separately prompted and read the diff independently. Convergence is closer to a vote than a duplicated error.
+
+**Rule:** Rejecting a 2-of-N or higher convergence finding requires a direct citation (SDK type, official docs URL, or prior user instruction with quote). No citation = accept the fix.
+
+**Case study (PR #133):** Codex flagged that Mux `master_access: 'temporary'` auto-reverts to `none` after 24h. Gemini echoed a round later. I rejected both rounds with confident prose calling it a "misunderstanding." After user pushback, 10 seconds of `grep master node_modules/@mux/mux-node/**/*.d.ts` surfaced: _"After 24 hours Master Access will revert to 'none'."_ The rejection would have shipped a bug where every video silently downgraded to the rendition 24h after upload — the exact regression the PR existed to prevent.
+
 ## Acknowledging Correct Feedback
 
 When feedback IS correct:
+
 ```
 ✅ "Fixed. [Brief description of what changed]"
 ✅ "Good catch - [specific issue]. Fixed in [location]."
@@ -150,6 +178,7 @@ When feedback IS correct:
 ## Gracefully Correcting Your Pushback
 
 If you pushed back and were wrong:
+
 ```
 ✅ "You were right - I checked [X] and it does [Y]. Implementing now."
 ✅ "Verified this and you're correct. My initial understanding was wrong because [reason]. Fixing."
@@ -163,37 +192,41 @@ State the correction factually and move on.
 
 ## Common Mistakes
 
-| Mistake | Fix |
-|---------|-----|
-| Performative agreement | State requirement or just act |
-| Blind implementation | Verify against codebase first |
-| Batch without testing | One at a time, test each |
-| Assuming reviewer is right | Check if breaks things |
-| Avoiding pushback | Technical correctness > comfort |
-| Partial implementation | Clarify all items first |
+| Mistake                      | Fix                                 |
+| ---------------------------- | ----------------------------------- |
+| Performative agreement       | State requirement or just act       |
+| Blind implementation         | Verify against codebase first       |
+| Batch without testing        | One at a time, test each            |
+| Assuming reviewer is right   | Check if breaks things              |
+| Avoiding pushback            | Technical correctness > comfort     |
+| Partial implementation       | Clarify all items first             |
 | Can't verify, proceed anyway | State limitation, ask for direction |
 
 ## Real Examples
 
 **Performative Agreement (Bad):**
+
 ```
 Reviewer: "Remove legacy code"
 ❌ "You're absolutely right! Let me remove that..."
 ```
 
 **Technical Verification (Good):**
+
 ```
 Reviewer: "Remove legacy code"
 ✅ "Checking... build target is 10.15+, this API needs 13+. Need legacy for backward compat. Current impl has wrong bundle ID - fix it or drop pre-13 support?"
 ```
 
 **YAGNI (Good):**
+
 ```
 Reviewer: "Implement proper metrics tracking with database, date filters, CSV export"
 ✅ "Grepped codebase - nothing calls this endpoint. Remove it (YAGNI)? Or is there usage I'm missing?"
 ```
 
 **Unclear Item (Good):**
+
 ```
 your human partner: "Fix items 1-6"
 You understand 1,2,3,6. Unclear on 4,5.

--- a/skills/vidably-exhaustive-research/SKILL.md
+++ b/skills/vidably-exhaustive-research/SKILL.md
@@ -65,6 +65,8 @@ Also dispatch to other models for additional perspectives if available:
 
 Collect their responses and incorporate unique suggestions you didn't find yourself.
 
+**Structured capture (for Step 7b logging):** Before synthesizing, record each model's raw option list separately in working memory, noting which options each model surfaced and any cited URLs. This is transient context only -- do not persist raw captures to files or logs (they may contain internal URLs or sensitive details). The per-model fields in the effectiveness tracker are derived from this captured data rather than reconstructed from memory.
+
 ## Step 3: Generate Exhaustive Options
 
 List every viable approach, including unconventional ones. Minimum 4 options.
@@ -153,6 +155,40 @@ echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --sho
 ```
 
 Replace `OPTIONS_COUNT` and `SOURCES_COUNT` with the actual numbers from this research session.
+
+## Step 7b: Log Research to Effectiveness Tracker
+
+After the user approves an option, append a new section to `docs/research-effectiveness.md` under the `## Research Log` heading:
+
+````markdown
+### [Branch Name] -- [Decision Topic]
+
+**Date:** [YYYY-MM-DD]
+**Models:** [list of models consulted]
+
+| Field                         | Value                                                                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------------- |
+| **Per-model option count**    | Claude: X, Codex: Y, Gemini: Z                                                              |
+| **Decision source**           | [which model(s) surfaced the chosen option]                                                 |
+| **Per-model unique insights** | Claude: [one-liner or "none"]. Codex: [one-liner or "none"]. Gemini: [one-liner or "none"]. |
+| **Source quality**            | Claude: pass/fail. Codex: pass/fail. Gemini: pass/fail.                                     |
+| **Option overlap**            | [N options surfaced by 2+ models independently]                                             |
+| **Downstream surprise**       | [left blank -- tagged during code review retro if applicable]                               |
+
+**Decision:** [chosen option and one-line rationale]
+````
+
+Then update the **Aggregate Model Profiles** table in `docs/research-effectiveness.md`:
+
+- **Tends to Surface Winning Option**: Update based on whether this model surfaced the chosen option.
+- **Unique Insight Rate**: Update based on whether this model contributed insights no other model surfaced.
+- **Source Quality Rate**: Update based on pass/fail for this session.
+
+If the user rejects all options or abandons the decision, still log the entry with Decision: "[abandoned -- reason]". This tracks research quality even when it doesn't produce a decision.
+
+**Sanitization rule:** Log normalized summaries only. Do not include secrets, tokens, PII, customer identifiers, raw payloads, or exploit details in effectiveness tracker entries.
+
+This logging step is mandatory and automated -- if the skill runs, the data gets logged.
 
 ## Interaction With Other Skills
 

--- a/skills/vidably-exhaustive-research/SKILL.md
+++ b/skills/vidably-exhaustive-research/SKILL.md
@@ -1,8 +1,138 @@
 ---
 name: vidably-exhaustive-research
-description: Use when making a consequential decision — architecture, vendor/library choice, schema/data model, external services, or reusable UX patterns — before choosing an approach, exhaustively search for every possible solution and their tradeoffs
+description: "Use when making a consequential decision — architecture, vendor/library choice, schema/data model, external services, or reusable UX patterns — before choosing an approach, exhaustively search for every possible solution and their tradeoffs."
 ---
 
-<!-- Full skill implementation coming soon. See https://github.com/Vidably/app for the implementation plan. -->
+# Exhaustive Research Before Decisions
 
-This skill is planned but not yet implemented. It will enforce exhaustive research before consequential decisions using a Type 1/Type 2 triage system.
+Before any consequential decision, exhaustively search for every possible solution and their tradeoffs. Present structured options to the user. Do NOT proceed until the user approves an approach.
+
+<HARD-GATE>
+Do NOT implement, write code, or choose an approach until you have:
+1. Triaged the decision as Type 1
+2. Searched external sources (not just training data)
+3. Presented 4+ options with tradeoffs
+4. Received explicit user approval
+</HARD-GATE>
+
+## Step 0: Triage — Is This a Consequential Decision?
+
+Before doing anything, classify the decision:
+
+**Type 1 (irreversible or high-cost) — REQUIRES this skill:**
+
+- Architecture patterns (state management, rendering strategy, data flow)
+- Vendor or library choices (database, auth, payments, video processing)
+- Schema or data model changes (new tables, field types, relationships)
+- External service integrations (APIs, webhooks, event systems)
+- Reusable UX patterns (design system choices, component architecture)
+
+**Type 2 (reversible and low-cost) — SKIP this skill:**
+
+- Bug fixes with obvious root cause
+- UI tweaks (spacing, colors, copy)
+- Already-specified decisions (plan says "use X")
+- Standard library usage (which React hook, which utility function)
+- Naming choices
+
+If uncertain, ask the user: "This feels like it could go either way — is [decision] worth researching exhaustively, or should we just pick the obvious approach?"
+
+## Step 1: Identify the Decision
+
+State the specific decision clearly. Not "how to build X" (too broad). Instead:
+
+- "Which state management approach for the video approval workflow"
+- "Which upload library for the creator recording flow"
+- "How to structure the evidence extraction pipeline"
+
+## Step 2: Search External Sources
+
+Your training data is stale. Search for current information before generating options.
+
+Use WebSearch and WebFetch to find:
+
+- **Official documentation** for relevant libraries/services
+- **Expert blog posts** from recognized practitioners (not SEO content farms)
+- **GitHub examples** of real implementations
+- **Stack Overflow / community discussions** about tradeoffs people discovered in practice
+
+Minimum 3 distinct sources. If you can't find 3, search with different terms or ask the user for leads.
+
+Also dispatch to other models for additional perspectives if available:
+
+- `codex exec "Research the best approaches for [decision]. List every viable option with concrete pros, cons, and code examples."` (if Codex CLI is available)
+- `gemini --allowed-mcp-server-names="" -p "Research [decision]. What are the current best practices as of 2026? List every approach."` (if Gemini CLI is available)
+
+Collect their responses and incorporate unique suggestions you didn't find yourself.
+
+## Step 3: Generate Exhaustive Options
+
+List every viable approach, including unconventional ones. Minimum 4 options.
+
+For each option, provide:
+
+| Dimension            | What to include                                    |
+| -------------------- | -------------------------------------------------- |
+| **Approach**         | Name and one-line summary                          |
+| **How it works**     | 3-5 sentence explanation                           |
+| **Code sketch**      | Concrete code showing the pattern (not pseudocode) |
+| **Pros**             | Specific, measurable benefits                      |
+| **Cons**             | Specific, measurable costs                         |
+| **Maintenance cost** | What does ongoing maintenance look like?           |
+| **Migration cost**   | How hard is it to switch away from this later?     |
+
+## Step 4: Rate and Compare
+
+Present a rating table:
+
+| Option   | Maintainability | Complexity | Extensibility | UX Quality | Total |
+| -------- | :-------------: | :--------: | :-----------: | :--------: | :---: |
+| Option A |        4        |     2      |       5       |     4      |  15   |
+| Option B |        3        |     4      |       3       |     5      |  15   |
+| ...      |                 |            |               |            |       |
+
+Ratings are 1-5 (1 = worst, 5 = best). Lower complexity is better (inverted — a 5 means simplest).
+
+## Step 5: Present Recommendation
+
+After the table, state your recommendation and why. The recommendation should reference:
+
+- Which option scores highest overall
+- Which tradeoffs matter most for this specific project
+- What the sources you consulted recommend
+- What the other models suggested (if dispatched)
+
+Then STOP and wait for user approval. Do not proceed until they choose.
+
+## Step 6: Document the Decision
+
+After user approves, append a decision record to the current spec or plan doc:
+
+```markdown
+## Decision: [Topic]
+
+**Chosen:** [Option name]
+**Rejected:** [Other options with one-line reasons]
+**Sources consulted:** [URLs]
+**Date:** [YYYY-MM-DD]
+```
+
+## Anti-Rationalization Table
+
+| Thought                                          | Reality                                                                                                                                            |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "I already know the best approach"               | Your training data is stale. Search anyway. The best option in 2024 may not be the best in 2026.                                                   |
+| "There are only 2 realistic options"             | You haven't looked hard enough. Search with different terms. Ask other models. Find at least 4.                                                    |
+| "Official docs won't have this"                  | Search first, then claim that. You'd be surprised.                                                                                                 |
+| "This is a simple choice, not worth researching" | Did you triage it? If it's Type 1, research it. If Type 2, skip the skill — don't rationalize skipping a Type 1.                                   |
+| "The user is waiting, I should be fast"          | A wrong decision costs 10x more than 5 minutes of research. The user explicitly wants exhaustive research.                                         |
+| "I searched and only found 2 options"            | Search with different terms. Try "[technology] alternatives 2026". Ask the user for leads. Dispatch to Codex or Gemini for different perspectives. |
+| "This is just an implementation detail"          | Does it affect schema, vendor choice, or architecture? If yes, it's Type 1.                                                                        |
+| "The previous conversation already decided this" | Verify the decision is still valid. Context may have changed. Sources may have updated.                                                            |
+| "The other models didn't add anything new"       | Still document that you checked. The absence of new options is itself signal that you've covered the space.                                        |
+
+## Interaction With Other Skills
+
+- `TRIGGERS BEFORE: brainstorming` — Research feeds into brainstorming options. If a Type 1 decision arises during brainstorming, pause and run this skill first.
+- `TRIGGERS BEFORE: writing-plans` — Plans should reference decisions made through this skill.
+- `COMPATIBLE WITH: systematic-debugging` — When debugging reveals a design flaw that requires an architectural decision, this skill applies.

--- a/skills/vidably-exhaustive-research/SKILL.md
+++ b/skills/vidably-exhaustive-research/SKILL.md
@@ -131,6 +131,29 @@ After user approves, append a decision record to the current spec or plan doc:
 | "The previous conversation already decided this" | Verify the decision is still valid. Context may have changed. Sources may have updated.                                                            |
 | "The other models didn't add anything new"       | Still document that you checked. The absence of new options is itself signal that you've covered the space.                                        |
 
+## Step 7: Update Workflow State and Event Log
+
+After the user approves an option (Step 5-6 complete), update the enforcement state:
+
+```bash
+# Update workflow state
+STATE=".claude/workflow-state.json"
+if [ -f "$STATE" ]; then
+  python3 -c "
+import json, datetime
+d = json.load(open('$STATE'))
+d['researchDone'] = True
+d['researchAt'] = datetime.datetime.utcnow().isoformat() + 'Z'
+json.dump(d, open('$STATE', 'w'))
+"
+fi
+
+# Append to event log
+echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --show-current)\",\"event\":\"skill_complete\",\"skill\":\"vidably-exhaustive-research\",\"sha\":\"$(git rev-parse --short HEAD)\",\"options\":OPTIONS_COUNT,\"sources\":SOURCES_COUNT}" >> .claude/workflow-events.jsonl
+```
+
+Replace `OPTIONS_COUNT` and `SOURCES_COUNT` with the actual numbers from this research session.
+
 ## Interaction With Other Skills
 
 - `TRIGGERS BEFORE: brainstorming` — Research feeds into brainstorming options. If a Type 1 decision arises during brainstorming, pause and run this skill first.

--- a/skills/vidably-exhaustive-research/SKILL.md
+++ b/skills/vidably-exhaustive-research/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: vidably-exhaustive-research
+description: Use when making a consequential decision — architecture, vendor/library choice, schema/data model, external services, or reusable UX patterns — before choosing an approach, exhaustively search for every possible solution and their tradeoffs
+---
+
+<!-- Full skill implementation coming soon. See https://github.com/Vidably/app for the implementation plan. -->
+
+This skill is planned but not yet implemented. It will enforce exhaustive research before consequential decisions using a Type 1/Type 2 triage system.

--- a/skills/vidably-exhaustive-research/SKILL.md
+++ b/skills/vidably-exhaustive-research/SKILL.md
@@ -61,7 +61,7 @@ Minimum 3 distinct sources. If you can't find 3, search with different terms or 
 Also dispatch to other models for additional perspectives if available:
 
 - `codex exec "Research the best approaches for [decision]. List every viable option with concrete pros, cons, and code examples."` (if Codex CLI is available)
-- `gemini --allowed-mcp-server-names="" -p "Research [decision]. What are the current best practices as of 2026? List every approach."` (if Gemini CLI is available)
+- `gemini --allowed-mcp-server-names _none -p "Research [decision]. What are the current best practices as of 2026? List every approach."` (if Gemini CLI is available)
 
 Collect their responses and incorporate unique suggestions you didn't find yourself.
 

--- a/skills/vidably-exhaustive-research/SKILL.md
+++ b/skills/vidably-exhaustive-research/SKILL.md
@@ -150,45 +150,53 @@ json.dump(d, open('$STATE', 'w'))
 "
 fi
 
-# Append to event log
-echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --show-current)\",\"event\":\"skill_complete\",\"skill\":\"vidably-exhaustive-research\",\"sha\":\"$(git rev-parse --short HEAD)\",\"options\":OPTIONS_COUNT,\"sources\":SOURCES_COUNT}" >> .claude/workflow-events.jsonl
+# Append structured event log entry
+cat <<JSON | node scripts/measurement/emit-event.mjs
+{
+  "stage": "research",
+  "event": "research_run_completed",
+  "source": "skill",
+  "payload": {
+    "decisionSummary": "DECISION_SUMMARY",
+    "models": MODELS_LIST,
+    "optionsByModel": OPTIONS_BY_MODEL,
+    "chosenOptionId": "CHOSEN_OPTION_ID",
+    "chosenByModels": CHOSEN_BY_MODELS,
+    "uniqueInsightsByModel": UNIQUE_INSIGHTS_BY_MODEL,
+    "sourceQualityByModel": SOURCE_QUALITY_BY_MODEL,
+    "overlapCount": OVERLAP_COUNT,
+    "sourcesCount": SOURCES_COUNT
+  }
+}
+JSON
+
+# Refresh the local talk report (best effort)
+node scripts/measurement/render-talk-report.mjs >/dev/null 2>&1 || true
 ```
 
-Replace `OPTIONS_COUNT` and `SOURCES_COUNT` with the actual numbers from this research session.
+Replace the placeholders with actual values from this research session:
 
-## Step 7b: Log Research to Effectiveness Tracker
+- `DECISION_SUMMARY`: one-line summary of the decision researched
+- `MODELS_LIST`: JSON array of logical model names, e.g. `["claude","codex","gemini"]`
+- `OPTIONS_BY_MODEL`: JSON object, e.g. `{"claude":4,"codex":3,"gemini":4}`
+- `CHOSEN_OPTION_ID`: short stable label for the selected option
+- `CHOSEN_BY_MODELS`: JSON array of models that independently surfaced the selected option
+- `UNIQUE_INSIGHTS_BY_MODEL`: JSON object with numeric counts
+- `SOURCE_QUALITY_BY_MODEL`: JSON object with `pass`/`fail` values
+- `OVERLAP_COUNT`: number of options surfaced by 2+ models
+- `SOURCES_COUNT`: total external sources consulted
 
-After the user approves an option, append a new section to `docs/research-effectiveness.md` under the `## Research Log` heading:
+## Step 7b: Refresh the Talk Data Report
 
-````markdown
-### [Branch Name] -- [Decision Topic]
+After the structured event is written, refresh the local talk-data report:
 
-**Date:** [YYYY-MM-DD]
-**Models:** [list of models consulted]
+```bash
+node scripts/measurement/render-talk-report.mjs
+```
 
-| Field                         | Value                                                                                       |
-| ----------------------------- | ------------------------------------------------------------------------------------------- |
-| **Per-model option count**    | Claude: X, Codex: Y, Gemini: Z                                                              |
-| **Decision source**           | [which model(s) surfaced the chosen option]                                                 |
-| **Per-model unique insights** | Claude: [one-liner or "none"]. Codex: [one-liner or "none"]. Gemini: [one-liner or "none"]. |
-| **Source quality**            | Claude: pass/fail. Codex: pass/fail. Gemini: pass/fail.                                     |
-| **Option overlap**            | [N options surfaced by 2+ models independently]                                             |
-| **Downstream surprise**       | [left blank -- tagged during code review retro if applicable]                               |
+This writes `.claude/talk-report.md`, which rolls up the current research, plan review, and code review data for the talk. Do not hand-edit tracker docs during the skill.
 
-**Decision:** [chosen option and one-line rationale]
-````
-
-Then update the **Aggregate Model Profiles** table in `docs/research-effectiveness.md`:
-
-- **Tends to Surface Winning Option**: Update based on whether this model surfaced the chosen option.
-- **Unique Insight Rate**: Update based on whether this model contributed insights no other model surfaced.
-- **Source Quality Rate**: Update based on pass/fail for this session.
-
-If the user rejects all options or abandons the decision, still log the entry with Decision: "[abandoned -- reason]". This tracks research quality even when it doesn't produce a decision.
-
-**Sanitization rule:** Log normalized summaries only. Do not include secrets, tokens, PII, customer identifiers, raw payloads, or exploit details in effectiveness tracker entries.
-
-This logging step is mandatory and automated -- if the skill runs, the data gets logged.
+**Sanitization rule:** Event payloads and the talk report must contain normalized summaries only. Do not include secrets, tokens, PII, customer identifiers, raw payloads, or exploit details.
 
 ## Interaction With Other Skills
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -84,17 +84,19 @@ Do NOT proceed to model review if verification fails. Fix first.
 
 Tag every finding with a category. This taxonomy grows over time — add new categories in the Post-CI Retrospective (Step 9) when findings don't fit existing ones.
 
-| Category           | What it covers                                                               | Source PR |
-| ------------------ | ---------------------------------------------------------------------------- | --------- |
-| `auth/security`    | Authorization bypass, injection, OWASP, auth error handling                  | baseline  |
-| `failure-modes`    | Retry exhaustion, stuck states, partial failures, missing onFailure handlers | #61       |
-| `data-integrity`   | Case sensitivity, uniqueness edge cases, nullability, type coercion          | #61       |
-| `api-correctness`  | External API query format, field names, pagination, SDK usage                | #61       |
-| `dev-compat`       | MSW mocks, env var assumptions, zero-secret contract compliance              | #61       |
-| `react-lifecycle`  | useEffect deps, stale closures, re-render storms, ref stability              | #61       |
-| `performance`      | N+1 queries, batch vs sequential, unnecessary computation                    | baseline  |
-| `type-safety`      | any casts, missing null checks, unsafe assertions                            | baseline  |
-| `plan-conformance` | Does the code match the spec/plan?                                           | baseline  |
+| Category             | What it covers                                                                                                                      | Source PR |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `auth/security`      | Authorization bypass, injection, OWASP, auth error handling                                                                         | baseline  |
+| `failure-modes`      | Retry exhaustion, stuck states, partial failures, missing onFailure handlers                                                        | #61       |
+| `data-integrity`     | Case sensitivity, uniqueness edge cases, nullability, type coercion                                                                 | #61       |
+| `api-correctness`    | External API query format, field names, pagination, SDK usage                                                                       | #61       |
+| `dev-compat`         | MSW mocks, env var assumptions, zero-secret contract compliance                                                                     | #61       |
+| `react-lifecycle`    | useEffect deps, stale closures, re-render storms, ref stability                                                                     | #61       |
+| `performance`        | N+1 queries, batch vs sequential, unnecessary computation                                                                           | baseline  |
+| `type-safety`        | any casts, missing null checks, unsafe assertions                                                                                   | baseline  |
+| `plan-conformance`   | Does the code match the spec/plan?                                                                                                  | baseline  |
+| `resource-lifecycle` | External resources created without TTL/expiry; unbounded growth of vendor-side objects (Shopify discounts, S3 keys, queue messages) | #147      |
+| `scope-coverage`     | Shopify/OAuth/IAM scopes don't cover all queries/mutations the code actually makes                                                  | #147      |
 
 ## Model Profiles
 
@@ -132,6 +134,12 @@ ALSO specifically check for (learned from past reviews):
 - Contract preservation: when migrating auth or refactoring, verify return types don't change (null → throw breaks callers). When fixing a pattern bug, grep for ALL instances of the same pattern. (PR #64)
 - Webhook retry safety: when changing webhook error responses from 200 to 500, verify ALL handlers are idempotent. Non-idempotent handlers (insert without unique guard) must return 200 on error to prevent retry-induced data duplication. (PR #66)
 - JSON serialization safety: when building strings for JSON output (especially script tags with JSON-LD), verify that escape sequences produce valid JSON. Backslash-bang is not a valid JSON escape — use Unicode escapes like `\u003C` instead. (PR #67)
+- Brand/tenant scoping in server actions: every server action that takes a session token AND a resource ID must verify resource ownership via `AND resource.brandId = auth.brandId` (or equivalent). Do not assume authentication implies authorization. (PR #147)
+- Inngest function idempotency: every `inngest.createFunction` needs an `idempotency` key derived from `event.data.<uniqueField>` so duplicate/replayed events don't trigger duplicate side effects. (PR #147, AGENTS.md defensive checklist)
+- UI refresh after server action: every server action called from a React component that mutates persistent state must trigger a UI re-fetch or state update afterwards (via `router.refresh()`, optimistic update, or explicit reload). A stale "Current: X" line after a successful save is a contradiction the user will notice. For App Bridge embedded apps, `router.refresh()` does not cross the iframe — use `window.location.reload()`. (PR #147)
+- External resource lifecycle: any vendor-side object created by the code (Shopify discount codes, S3 keys, Mux uploads, Inngest events that trigger persistent work) needs either a TTL/expiry or a documented cleanup path. Unbounded growth of vendor-side objects is a slow-burn liability. (PR #147)
+- OAuth/API scope coverage: for every external GraphQL query or mutation in the PR, verify the required scope is declared in the app config. e.g., a Shopify `orders(...)` query requires `read_orders` in `shopify.app.toml`. (PR #147)
+- Implementer-raised concerns tracking: if the implementing subagent's report flags a concern that you decide to defer, file a Linear ticket or add `// TODO(issue): ...` at the flagged site. Do NOT rely on "the next task will handle it" — the next task may not reference the concern. (PR #147)
 
 For each finding:
 - File and line number
@@ -143,13 +151,15 @@ For each finding:
 
 Do NOT flag: style/formatting, missing comments, import ordering, test coverage for unchanged code, or suggestions that add complexity without proportional value.
 
+SEVERITY FLOOR: if a finding maps directly to a rule in AGENTS.md's defensive checklist, severity is AT LEAST `important`. Do not downgrade to `minor` or "non-blocking" for something the project has explicitly documented as a required pattern. If you want to argue the rule doesn't apply here, quote the rule and explain why — don't silently lower the severity. (PR #147 — `sql NOW()` rule was rated minor, actually important.)
+
 [DIFF or FILE CONTENT]
 ```
 
 **Per-model prompt specialization:** After the base prompt, append a section for each model emphasizing its blind spots:
 
-- **Claude:** "Pay EXTRA attention to: dev-environment compatibility (MSW mocks, env var fallbacks, zero-secret contract), failure modes (retry exhaustion, partial failures, stuck states, webhook retry semantics), and API correctness (verify webhook payload fields against official spec, don't assume — check)."
-- **Codex:** "Pay EXTRA attention to: authorization and security (brand-scoping, auth bypass, OWASP), auth error handling (401 vs 500 responses), and API correctness (verify all fields in external API payloads are consumed, not just the obvious ones)."
+- **Claude:** "Pay EXTRA attention to: dev-environment compatibility (MSW mocks, env var fallbacks, zero-secret contract), failure modes (retry exhaustion, partial failures, stuck states, webhook retry semantics, **Inngest function idempotency keys — is `idempotency: 'event.data.<X>'` set on every createFunction?**), API correctness (verify webhook payload fields against official spec, don't assume — check), and UI-refresh-after-server-action patterns (no stale summary lines after save)."
+- **Codex:** "Pay EXTRA attention to: authorization and security (**brand/tenant scoping — every server action with a resource ID must verify ownership against auth**, auth bypass, OWASP), auth error handling (401 vs 500 responses), API correctness (verify all fields in external API payloads are consumed, not just the obvious ones), and **OAuth/scope coverage — for every external query, is the required scope declared in the app config?**"
 - **Gemini:** "Pay EXTRA attention to: failure modes (what happens when handlers throw — do callers get retries?), authorization/security (PII in logs, auth bypass), and contract preservation (do return types change when refactoring?)."
 
 The goal: **each model compensates for the others' weaknesses**, not duplicate their strengths.

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -19,6 +19,7 @@ Do NOT open a PR or invoke finishing-a-development-branch until:
 4. Critical/unanimous findings have been addressed
 5. If fixes were applied, re-review has been run on the updated diff
 6. The user has reviewed and approved the final consensus map
+7. If fixes were made: root cause analysis completed, prevention rule added
 </HARD-GATE>
 
 ## Step 1: Prepare the Diff
@@ -175,12 +176,69 @@ For each approved finding:
 
 This is the same re-review pattern the GH Action uses — each round reviews fresh code, not the same code debated again.
 
-After all rounds complete and verification passes, record skill usage for metrics:
+After all rounds complete and verification passes, proceed to root cause analysis.
+
+## Step 7: Root Cause Analysis (automatic when fixes were made)
+
+**Skip this step if the review produced zero fixes.** Otherwise, for every critical or unanimous finding that was fixed, ask: "Why did this bug survive implementation and testing? What structural change would prevent the entire class?"
+
+This is not optional. Fixing a bug is a patch. Fixing the bug class is engineering.
+
+### Process
+
+1. **Identify the root cause pattern** — not "I made a typo" but the structural reason. Common patterns:
+   - Code and documentation changed in the same PR but say opposite things (coherence failure)
+   - Uniform treatment of non-uniform things (e.g., all env vars handled the same way when some have defaults and some don't)
+   - Multi-file change where cross-file invariants weren't verified
+   - Missing test for the specific behavior that broke
+
+2. **Research prevention options** — dispatch a subagent to research exhaustively. Require at least 4 options spanning: agent instructions (AGENTS.md rules), tests, static analysis, and architectural/type-system approaches. Each option needs: what it is, how it would have caught THIS bug, and tradeoffs (cost, maintenance, false positives).
+
+3. **Rank by bang-for-buck** for a small team using AI agents heavily.
+
+4. **Implement the cheapest high-value prevention immediately** — typically an AGENTS.md rule (zero cost, instant). Commit it as part of this PR.
+
+5. **File a GitHub issue for deeper prevention** if a medium-cost option (tests, registry, CI check) scored high. Tag it `P3` — it's improvement, not launch-blocking.
+
+### Present to User
+
+```markdown
+## Root Cause Analysis
+
+### Why this bug survived
+
+[1-2 sentences: the structural reason, not "I made a mistake"]
+
+### Prevention implemented (this PR)
+
+- [What was added to AGENTS.md / code]
+
+### Prevention recommended (future)
+
+- [Medium-cost option] — [one-line description] (filed as #N)
+
+### Prevention considered but deferred
+
+- [Options that were too costly for current maturity]
+```
+
+### Anti-Rationalization
+
+| Thought                                           | Reality                                                                         |
+| ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| "The bug is fixed, let's move on"                 | The bug is fixed. The bug CLASS is not. You'll make the same mistake next week. |
+| "This was a one-off mistake"                      | If three models caught it, it's a pattern, not a fluke.                         |
+| "Adding an AGENTS.md rule is enough"              | It's a start. Rules are advisory. Tests are gates. Do both.                     |
+| "Root cause analysis is overkill for a minor fix" | This step only triggers for critical/unanimous findings. Those aren't minor.    |
+
+## Step 8: Record and Proceed to PR
+
+Record skill usage for metrics:
 
 - Append `vidably-multi-agent-code-review` to `.claude-skills-used` (gitignored)
 - The finishing-a-development-branch skill will include this in the PR body
 
-## Step 7: Proceed to PR
+## Step 9: Proceed to PR
 
 After review is complete and verified, invoke `finishing-a-development-branch` to open the PR. The PR will then receive the GH Action review (Claude + Security + Codex) as a safety net, but most issues should already be caught by this local review.
 
@@ -193,6 +251,7 @@ After review is complete and verified, invoke `finishing-a-development-branch` t
 | "I'll just open the PR and let the GH Action review it"        | The GH Action takes 15+ minutes and costs CI time. Local review takes 2-3 minutes and catches issues before they're visible on the PR.       |
 | "Only Codex is available, not enough for consensus"            | Two models (Claude + Codex) give you consensus/solo distinction. That's enough.                                                              |
 | "The Codex review found nothing, so there's nothing to report" | Report that. "No findings from Codex" is useful signal — it means Claude's findings are solo (lower confidence).                             |
+| "The bug is fixed, no need for root cause analysis"            | Fixing the bug is a patch. Fixing the bug class is engineering. If 3 models caught it, the process that produced it is broken.               |
 
 ## Interaction With Other Skills
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -34,6 +34,18 @@ Act on findings autonomously based on consensus level:
 
 Present the consensus map to the user for awareness, but do not wait for per-finding approval. The user reviews aggregate effectiveness data periodically, not individual findings.
 
+### Convergence rule: dismissing 2+ reviewers requires a citation
+
+When **two or more independent models** flag the same class of issue (`Unanimous` or `Majority`), rejection is only valid with a direct citation to an authoritative source:
+
+1. **Installed SDK / library types** in `node_modules` (grep and quote the docstring).
+2. **Current official API reference** by specific versioned URL — not marketing pages.
+3. **Prior user instruction** with a direct quote that explicitly addresses the disputed design.
+
+**No citation = accept the fix.** Prose reasoning alone ("I think Codex misunderstood…") is not a valid dismissal of converged findings. Writing confident rejection prose locks in a position before it's been verified — don't write it until the citation is in hand.
+
+**Case study (PR #133):** Codex flagged Mux `master_access: 'temporary'` auto-reverts after 24h. Gemini echoed the next round. Both were rejected with prose calling it a misunderstanding. 10 seconds of `grep` on the installed SDK types would have surfaced the authoritative docstring confirming the finding. The rejection would have shipped the exact bug the PR was supposed to prevent. This rule exists so that mistake is not repeatable.
+
 ## Step 1: Prepare the Diff
 
 Compute the diff against the base branch:

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -80,7 +80,7 @@ Updated after each Post-CI Retrospective (Step 9). Use these to specialize promp
 | ------- | ---------------------------------- | ----------------------------- | ------------ |
 | Claude  | `auth/security`, `react-lifecycle` | `dev-compat`, `failure-modes` | PR #61       |
 | Codex   | `dev-compat`, `data-integrity`     | `auth/security`               | PR #61       |
-| Gemini  | TBD                                | TBD                           | —            |
+| Gemini  | `plan-conformance`, `performance`  | TBD (1 PR baseline)           | PoC          |
 | Copilot | `failure-modes`, `data-integrity`  | TBD                           | PR #61       |
 
 ## Step 3: Dispatch to Available Models
@@ -134,22 +134,75 @@ Dispatch to all available models **in parallel**, independently:
 **Check and dispatch if present:**
 
 - Codex: `codex review --base main` (native code review mode — better than `codex exec` for diffs)
-- Gemini: `gemini --allowed-mcp-server-names _none -p "[review prompt] The branch is $(git branch --show-current) against main. Run git diff main...HEAD yourself to see the changes. Read any files you need for full context."`
+- Gemini: Use the **Gemini API with enriched context** (not the CLI — see below)
+
+**Gemini API Review (enriched context approach):**
+
+The Gemini CLI is too slow for reviews (~10+ min due to MCP initialization + Node.js overhead). Instead, call the Gemini API directly with enriched context that replicates what the CLI would read. This runs in ~50 seconds with equivalent or better finding quality (validated in PoC: enriched context found compliance-level bugs the diff-only approach missed).
+
+Build the enriched context by:
+
+1. Compute the diff: `git diff main...HEAD`
+2. For each file in the diff, include its **full content** (not just the hunks)
+3. For each changed file, follow `import` / `from` statements to local modules and include those too
+4. Include `packages/db/src/schema/*.ts` (the Drizzle schema — most bugs involve data)
+5. Include `AGENTS.md` (project context, conventions, maturity level, review instructions)
+
+Then call the API:
+
+```bash
+# Build the prompt with enriched context (see template below)
+# API key: read from ~/.gemini/.env or GEMINI_API_KEY env var
+
+curl -s "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=$GEMINI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contents": [{"parts": [{"text": "ENRICHED_PROMPT_HERE"}]}],
+    "generationConfig": {"temperature": 0, "maxOutputTokens": 8192}
+  }'
+```
+
+The enriched prompt template (wrap the base review prompt + per-model specialization with):
+
+````
+## Full File Contents (changed files + their imports)
+### path/to/changed-file.ts
+[full file content]
+
+### path/to/imported-module.ts
+[full file content]
+
+## Database Schema
+[all files from packages/db/src/schema/*.ts]
+
+## Project Conventions
+[AGENTS.md content]
+
+## Diff to Review
+```diff
+[git diff main...HEAD]
+```​
+````
+
+Use `jq` to JSON-escape the prompt for the API call. Extract the response text with:
+
+```bash
+jq -r '.candidates[0].content.parts[0].text' result.json
+```
 
 **For design/plan reviews (no diff):**
 
 - Codex: Pipe the content via stdin and use read-only sandbox: `echo "[review prompt with full design text]" | codex exec -s read-only -`
   - Without `-s read-only`, Codex will spend its entire budget exploring the repo instead of reviewing the provided text
   - The `-` at the end tells Codex to read the prompt from stdin
-- Gemini: `echo "[review prompt with full design text]" | gemini --allowed-mcp-server-names _none -p "Review this design for technical gaps..."`
+- Gemini: Same API approach — include the design text as context instead of the diff
 
 **CLI gotchas (learned from real usage):**
 
 - Codex `review` mode is purpose-built for diffs — prefer it over `exec` for code review
 - Codex `exec` for non-diff reviews MUST use `-s read-only` and pipe via stdin — otherwise it spirals into repo exploration and exhausts its budget without producing output (confirmed 2026-04-02, gpt-5.4)
 - Codex: Use `--base main` to review the current branch against main
-- Gemini: ALWAYS disable MCP servers with `--allowed-mcp-server-names _none` (passes a dummy name so no real MCP servers connect). Do NOT use `=""` — that passes an empty string which crashes the Gemini policy engine with "mcpName is required if specified (cannot be empty)".
-- Gemini: Do NOT pipe diffs via stdin — large diffs cause ENAMETOOLONG errors. Instead, tell Gemini the branch name and let it git diff itself.
+- Gemini: Do NOT use the CLI for reviews — it takes 10+ min due to MCP init overhead. Use the API with enriched context instead (~50s). The CLI is fine for interactive use where startup cost is amortized.
 - Both CLIs: 5-minute timeout. Kill and continue if exceeded.
 
 **Graceful degradation:** If no external CLIs are available:

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -19,7 +19,7 @@ Do NOT open a PR or invoke finishing-a-development-branch until:
 4. Critical/unanimous findings have been addressed
 5. If fixes were applied, re-review has been run on the updated diff
 6. The user has reviewed and approved the final consensus map
-7. If fixes were made: root cause analysis completed, prevention rule added
+7. Convention extraction completed, proposals presented to user
 </HARD-GATE>
 
 ## Step 1: Prepare the Diff
@@ -87,12 +87,12 @@ Dispatch to all available models **in parallel**, independently:
 
 **Always available:**
 
-- Claude Code subagent (Agent tool)
+- Claude Code subagent (Agent tool) — tell it the branch and base, let it git diff and read files itself. Do NOT send the diff content in the prompt.
 
 **Check and dispatch if present:**
 
 - Codex: `codex review --base main` (native code review mode — better than `codex exec` for diffs)
-- Gemini: `cat diff.txt | gemini --allowed-mcp-server-names="" -p "[review prompt]"`
+- Gemini: `gemini --allowed-mcp-server-names="" -p "[review prompt] The branch is $(git branch --show-current) against main. Run git diff main...HEAD yourself to see the changes. Read any files you need for full context."`
 
 **For design/plan reviews (no diff):**
 
@@ -107,7 +107,7 @@ Dispatch to all available models **in parallel**, independently:
 - Codex `exec` for non-diff reviews MUST use `-s read-only` and pipe via stdin — otherwise it spirals into repo exploration and exhausts its budget without producing output (confirmed 2026-04-02, gpt-5.4)
 - Codex: Use `--base main` to review the current branch against main
 - Gemini: ALWAYS disable MCP servers (`--allowed-mcp-server-names=""`) — they cause indefinite hangs
-- Gemini: stdin content is prepended to the `-p` prompt
+- Gemini: Do NOT pipe diffs via stdin — large diffs cause ENAMETOOLONG errors. Instead, tell Gemini the branch name and let it git diff itself.
 - Both CLIs: 5-minute timeout. Kill and continue if exceeded.
 
 **Graceful degradation:** If no external CLIs are available:
@@ -185,69 +185,36 @@ For each approved finding:
 
 This is the same re-review pattern the GH Action uses — each round reviews fresh code, not the same code debated again.
 
-After all rounds complete and verification passes, proceed to root cause analysis.
-
-## Step 7: Root Cause Analysis (automatic when fixes were made)
-
-**Skip this step if the review produced zero fixes.** Otherwise, for every critical or unanimous finding that was fixed, ask: "Why did this bug survive implementation and testing? What structural change would prevent the entire class?"
-
-This is not optional. Fixing a bug is a patch. Fixing the bug class is engineering.
-
-### Process
-
-1. **Identify the root cause pattern** — not "I made a typo" but the structural reason. Common patterns:
-   - Code and documentation changed in the same PR but say opposite things (coherence failure)
-   - Uniform treatment of non-uniform things (e.g., all env vars handled the same way when some have defaults and some don't)
-   - Multi-file change where cross-file invariants weren't verified
-   - Missing test for the specific behavior that broke
-
-2. **Research prevention options** — dispatch a subagent to research exhaustively. Require at least 4 options spanning: agent instructions (AGENTS.md rules), tests, static analysis, and architectural/type-system approaches. Each option needs: what it is, how it would have caught THIS bug, and tradeoffs (cost, maintenance, false positives).
-
-3. **Rank by bang-for-buck** for a small team using AI agents heavily.
-
-4. **Implement the cheapest high-value prevention immediately** — typically an AGENTS.md rule (zero cost, instant). Commit it as part of this PR.
-
-5. **File a GitHub issue for deeper prevention** if a medium-cost option (tests, registry, CI check) scored high. Tag it `P3` — it's improvement, not launch-blocking.
-
-### Present to User
-
-```markdown
-## Root Cause Analysis
-
-### Why this bug survived
-
-[1-2 sentences: the structural reason, not "I made a mistake"]
-
-### Prevention implemented (this PR)
-
-- [What was added to AGENTS.md / code]
-
-### Prevention recommended (future)
-
-- [Medium-cost option] — [one-line description] (filed as #N)
-
-### Prevention considered but deferred
-
-- [Options that were too costly for current maturity]
-```
-
-### Anti-Rationalization
-
-| Thought                                           | Reality                                                                         |
-| ------------------------------------------------- | ------------------------------------------------------------------------------- |
-| "The bug is fixed, let's move on"                 | The bug is fixed. The bug CLASS is not. You'll make the same mistake next week. |
-| "This was a one-off mistake"                      | If three models caught it, it's a pattern, not a fluke.                         |
-| "Adding an AGENTS.md rule is enough"              | It's a start. Rules are advisory. Tests are gates. Do both.                     |
-| "Root cause analysis is overkill for a minor fix" | This step only triggers for critical/unanimous findings. Those aren't minor.    |
-
-## Step 8: Record and Proceed to PR
-
-Record skill usage for metrics:
+After all rounds complete and verification passes, record skill usage for metrics:
 
 - Append `vidably-multi-agent-code-review` to `.claude-skills-used` (gitignored)
 - The finishing-a-development-branch skill will include this in the PR body
 
-## Step 9: Proceed to PR
+## Step 7: Convention Extraction
+
+After all review rounds are complete and verification passes, automatically extract systemic lessons. This step runs every time — it's how the system self-improves.
+
+**Read the project maturity level** from the `### Project Maturity` section of `AGENTS.md`. Use it to calibrate classifications below.
+
+For each finding from all rounds (accepted, dismissed, and false positives), classify:
+
+1. **CONVENTION GAP** — a rule in AGENTS.md would have prevented this finding from being written in the first place. Draft the exact addition: which section, what text, where it goes.
+2. **SKILL GAP** — this skill or another skill should change its behavior. Draft the exact change to the skill file.
+3. **MATURITY-GATED** — this finding is valid but appropriate for a higher maturity level than the current one. No action needed now. Note which level it belongs to.
+4. **ONE-OFF** — specific to this code, no systemic lesson. No action needed.
+
+Present each proposal:
+
+| Finding       | Classification         | Proposed Change                                     |
+| ------------- | ---------------------- | --------------------------------------------------- |
+| [description] | Convention gap         | [exact text to add to AGENTS.md, including section] |
+| [description] | Skill gap              | [exact change to skill file]                        |
+| [description] | Maturity-gated (scale) | None — revisit at `scale`                           |
+| [description] | One-off                | None                                                |
+
+Then STOP and wait for user approval on each convention/skill proposal. Apply approved changes and commit them alongside the PR.
+
+## Step 8: Proceed to PR
 
 After review is complete and verified, invoke `finishing-a-development-branch` to open the PR. The PR will then receive the GH Action review (Claude + Security + Codex) as a safety net, but most issues should already be caught by this local review.
 
@@ -260,7 +227,6 @@ After review is complete and verified, invoke `finishing-a-development-branch` t
 | "I'll just open the PR and let the GH Action review it"        | The GH Action takes 15+ minutes and costs CI time. Local review takes 2-3 minutes and catches issues before they're visible on the PR.       |
 | "Only Codex is available, not enough for consensus"            | Two models (Claude + Codex) give you consensus/solo distinction. That's enough.                                                              |
 | "The Codex review found nothing, so there's nothing to report" | Report that. "No findings from Codex" is useful signal — it means Claude's findings are solo (lower confidence).                             |
-| "The bug is fixed, no need for root cause analysis"            | Fixing the bug is a patch. Fixing the bug class is engineering. If 3 models caught it, the process that produced it is broken.               |
 
 ## Interaction With Other Skills
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -16,11 +16,23 @@ Do NOT open a PR or invoke finishing-a-development-branch until:
 1. Local verification passes (lint, typecheck, test, build)
 2. At least 2 independent model reviews have been collected
 3. Consensus scoring has been applied
-4. Critical/unanimous findings have been addressed
+4. Findings have been acted on based on consensus level (see Action Policy below)
 5. If fixes were applied, re-review has been run on the updated diff
-6. The user has reviewed and approved the final consensus map
-7. Convention extraction completed, proposals presented to user
+6. Convention extraction completed
 </HARD-GATE>
+
+## Action Policy
+
+Act on findings autonomously based on consensus level:
+
+| Consensus     | Action                                                                                                                                       |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Unanimous** | Fix immediately -- highest confidence                                                                                                        |
+| **Majority**  | Fix -- strong signal across models                                                                                                           |
+| **Split**     | Use judgment. Fix if the finding has concrete consequences; skip if it's a style or preference disagreement. Log your reasoning.             |
+| **Solo**      | Evaluate on merit. Fix if critical severity regardless of consensus. For important/minor, fix if the reasoning is sound. Log your reasoning. |
+
+Present the consensus map to the user for awareness, but do not wait for per-finding approval. The user reviews aggregate effectiveness data periodically, not individual findings.
 
 ## Step 1: Prepare the Diff
 
@@ -173,12 +185,14 @@ If the Gemini CLI is unavailable or you want faster results, call the Gemini API
 
 Deduplicate findings across models. Apply consensus scoring:
 
-| Consensus     | Definition                      | Action                                  |
-| ------------- | ------------------------------- | --------------------------------------- |
-| **Unanimous** | All reviewing models flagged it | Fix immediately — highest confidence    |
-| **Majority**  | >50% of models flagged it       | Strongly recommend fixing               |
-| **Split**     | Exactly 2 models disagree       | Use judgment — apply project philosophy |
-| **Solo**      | One model only                  | Evaluate on merit — do NOT auto-dismiss |
+| Consensus     | Definition                      |
+| ------------- | ------------------------------- |
+| **Unanimous** | All reviewing models flagged it |
+| **Majority**  | >50% of models flagged it       |
+| **Split**     | Exactly 2 models disagree       |
+| **Solo**      | One model only                  |
+
+See the **Action Policy** above for how to act on each level.
 
 **Critical finding from any model = fix it.** A solo critical (bug, security, data loss) should be fixed regardless of consensus. Consensus matters more for important/minor findings.
 
@@ -212,7 +226,7 @@ Deduplicate findings across models. Apply consensus scoring:
 - [finding] — [why: style preference / false positive / etc.]
 ```
 
-Then STOP and wait for user approval on which findings to fix.
+Present the consensus map, then proceed to apply fixes based on the Action Policy above. The user can intervene if they disagree, but the default is autonomous action.
 
 ## Step 6: Apply Fixes, Re-Verify, and Re-Review
 
@@ -269,7 +283,7 @@ Present each proposal:
 | [description] | Maturity-gated (scale) | None — revisit at `scale`                           |
 | [description] | One-off                | None                                                |
 
-Then STOP and wait for user approval on each convention/skill proposal. Apply approved changes and commit them alongside the PR.
+Then STOP and wait for user approval on each convention/skill proposal. Apply approved changes and commit them alongside the PR. (Convention proposals modify the review system itself, so they are excluded from the Action Policy and require explicit approval.)
 
 ## Step 8: Proceed to PR
 
@@ -341,6 +355,32 @@ Check the running trend in review-effectiveness.md:
 - Are any categories consistently missed by ALL local models? That's a systemic gap — consider adding a 4th model or a specialized linter.
 
 **The goal: CI should catch ZERO new findings that local review missed.** Every non-zero number is a learning opportunity, not a failure.
+
+### 9f: Downstream Surprise Check
+
+Check if this branch has upstream logs in `docs/research-effectiveness.md` or `docs/plan-review-effectiveness.md` by searching for the branch name.
+
+If upstream logs exist, review each code review finding and ask: **could upstream (research or plan review) have caught this?**
+
+For each finding where the answer is yes, route to the correct tracker:
+
+1. If the upstream log was in `docs/plan-review-effectiveness.md`, add an entry to **its** Downstream Surprise Log.
+2. If the upstream log was in `docs/research-effectiveness.md`, add an entry to **its** Downstream Surprise Log.
+3. If both stages had the opportunity, add one entry to each.
+
+Entry format:
+
+```markdown
+- **[Date]** -- Branch: `[branch-name]`. Code review found `[category]` issue: [one-line description]. [Research/Plan review] had the opportunity to catch this but didn't. (tagged_by: [agent], confidence: high/medium/low, reason: [one line])
+```
+
+This is agent-assisted tagging, not fully automatic. If confidence is "low," flag the entry for human review rather than auto-appending.
+
+4. Note the category and model attribution -- this feeds into the upstream model profiles over time.
+
+**Sanitization rule:** Log normalized summaries only. Do not include secrets, tokens, PII, customer identifiers, raw payloads, or exploit details in downstream surprise entries.
+
+If no upstream logs exist for this branch, skip this step. Not every branch goes through the full chain, and that's fine -- the data accumulates over time.
 
 ## Anti-Rationalization Table
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -92,21 +92,21 @@ Dispatch to all available models **in parallel**, independently:
 **Check and dispatch if present:**
 
 - Codex: `codex review --base main` (native code review mode — better than `codex exec` for diffs)
-- Gemini: `gemini --allowed-mcp-server-names="" -p "[review prompt] The branch is $(git branch --show-current) against main. Run git diff main...HEAD yourself to see the changes. Read any files you need for full context."`
+- Gemini: `gemini --allowed-mcp-server-names _none -p "[review prompt] The branch is $(git branch --show-current) against main. Run git diff main...HEAD yourself to see the changes. Read any files you need for full context."`
 
 **For design/plan reviews (no diff):**
 
 - Codex: Pipe the content via stdin and use read-only sandbox: `echo "[review prompt with full design text]" | codex exec -s read-only -`
   - Without `-s read-only`, Codex will spend its entire budget exploring the repo instead of reviewing the provided text
   - The `-` at the end tells Codex to read the prompt from stdin
-- Gemini: `echo "[review prompt with full design text]" | gemini --allowed-mcp-server-names="" -p "Review this design for technical gaps..."`
+- Gemini: `echo "[review prompt with full design text]" | gemini --allowed-mcp-server-names _none -p "Review this design for technical gaps..."`
 
 **CLI gotchas (learned from real usage):**
 
 - Codex `review` mode is purpose-built for diffs — prefer it over `exec` for code review
 - Codex `exec` for non-diff reviews MUST use `-s read-only` and pipe via stdin — otherwise it spirals into repo exploration and exhausts its budget without producing output (confirmed 2026-04-02, gpt-5.4)
 - Codex: Use `--base main` to review the current branch against main
-- Gemini: ALWAYS disable MCP servers (`--allowed-mcp-server-names=""`) — they cause indefinite hangs
+- Gemini: ALWAYS disable MCP servers with `--allowed-mcp-server-names _none` (passes a dummy name so no real MCP servers connect). Do NOT use `=""` — that passes an empty string which crashes the Gemini policy engine with "mcpName is required if specified (cannot be empty)".
 - Gemini: Do NOT pipe diffs via stdin — large diffs cause ENAMETOOLONG errors. Instead, tell Gemini the branch name and let it git diff itself.
 - Both CLIs: 5-minute timeout. Kill and continue if exceeded.
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -7,7 +7,9 @@ description: "Use after implementation is complete and tests pass, before openin
 
 After implementation is complete and local tests pass, dispatch the diff to multiple AI models for independent review before opening a PR. This catches bugs across model blind spots BEFORE they reach CI — faster and cheaper than waiting for the GH Action review.
 
-Research shows: different model architectures have uncorrelated blind spots, and multi-model consensus catches 3-5x more bugs than single-pass review. Extended debate rounds hurt (problem drift), so we use exactly 1 round of independent review + synthesis.
+Research shows: different model architectures have uncorrelated blind spots, and multi-model consensus catches 3-5x more bugs than single-pass review. Each round should review fresh code after fixes are applied (re-review pattern), not debate the same code (which causes problem drift).
+
+**Round policy:** Up to 3 rounds. Each round reviews the UPDATED diff after fixes are applied. Round 3 is conservative (only critical). Stop early if a round produces zero changes. Same re-review pattern as the GH Action — the quality bar is the same locally and in CI.
 
 <HARD-GATE>
 Do NOT open a PR or invoke finishing-a-development-branch until:
@@ -15,7 +17,8 @@ Do NOT open a PR or invoke finishing-a-development-branch until:
 2. At least 2 independent model reviews have been collected
 3. Consensus scoring has been applied
 4. Critical/unanimous findings have been addressed
-5. The user has reviewed and approved the consensus map
+5. If fixes were applied, re-review has been run on the updated diff
+6. The user has reviewed and approved the final consensus map
 </HARD-GATE>
 
 ## Step 1: Prepare the Diff
@@ -149,7 +152,7 @@ Deduplicate findings across models. Apply consensus scoring:
 
 Then STOP and wait for user approval on which findings to fix.
 
-## Step 6: Apply Fixes and Re-Verify
+## Step 6: Apply Fixes, Re-Verify, and Re-Review
 
 For each approved finding:
 
@@ -157,14 +160,29 @@ For each approved finding:
 2. Re-run `pnpm lint && pnpm typecheck && pnpm test && pnpm build`
 3. If any check fails, fix before continuing
 
-After all fixes are applied and verified, record skill usage for metrics:
+**If fixes were made, re-review (up to 3 rounds total):**
+
+4. Compute the UPDATED diff: `git diff main...HEAD`
+5. Dispatch to all available models again (Steps 3-5)
+6. Present the new consensus map to the user
+
+**Round policy:**
+
+- **Round 1:** Address all findings
+- **Round 2:** Address findings from round 2 reviews only (issues introduced by round 1 fixes, or issues missed in round 1)
+- **Round 3:** Only critical findings. Everything else is deferred.
+- **Stop early:** If a round produces zero accepted findings, the code is ready. Don't force more rounds.
+
+This is the same re-review pattern the GH Action uses — each round reviews fresh code, not the same code debated again.
+
+After all rounds complete and verification passes, record skill usage for metrics:
 
 - Append `vidably-multi-agent-code-review` to `.claude-skills-used` (gitignored)
 - The finishing-a-development-branch skill will include this in the PR body
 
 ## Step 7: Proceed to PR
 
-After review is complete and verified, invoke `finishing-a-development-branch` to open the PR. The PR will then receive a lighter-weight GH Action review (Claude + Security + Codex as a safety net), but most issues should already be caught by this local review.
+After review is complete and verified, invoke `finishing-a-development-branch` to open the PR. The PR will then receive the GH Action review (Claude + Security + Codex) as a safety net, but most issues should already be caught by this local review.
 
 ## Anti-Rationalization Table
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -134,76 +134,27 @@ Dispatch to all available models **in parallel**, independently:
 **Check and dispatch if present:**
 
 - Codex: `codex review --base main` (native code review mode — better than `codex exec` for diffs)
-- Gemini: Use the **Gemini API with enriched context** (not the CLI — see below)
+- Gemini: `gemini --allowed-mcp-server-names _none -p "[review prompt] The branch is $(git branch --show-current) against main. Run git diff main...HEAD yourself to see the changes. Read any files you need for full context."`
 
-**Gemini API Review (enriched context approach):**
+**Alternative: Gemini API with enriched context (~50s, no CLI overhead):**
 
-The Gemini CLI is too slow for reviews (~10+ min due to MCP initialization + Node.js overhead). Instead, call the Gemini API directly with enriched context that replicates what the CLI would read. This runs in ~50 seconds with equivalent or better finding quality (validated in PoC: enriched context found compliance-level bugs the diff-only approach missed).
-
-Build the enriched context by:
-
-1. Compute the diff: `git diff main...HEAD`
-2. For each file in the diff, include its **full content** (not just the hunks)
-3. For each changed file, follow `import` / `from` statements to local modules and include those too
-4. Include `packages/db/src/schema/*.ts` (the Drizzle schema — most bugs involve data)
-5. Include `AGENTS.md` (project context, conventions, maturity level, review instructions)
-
-Then call the API:
-
-```bash
-# Build the prompt with enriched context (see template below)
-# API key: read from ~/.gemini/.env or GEMINI_API_KEY env var
-
-curl -s "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=$GEMINI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "contents": [{"parts": [{"text": "ENRICHED_PROMPT_HERE"}]}],
-    "generationConfig": {"temperature": 0, "maxOutputTokens": 8192}
-  }'
-```
-
-The enriched prompt template (wrap the base review prompt + per-model specialization with):
-
-````
-## Full File Contents (changed files + their imports)
-### path/to/changed-file.ts
-[full file content]
-
-### path/to/imported-module.ts
-[full file content]
-
-## Database Schema
-[all files from packages/db/src/schema/*.ts]
-
-## Project Conventions
-[AGENTS.md content]
-
-## Diff to Review
-```diff
-[git diff main...HEAD]
-```​
-````
-
-Use `jq` to JSON-escape the prompt for the API call. Extract the response text with:
-
-```bash
-jq -r '.candidates[0].content.parts[0].text' result.json
-```
+If the Gemini CLI is unavailable or you want faster results, call the Gemini API directly with enriched context. Build the context by including: full content of changed files + their local imports + `packages/db/src/schema/*.ts` + `AGENTS.md` + the diff. Call `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=$GEMINI_API_KEY` with `temperature: 0, maxOutputTokens: 8192`. API key is in `~/.gemini/.env`. Use `jq` to JSON-escape the prompt. This finds compliance-level bugs the diff-only approach misses (validated in PoC).
 
 **For design/plan reviews (no diff):**
 
 - Codex: Pipe the content via stdin and use read-only sandbox: `echo "[review prompt with full design text]" | codex exec -s read-only -`
   - Without `-s read-only`, Codex will spend its entire budget exploring the repo instead of reviewing the provided text
   - The `-` at the end tells Codex to read the prompt from stdin
-- Gemini: Same API approach — include the design text as context instead of the diff
+- Gemini: `echo "[review prompt with full design text]" | gemini --allowed-mcp-server-names _none -p "Review this design for technical gaps..."`
 
 **CLI gotchas (learned from real usage):**
 
+- **TIMEOUTS: Both Codex and Gemini CLIs need 10 minutes (600000ms) for large diffs.** With `xhigh` reasoning, Codex reads files, runs searches, and reasons deeply — a 500+ line diff legitimately takes 5-10 min. The default 2-minute bash timeout will kill them mid-analysis, producing no findings. This was misdiagnosed as "hitting output limits" and "MCP init overhead" in early reviews — both were just timeout kills. Always use `timeout: 600000` for CLI review commands.
 - Codex `review` mode is purpose-built for diffs — prefer it over `exec` for code review
 - Codex `exec` for non-diff reviews MUST use `-s read-only` and pipe via stdin — otherwise it spirals into repo exploration and exhausts its budget without producing output (confirmed 2026-04-02, gpt-5.4)
 - Codex: Use `--base main` to review the current branch against main
-- Gemini: Do NOT use the CLI for reviews — it takes 10+ min due to MCP init overhead. Use the API with enriched context instead (~50s). The CLI is fine for interactive use where startup cost is amortized.
-- Both CLIs: 5-minute timeout. Kill and continue if exceeded.
+- Gemini: ALWAYS disable MCP servers with `--allowed-mcp-server-names _none` (passes a dummy name so no real MCP servers connect). Do NOT use `=""` — that passes an empty string which crashes the Gemini policy engine.
+- Gemini: Do NOT pipe diffs via stdin — large diffs cause ENAMETOOLONG errors. Instead, tell Gemini the branch name and let it git diff itself.
 
 **Graceful degradation:** If no external CLIs are available:
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -136,8 +136,8 @@ Dispatch to all available models **in parallel**, independently:
 
 **Check and dispatch if present:**
 
-- Codex: `codex review --base main` (native code review mode — better than `codex exec` for diffs)
-- Gemini: `gemini --allowed-mcp-server-names _none -p "[review prompt] The branch is $(git branch --show-current) against main. Run git diff main...HEAD yourself to see the changes. Read any files you need for full context."`
+- Codex: `./tools/run-cli-review.sh codex review --base main` (wrapper captures timing, exit code, full output)
+- Gemini: `./tools/run-cli-review.sh gemini --allowed-mcp-server-names _none -p "[review prompt] The branch is $(git branch --show-current) against main. Run git diff main...HEAD yourself to see the changes. Read any files you need for full context."`
 
 **Alternative: Gemini API with enriched context (~50s, no CLI overhead):**
 
@@ -153,7 +153,8 @@ If the Gemini CLI is unavailable or you want faster results, call the Gemini API
 **CLI gotchas (learned from real usage):**
 
 - **TIMEOUTS: Use `timeout: 1200000` (20 minutes) for all CLI review commands.** With `xhigh` reasoning, Codex reads files, runs web searches, and reasons deeply — it needs real time. The default 2-minute bash timeout will kill them mid-analysis, producing no findings. This was misdiagnosed as "hitting output limits" and "MCP init overhead" in early reviews — both were just timeout kills.
-- **TIMING: Wrap every CLI review call with timing** so we can calibrate timeouts with real data. Use: `START=$(date +%s); <command>; echo "REVIEW_TIMING: model=<model> diff_lines=<N> elapsed=$(($(date +%s) - START))s"`. Log this in the synthesis output so it gets captured in review-effectiveness.md.
+- **WRAPPER: Always use `./tools/run-cli-review.sh`** instead of calling CLI tools directly. It captures timing, exit code, signal info, and full output to `tools/review-logs/`. If a process is killed, it prints a WARNING automatically. A PostToolUse hook on Bash also detects timeout kills and injects a warning.
+- **IF A CLI TOOL APPEARS TO FAIL: Invoke the `diagnosing-failures` skill** before proposing any workaround. List at least 3 possible root causes and check evidence against each.
 - Codex `review` mode is purpose-built for diffs — prefer it over `exec` for code review
 - Codex `exec` for non-diff reviews MUST use `-s read-only` and pipe via stdin — otherwise it spirals into repo exploration and exhausts its budget without producing output (confirmed 2026-04-02, gpt-5.4)
 - Codex: Use `--base main` to review the current branch against main

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -76,12 +76,13 @@ Tag every finding with a category. This taxonomy grows over time — add new cat
 
 Updated after each Post-CI Retrospective (Step 9). Use these to specialize prompts — emphasize each model's **blind spots**, not strengths.
 
-| Model   | Strengths                          | Blind Spots                   | Last Updated |
-| ------- | ---------------------------------- | ----------------------------- | ------------ |
-| Claude  | `auth/security`, `react-lifecycle` | `dev-compat`, `failure-modes` | PR #61       |
-| Codex   | `dev-compat`, `data-integrity`     | `auth/security`               | PR #61       |
-| Gemini  | `plan-conformance`, `performance`  | TBD (1 PR baseline)           | PoC          |
-| Copilot | `failure-modes`, `data-integrity`  | TBD                           | PR #61       |
+| Model      | Strengths                                            | Blind Spots                                      | Last Updated |
+| ---------- | ---------------------------------------------------- | ------------------------------------------------ | ------------ |
+| Claude     | `auth/security`, `react-lifecycle`, `performance`    | `dev-compat`, `failure-modes`, `api-correctness` | PR #62-64    |
+| Codex      | `dev-compat`, `data-integrity`                       | `auth/security`, `api-correctness`               | PR #62-64    |
+| Gemini     | `plan-conformance`, `performance`                    | `failure-modes`, `auth/security`                 | PR #62-64    |
+| Codex (CI) | `api-correctness`, `failure-modes`, `data-integrity` | —                                                | PR #62-64    |
+| Copilot    | `failure-modes`, `api-correctness`                   | `auth/security`, `dev-compat`                    | PR #62-64    |
 
 ## Step 3: Dispatch to Available Models
 
@@ -99,10 +100,12 @@ Review for:
 6. Plan conformance (if a plan exists — does the code match the spec?)
 
 ALSO specifically check for (learned from past reviews):
-- Failure modes: what happens when retries exhaust? Are there stuck states? Missing onFailure handlers? (PR #61)
-- Data invariants: case-sensitive uniqueness, nullability edge cases, type coercion across DB boundaries (PR #61)
-- API correctness: verify external API query field names and pagination against official docs, not assumptions (PR #61)
+- Failure modes: what happens when retries exhaust? Are there stuck states? Missing onFailure handlers? Do webhook error responses allow the sender to retry for compliance-critical topics? (PR #61, #62)
+- Data invariants: case-sensitive uniqueness, nullability edge cases, type coercion across DB boundaries. For deletions/redactions, verify cascade behavior — nulling columns is not the same as deleting rows with FK cascades. (PR #61, #62)
+- API correctness: verify external API query field names and pagination against official docs, not assumptions. For webhook payloads, check ALL fields in the spec (e.g., Shopify GDPR payloads include orders_to_redact, orders_requested). (PR #61, #62)
 - Dev-environment contract: does every new external API call have an MSW mock? Can this code run with zero secrets? (PR #61)
+- Compliance/PII: never log PII (email, name, order IDs) in compliance handlers — it defeats redaction by creating copies in log storage. (PR #62)
+- Contract preservation: when migrating auth or refactoring, verify return types don't change (null → throw breaks callers). When fixing a pattern bug, grep for ALL instances of the same pattern. (PR #64)
 
 For each finding:
 - File and line number
@@ -119,9 +122,9 @@ Do NOT flag: style/formatting, missing comments, import ordering, test coverage 
 
 **Per-model prompt specialization:** After the base prompt, append a section for each model emphasizing its blind spots:
 
-- **Claude:** "Pay EXTRA attention to: dev-environment compatibility (MSW mocks, env var fallbacks, zero-secret contract), and failure modes (what happens when retries exhaust, partial failures, stuck states)."
-- **Codex:** "Pay EXTRA attention to: authorization and security (brand-scoping, auth bypass, OWASP), and auth error handling (401 vs 500 responses)."
-- **Gemini:** [Use base prompt until profile is established]
+- **Claude:** "Pay EXTRA attention to: dev-environment compatibility (MSW mocks, env var fallbacks, zero-secret contract), failure modes (retry exhaustion, partial failures, stuck states, webhook retry semantics), and API correctness (verify webhook payload fields against official spec, don't assume — check)."
+- **Codex:** "Pay EXTRA attention to: authorization and security (brand-scoping, auth bypass, OWASP), auth error handling (401 vs 500 responses), and API correctness (verify all fields in external API payloads are consumed, not just the obvious ones)."
+- **Gemini:** "Pay EXTRA attention to: failure modes (what happens when handlers throw — do callers get retries?), authorization/security (PII in logs, auth bypass), and contract preservation (do return types change when refactoring?)."
 
 The goal: **each model compensates for the others' weaknesses**, not duplicate their strengths.
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -94,9 +94,17 @@ Dispatch to all available models **in parallel**, independently:
 - Codex: `codex review --base main` (native code review mode — better than `codex exec` for diffs)
 - Gemini: `cat diff.txt | gemini --allowed-mcp-server-names="" -p "[review prompt]"`
 
+**For design/plan reviews (no diff):**
+
+- Codex: Pipe the content via stdin and use read-only sandbox: `echo "[review prompt with full design text]" | codex exec -s read-only -`
+  - Without `-s read-only`, Codex will spend its entire budget exploring the repo instead of reviewing the provided text
+  - The `-` at the end tells Codex to read the prompt from stdin
+- Gemini: `echo "[review prompt with full design text]" | gemini --allowed-mcp-server-names="" -p "Review this design for technical gaps..."`
+
 **CLI gotchas (learned from real usage):**
 
 - Codex `review` mode is purpose-built for diffs — prefer it over `exec` for code review
+- Codex `exec` for non-diff reviews MUST use `-s read-only` and pipe via stdin — otherwise it spirals into repo exploration and exhausts its budget without producing output (confirmed 2026-04-02, gpt-5.4)
 - Codex: Use `--base main` to review the current branch against main
 - Gemini: ALWAYS disable MCP servers (`--allowed-mcp-server-names=""`) — they cause indefinite hangs
 - Gemini: stdin content is prepended to the `-p` prompt

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -106,6 +106,8 @@ ALSO specifically check for (learned from past reviews):
 - Dev-environment contract: does every new external API call have an MSW mock? Can this code run with zero secrets? (PR #61)
 - Compliance/PII: never log PII (email, name, order IDs) in compliance handlers — it defeats redaction by creating copies in log storage. (PR #62)
 - Contract preservation: when migrating auth or refactoring, verify return types don't change (null → throw breaks callers). When fixing a pattern bug, grep for ALL instances of the same pattern. (PR #64)
+- Webhook retry safety: when changing webhook error responses from 200 to 500, verify ALL handlers are idempotent. Non-idempotent handlers (insert without unique guard) must return 200 on error to prevent retry-induced data duplication. (PR #66)
+- JSON serialization safety: when building strings for JSON output (especially script tags with JSON-LD), verify that escape sequences produce valid JSON. Backslash-bang is not a valid JSON escape — use Unicode escapes like `\u003C` instead. (PR #67)
 
 For each finding:
 - File and line number

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -238,10 +238,14 @@ For each approved finding:
 
 This is the same re-review pattern the GH Action uses — each round reviews fresh code, not the same code debated again.
 
-After all rounds complete and verification passes, record skill usage for metrics:
+After all rounds complete and verification passes, update the event log:
 
-- Append `vidably-multi-agent-code-review` to `.claude-skills-used` (gitignored)
-- The finishing-a-development-branch skill will include this in the PR body
+```bash
+# Append to event log
+echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --show-current)\",\"event\":\"code_review_complete\",\"sha\":\"$(git rev-parse --short HEAD)\",\"models\":MODELS_LIST,\"findings\":FINDINGS_COUNT,\"rounds\":ROUNDS_COUNT}" >> .claude/workflow-events.jsonl
+```
+
+Replace `MODELS_LIST` with a JSON array (e.g., `[\"codex\",\"gemini\"]`), `FINDINGS_COUNT` with total findings, and `ROUNDS_COUNT` with review rounds completed.
 
 ## Step 7: Convention Extraction
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -165,15 +165,16 @@ Then STOP and wait for user approval on which findings to fix.
 
 For each approved finding:
 
-1. Apply the fix
-2. Re-run `pnpm lint && pnpm typecheck && pnpm test && pnpm build`
-3. If any check fails, fix before continuing
+1. **Test-first fix (mandatory for control flow / sentinel changes):** Before applying the fix, write a test that would FAIL if the fix is wrong. Run it to confirm it fails with the current code. Then apply the fix and confirm it passes. This prevents fixes that "look right" but have a semantic flaw — the test is a proof that the fix works, not just that it compiles. Skip only for pure deletions or cosmetic changes.
+2. Apply the fix
+3. Re-run `pnpm lint && pnpm typecheck && pnpm test && pnpm build`
+4. If any check fails, fix before continuing
 
 **If fixes were made, re-review (up to 3 rounds total):**
 
-4. Compute the UPDATED diff: `git diff main...HEAD`
-5. Dispatch to all available models again (Steps 3-5)
-6. Present the new consensus map to the user
+5. Compute the UPDATED diff: `git diff main...HEAD`
+6. Dispatch to all available models again (Steps 3-5)
+7. Present the new consensus map to the user
 
 **Round policy:**
 

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -255,8 +255,22 @@ This is the same re-review pattern the GH Action uses — each round reviews fre
 After all rounds complete and verification passes, update the event log:
 
 ```bash
-# Append to event log
-echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --show-current)\",\"event\":\"code_review_complete\",\"sha\":\"$(git rev-parse --short HEAD)\",\"models\":MODELS_LIST,\"findings\":FINDINGS_COUNT,\"rounds\":ROUNDS_COUNT}" >> .claude/workflow-events.jsonl
+# Append structured event log entry
+cat <<JSON | node scripts/measurement/emit-event.mjs
+{
+  "stage": "code_review",
+  "event": "code_review_complete",
+  "source": "skill",
+  "payload": {
+    "models": MODELS_LIST,
+    "rounds": ROUNDS_COUNT,
+    "findingCount": FINDINGS_COUNT
+  }
+}
+JSON
+
+# Refresh the local talk report (best effort)
+node scripts/measurement/render-talk-report.mjs >/dev/null 2>&1 || true
 ```
 
 Replace `MODELS_LIST` with a JSON array (e.g., `[\"codex\",\"gemini\"]`), `FINDINGS_COUNT` with total findings, and `ROUNDS_COUNT` with review rounds completed.

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -56,9 +56,36 @@ shopify app build
 
 Do NOT proceed to model review if verification fails. Fix first.
 
+## Finding Categories
+
+Tag every finding with a category. This taxonomy grows over time — add new categories in the Post-CI Retrospective (Step 9) when findings don't fit existing ones.
+
+| Category           | What it covers                                                               | Source PR |
+| ------------------ | ---------------------------------------------------------------------------- | --------- |
+| `auth/security`    | Authorization bypass, injection, OWASP, auth error handling                  | baseline  |
+| `failure-modes`    | Retry exhaustion, stuck states, partial failures, missing onFailure handlers | #61       |
+| `data-integrity`   | Case sensitivity, uniqueness edge cases, nullability, type coercion          | #61       |
+| `api-correctness`  | External API query format, field names, pagination, SDK usage                | #61       |
+| `dev-compat`       | MSW mocks, env var assumptions, zero-secret contract compliance              | #61       |
+| `react-lifecycle`  | useEffect deps, stale closures, re-render storms, ref stability              | #61       |
+| `performance`      | N+1 queries, batch vs sequential, unnecessary computation                    | baseline  |
+| `type-safety`      | any casts, missing null checks, unsafe assertions                            | baseline  |
+| `plan-conformance` | Does the code match the spec/plan?                                           | baseline  |
+
+## Model Profiles
+
+Updated after each Post-CI Retrospective (Step 9). Use these to specialize prompts — emphasize each model's **blind spots**, not strengths.
+
+| Model   | Strengths                          | Blind Spots                   | Last Updated |
+| ------- | ---------------------------------- | ----------------------------- | ------------ |
+| Claude  | `auth/security`, `react-lifecycle` | `dev-compat`, `failure-modes` | PR #61       |
+| Codex   | `dev-compat`, `data-integrity`     | `auth/security`               | PR #61       |
+| Gemini  | TBD                                | TBD                           | —            |
+| Copilot | `failure-modes`, `data-integrity`  | TBD                           | PR #61       |
+
 ## Step 3: Dispatch to Available Models
 
-Construct the review prompt:
+Construct the **base review prompt**, then append model-specific emphasis from the blind spots column above:
 
 ```
 You are a senior engineer reviewing a code diff.
@@ -71,9 +98,16 @@ Review for:
 5. Missing error handling at system boundaries
 6. Plan conformance (if a plan exists — does the code match the spec?)
 
+ALSO specifically check for (learned from past reviews):
+- Failure modes: what happens when retries exhaust? Are there stuck states? Missing onFailure handlers? (PR #61)
+- Data invariants: case-sensitive uniqueness, nullability edge cases, type coercion across DB boundaries (PR #61)
+- API correctness: verify external API query field names and pagination against official docs, not assumptions (PR #61)
+- Dev-environment contract: does every new external API call have an MSW mock? Can this code run with zero secrets? (PR #61)
+
 For each finding:
 - File and line number
 - Severity: critical | important | minor
+- Category: [from the Finding Categories table]
 - What's wrong (specific, not vague)
 - Why it matters (concrete consequence)
 - Suggested fix (complete code, not "consider adding...")
@@ -82,6 +116,14 @@ Do NOT flag: style/formatting, missing comments, import ordering, test coverage 
 
 [DIFF or FILE CONTENT]
 ```
+
+**Per-model prompt specialization:** After the base prompt, append a section for each model emphasizing its blind spots:
+
+- **Claude:** "Pay EXTRA attention to: dev-environment compatibility (MSW mocks, env var fallbacks, zero-secret contract), and failure modes (what happens when retries exhaust, partial failures, stuck states)."
+- **Codex:** "Pay EXTRA attention to: authorization and security (brand-scoping, auth bypass, OWASP), and auth error handling (401 vs 500 responses)."
+- **Gemini:** [Use base prompt until profile is established]
+
+The goal: **each model compensates for the others' weaknesses**, not duplicate their strengths.
 
 Dispatch to all available models **in parallel**, independently:
 
@@ -218,6 +260,73 @@ Then STOP and wait for user approval on each convention/skill proposal. Apply ap
 
 After review is complete and verified, invoke `finishing-a-development-branch` to open the PR. The PR will then receive the GH Action review (Claude + Security + Codex) as a safety net, but most issues should already be caught by this local review.
 
+## Step 9: Post-CI Retrospective (Self-Improvement Loop)
+
+**Trigger:** After CI review comments appear on the PR. This step is MANDATORY — it's how the system learns. Do not skip it even if CI found nothing new.
+
+**This step runs automatically.** Do not wait for the user to ask "why did CI catch that?" — the whole point is that the system reflects without being prompted.
+
+### 9a: Collect CI Findings
+
+```bash
+# Pull all CI review comments
+gh api repos/Vidably/app/pulls/<PR_NUMBER>/comments --jq '.[] | {user: .user.login, body: .body, path: .path, line: .line}'
+gh api repos/Vidably/app/pulls/<PR_NUMBER>/reviews --jq '.[] | {user: .user.login, state: .state, body: .body}'
+gh api repos/Vidably/app/issues/<PR_NUMBER>/comments --jq '.[] | select(.user.login | test("bot|copilot|codex|github-actions")) | {user: .user.login, body: .body}'
+```
+
+### 9b: Diff Against Local Findings
+
+For each CI finding, classify:
+
+| Classification                   | Meaning                                            | Action                                               |
+| -------------------------------- | -------------------------------------------------- | ---------------------------------------------------- |
+| **Already fixed**                | Local review caught this and we fixed it before PR | None — CI reviewed stale code                        |
+| **New — would have been caught** | Finding falls into an existing checklist category  | Investigate why the prompt didn't surface it         |
+| **New — blind spot**             | Finding is a category we don't check for yet       | Add to Finding Categories table + evolving checklist |
+| **New — model limitation**       | We check for this, but the model(s) missed it      | Update Model Profiles table                          |
+| **False positive**               | CI flagged something that isn't actually an issue  | Note it — track CI false positive rate too           |
+
+### 9c: Update the System
+
+For each "New — blind spot" finding:
+
+1. Add a row to the **Finding Categories** table with the source PR
+2. Add a line to the **"ALSO specifically check for"** section of the review prompt (Step 3)
+3. Add to the **per-model prompt specialization** if it maps to a model's blind spot
+
+For each "New — model limitation" finding:
+
+1. Update the **Model Profiles** table — if a model missed something in its blind spot despite the specialized prompt, escalate the emphasis
+2. If a model consistently misses a category (3+ PRs), consider whether it's worth prompting for at all vs relying on other models
+
+### 9d: Update review-effectiveness.md
+
+Add a retrospective entry:
+
+```markdown
+### Post-CI Retrospective: PR #XX
+
+| CI Finding    | Category        | Classification   | Action Taken        |
+| ------------- | --------------- | ---------------- | ------------------- |
+| [description] | `failure-modes` | New — blind spot | Added to checklist  |
+| [description] | `auth/security` | Already fixed    | None (stale review) |
+
+**CI-catches-local-missed (genuine):** X (down from Y last PR)
+**New checklist items added:** Z
+**Model profile updates:** [list]
+```
+
+### 9e: Verify Improvement Trend
+
+Check the running trend in review-effectiveness.md:
+
+- Is "CI catches local missed" trending down? If yes, the system is learning.
+- If it's flat or rising, the retrospective isn't producing effective checklist items — flag this to the user.
+- Are any categories consistently missed by ALL local models? That's a systemic gap — consider adding a 4th model or a specialized linter.
+
+**The goal: CI should catch ZERO new findings that local review missed.** Every non-zero number is a learning opportunity, not a failure.
+
 ## Anti-Rationalization Table
 
 | Thought                                                        | Reality                                                                                                                                      |
@@ -227,9 +336,12 @@ After review is complete and verified, invoke `finishing-a-development-branch` t
 | "I'll just open the PR and let the GH Action review it"        | The GH Action takes 15+ minutes and costs CI time. Local review takes 2-3 minutes and catches issues before they're visible on the PR.       |
 | "Only Codex is available, not enough for consensus"            | Two models (Claude + Codex) give you consensus/solo distinction. That's enough.                                                              |
 | "The Codex review found nothing, so there's nothing to report" | Report that. "No findings from Codex" is useful signal — it means Claude's findings are solo (lower confidence).                             |
+| "CI didn't find anything new, skip the retrospective"          | Run it anyway. Confirming zero delta IS the measurement. And "already fixed" findings need classification too.                               |
+| "I'll do the retrospective later"                              | Do it now, while CI comments are fresh. Later means never — the next task will take priority.                                                |
 
 ## Interaction With Other Skills
 
 - `TRIGGERS AFTER: verification-before-completion` — Run this after code is verified but before claiming completion.
 - `TRIGGERS BEFORE: finishing-a-development-branch` — Must complete before opening a PR.
+- `TRIGGERS AFTER: CI review comments appear on PR` — Step 9 (Post-CI Retrospective) runs automatically.
 - `COMPATIBLE WITH: requesting-code-review` — This is the multi-model version of the upstream code review skill.

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -149,7 +149,8 @@ If the Gemini CLI is unavailable or you want faster results, call the Gemini API
 
 **CLI gotchas (learned from real usage):**
 
-- **TIMEOUTS: Both Codex and Gemini CLIs need 10 minutes (600000ms) for large diffs.** With `xhigh` reasoning, Codex reads files, runs searches, and reasons deeply — a 500+ line diff legitimately takes 5-10 min. The default 2-minute bash timeout will kill them mid-analysis, producing no findings. This was misdiagnosed as "hitting output limits" and "MCP init overhead" in early reviews — both were just timeout kills. Always use `timeout: 600000` for CLI review commands.
+- **TIMEOUTS: Use `timeout: 1200000` (20 minutes) for all CLI review commands.** With `xhigh` reasoning, Codex reads files, runs web searches, and reasons deeply — it needs real time. The default 2-minute bash timeout will kill them mid-analysis, producing no findings. This was misdiagnosed as "hitting output limits" and "MCP init overhead" in early reviews — both were just timeout kills.
+- **TIMING: Wrap every CLI review call with timing** so we can calibrate timeouts with real data. Use: `START=$(date +%s); <command>; echo "REVIEW_TIMING: model=<model> diff_lines=<N> elapsed=$(($(date +%s) - START))s"`. Log this in the synthesis output so it gets captured in review-effectiveness.md.
 - Codex `review` mode is purpose-built for diffs — prefer it over `exec` for code review
 - Codex `exec` for non-diff reviews MUST use `-s read-only` and pipe via stdin — otherwise it spirals into repo exploration and exhausts its budget without producing output (confirmed 2026-04-02, gpt-5.4)
 - Codex: Use `--base main` to review the current branch against main

--- a/skills/vidably-multi-agent-code-review/SKILL.md
+++ b/skills/vidably-multi-agent-code-review/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: vidably-multi-agent-code-review
+description: "Use after implementation is complete and tests pass, before opening a PR — dispatches the code diff to multiple AI models for independent review, then synthesizes findings with consensus scoring."
+---
+
+# Multi-Agent Code Review (Local, Pre-PR)
+
+After implementation is complete and local tests pass, dispatch the diff to multiple AI models for independent review before opening a PR. This catches bugs across model blind spots BEFORE they reach CI — faster and cheaper than waiting for the GH Action review.
+
+Research shows: different model architectures have uncorrelated blind spots, and multi-model consensus catches 3-5x more bugs than single-pass review. Extended debate rounds hurt (problem drift), so we use exactly 1 round of independent review + synthesis.
+
+<HARD-GATE>
+Do NOT open a PR or invoke finishing-a-development-branch until:
+1. Local verification passes (lint, typecheck, test, build)
+2. At least 2 independent model reviews have been collected
+3. Consensus scoring has been applied
+4. Critical/unanimous findings have been addressed
+5. The user has reviewed and approved the consensus map
+</HARD-GATE>
+
+## Step 1: Prepare the Diff
+
+Compute the diff against the base branch:
+
+```bash
+git diff main...HEAD
+```
+
+If the diff exceeds 500 lines, split into per-file chunks and review each chunk separately. Do NOT silently truncate — every changed line must be reviewed.
+
+Also read the plan or spec if one exists — reviewers should check plan conformance, not just code quality.
+
+## Step 2: Run Local Verification First
+
+Before dispatching to models, run the full verification suite:
+
+```bash
+pnpm lint && pnpm typecheck && pnpm test && pnpm build
+```
+
+If the diff touches pages or API routes:
+
+```bash
+pnpm --filter @vidably/web test:e2e
+```
+
+If the diff touches Shopify extensions:
+
+```bash
+shopify app build
+```
+
+Do NOT proceed to model review if verification fails. Fix first.
+
+## Step 3: Dispatch to Available Models
+
+Construct the review prompt:
+
+```
+You are a senior engineer reviewing a code diff.
+
+Review for:
+1. Bugs, logic errors, and runtime failures
+2. Security vulnerabilities (OWASP top 10, injection, auth bypass)
+3. Type safety issues (any casts, missing null checks, unsafe assertions)
+4. Unnecessary complexity (could be simpler or use a library default)
+5. Missing error handling at system boundaries
+6. Plan conformance (if a plan exists — does the code match the spec?)
+
+For each finding:
+- File and line number
+- Severity: critical | important | minor
+- What's wrong (specific, not vague)
+- Why it matters (concrete consequence)
+- Suggested fix (complete code, not "consider adding...")
+
+Do NOT flag: style/formatting, missing comments, import ordering, test coverage for unchanged code, or suggestions that add complexity without proportional value.
+
+[DIFF or FILE CONTENT]
+```
+
+Dispatch to all available models **in parallel**, independently:
+
+**Always available:**
+
+- Claude Code subagent (Agent tool)
+
+**Check and dispatch if present:**
+
+- Codex: `codex review --base main` (native code review mode — better than `codex exec` for diffs)
+- Gemini: `cat diff.txt | gemini --allowed-mcp-server-names="" -p "[review prompt]"`
+
+**CLI gotchas (learned from real usage):**
+
+- Codex `review` mode is purpose-built for diffs — prefer it over `exec` for code review
+- Codex: Use `--base main` to review the current branch against main
+- Gemini: ALWAYS disable MCP servers (`--allowed-mcp-server-names=""`) — they cause indefinite hangs
+- Gemini: stdin content is prepended to the `-p` prompt
+- Both CLIs: 5-minute timeout. Kill and continue if exceeded.
+
+**Graceful degradation:** If no external CLIs are available:
+
+1. Dispatch Claude subagent with security-focused prompt
+2. Dispatch Claude subagent with maintainability-focused prompt
+3. Two perspectives from one model family is still better than one perspective
+
+## Step 4: Synthesize with Consensus Scoring
+
+Deduplicate findings across models. Apply consensus scoring:
+
+| Consensus     | Definition                      | Action                                  |
+| ------------- | ------------------------------- | --------------------------------------- |
+| **Unanimous** | All reviewing models flagged it | Fix immediately — highest confidence    |
+| **Majority**  | >50% of models flagged it       | Strongly recommend fixing               |
+| **Split**     | Exactly 2 models disagree       | Use judgment — apply project philosophy |
+| **Solo**      | One model only                  | Evaluate on merit — do NOT auto-dismiss |
+
+**Critical finding from any model = fix it.** A solo critical (bug, security, data loss) should be fixed regardless of consensus. Consensus matters more for important/minor findings.
+
+**Anti-sycophancy check:** If all models agree on a finding, verify it's genuine agreement, not just repeating the same training pattern. Check: does the finding reference a specific line and explain a concrete consequence?
+
+## Step 5: Present Consensus Map
+
+```markdown
+## Pre-PR Code Review Consensus
+
+### Models Consulted
+
+- Claude Code subagent: [# findings]
+- Codex: [# findings or "not available"]
+- Gemini: [# findings or "not available"]
+
+### Critical Findings (fix before PR)
+
+| Finding           | File:Line       | Consensus | Models | Fix        |
+| ----------------- | --------------- | --------- | ------ | ---------- |
+| [bug description] | `src/foo.ts:42` | Unanimous | All    | [code fix] |
+
+### Important Findings (recommend fixing)
+
+| Finding | File:Line       | Consensus | Models        | Fix        |
+| ------- | --------------- | --------- | ------------- | ---------- |
+| [issue] | `src/bar.ts:78` | Majority  | Claude, Codex | [code fix] |
+
+### Dismissed
+
+- [finding] — [why: style preference / false positive / etc.]
+```
+
+Then STOP and wait for user approval on which findings to fix.
+
+## Step 6: Apply Fixes and Re-Verify
+
+For each approved finding:
+
+1. Apply the fix
+2. Re-run `pnpm lint && pnpm typecheck && pnpm test && pnpm build`
+3. If any check fails, fix before continuing
+
+After all fixes are applied and verified, record skill usage for metrics:
+
+- Append `vidably-multi-agent-code-review` to `.claude-skills-used` (gitignored)
+- The finishing-a-development-branch skill will include this in the PR body
+
+## Step 7: Proceed to PR
+
+After review is complete and verified, invoke `finishing-a-development-branch` to open the PR. The PR will then receive a lighter-weight GH Action review (Claude + Security + Codex as a safety net), but most issues should already be caught by this local review.
+
+## Anti-Rationalization Table
+
+| Thought                                                        | Reality                                                                                                                                      |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Tests pass, so the code is fine"                              | Tests verify behavior, not quality. Multi-model review catches design issues, security holes, and maintainability problems that tests can't. |
+| "The diff is small, no need for multi-model review"            | Small diffs can introduce big bugs. A one-line auth bypass is a small diff. Review anyway.                                                   |
+| "I'll just open the PR and let the GH Action review it"        | The GH Action takes 15+ minutes and costs CI time. Local review takes 2-3 minutes and catches issues before they're visible on the PR.       |
+| "Only Codex is available, not enough for consensus"            | Two models (Claude + Codex) give you consensus/solo distinction. That's enough.                                                              |
+| "The Codex review found nothing, so there's nothing to report" | Report that. "No findings from Codex" is useful signal — it means Claude's findings are solo (lower confidence).                             |
+
+## Interaction With Other Skills
+
+- `TRIGGERS AFTER: verification-before-completion` — Run this after code is verified but before claiming completion.
+- `TRIGGERS BEFORE: finishing-a-development-branch` — Must complete before opening a PR.
+- `COMPATIBLE WITH: requesting-code-review` — This is the multi-model version of the upstream code review skill.

--- a/skills/vidably-multi-agent-plan-review/SKILL.md
+++ b/skills/vidably-multi-agent-plan-review/SKILL.md
@@ -15,9 +15,22 @@ Research shows: multi-model consensus catches 80% of bugs vs 53% for single mode
 Do NOT begin implementation until:
 1. At least 2 independent model reviews have been collected
 2. Consensus scoring has been applied to all findings
-3. Accepted findings have been fixed and the plan re-reviewed (if fixes were made)
-4. The user has reviewed and approved the final consensus map
+3. Findings have been acted on based on consensus level (see Action Policy below)
+4. If fixes were made, the plan has been re-reviewed
 </HARD-GATE>
+
+## Action Policy
+
+Act on findings autonomously based on consensus level:
+
+| Consensus     | Action                                                                                                                                       |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Unanimous** | Fix immediately -- highest confidence                                                                                                        |
+| **Majority**  | Fix -- strong signal across models                                                                                                           |
+| **Split**     | Use judgment. Fix if the finding has concrete consequences; skip if it's a style or preference disagreement. Log your reasoning.             |
+| **Solo**      | Evaluate on merit. Fix if critical severity regardless of consensus. For important/minor, fix if the reasoning is sound. Log your reasoning. |
+
+Present the consensus map to the user for awareness, but do not wait for per-finding approval. The user reviews aggregate effectiveness data periodically, not individual findings.
 
 ## Step 1: Prepare the Plan for Review
 
@@ -70,16 +83,20 @@ Dispatch the plan to all available models **in parallel** for independent review
 
 This provides perspective diversity even with a single model family.
 
+**Fallback reviewer identity:** When logging to the effectiveness tracker, collapse fallback Claude subagents into a single logical "Claude" reviewer. Do not count them as two separate models -- the hit-rate matrix tracks model architectures, not prompt variants.
+
 ## Step 3: Collect and Score Findings
 
 After all models respond, deduplicate findings by theme and apply consensus scoring:
 
-| Consensus Level                    | Definition                             | Default Action                              |
-| ---------------------------------- | -------------------------------------- | ------------------------------------------- |
-| **Unanimous** (all models agree)   | Every model that reviewed flagged this | Fix it — high confidence                    |
-| **Majority** (>50% agree, not all) | Most models flagged it, some didn't    | Likely fix — investigate carefully          |
-| **Split** (2+ agree, ≤50%)         | Models disagree                        | Use judgment — apply project philosophy     |
-| **Solo** (1 model only)            | Only one model flagged it              | Evaluate independently — don't auto-dismiss |
+| Consensus Level                    | Definition                             |
+| ---------------------------------- | -------------------------------------- |
+| **Unanimous** (all models agree)   | Every model that reviewed flagged this |
+| **Majority** (>50% agree, not all) | Most models flagged it, some didn't    |
+| **Split** (2+ agree, ≤50%)         | Models disagree                        |
+| **Solo** (1 model only)            | Only one model flagged it              |
+
+See the **Action Policy** above for how to act on each level.
 
 **Scoring formula:** `severity × agreement_count` — findings flagged by more models rank higher.
 
@@ -116,14 +133,14 @@ Present findings to the user in this format:
 - [findings that were evaluated and dismissed with reasoning]
 ```
 
-Then STOP and wait for user approval.
+Present the consensus map, then proceed to apply fixes based on the Action Policy above. The user can intervene if they disagree, but the default is autonomous action.
 
-## Step 5: Apply Approved Changes and Re-Review
+## Step 5: Apply Fixes and Re-Review
 
-After user reviews the consensus map:
+After presenting the consensus map, apply fixes per the Action Policy:
 
-1. Apply approved changes to the plan file
-2. Note rejected findings and reasons
+1. Apply fixes to the plan file based on consensus level
+2. Note skipped findings with reasoning (logged in Step 6b)
 3. Re-read the updated plan to verify consistency
 
 **If changes were made, re-review (up to 3 rounds total):**
@@ -147,13 +164,13 @@ This is the same re-review pattern the GH Action uses — each round reviews fre
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | "The plan looks fine, no need for multi-model review"             | You wrote the plan. You have blind spots. That's exactly why we use multiple models.       |
 | "Only one external model is available, not worth it"              | Two perspectives (Claude + one external) is still better than one. Dispatch what you have. |
-| "The findings are all minor"                                      | Present them anyway. The user decides what's minor, not you.                               |
+| "The findings are all minor"                                      | Present them anyway. The consensus map shows the user what was found; the Action Policy governs disposition. |
 | "I'll just incorporate the feedback myself without presenting it" | The consensus map IS the deliverable. The user must see which models agreed and disagreed. |
 | "This is a small plan, multi-model review is overkill"            | Small plans with wrong assumptions waste more time than large plans. Review anyway.        |
 
 ## Step 6: Update Workflow State and Event Log
 
-After the user approves the final consensus map (plan review complete), update the enforcement state. **This is the gate key — once this fires, the Write/Edit implementation gate unlocks.**
+After all review rounds complete and findings have been acted on per the Action Policy, update the enforcement state. The user can intervene at any point, but the default is autonomous completion. **This is the gate key — once this fires, the Write/Edit implementation gate unlocks.**
 
 ```bash
 # Update workflow state (this unlocks the implementation gate)
@@ -173,6 +190,35 @@ echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --sho
 ```
 
 Replace `MODELS_LIST` with a JSON array of model names used (e.g., `[\"codex\",\"gemini\"]`), `FINDINGS_COUNT` with total findings across all rounds, and `ROUNDS_COUNT` with the number of review rounds.
+
+## Step 6b: Log Findings to Effectiveness Tracker
+
+After all review rounds complete, append a new section to `docs/plan-review-effectiveness.md` under the `## Plan Review Log` heading:
+
+```markdown
+### [Branch Name] -- [Feature Description]
+
+**Date:** [YYYY-MM-DD]
+**Models:** [list of models used]
+**Rounds:** [number of review rounds]
+
+| Finding       | Flagged By    | Category         | Consensus | Disposition | Reasoning |
+| ------------- | ------------- | ---------------- | --------- | ----------- | --------- |
+| [description] | Claude, Codex | `failure-modes`  | Majority  | Fixed       | --        |
+| [description] | Gemini        | `data-integrity` | Solo      | Skipped     | [why]     |
+
+**Key takeaways:** [auto-generated summary of what was found and patterns observed]
+```
+
+Then update the tracking tables in `docs/plan-review-effectiveness.md`:
+
+- **Model Hit Rate by Category**: For each finding, increment `total opportunities` for every model that reviewed. Increment `caught` for each model that flagged the finding.
+- **Model Profiles**: Update if new strengths or blind spots become apparent.
+- **Aggregate Metrics**: Update with the new data point.
+
+**Sanitization rule:** Log normalized summaries only. Do not include secrets, tokens, PII, customer identifiers, raw payloads, or exploit details in effectiveness tracker entries.
+
+This logging step is mandatory and automated -- if the skill runs, the data gets logged.
 
 ## Interaction With Other Skills
 

--- a/skills/vidably-multi-agent-plan-review/SKILL.md
+++ b/skills/vidably-multi-agent-plan-review/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: vidably-multi-agent-plan-review
+description: "Use after writing or updating an implementation plan, before beginning implementation — dispatches the plan to multiple AI models for independent critique, then synthesizes findings with consensus scoring."
+---
+
+# Multi-Agent Plan Review
+
+After writing a plan and before implementing it, dispatch the plan to multiple AI models for independent review. Each model reviews independently (no shared context — this prevents premature convergence). Then synthesize findings using consensus scoring.
+
+Research shows: multi-model debate catches 80% of bugs vs 53% for single model, and consensus-based approaches outperform voting for knowledge tasks like review (+2.8% accuracy). Independent initial drafts are critical — they boost accuracy by +3.3%.
+
+<HARD-GATE>
+Do NOT begin implementation until:
+1. At least 2 independent model reviews have been collected
+2. Consensus scoring has been applied to all findings
+3. The user has reviewed and approved the consensus map
+</HARD-GATE>
+
+## Step 1: Prepare the Plan for Review
+
+Read the plan file. Verify it's complete (not a draft or placeholder). If incomplete, tell the user it's not ready for review.
+
+Construct the review prompt — this exact prompt goes to every model:
+
+```
+You are a senior software architect reviewing an implementation plan.
+
+Review for:
+1. Missing steps or gaps — are there steps that should exist but don't?
+2. Over-engineering — is anything unnecessarily complex for the stated goals?
+3. Feasibility — are any steps impossible or unrealistic?
+4. Ordering issues — are dependencies between steps correct?
+5. Simpler alternatives — could any step be achieved more simply?
+
+For each finding: state what's wrong, why it matters, and what to do instead. Only flag substantive concerns — not style, formatting, or documentation.
+
+Here is the plan:
+
+[PLAN CONTENT]
+```
+
+## Step 2: Dispatch to Available Models
+
+Dispatch the plan to all available models **in parallel** for independent review. Each model must review independently — do not share one model's findings with another.
+
+**Always available:**
+
+- Claude Code subagent (use the Agent tool with a fresh subagent)
+
+**Check availability and dispatch if present:**
+
+- Codex: `which codex && codex exec -C "$(pwd)" "[review prompt]"`
+- Gemini: `which gemini && gemini --allowed-mcp-server-names="" -p "[review prompt]"`
+
+**CLI gotchas (learned from real usage):**
+
+- Codex: No `--quiet` flag. Use `codex exec`. For large plans, use stdin: `cat plan.md | codex exec -C "$(pwd)" -`
+- Gemini: MCP servers can hang indefinitely. ALWAYS use `--allowed-mcp-server-names=""` for non-interactive mode.
+- Gemini: `-p` flag is REQUIRED for headless mode. Without it, Gemini opens an interactive session.
+- Codex: Use `-C <dir>` to set the working directory. Without it, Codex runs from the default directory and can't find repo files.
+- Both: Set a 5-minute timeout. Kill and move on if exceeded.
+
+**Graceful degradation:** If external CLIs aren't available, dispatch two Claude Code subagents with different system prompts:
+
+1. "You are a security-focused architect. Focus on threat modeling, auth boundaries, and data flow risks."
+2. "You are a performance-focused architect. Focus on scalability, latency, unnecessary complexity, and operational cost."
+
+This provides perspective diversity even with a single model family.
+
+## Step 3: Collect and Score Findings
+
+After all models respond, deduplicate findings by theme and apply consensus scoring:
+
+| Consensus Level                    | Definition                             | Default Action                              |
+| ---------------------------------- | -------------------------------------- | ------------------------------------------- |
+| **Unanimous** (all models agree)   | Every model that reviewed flagged this | Fix it — high confidence                    |
+| **Majority** (>50% agree, not all) | Most models flagged it, some didn't    | Likely fix — investigate carefully          |
+| **Split** (2+ agree, ≤50%)         | Models disagree                        | Use judgment — apply project philosophy     |
+| **Solo** (1 model only)            | Only one model flagged it              | Evaluate independently — don't auto-dismiss |
+
+**Scoring formula:** `severity × agreement_count` — findings flagged by more models rank higher.
+
+**Solo findings deserve attention.** Research shows different model architectures have uncorrelated blind spots. A solo security finding may be the most important one. Evaluate on merit, not consensus alone.
+
+## Step 4: Present Consensus Map
+
+Present findings to the user in this format:
+
+```markdown
+## Plan Review Consensus — [Plan Name]
+
+### Models Consulted
+
+- Claude Code subagent: [summary of review]
+- Codex: [summary or "not available"]
+- Gemini: [summary or "not available"]
+
+### Findings (ranked by severity × agreement)
+
+| Finding | Consensus | Models        | Severity  | Recommendation            |
+| ------- | --------- | ------------- | --------- | ------------------------- |
+| [issue] | Unanimous | All 3         | Critical  | Fix before implementation |
+| [issue] | Majority  | Claude, Codex | Important | Recommend fixing          |
+| [issue] | Solo      | Gemini        | Important | Evaluate — [reasoning]    |
+
+### Recommended Plan Changes
+
+1. [specific change with location in plan]
+2. ...
+
+### No Action Needed
+
+- [findings that were evaluated and dismissed with reasoning]
+```
+
+Then STOP and wait for user approval.
+
+## Step 5: Apply Approved Changes
+
+After user reviews the consensus map:
+
+- Apply approved changes to the plan file
+- Note rejected findings and reasons
+- Re-read the updated plan to verify consistency
+
+## Anti-Rationalization Table
+
+| Thought                                                           | Reality                                                                                    |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| "The plan looks fine, no need for multi-model review"             | You wrote the plan. You have blind spots. That's exactly why we use multiple models.       |
+| "Only one external model is available, not worth it"              | Two perspectives (Claude + one external) is still better than one. Dispatch what you have. |
+| "The findings are all minor"                                      | Present them anyway. The user decides what's minor, not you.                               |
+| "I'll just incorporate the feedback myself without presenting it" | The consensus map IS the deliverable. The user must see which models agreed and disagreed. |
+| "This is a small plan, multi-model review is overkill"            | Small plans with wrong assumptions waste more time than large plans. Review anyway.        |
+
+## Interaction With Other Skills
+
+- `TRIGGERS AFTER: writing-plans` — Automatically invoke this skill after a plan is written.
+- `TRIGGERS BEFORE: subagent-driven-development` — Plan must be reviewed before implementation begins.
+- `TRIGGERS BEFORE: executing-plans` — Same gate for inline execution.

--- a/skills/vidably-multi-agent-plan-review/SKILL.md
+++ b/skills/vidably-multi-agent-plan-review/SKILL.md
@@ -151,6 +151,29 @@ This is the same re-review pattern the GH Action uses — each round reviews fre
 | "I'll just incorporate the feedback myself without presenting it" | The consensus map IS the deliverable. The user must see which models agreed and disagreed. |
 | "This is a small plan, multi-model review is overkill"            | Small plans with wrong assumptions waste more time than large plans. Review anyway.        |
 
+## Step 6: Update Workflow State and Event Log
+
+After the user approves the final consensus map (plan review complete), update the enforcement state. **This is the gate key — once this fires, the Write/Edit implementation gate unlocks.**
+
+```bash
+# Update workflow state (this unlocks the implementation gate)
+STATE=".claude/workflow-state.json"
+if [ -f "$STATE" ]; then
+  python3 -c "
+import json, datetime
+d = json.load(open('$STATE'))
+d['planReviewed'] = True
+d['planReviewedAt'] = datetime.datetime.utcnow().isoformat() + 'Z'
+json.dump(d, open('$STATE', 'w'))
+"
+fi
+
+# Append to event log
+echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --show-current)\",\"event\":\"plan_review_complete\",\"sha\":\"$(git rev-parse --short HEAD)\",\"models\":MODELS_LIST,\"findings\":FINDINGS_COUNT,\"rounds\":ROUNDS_COUNT}" >> .claude/workflow-events.jsonl
+```
+
+Replace `MODELS_LIST` with a JSON array of model names used (e.g., `[\"codex\",\"gemini\"]`), `FINDINGS_COUNT` with total findings across all rounds, and `ROUNDS_COUNT` with the number of review rounds.
+
 ## Interaction With Other Skills
 
 - `TRIGGERS AFTER: writing-plans` — Automatically invoke this skill after a plan is written.

--- a/skills/vidably-multi-agent-plan-review/SKILL.md
+++ b/skills/vidably-multi-agent-plan-review/SKILL.md
@@ -185,40 +185,47 @@ json.dump(d, open('$STATE', 'w'))
 "
 fi
 
-# Append to event log
-echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --show-current)\",\"event\":\"plan_review_complete\",\"sha\":\"$(git rev-parse --short HEAD)\",\"models\":MODELS_LIST,\"findings\":FINDINGS_COUNT,\"rounds\":ROUNDS_COUNT}" >> .claude/workflow-events.jsonl
+# Append structured event log entry
+cat <<JSON | node scripts/measurement/emit-event.mjs
+{
+  "stage": "plan_review",
+  "event": "plan_review_run_completed",
+  "source": "skill",
+  "payload": {
+    "planPath": "PLAN_PATH",
+    "models": MODELS_LIST,
+    "rounds": ROUNDS_COUNT,
+    "findingCount": FINDINGS_COUNT,
+    "categoryCounts": CATEGORY_COUNTS,
+    "consensusCounts": CONSENSUS_COUNTS
+  }
+}
+JSON
+
+# Refresh the local talk report (best effort)
+node scripts/measurement/render-talk-report.mjs >/dev/null 2>&1 || true
 ```
 
-Replace `MODELS_LIST` with a JSON array of model names used (e.g., `[\"codex\",\"gemini\"]`), `FINDINGS_COUNT` with total findings across all rounds, and `ROUNDS_COUNT` with the number of review rounds.
+Replace the placeholders with actual values from this review:
 
-## Step 6b: Log Findings to Effectiveness Tracker
+- `PLAN_PATH`: repo-relative path to the reviewed plan file
+- `MODELS_LIST`: JSON array of logical model names
+- `ROUNDS_COUNT`: number of review rounds completed
+- `FINDINGS_COUNT`: total findings accepted or recorded across all rounds
+- `CATEGORY_COUNTS`: JSON object of findings by category
+- `CONSENSUS_COUNTS`: JSON object of findings by consensus bucket
 
-After all review rounds complete, append a new section to `docs/plan-review-effectiveness.md` under the `## Plan Review Log` heading:
+## Step 6b: Refresh the Talk Data Report
 
-```markdown
-### [Branch Name] -- [Feature Description]
+After the structured event is written, refresh the local talk-data report:
 
-**Date:** [YYYY-MM-DD]
-**Models:** [list of models used]
-**Rounds:** [number of review rounds]
-
-| Finding       | Flagged By    | Category         | Consensus | Disposition | Reasoning |
-| ------------- | ------------- | ---------------- | --------- | ----------- | --------- |
-| [description] | Claude, Codex | `failure-modes`  | Majority  | Fixed       | --        |
-| [description] | Gemini        | `data-integrity` | Solo      | Skipped     | [why]     |
-
-**Key takeaways:** [auto-generated summary of what was found and patterns observed]
+```bash
+node scripts/measurement/render-talk-report.mjs
 ```
 
-Then update the tracking tables in `docs/plan-review-effectiveness.md`:
+This writes `.claude/talk-report.md`, which rolls up the current structured data for the talk. Do not hand-edit plan-review tracker docs during the skill.
 
-- **Model Hit Rate by Category**: For each finding, increment `total opportunities` for every model that reviewed. Increment `caught` for each model that flagged the finding.
-- **Model Profiles**: Update if new strengths or blind spots become apparent.
-- **Aggregate Metrics**: Update with the new data point.
-
-**Sanitization rule:** Log normalized summaries only. Do not include secrets, tokens, PII, customer identifiers, raw payloads, or exploit details in effectiveness tracker entries.
-
-This logging step is mandatory and automated -- if the skill runs, the data gets logged.
+**Sanitization rule:** Event payloads and the talk report must contain normalized summaries only. Do not include secrets, tokens, PII, customer identifiers, raw payloads, or exploit details.
 
 ## Interaction With Other Skills
 

--- a/skills/vidably-multi-agent-plan-review/SKILL.md
+++ b/skills/vidably-multi-agent-plan-review/SKILL.md
@@ -53,12 +53,12 @@ Dispatch the plan to all available models **in parallel** for independent review
 **Check availability and dispatch if present:**
 
 - Codex: `which codex && codex exec -C "$(pwd)" "[review prompt]"`
-- Gemini: `which gemini && gemini --allowed-mcp-server-names="" -p "[review prompt]"`
+- Gemini: `which gemini && gemini --allowed-mcp-server-names _none -p "[review prompt]"`
 
 **CLI gotchas (learned from real usage):**
 
 - Codex: No `--quiet` flag. Use `codex exec`. For large plans, use stdin: `cat plan.md | codex exec -C "$(pwd)" -`
-- Gemini: MCP servers can hang indefinitely. ALWAYS use `--allowed-mcp-server-names=""` for non-interactive mode.
+- Gemini: ALWAYS disable MCP servers with `--allowed-mcp-server-names _none` (passes a dummy name so no real MCP servers connect). Do NOT use `=""` — that passes an empty string which crashes the Gemini policy engine.
 - Gemini: `-p` flag is REQUIRED for headless mode. Without it, Gemini opens an interactive session.
 - Codex: Use `-C <dir>` to set the working directory. Without it, Codex runs from the default directory and can't find repo files.
 - Both: Set a 5-minute timeout. Kill and move on if exceeded.

--- a/skills/vidably-multi-agent-plan-review/SKILL.md
+++ b/skills/vidably-multi-agent-plan-review/SKILL.md
@@ -7,13 +7,16 @@ description: "Use after writing or updating an implementation plan, before begin
 
 After writing a plan and before implementing it, dispatch the plan to multiple AI models for independent review. Each model reviews independently (no shared context — this prevents premature convergence). Then synthesize findings using consensus scoring.
 
-Research shows: multi-model debate catches 80% of bugs vs 53% for single model, and consensus-based approaches outperform voting for knowledge tasks like review (+2.8% accuracy). Independent initial drafts are critical — they boost accuracy by +3.3%.
+Research shows: multi-model consensus catches 80% of bugs vs 53% for single model (+2.8% accuracy). Independent initial drafts boost accuracy by +3.3%. Each round should review fresh content (re-review pattern), not debate the same content (which causes problem drift).
+
+**Round policy:** Up to 3 rounds. Each round reviews the UPDATED plan after fixes are applied. Round 3 is conservative (only critical findings). Stop early if a round produces zero changes. This is the same re-review pattern used in the GH Action — the quality bar should be the same locally and in CI.
 
 <HARD-GATE>
 Do NOT begin implementation until:
 1. At least 2 independent model reviews have been collected
 2. Consensus scoring has been applied to all findings
-3. The user has reviewed and approved the consensus map
+3. Accepted findings have been fixed and the plan re-reviewed (if fixes were made)
+4. The user has reviewed and approved the final consensus map
 </HARD-GATE>
 
 ## Step 1: Prepare the Plan for Review
@@ -115,13 +118,28 @@ Present findings to the user in this format:
 
 Then STOP and wait for user approval.
 
-## Step 5: Apply Approved Changes
+## Step 5: Apply Approved Changes and Re-Review
 
 After user reviews the consensus map:
 
-- Apply approved changes to the plan file
-- Note rejected findings and reasons
-- Re-read the updated plan to verify consistency
+1. Apply approved changes to the plan file
+2. Note rejected findings and reasons
+3. Re-read the updated plan to verify consistency
+
+**If changes were made, re-review (up to 3 rounds total):**
+
+4. Dispatch the UPDATED plan to all available models (Steps 2-4 again)
+5. This catches issues introduced by the fixes and gaps the first round missed
+6. Present the new consensus map to the user
+
+**Round policy:**
+
+- **Round 1:** Address all findings
+- **Round 2:** Address findings from round 2 reviews only (issues introduced by round 1 fixes, or issues missed in round 1)
+- **Round 3:** Only critical findings. Everything else is deferred.
+- **Stop early:** If a round produces zero accepted findings, the plan is ready. Don't force more rounds.
+
+This is the same re-review pattern the GH Action uses — each round reviews fresh content, not the same content debated again.
 
 ## Anti-Rationalization Table
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -16,6 +16,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill).
 
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
+
 - (User preferences for plan location override this default)
 
 ## Scope Check
@@ -36,6 +37,7 @@ This structure informs the task decomposition. Each task should produce self-con
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**
+
 - "Write the failing test" - step
 - "Run it to make sure it fails" - step
 - "Implement the minimal code to make the test pass" - step
@@ -66,6 +68,7 @@ This structure informs the task decomposition. Each task should produce self-con
 ### Task N: [Component Name]
 
 **Files:**
+
 - Create: `exact/path/to/file.py`
 - Modify: `exact/path/to/existing.py:123-145`
 - Test: `tests/exact/path/to/test.py`
@@ -106,6 +109,7 @@ git commit -m "feat: add specific feature"
 ## No Placeholders
 
 Every step must contain the actual content an engineer needs. These are **plan failures** — never write them:
+
 - "TBD", "TODO", "implement later", "fill in details"
 - "Add appropriate error handling" / "add validation" / "handle edge cases"
 - "Write tests for the above" (without actual test code)
@@ -114,6 +118,7 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - References to types, functions, or methods not defined in any task
 
 ## Remember
+
 - Exact file paths always
 - Complete code in every step — if a step changes code, show the code
 - Exact commands with expected output
@@ -144,9 +149,32 @@ After saving the plan, offer execution choice:
 **Which approach?"**
 
 **If Subagent-Driven chosen:**
+
 - **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
 - Fresh subagent per task + two-stage review
 
 **If Inline Execution chosen:**
+
 - **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
 - Batch execution with checkpoints for review
+
+## Update Workflow State and Event Log
+
+After the plan is written and the user has chosen an execution approach, update the enforcement state:
+
+```bash
+# Update workflow state
+STATE=".claude/workflow-state.json"
+if [ -f "$STATE" ]; then
+  python3 -c "
+import json, datetime
+d = json.load(open('$STATE'))
+d['planDone'] = True
+d['planAt'] = datetime.datetime.utcnow().isoformat() + 'Z'
+json.dump(d, open('$STATE', 'w'))
+"
+fi
+
+# Append to event log
+echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"branch\":\"$(git branch --show-current)\",\"event\":\"skill_complete\",\"skill\":\"writing-plans\",\"sha\":\"$(git rev-parse --short HEAD)\"}" >> .claude/workflow-events.jsonl
+```


### PR DESCRIPTION
Retro outcome from vidably-app PR #147.

## Problem

7 of 10 CI-caught findings on vidably-app PR #147 were missed by 3 rounds of local multi-agent review. Analysis:

- **4 findings** were existing AGENTS.md defensive-checklist items (brand/tenant scoping, Inngest idempotency keys, UI refresh after server action, etc.) that the review prompt referenced by URL but never enforced inline. Reviewers didn't walk the checklist because the prompt didn't list the items.
- **2 findings** were genuine new blind spots: external-resource lifecycle (Shopify discount codes never expire), OAuth scope coverage vs actual GraphQL queries.
- **1 finding** was a severity misjudgment: Claude reviewer flagged a `new Date()` audit timestamp as "minor non-blocking" when AGENTS.md explicitly requires `sql NOW()` for audit columns.

## Changes (1 commit)

Commit `c68413d`:

- Add 7 new "ALSO specifically check for" items that enumerate AGENTS.md rules inline in the review prompt: brand/tenant scoping, Inngest idempotency, UI refresh after server action, external-resource lifecycle (TTL), OAuth scope coverage, implementer-concern tracking.
- Add two new Finding Categories: `resource-lifecycle`, `scope-coverage`.
- Add **SEVERITY FLOOR** rule: findings that map to an AGENTS.md checklist item are at least `important`; cannot be silently downgraded to `minor` or "non-blocking."
- Update Claude + Codex per-model specialization with the newly-surfaced blind spots.

## Companion change

Landed directly on `Vidably/app` `main` (commit `678faac`) since it's a one-line shell-wrapper change: `.github/scripts/run-gemini-review.sh` switched from `--approval-mode yolo` to `--approval-mode plan`. Twice during PR #147 Gemini went rogue under yolo and rewrote source files uninvited. Plan mode is read-only.

## Test plan

- [ ] On the next vidably-app PR that goes through the full review chain, check whether local review surfaces AGENTS.md checklist items it was missing before. Target: CI-catches-local-missed count drops from 7 toward 0.
- [ ] Verify Gemini under `plan` mode reads diffs successfully. The old AGENTS.md text claimed `plan` "silently fails to read code" — the plan-mode research suggests that was a misdiagnosis. If plan produces empty proofs, we debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)