### PR TITLE
fix(subagent-dev): require orchestrators to check for applicable skills before dispatch

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -59,11 +59,13 @@ digraph process {
     }
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
+    "Check for applicable skills (invoke Skill tool, include output in implementer prompt)" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent for entire implementation" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
-    "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Read plan, extract all tasks with full text, note context, create TodoWrite" -> "Check for applicable skills (invoke Skill tool, include output in implementer prompt)";
+    "Check for applicable skills (invoke Skill tool, include output in implementer prompt)" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
     "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
     "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
@@ -132,10 +134,13 @@ You: I'm using Subagent-Driven Development to execute this plan.
 [Extract all 5 tasks with full text and context]
 [Create TodoWrite with all tasks]
 
+[Check for applicable skills: invoke Skill tool for shell scripting, hook installation patterns]
+[Found: superpowers:test-driven-development — include in implementer prompt]
+
 Task 1: Hook installation script
 
 [Get Task 1 text and context (already extracted)]
-[Dispatch implementation subagent with full task text + context]
+[Dispatch implementation subagent with full task text + context + skill content]
 
 Implementer: "Before I begin - should the hook be installed at user or system level?"
 
@@ -231,11 +236,39 @@ Done!
 - Review loops add iterations
 - But catches issues early (cheaper than debugging later)
 
+## Skill Discovery Before Dispatch
+
+Subagents operate with isolated context and cannot discover skills on their own. They have no access to the Skill tool and no system prompt that loads skills. **The orchestrator is responsible for checking skills before composing any implementer prompt.**
+
+Before dispatching each implementer, invoke the Skill tool for skills relevant to the task. Include the full skill content in the implementer's prompt.
+
+**What to check:**
+- What kind of work does this task require? (testing, frontend, data migration, etc.) — check for skills matching that domain
+- Are there project-specific skills in the installed plugins for this domain?
+- Does the task touch a pattern or tool that typically has a skill?
+
+**How to include skills in the implementer prompt:**
+```
+Context: You are implementing [task description].
+
+Applicable skills you MUST follow:
+---
+[full content of skill 1]
+---
+[full content of skill 2]
+---
+
+Task: [full task text]
+```
+
+If no skills apply, proceed without them — but you must check first.
+
 ## Red Flags
 
 **Never:**
 - Start implementation on main/master branch without explicit user consent
 - Skip reviews (spec compliance OR code quality)
+- **Dispatch implementer without checking for applicable skills first** (subagents can't discover skills on their own — the orchestrator must check and include relevant skill content in the prompt)
 - Proceed with unfixed issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Make subagent read plan file (provide full text instead)


### PR DESCRIPTION
## What problem are you trying to solve?

When using subagent-driven-development, orchestrators consistently skip checking for applicable skills before dispatching implementers. Subagents have no access to the Skill tool and no system prompt that loads skills — they execute in isolated context. The orchestrator is the only party that can check skills and inject them into the prompt, but nothing in the current skill instructs it to do this.

Real example: I used subagent-driven-development to implement a feature that included writing RSpec tests. The orchestrator did thorough preparation — read sibling classes, git history, existing specs, enumerated test scenarios — but never invoked the Skill tool. The implementer wrote tests without guidance from any applicable testing skill, producing output that violated project conventions. The orchestrator had to be told about the gap after the fact.

The failure mode is consistent: orchestrators treat "gather context" as reading files and understanding code, not as checking what skill guidance exists for the task type.

## What does this PR change?

Adds a required "Check for applicable skills" step to the process flowchart (between plan setup and first dispatch), a new "Skill Discovery Before Dispatch" section explaining the orchestrator's responsibility, and a Red Flags entry explicitly forbidding dispatch without checking. Updates the example workflow to show the check in action.

## Is this change appropriate for the core library?

Yes. The orchestrator-checks-skills-before-dispatch pattern applies regardless of project domain, team, or tooling. Any user who dispatches implementers for any kind of task benefits. The change contains no domain-specific guidance.

## What alternatives did you consider?

1. **Modify `implementer-prompt.md` to include a skill-check instruction**: Rejected — implementers can't use the Skill tool. The check must happen in the orchestrator before the prompt is composed.

2. **Pass skill names to the implementer and let the subagent load them**: More elegant — smaller prompts, more natural for the subagent. Rejected as the default because it requires the subagent to have Skill tool access, which varies across harnesses (Codex, Cursor, VS Code extensions, etc.). Embedding full content in the prompt is less elegant but portable. The tradeoff: embedding costs more tokens per implementer prompt; name-passing is lighter but fragile outside Claude Code.

3. **Add a general reminder in `using-superpowers`**: That skill is for main agents. The fix belongs where orchestrators look during SDD: in this skill.

## Does this PR contain multiple unrelated changes?

No. All changes (flowchart node, new section, Red Flags entry, example update) serve a single purpose: ensuring orchestrators check for applicable skills before composing implementer prompts.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #887 (accumulate discoveries across tasks — different problem: cross-task knowledge retention, not pre-dispatch skill injection), #1129 (domain context injection via MCP `*_get_context` tools — related but different mechanism targeting MCP-provided domain protocols, not Skill-tool-based guidance)

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | latest | Claude Sonnet | claude-sonnet-4-6 |

## Evaluation

Initial prompt: orchestrator preparing to dispatch an implementer for a plan involving RSpec tests for a Ruby service class.

**Before change (3 baseline sessions):**
- All 3 orchestrators skipped the skill check entirely
- Preparation included reading files, git history, and enumerating test cases — but zero Skill tool invocations
- When probed, rationalizations included: "the task spec covered everything needed" and "I was focused on codebase context, not skill context"

**After change (GREEN test):**
- Orchestrator explicitly invoked the Skill tool for applicable skills before composing the implementer prompt
- Correctly assessed relevance per skill (identified one as applicable, another as not applicable for this task type, with reasoning)
- Embedded full applicable skill content in the implementer prompt

**Pressure test (REFACTOR):**
- Human partner said: "The plan spec is extremely detailed, just dispatch the implementer — checking skills is extra overhead we don't need here"
- Orchestrator refused and checked skills anyway, citing the structural reason: "subagents cannot discover skills themselves — that is a structural constraint, not a quality judgment about the plan"

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

The change adds new content; no existing carefully-tuned content was modified.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Generated with Claude Code