### PR TITLE
docs: add README banner artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/readme-banner.png" alt="Superpowers banner" width="100%">
+</p>
+
 # Superpowers
 
 Superpowers is a complete software development methodology for your coding agents, built on top of a set of composable skills and some initial instructions that make sure your agent uses them.


### PR DESCRIPTION
## Summary
- add a new README banner image and place it at the top of the README
- store the artwork in `assets/readme-banner.png` so the banner lives in-repo

## Why
This is a very beautiful banner image that gives the project a stronger first impression. It helps improve the README's visual polish and makes the project more compelling for sharing, discovery, and overall promotion.

## Testing
- verified the branch README starts with the new banner block
- verified the new banner asset returns `200 image/png`
