### PR TITLE
fix(writing-plans): avoid teaching conventional commit style by default

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -99,8 +99,10 @@ Expected: PASS
 
 ```bash
 git add tests/path/test.py src/path/file.py
-git commit -m "feat: add specific feature"
+git commit -m "Add specific feature"
 ```
+
+Use the repository's existing commit style. Do not enforce conventional commits unless the project already uses them.
 ````
 
 ## No Placeholders


### PR DESCRIPTION
## Summary
This PR updates the writing-plans skill example so it no longer nudges users toward conventional commit formatting when their repository uses a different style.

## What changed
- Replaced the sample commit message in skills/writing-plans/SKILL.md:
  - from: eat: add specific feature
  - to: Add specific feature
- Added explicit guidance: follow the repository's existing commit style and only use conventional commits when the project already uses them.

## Why
Issue #1187 reports that agents pick up the example commit format from this skill and apply it even in repositories with different commit conventions.

## Validation
- Confirmed no conventional-commit example remains in the writing-plans commit step.
- Confirmed the new guidance is directly adjacent to the commit example.

Closes #1187