### PR TITLE
fix(cursor): run SessionStart via run-hook.cmd on Windows

### DIFF
--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -3,7 +3,7 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "./hooks/session-start"
+        "command": "./hooks/run-hook.cmd session-start"
       }
     ]
   }


### PR DESCRIPTION
## Problem

On Windows, Cursor runs plugin `sessionStart` hook commands under CMD. The Cursor hooks file pointed at `./hooks/session-start`, an extensionless bash script. CMD does not execute it as bash; Windows shows the file-association / Open with dialog when a new agent session starts.

## Fix

Use the same `run-hook.cmd` polyglot wrapper already used by `hooks/hooks.json` for Claude Code SessionStart: `./hooks/run-hook.cmd session-start`. That locates Git Bash and runs the script.

Plugin-relative `./hooks/...` matches the Cursor plugins reference pattern for hook commands.

## Testing

From the plugin root, `cmd /c ".\hooks\run-hook.cmd session-start"` returns valid JSON with `additional_context` on Windows with Git for Windows installed.
