### PR TITLE
fix(opencode): cache bootstrap content to remove per-step disk I/O

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -11,6 +11,7 @@ import os from 'os';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+let cachedBootstrapContent = null;
 
 // Simple frontmatter extraction (avoid dependency on skills-core for bootstrap)
 const extractAndStripFrontmatter = (content) => {
@@ -54,9 +55,16 @@ export const SuperpowersPlugin = async ({ client, directory }) => {
 
   // Helper to generate bootstrap content
   const getBootstrapContent = () => {
+    if (cachedBootstrapContent !== null) {
+      return cachedBootstrapContent;
+    }
+
     // Try to load using-superpowers skill
     const skillPath = path.join(superpowersSkillsDir, 'using-superpowers', 'SKILL.md');
-    if (!fs.existsSync(skillPath)) return null;
+    if (!fs.existsSync(skillPath)) {
+      cachedBootstrapContent = null;
+      return null;
+    }
 
     const fullContent = fs.readFileSync(skillPath, 'utf8');
     const { content } = extractAndStripFrontmatter(fullContent);
@@ -70,7 +78,7 @@ When skills reference tools you don't have, substitute OpenCode equivalents:
 
 Use OpenCode's native \`skill\` tool to list and load skills.`;
 
-    return `<EXTREMELY_IMPORTANT>
+    cachedBootstrapContent = `<EXTREMELY_IMPORTANT>
 You have superpowers.
 
 **IMPORTANT: The using-superpowers skill content is included below. It is ALREADY LOADED - you are currently following it. Do NOT use the skill tool to load "using-superpowers" again - that would be redundant.**
@@ -79,6 +87,8 @@ ${content}
 
 ${toolMapping}
 </EXTREMELY_IMPORTANT>`;
+
+    return cachedBootstrapContent;
   };
 
   return {

--- a/tests/opencode/test-plugin-loading.sh
+++ b/tests/opencode/test-plugin-loading.sh
@@ -78,5 +78,15 @@ else
     exit 1
 fi
 
+# Test 7: Verify bootstrap cache exists to avoid repeated disk reads
+echo "Test 7: Checking bootstrap content cache..."
+if grep -q 'let cachedBootstrapContent = null;' "$SUPERPOWERS_PLUGIN_FILE" && \
+   grep -q 'if (cachedBootstrapContent !== null)' "$SUPERPOWERS_PLUGIN_FILE"; then
+    echo "  [PASS] Module-level bootstrap cache is present"
+else
+    echo "  [FAIL] Bootstrap cache markers not found in plugin"
+    exit 1
+fi
+
 echo ""
 echo "=== All plugin loading tests passed ==="


### PR DESCRIPTION
## Summary
This PR caches OpenCode bootstrap content at module scope so the plugin does not re-read and re-parse using-superpowers/SKILL.md on every agent step.

## What changed
- Added cachedBootstrapContent in .opencode/plugins/superpowers.js.
- getBootstrapContent() now returns the cached value after first load.
- Added a plugin-loading regression check in 	ests/opencode/test-plugin-loading.sh to ensure cache markers remain present.

## Why
The experimental.chat.messages.transform hook is invoked each agent step. Without cache, each step performs repeated file I/O + parsing for static content.

## Validation
- 
ode --check .opencode/plugins/superpowers.js
- Verified cache markers in plugin source via grep/select-string.

Closes #1206
Refs #1202