### PR TITLE
Add install instructions for GitHub Copilot chat in Visual Studio Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ copilot plugin marketplace add obra/superpowers-marketplace
 copilot plugin install superpowers@superpowers-marketplace
 ```
 
-### GitHub Copilot chat in Visual Studio Code vscode)
+### GitHub Copilot chat in Visual Studio Code (vscode)
 
 * In the copilot chat pane, click the settings icon top-right
 * Click on Plugins and next to "Browse Marketplace" button, click the "+" to add a marketplace

--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ copilot plugin marketplace add obra/superpowers-marketplace
 copilot plugin install superpowers@superpowers-marketplace
 ```
 
+### GitHub Copilot chat in Visual Studio Code vscode)
+
+* In the copilot chat pane, click the settings icon top-right
+* Click on Plugins and next to "Browse Marketplace" button, click the "+" to add a marketplace
+* Enter `https://github.com/obra/superpowers.git` for the marketplace URL
+* Ensure the `superpowers` plugin is enabled in the plugin list
+* Now you can use the agents and skills in your chat sessions! For example to use the brainstorm skill: `/brainstorm Help me brainstorm how CQRS can fit into my codebase`.
+
+**Detailed docs:** [Configure plugin marketplaces](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces)
+
 ### Gemini CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ copilot plugin install superpowers@superpowers-marketplace
 * Click on Plugins and next to "Browse Marketplace" button, click the "+" to add a marketplace
 * Enter `https://github.com/obra/superpowers.git` for the marketplace URL
 * Ensure the `superpowers` plugin is enabled in the plugin list
-* Now you can use the agents and skills in your chat sessions! For example to use the brainstorm skill: `/brainstorm Help me brainstorm how CQRS can fit into my codebase`.
+* Now you can use the agents and skills in your chat sessions! For example to use the brainstorming skill: `/brainstorming Help me brainstorm how CQRS can fit into my codebase`.
 
 **Detailed docs:** [Configure plugin marketplaces](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces)
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ copilot plugin install superpowers@superpowers-marketplace
 ### GitHub Copilot chat in Visual Studio Code (vscode)
 
 * In the copilot chat pane, click the settings icon top-right
-* Click on Plugins and next to "Browse Marketplace" button, click the "+" to add a marketplace
-* Enter `https://github.com/obra/superpowers.git` for the marketplace URL
+* Click **Plugins**, then click the **+** button labeled `Install Plugin from Source`
+* Enter `https://github.com/obra/superpowers.git` as the plugin source URL
 * Ensure the `superpowers` plugin is enabled in the plugin list
-* Now you can use the agents and skills in your chat sessions! For example to use the brainstorming skill: `/brainstorming Help me brainstorm how CQRS can fit into my codebase`.
+* Now you can use the agents and skills in your chat sessions. Skills are usually auto-invoked when relevant, and you can manually trigger one if needed (for example: `/superpowers brainstorming Help me brainstorm how CQRS can fit into my codebase`).
 
 **Detailed docs:** [Configure plugin marketplaces](https://code.visualstudio.com/docs/copilot/customization/agent-plugins#_configure-plugin-marketplaces)
 


### PR DESCRIPTION
Add instructions for installing for GitHub Copilot chat in Visual Studio Code.

## What problem are you trying to solve?
No installation instructions for GitHub Copilot chat in Visual Studio Code.

## What does this PR change?
Adds installation instructions for GitHub Copilot chat in Visual Studio Code.

## Is this change appropriate for the core library?
Yes

## What alternatives did you consider?
No existing issue or pull request found for this request.

## Does this PR contain multiple unrelated changes?
No

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Visual Studio Code                 | 1.115.0          | N/A   | N/A              |

## Evaluation
- What was the initial prompt you (or your human partner) used to start
  the session that led to this change? Manually added after testing the installation steps in vscode, no prompt was used.
- How many eval sessions did you run AFTER making the change? None, it is not a skill but README documentation.
- How did outcomes change compared to before the change? Now has instructions on how to install superpowers plugin in Visual Studio Code.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
