### PR TITLE
Add subagent-delegation skill: pre-execution decision framework for when to delegate

### DIFF
--- a/skills/subagent-delegation/SKILL.md
+++ b/skills/subagent-delegation/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: subagent-delegation
+description: Use before executing any non-trivial task to decide whether to delegate to a subagent or execute inline. Covers research-heavy tasks, independent parallel work, fresh-perspective review, pre-commit verification, and pipeline workflows. When in doubt, bias toward delegating.
+---
+
+# Subagent Delegation
+
+<SUBAGENT-STOP>
+You are a subagent executing a delegated task. Do not apply this skill — proceed directly with your task.
+</SUBAGENT-STOP>
+
+## Overview
+
+Two separate reasons to delegate — most people only know one:
+
+1. **Context isolation**: The subagent does the heavy lifting in its own context and returns only what you need. Raw file reads, search results, and intermediate comparisons stay out of your main thread.
+
+2. **Independent judgment**: A subagent starts fresh, unburdened by your conversation history, assumptions, and blind spots. For review and verification tasks, this independence is the point — you cannot give an unbiased opinion of your own work.
+
+**Core question:** should this task happen here, or over there?
+
+## When to Delegate
+
+Delegate when **any** of these apply:
+
+| Signal | Threshold | Why |
+|---|---|---|
+| **Research-heavy** | 10+ files to explore | Raw reads pollute context; you need synthesized findings |
+| **Multiple independent tasks** | 3+ pieces with no dependencies | Parallel subagents finish faster; each stays focused |
+| **Fresh perspective needed** | Review, verification, challenging assumptions | Subagent doesn't inherit your blind spots |
+| **Verification before committing** | Pre-commit quality check | Independent eyes catch what familiarity obscures |
+| **Pipeline workflow** | Distinct phases with clear file-based handoffs | Each stage benefits from focused context |
+
+**When in doubt, delegate.** A healthy main context is worth more than the overhead of spawning a subagent.
+
+## When to Keep Inline
+
+Hard blockers — keep inline when **any** of these are true:
+
+- **Tight feedback loop** — debugging where you need error → hypothesis → fix → observe in one thread
+- **Context-state dependency** — step B needs the full conversational output of step A, and that state can't be written to a file. Note: if the dependency is a *file* (step A writes `spec.md`, step B reads it), that's a pipeline — delegate each stage with file-based handoffs
+- **Shared file writes** — task writes to files the main thread is also modifying (conflict risk)
+- **Agent coordination** — subagents can't talk to each other; tasks requiring inter-agent negotiation stay inline
+- **Truly trivial** — a single-function lookup or single-file read with minimal output
+
+## How to Delegate
+
+### 1. Choose subagent type
+
+| Task nature | subagent_type |
+|---|---|
+| Read files, explore codebase, search, analyze | `Explore` |
+| Plan an approach, design a solution | `Plan` |
+| Write files, run commands, make changes | `general-purpose` |
+
+### 2. Write a prompt with two contracts
+
+Every delegated prompt must specify:
+
+**Input Contract:**
+- One-sentence task background
+- Specific resources to access (file paths, repos, search terms)
+- Explicit scope boundary ("only look at X, ignore Y")
+- For fresh-perspective tasks: "Do not use context from the main conversation — evaluate independently"
+
+**Output Contract:**
+- The conclusion (direct answer, not a narrative)
+- Key evidence with `file:line` references or direct quotes
+- Material gaps or uncertainties
+- **Prohibited:** raw file dumps, unstructured summaries, preamble without substance
+
+**Template:**
+
+```
+[One sentence: what you're trying to learn, verify, or review]
+
+Access: [specific files, directories, repos, or search scope]
+Do not: [explicit out-of-scope items]
+[Fresh perspective: "Do not use context from the main conversation — evaluate independently."]
+
+Return:
+- Conclusion: [direct answer]
+- Evidence: [findings with file:line refs]
+- Gaps: [anything you couldn't determine]
+```
+
+## Output Quality Gate
+
+When the subagent returns:
+- Is the conclusion actionable? (specific finding, not vague summary)
+- Does the evidence back it? (file:line refs or direct quotes)
+- Does it cover the scope you asked for?
+
+If too vague: re-delegate once with a more explicit Output Contract. If still insufficient: bring inline — some tasks need the iterative loop.
+
+## Relationship to Other Skills
+
+This skill is a **pre-execution layer** — it runs before other skills, not instead of them.
+
+- `dispatching-parallel-agents`: coordinates multiple subagents once you've decided to delegate. Use this skill to decide *whether* to delegate; use that skill to coordinate *how* when 3+ tasks run in parallel.
+- `subagent-driven-development`: a full SDD workflow for executing implementation plans. This skill is the simpler, earlier question: does *this task* belong in a subagent at all?
+- After deciding inline: proceed with brainstorming, TDD, debugging, or whichever skill applies.
+
+## Examples
+
+**Delegate:**
+- "Read the auth implementation in this repo and summarize how it works" → research-heavy → `Explore` subagent
+- "Check whether our implementation matches this spec" → verification → `Explore` subagent, output: pass/fail + gaps
+- "Review this implementation before I commit — I want unbiased eyes" → fresh perspective → read-only subagent, "evaluate independently"
+- "Design API contract, then implement endpoints, then write tests" → pipeline with file handoffs → chain subagents, each reads previous stage's output file
+
+**Keep inline:**
+- Debugging a failing test → tight feedback loop
+- Editing a file based on earlier context in this conversation → context-state dependency
+- Looking up one specific function → trivial

--- a/skills/subagent-delegation/SKILL.md
+++ b/skills/subagent-delegation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: subagent-delegation
-description: Use before executing any non-trivial task to decide whether to delegate to a subagent or execute inline. Covers research-heavy tasks, independent parallel work, fresh-perspective review, pre-commit verification, and pipeline workflows. When in doubt, bias toward delegating.
+description: Use before executing any non-trivial task to decide whether to delegate to a subagent or execute inline. Covers research-heavy tasks, external resource aggregation, independent parallel work, fresh-perspective review, pre-commit verification, and pipeline workflows. When in doubt, bias toward delegating.
+when_to_use: Trigger before executing tasks like "read this codebase and summarize", "compare these implementations", "validate this spec against the code", "review this code for issues", "verify before I commit", "write docs based on git diff", or any multi-stage task where phases can be handed off cleanly. Also trigger when the task involves 10+ files, 3+ independent pieces of work, or aggregating results from 3+ external sources.
 ---
 
 # Subagent Delegation
@@ -26,6 +27,7 @@ Delegate when **any** of these apply:
 | Signal | Threshold | Why |
 |---|---|---|
 | **Research-heavy** | 10+ files to explore | Raw reads pollute context; you need synthesized findings |
+| **External resource aggregation** | 3+ external repos, URLs, or APIs to fetch and integrate | Each fetch result pollutes main context; subagent returns only the synthesis |
 | **Multiple independent tasks** | 3+ pieces with no dependencies | Parallel subagents finish faster; each stays focused |
 | **Fresh perspective needed** | Review, verification, challenging assumptions | Subagent doesn't inherit your blind spots |
 | **Verification before committing** | Pre-commit quality check | Independent eyes catch what familiarity obscures |
@@ -38,7 +40,7 @@ Delegate when **any** of these apply:
 Hard blockers — keep inline when **any** of these are true:
 
 - **Tight feedback loop** — debugging where you need error → hypothesis → fix → observe in one thread
-- **Context-state dependency** — step B needs the full conversational output of step A, and that state can't be written to a file. Note: if the dependency is a *file* (step A writes `spec.md`, step B reads it), that's a pipeline — delegate each stage with file-based handoffs
+- **Context-state dependency** — step B needs the full conversational output of step A, and that state can't be written to a file. Note: if the dependency is a *file* (step A writes `spec.md`, step B reads it), that's a **pipeline** — delegate each stage with file-based handoffs
 - **Shared file writes** — task writes to files the main thread is also modifying (conflict risk)
 - **Agent coordination** — subagents can't talk to each other; tasks requiring inter-agent negotiation stay inline
 - **Truly trivial** — a single-function lookup or single-file read with minimal output
@@ -104,10 +106,12 @@ This skill is a **pre-execution layer** — it runs before other skills, not ins
 ## Examples
 
 **Delegate:**
-- "Read the auth implementation in this repo and summarize how it works" → research-heavy → `Explore` subagent
+- "Read the auth implementation in this repo and summarize how it works" → research-heavy (10+ files) → `Explore` subagent
 - "Check whether our implementation matches this spec" → verification → `Explore` subagent, output: pass/fail + gaps
 - "Review this implementation before I commit — I want unbiased eyes" → fresh perspective → read-only subagent, "evaluate independently"
+- "Write docs based on the git diff" → independent task → `general-purpose` subagent reads diff, writes docs, returns draft
 - "Design API contract, then implement endpoints, then write tests" → pipeline with file handoffs → chain subagents, each reads previous stage's output file
+- "Search GitHub trending and gather info on 20 repos" → external resource aggregation → `Explore` subagent returns synthesis only
 
 **Keep inline:**
 - Debugging a failing test → tight feedback loop


### PR DESCRIPTION
## What problem are you trying to solve?

In practice, I kept running into a recurring failure mode: I'd start a task inline — reading 15 files to understand an auth implementation, or exploring a codebase before implementing a feature — and by the time I had what I needed, my main context was buried under thousands of tokens of raw file content I'd never reference again. The information I actually needed was a 10-line summary. The problem wasn't that I didn't know subagents existed; it was that I had no systematic trigger for *when* to reach for them.

The second failure mode: even when I did delegate, I'd write a vague prompt with no output structure, get back 800 lines of raw exploration, and either dump it into the main context (defeating the purpose) or re-ask inline anyway.

There's also a third case that's underappreciated: review and verification tasks. I'd ask myself to review my own implementation and get a biased answer because I was carrying all the context of how I built it. A subagent that starts fresh gives genuinely independent judgment — not just context savings.

A fourth case emerged during use: fetching and integrating results from multiple external sources (GitHub repos, URLs, APIs). Each fetch result accumulates in the main context even though only the synthesized conclusion is needed. This is structurally identical to the research-heavy case but distinct enough to name separately.

## What does this PR change?

Adds `skills/subagent-delegation/SKILL.md` — a pre-execution decision framework that determines whether a task should be delegated to a subagent or executed inline. It covers six delegation trigger signals, hard blockers with a pipeline vs. context-state-dependency distinction, subagent type routing, and Input/Output Contract enforcement to ensure delegated prompts return actionable results.

The six trigger signals:
1. Research-heavy (10+ files)
2. External resource aggregation (3+ external repos/URLs/APIs to fetch and integrate)
3. Multiple independent tasks (3+ with no dependencies)
4. Fresh perspective needed (review, verification, challenging assumptions)
5. Verification before committing
6. Pipeline workflow (distinct phases with file-based handoffs)

Also includes a `when_to_use` frontmatter field with concrete trigger phrases for reliable auto-invocation.

## Is this change appropriate for the core library?

Yes. The skill addresses a universal problem in any Claude Code session regardless of domain, project type, or tooling. It doesn't integrate any third-party service or promote any specific workflow tool. The decision of "should this task run in a subagent?" is as general-purpose as systematic-debugging or verification-before-completion.

## What alternatives did you consider?

**Extending dispatching-parallel-agents**: That skill addresses coordination of multiple concurrent subagents once the decision to delegate is made. Adding a "should I delegate at all?" section would conflate two different decisions and make the skill harder to invoke at the right moment.

**Extending subagent-driven-development**: SDD is a full workflow for executing implementation plans. It presupposes you're already in a structured development loop. The delegation decision happens earlier and more frequently — before any individual research task, review request, or pipeline stage.

**CLAUDE.md rule only**: A one-line rule ("delegate when tasks are heavy") lacks the specificity to actually change behavior. The six-signal table, hard blocker list, and Output Contract template are what make the decision actionable.

## Does this PR contain multiple unrelated changes?

No. Single new skill file only.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for this specific decision-layer concept

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code (mc --code wrapper) | superpowers 5.0.6 | Claude Opus | claude-opus-4-6 (1M context) |

## Evaluation

Initial prompt that motivated this change: "I want a skill that makes me automatically delegate tasks to subagents when appropriate, instead of flooding my main context with file reads I don't need."

After developing the skill, tested against all 8 scenarios from Anthropic's official subagent guidance blog post (April 2026):

**Should delegate — all correctly triggered:**
- Research before implementing (reading 10+ files) ✅
- Parallel modifications across 3 independent files ✅
- Independent review (fresh perspective, no prior context) ✅
- Pipeline workflow with file-based handoffs ✅

**Should stay inline — all correctly blocked:**
- Sequential dependent work (context-state dependency) ✅
- Same-file edits (shared file writes) ✅
- Small tasks (trivial blocker) ✅
- Work requiring agent coordination ✅

Before: main context regularly accumulated 5,000–15,000 tokens of intermediate file reads before producing a 200-token conclusion. After: research tasks return structured summaries; main context stays focused on the conversation.

## Rigor

- [x] I used `superpowers:writing-skills` during development of this skill
- [x] Tested adversarially: attempted to trigger false positives (trivial tasks that should stay inline) and false negatives (heavy research tasks that should delegate) — both handled correctly by the signal/blocker structure
- [x] The pipeline vs. context-state-dependency distinction was the hardest edge case; added explicit inline note in the blocker section after it caused a misclassification in testing
- [x] Did not modify any existing skill content

## Human review
- [x] A human has reviewed the complete proposed diff before submission