### PR TITLE
Fix: add missing 'no' edge to 'One agent per problem domain' node

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -26,6 +26,7 @@ digraph when_to_use {
     "Parallel dispatch" [shape=box];
 
     "Multiple failures?" -> "Are they independent?" [label="yes"];
+    "Multiple failures?" -> "One agent per problem domain" [label="no" ];
     "Are they independent?" -> "Single agent investigates all" [label="no - related"];
     "Are they independent?" -> "Can they work in parallel?" [label="yes"];
     "Can they work in parallel?" -> "Parallel dispatch" [label="yes"];


### PR DESCRIPTION
## What problem are you trying to solve?
The agent dispatch flowchart (DOT file) had a disconnected node. The decision tree was missing the logical "no" path from the initial "Multiple failures?" diamond. As a result, the "One agent per problem domain" node was floating without any incoming edges, making the diagram incomplete.

## What does this PR change?
It adds the missing `->` connection with the `[label="no"]` condition to the `.dot` file. This connects the "Multiple failures?" node to the "One agent per problem domain" node, completing the intended logic.

## Is this change appropriate for the core library?
Yes, it is a simple bug fix for an existing diagram/documentation file.

## What alternatives did you consider?
N/A. The only alternative was leaving the flowchart logically broken.

## Does this PR contain multiple unrelated changes?
No. It is a single-line fix.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| N/A (Graphviz diagram fix)          |                 |       |                  |

## Evaluation
- What was the initial prompt you (or your human partner) used to start the session that led to this change?
N/A. Spotted manually while reading the skill and rendering the `.dot` file.
- How many eval sessions did you run AFTER making the change?
N/A. Visually confirmed the rendered diagram is now correct.
- How did outcomes change compared to before the change?
The diagram now correctly routes a single failure to a single agent.

## Rigor
*(Note: Some checkboxes left unchecked as this is purely a visual flowchart fix, not a behavior-shaping skills change).*
- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement


## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission