### PR TITLE
fix(finishing-branch): prevent cwd-vanishes bug when run inside a linked worktree

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -46,7 +46,29 @@ git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
 
 Or ask: "This branch split from main - is that correct?"
 
-### Step 3: Present Options
+### Step 3: Identify Worktree Context
+
+**Capture context before any destructive action.** If the current shell is inside a linked worktree that will later be removed, every subsequent Bash call will fail with "cwd doesn't exist" the instant `git worktree remove` runs — you must know where to `cd` *before* then.
+
+```bash
+# Current working tree (where the shell is now)
+CURRENT_WORKTREE="$(git rev-parse --show-toplevel)"
+
+# Main working tree (first entry in `git worktree list`)
+MAIN_WORKTREE="$(git worktree list --porcelain | awk 'NR==1 && /^worktree / {print $2}')"
+
+# Are we inside a linked worktree (not the main one)?
+if [ "$CURRENT_WORKTREE" != "$MAIN_WORKTREE" ]; then
+  IN_WORKTREE=yes
+  WORKTREE_PATH="$CURRENT_WORKTREE"
+else
+  IN_WORKTREE=no
+fi
+```
+
+Remember `$MAIN_WORKTREE` and `$WORKTREE_PATH` for later steps.
+
+### Step 4: Present Options
 
 Present exactly these 4 options:
 
@@ -63,18 +85,19 @@ Which option?
 
 **Don't add explanation** - keep options concise.
 
-### Step 4: Execute Choice
+### Step 5: Execute Choice
 
 #### Option 1: Merge Locally
 
+**CRITICAL:** If `IN_WORKTREE=yes`, `cd` to `$MAIN_WORKTREE` *before* touching branches. Running `git checkout <base-branch>` inside a linked worktree switches *that* worktree, not the main one — then Step 6 deletes the directory the shell is standing in.
+
 ```bash
-# Switch to base branch
+# Leave the linked worktree before doing branch ops
+[ "$IN_WORKTREE" = yes ] && cd "$MAIN_WORKTREE"
+
+# Switch to base branch (safely, in the main working tree)
 git checkout <base-branch>
-
-# Pull latest
 git pull
-
-# Merge feature branch
 git merge <feature-branch>
 
 # Verify tests on merged result
@@ -84,7 +107,7 @@ git merge <feature-branch>
 git branch -d <feature-branch>
 ```
 
-Then: Cleanup worktree (Step 5)
+Then: Cleanup worktree (Step 6)
 
 #### Option 2: Push and Create PR
 
@@ -103,7 +126,7 @@ EOF
 )"
 ```
 
-Then: Cleanup worktree (Step 5)
+No `cd` needed — Option 2 does not remove the worktree.
 
 #### Option 3: Keep As-Is
 
@@ -126,37 +149,42 @@ Type 'discard' to confirm.
 Wait for exact confirmation.
 
 If confirmed:
+
 ```bash
+# Same cwd safety as Option 1
+[ "$IN_WORKTREE" = yes ] && cd "$MAIN_WORKTREE"
+
 git checkout <base-branch>
 git branch -D <feature-branch>
 ```
 
-Then: Cleanup worktree (Step 5)
+Then: Cleanup worktree (Step 6)
 
-### Step 5: Cleanup Worktree
+### Step 6: Cleanup Worktree
 
-**For Options 1, 2, 4:**
+**For Options 1, 2, 4 — if `IN_WORKTREE=yes`:**
 
-Check if in worktree:
+**CRITICAL:** The shell must *not* be inside the worktree you're removing. If Step 5 already `cd`-ed out, this is a no-op; if you skipped it, do it now.
+
 ```bash
-git worktree list | grep $(git branch --show-current)
+# Make sure we're not standing in the directory about to be removed
+cd "$MAIN_WORKTREE"
+
+git worktree remove "$WORKTREE_PATH"
 ```
 
-If yes:
-```bash
-git worktree remove <worktree-path>
-```
+If you skip the `cd`, `git worktree remove` deletes the shell's cwd and every subsequent Bash tool call fails with "cwd doesn't exist".
 
 **For Option 3:** Keep worktree.
 
 ## Quick Reference
 
-| Option | Merge | Push | Keep Worktree | Cleanup Branch |
-|--------|-------|------|---------------|----------------|
-| 1. Merge locally | ✓ | - | - | ✓ |
-| 2. Create PR | - | ✓ | ✓ | - |
-| 3. Keep as-is | - | - | ✓ | - |
-| 4. Discard | - | - | - | ✓ (force) |
+| Option | Merge | Push | Keep Worktree | Cleanup Branch | Needs cd out |
+|--------|-------|------|---------------|----------------|--------------|
+| 1. Merge locally | ✓ | - | - | ✓ | ✓ |
+| 2. Create PR | - | ✓ | ✓ | - | - |
+| 3. Keep as-is | - | - | ✓ | - | - |
+| 4. Discard | - | - | - | ✓ (force) | ✓ |
 
 ## Common Mistakes
 
@@ -176,6 +204,14 @@ git worktree remove <worktree-path>
 - **Problem:** Accidentally delete work
 - **Fix:** Require typed "discard" confirmation
 
+**Running destructive ops from inside the worktree being removed**
+- **Problem:** `git worktree remove` deletes the shell's cwd; every subsequent Bash call fails with "cwd doesn't exist" and the session wedges.
+- **Fix:** In Step 3, capture `$MAIN_WORKTREE`. Before any `checkout`/`merge`/`branch -d`/`worktree remove`, `cd "$MAIN_WORKTREE"` when `IN_WORKTREE=yes`.
+
+**Running `git checkout <base>` inside a linked worktree**
+- **Problem:** Switches the linked worktree's HEAD to base, instead of operating in the main working tree. Merge lands in the wrong files and the worktree you're about to delete is now checked out to base.
+- **Fix:** `cd "$MAIN_WORKTREE"` *before* the checkout (Options 1 and 4).
+
 ## Red Flags
 
 **Never:**
@@ -183,12 +219,14 @@ git worktree remove <worktree-path>
 - Merge without verifying tests on result
 - Delete work without confirmation
 - Force-push without explicit request
+- Run `git worktree remove` while the shell's cwd is inside that worktree
 
 **Always:**
 - Verify tests before offering options
+- Capture `$MAIN_WORKTREE` / `$WORKTREE_PATH` in Step 3 before any destructive op
 - Present exactly 4 options
 - Get typed confirmation for Option 4
-- Clean up worktree for Options 1 & 4 only
+- Clean up worktree for Options 1 & 4 only, from `$MAIN_WORKTREE`
 
 ## Integration
 


### PR DESCRIPTION
## Summary

When `finishing-a-development-branch` is invoked from inside a linked git worktree (the common case when paired with `using-git-worktrees`), the skill wedges the Claude Code session mid-cleanup. I hit this today after running the skill from a worktree — every Bash call after the `git worktree remove` failed with "cwd doesn't exist."

Two concrete bugs in the current flow:

1. **Step 4 Option 1 / Option 4** run `git checkout <base-branch>` inside the linked worktree, which switches *that* worktree's HEAD instead of operating in the main working tree. The merge lands on the wrong files, and the worktree is now checked out to base while still flagged for removal.
2. **Step 5** then runs `git worktree remove <path>` while the shell's cwd is inside that very directory. The directory vanishes from under the shell and every subsequent tool call fails.

## Fix

- Add a new **Step 3: Identify Worktree Context** that captures `CURRENT_WORKTREE` / `MAIN_WORKTREE` / `WORKTREE_PATH` / `IN_WORKTREE` before any destructive action.
- In **Option 1** and **Option 4**, prepend `[ "$IN_WORKTREE" = yes ] && cd "$MAIN_WORKTREE"` so branch ops run in the main working tree, not the worktree about to be deleted.
- In the new **Step 6: Cleanup Worktree**, `cd "$MAIN_WORKTREE"` before `git worktree remove "$WORKTREE_PATH"`.
- Renumber existing Step 3/4/5 to 4/5/6 and update cross-references.
- Add two entries to **Common Mistakes** and one to **Red Flags** documenting the failure modes so the lesson sticks.

Option 2 (Push and PR) and Option 3 (Keep as-is) are unaffected — they don't remove the worktree.

## Test Plan

- [ ] Run skill from a linked worktree, choose Option 1 — merge lands in main working tree, worktree removed cleanly, shell still functional.
- [ ] Run skill from a linked worktree, choose Option 4 — branch deleted from main working tree, worktree removed, shell still functional.
- [ ] Run skill from the main working tree (non-worktree case) — `IN_WORKTREE=no`, no extra `cd`, existing behavior preserved.
- [ ] Run skill from a linked worktree, choose Option 2 — no `cd`, worktree kept, PR opens.
- [ ] Run skill from a linked worktree, choose Option 3 — no `cd`, worktree kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)