### PR TITLE
docs(subagent-driven-development): expand parallel-dispatch red flag with worktree pattern

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -237,7 +237,7 @@ Done!
 - Start implementation on main/master branch without explicit user consent
 - Skip reviews (spec compliance OR code quality)
 - Proceed with unfixed issues
-- Dispatch multiple implementation subagents in parallel (conflicts)
+- Dispatch multiple implementation subagents in parallel **without per-agent git worktrees** — shared-worktree parallelism causes git-index races, pre-commit hook contention, stash pollution, and orphan-import typecheck breaks. The fix is NOT to cap agent count; the fix is to give each agent its own `git worktree` on its own short-lived branch and let the orchestrator serialize the merges (`git merge --ff-only` per branch). Use `superpowers:using-git-worktrees` as the scaffolder. Read-only agents (exploration, review, audit) may share a worktree.
 - Make subagent read plan file (provide full text instead)
 - Skip scene-setting context (subagent needs to understand where task fits)
 - Ignore subagent questions (answer before letting them proceed)


### PR DESCRIPTION
## Problem

The current Red Flag entry in `skills/subagent-driven-development/SKILL.md`:

> Dispatch multiple implementation subagents in parallel (conflicts)

reads as a blanket prohibition on parallelism, which throws away one of the main reasons to use subagent-driven development. The *actual* failure mode is shared-worktree contention, not parallelism itself.

## Real-world failure modes (one shared worktree, N implementers)

- **git-index races** on concurrent `git add` / `git commit`
- **pre-commit hook contention** (lockfile collisions, lint state corruption, husky retries clobbering each other)
- **stash pollution** — one agent's WIP leaks into another agent's diff
- **orphan-import typecheck breaks** — agent A imports from a file agent B just deleted (or vice versa); both agents' commits look fine in isolation, the merged tree is broken

## Fix

Per-agent isolation, not per-agent serialization. Each implementer gets its own `git worktree` on a short-lived branch; the orchestrator dispatches in parallel and serializes only the *merge* step (`git merge --ff-only` per branch). Read-only agents (exploration, review, audit) can still share a worktree safely.

This is exactly what `superpowers:using-git-worktrees` already scaffolds, so the updated line points there explicitly. Net effect: 10-agent dispatches become safe and routine instead of forbidden.

## Change

One-line edit to the Red Flags section. No structural changes.

```diff
- - Dispatch multiple implementation subagents in parallel (conflicts)
+ - Dispatch multiple implementation subagents in parallel **without per-agent git worktrees** — shared-worktree parallelism causes git-index races, pre-commit hook contention, stash pollution, and orphan-import typecheck breaks. The fix is NOT to cap agent count; the fix is to give each agent its own `git worktree` on its own short-lived branch and let the orchestrator serialize the merges (`git merge --ff-only` per branch). Use `superpowers:using-git-worktrees` as the scaffolder. Read-only agents (exploration, review, audit) may share a worktree.
```

## Origin

Hit by a real 10-agent dispatch on a Drizzle/RBAC migration sweep — every failure mode above fired in the same session. Switching to one worktree per agent + ff-only merge made the next 10-way dispatch land cleanly.