### PR TITLE
fix(finishing-a-development-branch): guard clean tree + handle linked-worktree cwd

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -9,15 +9,34 @@ description: Use when implementation is complete, all tests pass, and you need t
 
 Guide completion of development work by presenting clear options and handling chosen workflow.
 
-**Core principle:** Verify tests → Present options → Execute choice → Clean up.
+**Core principle:** Verify clean tree + tests → Present options → Execute choice → Clean up.
 
 **Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
 
 ## The Process
 
-### Step 1: Verify Tests
+### Step 1: Verify Clean Tree and Tests
 
-**Before presenting options, verify tests pass:**
+**Before presenting options, verify two things:**
+
+**1a. Working tree is clean:**
+
+```bash
+git status --porcelain
+```
+
+**If output is non-empty:**
+```
+Uncommitted changes in working tree:
+
+[git status --porcelain output]
+
+Cannot proceed — finish-branch only integrates *committed* work. Commit or stash first, then re-run.
+```
+
+Stop. Do not proceed. The user must decide what belongs on the branch before finishing it — this skill will not stage changes on their behalf.
+
+**1b. Tests pass:**
 
 ```bash
 # Run project's test suite
@@ -35,7 +54,7 @@ Cannot proceed with merge/PR until tests pass.
 
 Stop. Don't proceed to Step 2.
 
-**If tests pass:** Continue to Step 2.
+**If both pass:** Continue to Step 2.
 
 ### Step 2: Determine Base Branch
 
@@ -46,7 +65,29 @@ git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
 
 Or ask: "This branch split from main - is that correct?"
 
-### Step 3: Present Options
+### Step 3: Identify Worktree Context
+
+**Capture context before any destructive action.** If the current shell is inside a linked worktree that will later be removed, every subsequent command will fail with "cwd doesn't exist" the instant `git worktree remove` runs — you must know where to `cd` *before* then.
+
+```bash
+# Current working tree (where the shell is now)
+CURRENT_WORKTREE="$(git rev-parse --show-toplevel)"
+
+# Main working tree (first entry in `git worktree list`)
+MAIN_WORKTREE="$(git worktree list --porcelain | awk 'NR==1 && /^worktree / {print $2}')"
+
+# Are we inside a linked worktree (not the main one)?
+if [ "$CURRENT_WORKTREE" != "$MAIN_WORKTREE" ]; then
+  IN_WORKTREE=yes
+  WORKTREE_PATH="$CURRENT_WORKTREE"
+else
+  IN_WORKTREE=no
+fi
+```
+
+Remember `$MAIN_WORKTREE` and `$WORKTREE_PATH` for later steps.
+
+### Step 4: Present Options
 
 Present exactly these 4 options:
 
@@ -63,18 +104,19 @@ Which option?
 
 **Don't add explanation** - keep options concise.
 
-### Step 4: Execute Choice
+### Step 5: Execute Choice
 
 #### Option 1: Merge Locally
 
+**CRITICAL:** If `IN_WORKTREE=yes`, `cd` to `$MAIN_WORKTREE` *before* touching branches. Running `git checkout <base-branch>` inside a linked worktree switches *that* worktree, not the main one — then Step 6 deletes the directory the shell is standing in.
+
 ```bash
-# Switch to base branch
+# Leave the linked worktree before doing branch ops
+[ "$IN_WORKTREE" = yes ] && cd "$MAIN_WORKTREE"
+
+# Switch to base branch (safely, in the main working tree)
 git checkout <base-branch>
-
-# Pull latest
 git pull
-
-# Merge feature branch
 git merge <feature-branch>
 
 # Verify tests on merged result
@@ -84,7 +126,7 @@ git merge <feature-branch>
 git branch -d <feature-branch>
 ```
 
-Then: Cleanup worktree (Step 5)
+Then: Cleanup worktree (Step 6)
 
 #### Option 2: Push and Create PR
 
@@ -103,7 +145,7 @@ EOF
 )"
 ```
 
-Then: Cleanup worktree (Step 5)
+No `cd` needed — Option 2 does not remove the worktree.
 
 #### Option 3: Keep As-Is
 
@@ -126,39 +168,48 @@ Type 'discard' to confirm.
 Wait for exact confirmation.
 
 If confirmed:
+
 ```bash
+# Same cwd safety as Option 1
+[ "$IN_WORKTREE" = yes ] && cd "$MAIN_WORKTREE"
+
 git checkout <base-branch>
 git branch -D <feature-branch>
 ```
 
-Then: Cleanup worktree (Step 5)
+Then: Cleanup worktree (Step 6)
 
-### Step 5: Cleanup Worktree
+### Step 6: Cleanup Worktree
 
-**For Options 1, 2, 4:**
+**For Options 1, 2, 4 — if `IN_WORKTREE=yes`:**
 
-Check if in worktree:
+**CRITICAL:** The shell must *not* be inside the worktree you're removing. If Step 5 already `cd`-ed out, this is a no-op; if you skipped it, do it now.
+
 ```bash
-git worktree list | grep $(git branch --show-current)
+# Make sure we're not standing in the directory about to be removed
+cd "$MAIN_WORKTREE"
+
+git worktree remove "$WORKTREE_PATH"
 ```
 
-If yes:
-```bash
-git worktree remove <worktree-path>
-```
+If you skip the `cd`, `git worktree remove` deletes the shell's cwd and every subsequent command fails with "cwd doesn't exist".
 
 **For Option 3:** Keep worktree.
 
 ## Quick Reference
 
-| Option | Merge | Push | Keep Worktree | Cleanup Branch |
-|--------|-------|------|---------------|----------------|
-| 1. Merge locally | ✓ | - | - | ✓ |
-| 2. Create PR | - | ✓ | ✓ | - |
-| 3. Keep as-is | - | - | ✓ | - |
-| 4. Discard | - | - | - | ✓ (force) |
+| Option | Merge | Push | Keep Worktree | Cleanup Branch | Needs cd out |
+|--------|-------|------|---------------|----------------|--------------|
+| 1. Merge locally | ✓ | - | - | ✓ | ✓ |
+| 2. Create PR | - | ✓ | ✓ | - | - |
+| 3. Keep as-is | - | - | ✓ | - | - |
+| 4. Discard | - | - | - | ✓ (force) | ✓ |
 
 ## Common Mistakes
+
+**Skipping clean-tree verification**
+- **Problem:** Proceeding with uncommitted changes causes confusion — user expects the skill to stage their unsaved work, skill assumes committed work, and options become ambiguous ("what does discard mean for my uncommitted files?").
+- **Fix:** In Step 1, refuse if `git status --porcelain` is non-empty. Point user to `git add` + `git commit` or `git stash` first.
 
 **Skipping test verification**
 - **Problem:** Merge broken code, create failing PR
@@ -176,19 +227,32 @@ git worktree remove <worktree-path>
 - **Problem:** Accidentally delete work
 - **Fix:** Require typed "discard" confirmation
 
+**Running destructive ops from inside the worktree being removed**
+- **Problem:** `git worktree remove` deletes the shell's cwd; every subsequent command fails with "cwd doesn't exist" and the session wedges.
+- **Fix:** In Step 3, capture `$MAIN_WORKTREE`. Before any `checkout`/`merge`/`branch -d`/`worktree remove`, `cd "$MAIN_WORKTREE"` when `IN_WORKTREE=yes`.
+
+**Running `git checkout <base>` inside a linked worktree**
+- **Problem:** Switches the linked worktree's HEAD to base, instead of operating in the main working tree. Merge lands in the wrong files and the worktree you're about to delete is now checked out to base.
+- **Fix:** `cd "$MAIN_WORKTREE"` *before* the checkout (Options 1 and 4).
+
 ## Red Flags
 
 **Never:**
+- Proceed with a dirty working tree (uncommitted changes)
 - Proceed with failing tests
+- Stage uncommitted files on the user's behalf — that's a separate decision
 - Merge without verifying tests on result
 - Delete work without confirmation
 - Force-push without explicit request
+- Run `git worktree remove` while the shell's cwd is inside that worktree
 
 **Always:**
+- Verify `git status --porcelain` is empty before offering options
 - Verify tests before offering options
+- Capture `$MAIN_WORKTREE` / `$WORKTREE_PATH` in Step 3 before any destructive op
 - Present exactly 4 options
 - Get typed confirmation for Option 4
-- Clean up worktree for Options 1 & 4 only
+- Clean up worktree for Options 1 & 4 only, from `$MAIN_WORKTREE`
 
 ## Integration
 


### PR DESCRIPTION
## Summary

Two bugs in `finishing-a-development-branch` were silently corrupting sessions run from inside a linked git worktree, or with uncommitted changes in the tree.

### Bug 1 — cwd vanishes mid-skill

Step 5 ran `git worktree remove <path>` without first `cd`-ing out of that worktree. If the shell's cwd was inside the removed worktree (always, when the skill triggers from inside one), every subsequent command failed with `"cwd doesn't exist"` and the session wedged.

Options 1 and 4 also ran `git checkout <base-branch>` from inside the linked worktree, which switches *that* worktree to the base branch rather than operating in the main working tree. The merge then lands in the wrong files and the worktree about to be deleted is now checked out to base.

### Bug 2 — uncommitted work swept into ambiguity

Step 1 only verified tests passed; it never checked `git status --porcelain`. Users with uncommitted changes ran the skill expecting it to integrate their unsaved work — the skill assumed committed work and produced confusing behavior under all four options. "What does discard mean for my uncommitted files?" became an unanswerable question inside the skill.

The skill's job is integration (merge/PR/discard), not staging. If there's uncommitted work, the user hasn't decided yet what belongs on the branch — silent assumption is worse than refusal.

## Changes

- **Step 1** now verifies `git status --porcelain` is empty *before* running tests, with a refusal that points to `git add`+`git commit` or `git stash`.
- **New Step 3** captures `MAIN_WORKTREE`, `WORKTREE_PATH`, and `IN_WORKTREE` using `git worktree list --porcelain` before any destructive action.
- **Options 1 and 4** `cd "$MAIN_WORKTREE"` before `git checkout <base-branch>` when in a linked worktree.
- **Step 6** (formerly 5) `cd`s to `$MAIN_WORKTREE` before `git worktree remove "$WORKTREE_PATH"`, using the captured path rather than grepping the current branch name.
- Quick Reference gains a "Needs cd out" column.
- Common Mistakes / Red Flags updated with the two new failure modes.

## How it was found

Hit both bugs back-to-back in a real session using worktrees for parallel feature work:

1. Ran `/superpowers:finishing-a-development-branch` inside a worktree → chose Option 1 (merge locally) → Step 5 removed the worktree → shell cwd disappeared → all subsequent `Bash` tool calls failed with `"cwd doesn't exist"` → session unrecoverable.
2. Restarted. Had uncommitted work spread across a feature branch. Ran the skill again → tests passed → presented 4 options → picked Discard → skill's Discard semantics only apply to commits, so the uncommitted files stayed on disk, orphaned from the deleted branch, with no clear mental model for what just happened.

The fix-pass was reproduced working in the same session setup.

## Test Plan

- [ ] Clean-tree check fires: `echo x > dirty && git add dirty` then run the skill → should refuse at Step 1b, not present options.
- [ ] Worktree cwd handling works: `git worktree add ../wt-test -b feat/test && cd ../wt-test`, make a commit, run the skill → choose Option 1 → merge lands in main working tree, worktree removed, shell cwd ends up valid.
- [ ] Option 4 in worktree: same setup, choose Discard → branch deleted, worktree removed, shell cwd still valid.
- [ ] Non-worktree case still works: run from main working tree → `IN_WORKTREE=no` → `cd` calls no-op → behavior unchanged vs. pre-patch.