### PR TITLE
Add agent-level bootstrap control and skills path resolution fixes

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -1,7 +1,7 @@
 /**
  * Superpowers plugin for OpenCode.ai
  *
- * Injects superpowers bootstrap context via system prompt transform.
+ * Injects superpowers bootstrap context via chat.message hook.
  * Auto-registers skills directory via config hook (no symlinks needed).
  */
 
@@ -12,15 +12,16 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Simple frontmatter extraction (avoid dependency on skills-core for bootstrap)
+const stripJsonComments = (content) => content
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/(^|\s)\/\/.*$/gm, '$1');
+
 const extractAndStripFrontmatter = (content) => {
   const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) return { frontmatter: {}, content };
-
   const frontmatterStr = match[1];
   const body = match[2];
   const frontmatter = {};
-
   for (const line of frontmatterStr.split('\n')) {
     const colonIdx = line.indexOf(':');
     if (colonIdx > 0) {
@@ -29,11 +30,9 @@ const extractAndStripFrontmatter = (content) => {
       frontmatter[key] = value;
     }
   }
-
   return { frontmatter, content: body };
 };
 
-// Normalize a path: trim whitespace, expand ~, resolve to absolute
 const normalizePath = (p, homeDir) => {
   if (!p || typeof p !== 'string') return null;
   let normalized = p.trim();
@@ -46,21 +45,108 @@ const normalizePath = (p, homeDir) => {
   return path.resolve(normalized);
 };
 
-export const SuperpowersPlugin = async ({ client, directory }) => {
+const getDisabledBootstrapAgents = (options) => {
+  const agents = options?.disableBootstrapForAgents;
+  return Array.isArray(agents) ? agents.filter((agent) => typeof agent === 'string' && agent.trim()) : [];
+};
+
+const resolveSuperpowersSkillsDir = (configDir) => {
+  const candidates = [
+    path.join(configDir, 'superpowers', 'skills'),
+    path.resolve(__dirname, '..', 'superpowers', 'skills'),
+    path.resolve(__dirname, '../../superpowers/skills'),
+    path.resolve(__dirname, '../../skills')
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.readdirSync(candidate).length > 0) {
+      return candidate;
+    }
+  }
+  return candidates[0];
+};
+
+const DEFAULT_OPTIONS = {
+  disableBootstrapForAgents: []
+};
+
+const loadJsonc = (filePath) => {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(stripJsonComments(content));
+  } catch {
+    return null;
+  }
+};
+
+const deepMerge = (base, override) => {
+  const result = { ...base };
+  for (const key of Object.keys(override)) {
+    const baseVal = result[key];
+    const overrideVal = override[key];
+    if (Array.isArray(baseVal) && Array.isArray(overrideVal)) {
+      result[key] = [...baseVal, ...overrideVal];
+    } else if (typeof baseVal === 'object' && typeof overrideVal === 'object' && baseVal !== null && overrideVal !== null) {
+      result[key] = deepMerge(baseVal, overrideVal);
+    } else {
+      result[key] = overrideVal;
+    }
+  }
+  return result;
+};
+
+const loadLayeredOptions = (homeDir, configDir, projectDir) => {
+  let options = { ...DEFAULT_OPTIONS };
+
+  const effectiveConfigDir = process.env.OPENCODE_CONFIG_DIR || configDir;
+  const userConfigPath = path.join(effectiveConfigDir, 'plugins', 'superpowers.jsonc');
+  const userConfig = loadJsonc(userConfigPath);
+  if (userConfig) {
+    options = deepMerge(options, userConfig);
+  }
+
+  if (projectDir) {
+    const projectConfigPath = path.join(projectDir, '.opencode', 'plugins', 'superpowers.jsonc');
+    const projectConfig = loadJsonc(projectConfigPath);
+    if (projectConfig) {
+      options = deepMerge(options, projectConfig);
+    }
+  }
+
+  return options;
+};
+
+const getAgentNameFromInput = (input) => {
+  const candidates = [
+    input?.agent,
+    input?.agent?.name,
+    input?.session?.agent,
+    input?.session?.agent?.name,
+    input?.session?.config?.agent,
+    input?.session?.config?.agent?.name,
+    input?.chat?.agent,
+    input?.chat?.agent?.name,
+    input?.message?.agent,
+    input?.message?.agent?.name,
+    input?.metadata?.agent,
+    input?.metadata?.agent?.name
+  ];
+  return candidates.find((candidate) => typeof candidate === 'string' && candidate.trim()) || null;
+};
+
+export const SuperpowersPlugin = async ({ client, directory }, options = {}) => {
   const homeDir = os.homedir();
-  const superpowersSkillsDir = path.resolve(__dirname, '../../skills');
   const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
   const configDir = envConfigDir || path.join(homeDir, '.config/opencode');
+  const resolvedOptions = { ...loadLayeredOptions(homeDir, configDir, directory), ...options };
+  const bootstrappedSessions = new Set();
+  const superpowersSkillsDir = resolveSuperpowersSkillsDir(configDir);
 
-  // Helper to generate bootstrap content
   const getBootstrapContent = () => {
-    // Try to load using-superpowers skill
     const skillPath = path.join(superpowersSkillsDir, 'using-superpowers', 'SKILL.md');
     if (!fs.existsSync(skillPath)) return null;
-
     const fullContent = fs.readFileSync(skillPath, 'utf8');
     const { content } = extractAndStripFrontmatter(fullContent);
-
     const toolMapping = `**Tool Mapping for OpenCode:**
 When skills reference tools you don't have, substitute OpenCode equivalents:
 - \`TodoWrite\` → \`todowrite\`
@@ -82,10 +168,6 @@ ${toolMapping}
   };
 
   return {
-    // Inject skills path into live config so OpenCode discovers superpowers skills
-    // without requiring manual symlinks or config file edits.
-    // This works because Config.get() returns a cached singleton — modifications
-    // here are visible when skills are lazily discovered later.
     config: async (config) => {
       config.skills = config.skills || {};
       config.skills.paths = config.skills.paths || [];
@@ -94,19 +176,19 @@ ${toolMapping}
       }
     },
 
-    // Inject bootstrap into the first user message of each session.
-    // Using a user message instead of a system message avoids:
-    //   1. Token bloat from system messages repeated every turn (#750)
-    //   2. Multiple system messages breaking Qwen and other models (#894)
-    'experimental.chat.messages.transform': async (_input, output) => {
+    'chat.message': async (input, output) => {
+      const agentName = getAgentNameFromInput(input);
+      const disabledAgents = getDisabledBootstrapAgents(resolvedOptions);
+      if (agentName && disabledAgents.includes(agentName)) return;
+      if (input?.sessionID && bootstrappedSessions.has(input.sessionID)) return;
+
       const bootstrap = getBootstrapContent();
-      if (!bootstrap || !output.messages.length) return;
-      const firstUser = output.messages.find(m => m.info.role === 'user');
-      if (!firstUser || !firstUser.parts.length) return;
-      // Only inject once
-      if (firstUser.parts.some(p => p.type === 'text' && p.text.includes('EXTREMELY_IMPORTANT'))) return;
-      const ref = firstUser.parts[0];
-      firstUser.parts.unshift({ ...ref, type: 'text', text: bootstrap });
+      if (!bootstrap || !output.parts?.length) return;
+      if (output.parts.some(p => p.type === 'text' && p.text.includes('EXTREMELY_IMPORTANT'))) return;
+
+      const ref = output.parts[0];
+      output.parts.unshift({ ...ref, type: 'text', text: bootstrap });
+      if (input?.sessionID) bootstrappedSessions.add(input.sessionID);
     }
   };
 };

--- a/.opencode/plugins/superpowers.jsonc
+++ b/.opencode/plugins/superpowers.jsonc
@@ -1,0 +1,16 @@
+// Superpowers Plugin Configuration
+//
+// Priority (lowest to highest):
+//   1. Plugin built-in defaults
+//   2. User config: ~/.config/opencode/plugins/superpowers.jsonc
+//   3. Project config: <project>/.opencode/plugins/superpowers.jsonc
+//
+// Each layer merges/overrides the previous. Arrays are concatenated.
+
+{
+  // Skip superpowers bootstrap injection for agents that should stay clean.
+  "disableBootstrapForAgents": [
+    "no-skills",
+    "empty-no"
+  ]
+}

--- a/tests/opencode/run-tests.sh
+++ b/tests/opencode/run-tests.sh
@@ -58,6 +58,7 @@ done
 
 # List of tests to run (no external dependencies)
 tests=(
+    "test-bootstrap-agent-control.sh"
     "test-plugin-loading.sh"
 )
 

--- a/tests/opencode/test-bootstrap-agent-control.mjs
+++ b/tests/opencode/test-bootstrap-agent-control.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SuperpowersPlugin } from '../../.opencode/plugins/superpowers.js';
+
+const makeOutput = () => ({
+  parts: [{ type: 'text', text: 'hello' }]
+});
+
+const getAgentNameFromInput = (input) => {
+  const candidates = [
+    input?.agent,
+    input?.agent?.name,
+    input?.session?.agent,
+    input?.session?.agent?.name,
+    input?.session?.config?.agent,
+    input?.session?.config?.agent?.name,
+    input?.chat?.agent,
+    input?.chat?.agent?.name,
+    input?.message?.agent,
+    input?.message?.agent?.name,
+    input?.metadata?.agent,
+    input?.metadata?.agent?.name
+  ];
+  return candidates.find((candidate) => typeof candidate === 'string' && candidate.trim()) || null;
+};
+
+const getDisabledBootstrapAgents = (options) => {
+  const agents = options?.disableBootstrapForAgents;
+  return Array.isArray(agents) ? agents.filter((agent) => typeof agent === 'string' && agent.trim()) : [];
+};
+
+const opencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
+const tempRoot = opencodeConfigDir ? path.dirname(opencodeConfigDir) : fs.mkdtempSync(path.join(os.tmpdir(), 'superpowers-plugin-test-'));
+const configRoot = opencodeConfigDir || path.join(tempRoot, '.config', 'opencode');
+const pluginDir = path.join(configRoot, 'plugins');
+const skillsDir = path.join(tempRoot, 'skills', 'using-superpowers');
+fs.mkdirSync(pluginDir, { recursive: true });
+fs.mkdirSync(skillsDir, { recursive: true });
+fs.copyFileSync(new URL('../../.opencode/plugins/superpowers.js', import.meta.url), path.join(pluginDir, 'superpowers.js'));
+fs.writeFileSync(path.join(pluginDir, 'superpowers.jsonc'), JSON.stringify({ disableBootstrapForAgents: ['empty-no', 'no-skills'] }));
+fs.copyFileSync(new URL('../../skills/using-superpowers/SKILL.md', import.meta.url), path.join(skillsDir, 'SKILL.md'));
+
+const pluginModule = await import(`file://${path.join(pluginDir, 'superpowers.js')}`);
+const plugin = await pluginModule.SuperpowersPlugin({}, {});
+const config = {};
+await plugin.config(config);
+const chatMessage = plugin['chat.message'];
+
+assert.deepEqual(getDisabledBootstrapAgents({ disableBootstrapForAgents: ['empty-no', 'no-skills'] }), ['empty-no', 'no-skills']);
+assert.deepEqual(getDisabledBootstrapAgents({}), []);
+assert.equal(getAgentNameFromInput({ agent: 'empty-no' }), 'empty-no');
+assert.equal(getAgentNameFromInput({ session: { agent: { name: 'plan' } } }), 'plan');
+assert.equal(getAgentNameFromInput({ metadata: { agent: 'build' } }), 'build');
+assert.equal(getAgentNameFromInput({}), null);
+
+// Test disabled agent (top-level agent field)
+const disabledTopLevel = makeOutput();
+await chatMessage({ agent: 'empty-no', sessionID: 's1' }, disabledTopLevel);
+assert.equal(disabledTopLevel.parts.length, 1, 'disabled top-level agent should skip bootstrap');
+assert.equal(disabledTopLevel.parts[0].text, 'hello', 'text should be unchanged');
+
+// Test disabled agent (nested agent in session)
+const disabledNested = makeOutput();
+await chatMessage({ session: { agent: { name: 'no-skills' } }, sessionID: 's2' }, disabledNested);
+assert.equal(disabledNested.parts.length, 1, 'disabled nested agent should skip bootstrap');
+assert.equal(disabledNested.parts[0].text, 'hello', 'text should be unchanged');
+
+// Test enabled agent - bootstrap is prepended to output.parts
+const enabledAgent = makeOutput();
+await chatMessage({ agent: 'build', sessionID: 's3' }, enabledAgent);
+assert.equal(enabledAgent.parts.length, 2, 'enabled agent should have 2 parts (bootstrap prepended)');
+assert.match(enabledAgent.parts[0].text, /^<EXTREMELY_IMPORTANT>/, 'bootstrap should be prepended');
+
+// Test second message in same session (should not reinject)
+const secondMessage = makeOutput();
+await chatMessage({ agent: 'build', sessionID: 's3' }, secondMessage);
+assert.equal(secondMessage.parts.length, 1, 'later messages in same session should not reinject bootstrap');
+assert.equal(secondMessage.parts[0].text, 'hello', 'text should be unchanged (no reinject)');
+
+console.log('bootstrap agent control tests passed');
+
+fs.rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/opencode/test-bootstrap-agent-control.sh
+++ b/tests/opencode/test-bootstrap-agent-control.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Test: Bootstrap Agent Control
+# Verifies agent-scoped bootstrap skipping without requiring OpenCode runtime.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== Test: Bootstrap Agent Control ==="
+
+source "$SCRIPT_DIR/setup.sh"
+trap cleanup_test_env EXIT
+
+node "$SCRIPT_DIR/test-bootstrap-agent-control.mjs"
+
+echo ""
+echo "=== Bootstrap agent control test passed ==="


### PR DESCRIPTION
## Summary
- Add `disableBootstrapForAgents` config for per-agent bootstrap skipping
- Fix skills path resolution for various install layouts
- Add `chat.message` hook for agent-scoped bootstrap control
- Add tests for bootstrap agent control

## Motivation
Currently the superpowers plugin injects bootstrap into ALL agents unconditionally. Some agents (like `no-skills`, `empty-no`) should skip bootstrap injection entirely. This change enables that via configuration:

```jsonc
{
  "superpowers": {
    "disableBootstrapForAgents": ["no-skills", "empty-no"]
  }
}
```

## Testing
- `test-bootstrap-agent-control.sh` verifies agents in `disableBootstrapForAgents` skip bootstrap while others receive it