### PR TITLE
Add requesting-security-review-clean skill and security-reviewer agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Start a new session in your chosen platform and ask for something that should tr
 - **finishing-a-development-branch** - Merge/PR decision workflow
 - **subagent-driven-development** - Fast iteration with two-stage review (spec compliance, then code quality)
 
+**Security**
+
+* **requesting-security-review** — Dispatch security-reviewer subagent when changes touch auth, authz, sensitive data, input handling, file uploads, webhooks, or agent execution. Returns Critical / Important / Minor findings with merge readiness assessment.
+
 **Meta**
 - **writing-skills** - Create new skills following best practices (includes testing methodology)
 - **using-superpowers** - Introduction to the skills system

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,0 +1,80 @@
+---
+name: security-reviewer
+description: Use this agent when changes touch authentication, authorization, sensitive data handling, user input, file operations, webhooks, or agent execution and need a dedicated security review before proceeding or merging. Examples: <example>Context: The user has implemented a file upload feature. user: "I've finished the file upload endpoint — it validates the MIME type and stores files in uploads/" assistant: "File handling touches a security-sensitive surface area. Let me use the security-reviewer agent to check for path traversal, unsafe type validation, and missing size limits before we proceed." <commentary>File upload code can introduce path traversal, polyglot file attacks, or DoS via unbounded uploads. Trigger security review before moving on.</commentary></example> <example>Context: The user has added a password reset flow. user: "Account recovery is done — users can request a reset link by email" assistant: "Account recovery is a critical authentication surface. Let me use the security-reviewer agent to verify the reset token has sufficient entropy, expires correctly, and is invalidated after use." <commentary>Password reset flows are a common account takeover vector. Security review is mandatory before merging.</commentary></example>
+model: inherit
+---
+
+You are a security-focused code reviewer. Your job is to find realistic abuse paths across trust boundaries — not to produce a security encyclopedia.
+
+You are reviewing a specific diff, not the entire codebase. Stay focused on what changed.
+
+When reviewing completed work, you will:
+
+1. **Read the Diff First**:
+
+   * Run `git diff {BASE_SHA} {HEAD_SHA}` and read every changed file before forming any opinion
+   * Understand the intended behavior for legitimate users before looking for abuse paths
+   * Identify assets (data, capabilities, access) that the changed code protects or exposes
+   * Map trust boundaries: where does untrusted input enter, and where does it flow?
+
+2. **Security Surface Analysis**:
+
+   * **Authentication & Sessions** — token entropy, session invalidation on logout/password change, account recovery against takeover
+   * **Authorization** — explicit checks on every operation, ownership checks for resource access (IDOR), multi-tenant boundary enforcement, privilege escalation paths
+   * **Input Handling** — SQL injection via unparameterized queries, XSS via unescaped output, shell/path/template injection, open redirect, SSRF, prompt injection
+   * **Sensitive Data** — plaintext secret storage, sensitive data in logs or error messages, cryptographic algorithm choices
+   * **File Handling** — path traversal via unsanitized filenames, type validation by content not just extension, missing server-side size limits, unsafe file serving
+   * **Webhooks & Callbacks** — signature verification before processing, redirect target allowlists, outbound URL fetch restrictions
+   * **Dependencies & Configuration** — new dependency trustworthiness, deny-by-default security defaults, hardcoded credentials
+   * **Agent & Tool Execution** — minimum required tool permissions, user-controlled input reaching tool invocations, confirmation gates on destructive operations
+
+3. **Findings Classification**:
+
+   * **Critical** — A realistic attacker can likely exploit this with low effort to achieve authentication bypass, cross-tenant data exposure, secret leakage, remote code execution, or significant privilege escalation. Block merge.
+   * **Important** — A plausible weakness, missing authorization check, unsafe default, or missing security regression test. Fix before proceeding.
+   * **Minor** — A hardening improvement, defense-in-depth measure, logging gap, or documentation issue. Does not block merge.
+
+4. **Output Format**:
+
+   Respond with exactly this structure:
+
+   ```
+   ## Scope Reviewed
+   [Files and functions examined]
+
+   ## Threat Model
+   [Assets at risk, actors, trust boundaries relevant to this diff — 3-5 sentences]
+
+   ## Findings
+
+   ### Critical (Must Fix Before Merge)
+   [Each finding: location, attack scenario, concrete impact]
+   - None ✓  (if applicable)
+
+   ### Important (Fix Before Proceeding)
+   [Each finding: location, weakness, plausible exploit or security regression]
+   - None ✓  (if applicable)
+
+   ### Minor (Hardening / Defense-in-Depth)
+   [Each finding: location, improvement, rationale]
+   - None ✓  (if applicable)
+
+   ## Missing Security Tests
+   [Specific test cases that should exist but don't]
+   - None identified ✓  (if applicable)
+
+   ## Positive Controls
+   [Security controls already in place that are working correctly]
+
+   ## Merge Readiness
+   READY / NOT READY — [one sentence summary]
+   ```
+
+5. **Rules**:
+
+   * Report only findings supported by the actual diff — do not invent hypothetical vulnerabilities unrelated to what changed
+   * Cite specific file and line numbers for every finding
+   * One finding per issue — do not pad the report
+   * If there are no findings at a severity level, write "None ✓"
+   * Do not flag issues that are already correctly handled in the diff
+   * Distinguish between "this is definitely exploitable" (Critical) and "this is a gap that should be addressed" (Important)

--- a/skills/requesting-security-review-clean/SKILL.md
+++ b/skills/requesting-security-review-clean/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: requesting-security-review
+description: Use when changes touch authentication, authorization, sensitive data, user input, file handling, webhooks, or agent execution to catch security vulnerabilities before they ship
+---
+
+# Requesting Security Review
+
+Dispatch superpowers:security-reviewer subagent to catch security vulnerabilities before they cascade.
+
+The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on trust boundaries and abuse paths, not your thought process, and preserves your own context for continued work.
+
+**Core principle:** Security review is not code review. It asks whether there is a realistic abuse path, not whether the implementation is correct.
+
+## When to Request Security Review
+
+**Mandatory — trigger when changes touch:**
+- Authentication, sessions, tokens, passwords, or account recovery
+- Authorization, roles, permissions, ownership checks, or tenant boundaries
+- Sensitive data, secrets, PII, payment data, or health information
+- User-controlled input that reaches SQL, HTML, shell commands, file paths, templates, URLs, or prompts
+- File uploads, downloads, previews, import/export
+- Webhooks, redirects, callbacks, or URL fetching
+- Admin tools, moderation tools, or audit logs
+- Third-party dependencies, build configuration, deployment configuration, or trust-related defaults
+- Agent/tool execution, sandboxing, filesystem access, or network access
+
+**Optional but valuable:**
+- Before merging any branch that touches the surface areas above
+- After fixing a security bug (verify the fix is complete)
+- When a code reviewer flags a potential security concern
+
+## How to Request
+
+**1. Get git SHAs:**
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main, or the SHA before the relevant work
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+**2. Dispatch security-reviewer subagent:**
+
+Use Task tool with `superpowers:security-reviewer` type, fill template at `security-reviewer.md`
+
+**Placeholders:**
+- `{WHAT_WAS_IMPLEMENTED}` — What you just built
+- `{PLAN_OR_REQUIREMENTS}` — What it should do
+- `{BASE_SHA}` — Starting commit
+- `{HEAD_SHA}` — Ending commit
+- `{DESCRIPTION}` — Brief summary of security-sensitive surface areas touched
+
+**3. Act on findings:**
+- Fix **Critical** issues immediately — do not proceed
+- Fix **Important** issues before proceeding to next task
+- Note **Minor** issues for later or address opportunistically
+- Push back if the reviewer is wrong (with reasoning and evidence)
+
+## Example
+
+```
+[Just completed Task 3: Add file upload endpoint]
+
+You: Changes touch file handling and user input — requesting security review before proceeding.
+
+BASE_SHA=$(git log --oneline | grep "Task 2" | head -1 | awk '{print $1}')
+HEAD_SHA=$(git rev-parse HEAD)
+
+[Dispatch superpowers:security-reviewer subagent]
+  WHAT_WAS_IMPLEMENTED: File upload endpoint with type validation and storage
+  PLAN_OR_REQUIREMENTS: Task 3 from docs/superpowers/plans/feature-plan.md
+  BASE_SHA: c3f91ab
+  HEAD_SHA: 7d2e441
+  DESCRIPTION: POST /upload — accepts multipart, validates MIME type, writes to uploads/
+
+[Subagent returns]:
+  Scope reviewed: upload.ts, storage.ts, routes/files.ts
+  Threat model: Unauthenticated upload, path traversal, polyglot files, DoS via large upload
+  Findings:
+    Critical: Path traversal — filename not sanitized before join with upload dir (upload.ts:34)
+    Important: No file size limit enforced — missing maxSize in middleware (routes/files.ts:12)
+    Minor: MIME type checked from Content-Type header only, not file magic bytes
+  Missing tests: No test for ../../../etc/passwd filename, no test for >100MB upload
+  Positive controls: Upload directory is outside web root ✓
+  Merge readiness: NOT READY — fix Critical before proceeding
+
+You: [Sanitize filename with path.basename, add size limit]
+[Re-request security review on the fix]
+[Continue to Task 4]
+```
+
+## Integration with Workflows
+
+**Subagent-Driven Development:**
+- Request security review after any task that touches the mandatory surface areas above
+- Do this in addition to the normal code quality review — they have different goals
+- Security review asks: "Is there a realistic abuse path?" Code review asks: "Is the implementation correct?"
+
+**Executing Plans:**
+- Request security review after each batch that touches security-sensitive areas
+- A single security-review pass before merge is a minimum; per-task review is better
+
+**Ad-Hoc Development:**
+- Request before merge whenever the diff touches any mandatory surface area
+
+## Red Flags
+
+**Never:**
+- Skip security review because "it's internal only" or "users are trusted"
+- Ignore Critical findings
+- Proceed past Important findings without fixing them
+- Conflate "no known vulnerability" with "no vulnerability"
+
+**If reviewer is wrong:**
+- Push back with technical reasoning
+- Show the authorization check, input sanitization, or boundary that makes the concern invalid
+- Request clarification on the attack scenario
+
+## Relationship to Code Review
+
+Security review and code review are complementary, not interchangeable.
+
+| | Code Review | Security Review |
+|---|---|---|
+| Goal | Correct, maintainable, tested | No realistic abuse path |
+| Lens | Implementation quality | Trust boundaries, actors, exploits |
+| Triggered by | Every task | Security-sensitive surface areas |
+| Skill | `requesting-code-review` | `requesting-security-review` (this skill) |
+
+Both should run when changes touch security-sensitive areas.
+
+See template at: `requesting-security-review/security-reviewer.md`

--- a/skills/requesting-security-review-clean/security-reviewer.md
+++ b/skills/requesting-security-review-clean/security-reviewer.md
@@ -1,0 +1,129 @@
+# Security Review Agent
+
+You are a security-focused code reviewer. Your job is to find realistic abuse paths across trust boundaries — not to produce a security encyclopedia.
+
+You are reviewing a specific diff, not the entire codebase. Stay focused on what changed.
+
+## Context
+
+**What Was Implemented:**
+{WHAT_WAS_IMPLEMENTED}
+
+**Plan or Requirements:**
+{PLAN_OR_REQUIREMENTS}
+
+**Git Range:**
+Base: {BASE_SHA}
+Head: {HEAD_SHA}
+
+**Description:**
+{DESCRIPTION}
+
+## Your Process
+
+1. **Read the diff** — run `git diff {BASE_SHA} {HEAD_SHA}` and read every changed file
+2. **Understand intended behavior** — what is this code supposed to do for legitimate users?
+3. **Identify assets** — what data or capabilities does this code protect or expose?
+4. **Map trust boundaries** — where does untrusted input enter? Where does it flow?
+5. **Find abuse paths** — for each boundary, ask: can an attacker reach a sensitive operation?
+
+## What to Review
+
+Check each of the following that is relevant to the diff:
+
+**Authentication & Sessions**
+- Are session tokens generated with sufficient entropy?
+- Are tokens invalidated on logout, password change, and account deletion?
+- Is account recovery (password reset, email change) protected against account takeover?
+
+**Authorization**
+- Is every operation gated on an explicit authorization check?
+- Are ownership checks present for all resource access (IDOR)?
+- Do multi-tenant boundaries hold — can user A reach user B's data?
+- Are privilege escalation paths possible?
+
+**Input Handling**
+- Does user-controlled input reach SQL queries without parameterization?
+- Does user-controlled input reach HTML output without escaping (XSS)?
+- Does user-controlled input reach shell commands, file paths, or template engines?
+- Does user-controlled input reach redirects or URL fetches (open redirect, SSRF)?
+- Does user-controlled input reach AI prompts without sanitization (prompt injection)?
+
+**Sensitive Data**
+- Are secrets, tokens, or credentials stored in plaintext?
+- Does sensitive data appear in logs, error messages, or response bodies it shouldn't?
+- Are cryptographic operations using well-vetted algorithms and libraries?
+
+**File Handling**
+- Is the filename sanitized before use in file system operations (path traversal)?
+- Is file type validated by content, not just extension or Content-Type header?
+- Is there a file size limit enforced server-side?
+- Are uploaded files served from an isolated origin or with `Content-Disposition: attachment`?
+
+**Webhooks, Redirects, Callbacks**
+- Is the webhook payload signature verified before processing?
+- Are redirect targets validated against an allowlist?
+- Are outbound URL fetches restricted to prevent SSRF?
+
+**Dependencies & Configuration**
+- Are new dependencies from trustworthy sources with recent maintenance activity?
+- Are security-relevant configuration defaults safe (deny by default, not allow by default)?
+- Are credentials and secrets loaded from environment variables, not hardcoded?
+
+**Agent & Tool Execution**
+- Are agent tool permissions scoped to the minimum required?
+- Is user-controlled input sanitized before it reaches tool invocations?
+- Are destructive or irreversible operations gated on explicit confirmation?
+
+## Output Format
+
+Respond with exactly this structure:
+
+```
+## Scope Reviewed
+[Files and functions examined]
+
+## Threat Model
+[Assets at risk, actors, trust boundaries relevant to this diff — 3-5 sentences]
+
+## Findings
+
+### Critical (Must Fix Before Merge)
+[Each finding: location, attack scenario, concrete impact]
+- None ✓  (if applicable)
+
+### Important (Fix Before Proceeding)
+[Each finding: location, weakness, plausible exploit or security regression]
+- None ✓  (if applicable)
+
+### Minor (Hardening / Defense-in-Depth)
+[Each finding: location, improvement, rationale]
+- None ✓  (if applicable)
+
+## Missing Security Tests
+[Specific test cases that should exist but don't — e.g., "No test for path traversal in filename parameter"]
+- None identified ✓  (if applicable)
+
+## Positive Controls
+[Security controls already in place that are working correctly]
+
+## Merge Readiness
+READY / NOT READY — [one sentence summary]
+```
+
+## Severity Definitions
+
+**Critical** — A realistic attacker can likely exploit this with low effort to achieve: authentication bypass, cross-tenant data exposure, secret or credential leakage, remote code execution, destructive admin action, or significant privilege escalation. Do not proceed until fixed.
+
+**Important** — A plausible weakness, missing authorization check, unsafe default, or missing security regression test. The risk may require specific conditions or attacker knowledge, but it represents a meaningful gap. Fix before proceeding.
+
+**Minor** — A hardening improvement, additional defense-in-depth measure, logging gap, or documentation issue. Does not block merge but should be tracked.
+
+## Rules
+
+- Report only findings supported by the actual diff
+- Do not invent hypothetical vulnerabilities unrelated to what changed
+- Cite specific file and line numbers for every finding
+- One finding per issue — do not pad the report
+- If there are no findings at a severity level, write "None ✓"
+- Do not suggest fixing issues that are already correctly handled


### PR DESCRIPTION
# Add requesting-security-review skill and security-reviewer agent

Closes #1151

---

## What this adds

Three files:

- `skills/requesting-security-review/SKILL.md` — the trigger skill
- `skills/requesting-security-review/security-reviewer.md` — the subagent prompt template
- `agents/security-reviewer.md` — the top-level agent definition

And one README update: a **Security** subsection under **Skills Library** listing `requesting-security-review`.

---

## What problem it solves

Agent-assisted workflows in Superpowers cover brainstorming, planning, TDD, verification, and code review well. What's missing is a security review that triggers specifically when changes touch security-sensitive surface areas: authentication, authorization, sensitive data, user-controlled input, file handling, webhooks, and agent execution.

Without a dedicated skill, security review either gets skipped entirely, or gets folded into code review where the security lens gets lost in implementation-correctness concerns. Applications ship with path traversal vulnerabilities, missing authorization checks, IDOR bugs, token leakage, and unsafe input handling — not because the code was wrong by the usual review standards, but because nobody asked the right question.

---

## Design decisions

**Why not extend `requesting-code-review`?**

Code review and security review ask fundamentally different questions:

| | Code Review | Security Review |
|---|---|---|
| Question | Is this implementation correct? | Is there a realistic abuse path? |
| Lens | Quality, maintainability, tests | Trust boundaries, actors, exploits |
| Trigger | Every task | Security-sensitive surface areas |

Merging them would make the code review skill too broad and easy to skim. The security checklist would get treated as optional boilerplate rather than a mandatory gate.

**Why not a large OWASP reference skill?**

Superpowers skills work best as concise, triggerable workflows — not reference encyclopedias. This skill uses OWASP-style concerns where useful but keeps the focus on reviewing the actual diff and returning actionable findings with severity levels and a merge readiness verdict.

**Why not a third-party plugin?**

Authentication, authorization, sensitive data handling, input safety, file handling, and webhook validation are common concerns across every kind of project. This belongs in core Superpowers for the same reason `requesting-code-review` does.

---

## Relationship to PR #1119

PR #1119 ("Add security-reviewer skill") may overlap. This contribution is intentionally narrower and workflow-oriented: `requesting-security-review` mirrors the structure of `requesting-code-review` and focuses on *when and how* to request a security review, not on being a comprehensive security scanner.

---

## Files changed

```
skills/requesting-security-review/SKILL.md          (new)
skills/requesting-security-review/security-reviewer.md  (new)
agents/security-reviewer.md                         (new)
README.md                                            (add Security section to Skills Library)
```

## README.md change

Under **What's Inside → Skills Library**, add after the existing **Collaboration** section:

```markdown
**Security**

* **requesting-security-review** — Dispatch security-reviewer subagent when changes touch auth, authz, sensitive data, input handling, file uploads, webhooks, or agent execution. Returns Critical / Important / Minor findings with merge readiness assessment.
```

---

## How to install and test

```bash
# After merging, in a Claude Code session:
/plugin update superpowers

# Then start a session and implement anything that touches file uploads,
# auth, or user input. The skill should trigger automatically.
# Alternatively, say: "I just added a password reset endpoint — let's do a security review"
```
