### PR TITLE
Fix: cache bootstrap content to eliminate per-step file I/O

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -52,8 +52,14 @@ export const SuperpowersPlugin = async ({ client, directory }) => {
   const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
   const configDir = envConfigDir || path.join(homeDir, '.config/opencode');
 
-  // Helper to generate bootstrap content
+  // Module-level cache for bootstrap content (avoids per-step file I/O)
+  // Cache is plugin-instance-global so it persists across hook invocations within a session
+  let _bootstrapCache = null;
+
+  // Helper to generate bootstrap content (cached after first call)
   const getBootstrapContent = () => {
+    if (_bootstrapCache !== null) return _bootstrapCache;
+
     // Try to load using-superpowers skill
     const skillPath = path.join(superpowersSkillsDir, 'using-superpowers', 'SKILL.md');
     if (!fs.existsSync(skillPath)) return null;
@@ -70,7 +76,7 @@ When skills reference tools you don't have, substitute OpenCode equivalents:
 
 Use OpenCode's native \`skill\` tool to list and load skills.`;
 
-    return `<EXTREMELY_IMPORTANT>
+    _bootstrapCache = `<EXTREMELY_IMPORTANT>
 You have superpowers.
 
 **IMPORTANT: The using-superpowers skill content is included below. It is ALREADY LOADED - you are currently following it. Do NOT use the skill tool to load "using-superpowers" again - that would be redundant.**
@@ -79,6 +85,7 @@ ${content}
 
 ${toolMapping}
 </EXTREMELY_IMPORTANT>`;
+    return _bootstrapCache;
   };
 
   return {


### PR DESCRIPTION
## What
Cache `getBootstrapContent()` result at plugin instance level so the SKILL.md file is read and parsed only on first call instead of every agent step.

## Why
The `experimental.chat.messages.transform` hook fires every agent step. In a 10-step session this was causing 10 `fs.existsSync` + 10 `fs.readFileSync` + 10 frontmatter regex parses for content that never changes during a session.

## How
- Added `_bootstrapCache` module-level variable inside `SuperpowersPlugin`
- `getBootstrapContent()` now returns the cached string on subsequent calls (zero filesystem access after first call)

## Testing
Start an OpenCode session with superpowers, observe that `getBootstrapContent` is called once per session rather than once per step.

Fixes #1206.