### PR TITLE
Support AskUserQuestion tool when in Claude

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -7,7 +7,7 @@ description: "You MUST use this before any creative work - creating features, bu
 
 Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
 
-Start by understanding the current project context, then ask questions one at a time via the `AskUserQuestions` tool to refine the idea. Once you understand what you're building, present the design and get user approval.
+Start by understanding the current project context, then ask questions one at a time via the `AskUserQuestion` tool to refine the idea. Once you understand what you're building, present the design and get user approval.
 
 <HARD-GATE>
 Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
@@ -74,7 +74,7 @@ digraph brainstorming {
 - If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
 - For appropriately-scoped projects, ask questions one at a time to refine the idea
 - Prefer multiple choice questions when possible, but open-ended is fine too
-- In Claude Code, ask those questions via the `AskUserQuestions` tool instead of plain chat; keep clarifications integrated in the native question UI
+- In Claude Code, ask those questions via the `AskUserQuestion` tool instead of plain chat; keep clarifications integrated in the native question UI
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
 - Focus on understanding: purpose, constraints, success criteria
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -7,7 +7,7 @@ description: "You MUST use this before any creative work - creating features, bu
 
 Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
 
-Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.
+Start by understanding the current project context, then ask questions one at a time via the `AskUserQuestions` tool to refine the idea. Once you understand what you're building, present the design and get user approval.
 
 <HARD-GATE>
 Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
@@ -74,6 +74,7 @@ digraph brainstorming {
 - If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
 - For appropriately-scoped projects, ask questions one at a time to refine the idea
 - Prefer multiple choice questions when possible, but open-ended is fine too
+- In Claude Code, ask those questions via the `AskUserQuestions` tool instead of plain chat; keep clarifications integrated in the native question UI
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
 - Focus on understanding: purpose, constraints, success criteria
 

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -43,7 +43,7 @@ Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-too
 
 ## Asking Questions in Claude Code
 
-When a skill or workflow needs to ask the user something in Claude Code, use the `AskUserQuestions` tool instead of asking in plain chat. This applies to clarifying questions, multiple-choice questions, and approval prompts. If the current platform does not expose `AskUserQuestions`, fall back to the platform's normal user-question mechanism.
+When a skill or workflow needs to ask the user something in Claude Code, use the `AskUserQuestion` tool instead of asking in plain chat. This applies to clarifying questions, multiple-choice questions, and approval prompts. If the current platform does not expose `AskUserQuestion`, fall back to the platform's normal user-question mechanism.
 
 ## The Rule
 

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -41,6 +41,10 @@ Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-too
 
 # Using Skills
 
+## Asking Questions in Claude Code
+
+When a skill or workflow needs to ask the user something in Claude Code, use the `AskUserQuestions` tool instead of asking in plain chat. This applies to clarifying questions, multiple-choice questions, and approval prompts. If the current platform does not expose `AskUserQuestions`, fall back to the platform's normal user-question mechanism.
+
 ## The Rule
 
 **Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.


### PR DESCRIPTION
## What problem are you trying to solve?
When using superpowers I always felt that my flow would feel more integrated into ClaudeCode if AskUserQuestions tool was used. This I believe is supported in many harnesses, so I'm open to make the statements more generic.

## What does this PR change?
Adds instructions to use AskUserQuestions tool when in Claude.

## Is this change appropriate for the core library?
Yep, usefull for all work, if done from Claude.

## What alternatives did you consider?
Keep a local fork

## Does this PR contain multiple unrelated changes?
No.

## Existing PRs
- [X] I have reviewed all open AND closed PRs for duplicates or prior art


## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| ClaudeCode                                     | all                 |  all      | /                  |

## Evaluation
- What was the initial prompt you (or your human partner) used to start
  the session that led to this change?
All prompts expect pure text responses.
- How many eval sessions did you run AFTER making the change?
A handful.
- How did outcomes change compared to before the change?
I like using AskUserQuestions tool.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

### Evaluation
I compared b55764852ac78870e65c6565fb585b6cd8b3c5c9 against the end state of this branch (ac68b41) using adversarial pressure prompts run through codex exec.
Results:
| State | General prompt | Brainstorming prompt | Fallback prompt |
| --- | --- | --- | --- |
| b55764852ac78870e65c6565fb585b6cd8b3c5c9 | no explicit tool specified | no explicit tool specified | no explicit tool specified |
| ac68b41 | AskUserQuestion | AskUserQuestion | AskUserQuestion |

This shows the branch changed the skill guidance from having no explicit Claude Code question-tool instruction at the base SHA to consistently steering the model to AskUserQuestion in the final state,
including under review-pressure and candidate-name pressure prompts.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
I wrote I by hand.
