### PR TITLE
fix(brainstorming): use CLAUDE_PLUGIN_ROOT in visual companion script paths

### DIFF
--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -34,7 +34,7 @@ The server watches a directory for HTML files and serves the newest one to the b
 
 ```bash
 # Start server with persistence (mockups saved to project)
-scripts/start-server.sh --project-dir /path/to/project
+${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/start-server.sh --project-dir /path/to/project
 
 # Returns: {"type":"server-started","port":52341,"url":"http://localhost:52341",
 #           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/content",
@@ -52,7 +52,7 @@ Save `screen_dir` and `state_dir` from the response. Tell user to open the URL.
 **Claude Code (macOS / Linux):**
 ```bash
 # Default mode works — the script backgrounds the server itself
-scripts/start-server.sh --project-dir /path/to/project
+${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/start-server.sh --project-dir /path/to/project
 ```
 
 **Claude Code (Windows):**
@@ -60,7 +60,7 @@ scripts/start-server.sh --project-dir /path/to/project
 # Windows auto-detects and uses foreground mode, which blocks the tool call.
 # Use run_in_background: true on the Bash tool call so the server survives
 # across conversation turns.
-scripts/start-server.sh --project-dir /path/to/project
+${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/start-server.sh --project-dir /path/to/project
 ```
 When calling this via the Bash tool, set `run_in_background: true`. Then read `$STATE_DIR/server-info` on the next turn to get the URL and port.
 
@@ -68,14 +68,14 @@ When calling this via the Bash tool, set `run_in_background: true`. Then read `$
 ```bash
 # Codex reaps background processes. The script auto-detects CODEX_CI and
 # switches to foreground mode. Run it normally — no extra flags needed.
-scripts/start-server.sh --project-dir /path/to/project
+${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/start-server.sh --project-dir /path/to/project
 ```
 
 **Gemini CLI:**
 ```bash
 # Use --foreground and set is_background: true on your shell tool call
 # so the process survives across turns
-scripts/start-server.sh --project-dir /path/to/project --foreground
+${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/start-server.sh --project-dir /path/to/project --foreground
 ```
 
 **Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.
@@ -83,7 +83,7 @@ scripts/start-server.sh --project-dir /path/to/project --foreground
 If the URL is unreachable from your browser (common in remote/containerized setups), bind a non-loopback host:
 
 ```bash
-scripts/start-server.sh \
+${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/start-server.sh \
   --project-dir /path/to/project \
   --host 0.0.0.0 \
   --url-host localhost
@@ -276,12 +276,12 @@ If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser 
 ## Cleaning Up
 
 ```bash
-scripts/stop-server.sh $SESSION_DIR
+${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/stop-server.sh $SESSION_DIR
 ```
 
 If the session used `--project-dir`, mockup files persist in `.superpowers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
 
 ## Reference
 
-- Frame template (CSS reference): `scripts/frame-template.html`
-- Helper script (client-side): `scripts/helper.js`
+- Frame template (CSS reference): `${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/frame-template.html`
+- Helper script (client-side): `${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/helper.js`


### PR DESCRIPTION
## What problem are you trying to solve?

When an agent tries to start the visual companion server, it looks for `scripts/start-server.sh` relative to an unspecified working directory. Since the scripts were moved from `lib/brainstorm-server/` to `skills/brainstorming/scripts/` (per the agentskills.io spec), the bare `scripts/` prefix no longer resolves correctly. Agents consistently try the top-level `scripts/` directory (which only contains `bump-version.sh` and `sync-to-codex-plugin.sh`), fail to find `start-server.sh`, and give up — telling the user the visual companion is unavailable.

This was reproduced on Claude Code (Windows + Git Bash) today and is tracked in issue #1134, which was filed the same day by another user experiencing the identical failure mode on macOS.

Exact failure sequence from both reports:
1. Agent runs `scripts/start-server.sh` → not found
2. Agent runs `ls .../superpowers/5.0.7/scripts/` → sees only maintenance scripts
3. Agent concludes "visual companion server scripts aren't available in this version" and falls back to terminal-only brainstorming

## What does this PR change?

Replaces all bare `scripts/` references in `visual-companion.md` with the full `${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/` path. Affects `start-server.sh`, `stop-server.sh`, `frame-template.html`, and `helper.js` references (9 lines total, 1 file).

## Is this change appropriate for the core library?

Yes. This is a documentation fix for a core skill that affects all users on all platforms. The bug causes a reliable failure for any agent following the visual companion guide as written.

## What alternatives did you consider?

- **Add a wrapper in top-level `scripts/`** that delegates to the correct path — rejected, adds unnecessary indirection and a file to maintain.
- **Move scripts back to top-level `scripts/`** — rejected, the current location follows the agentskills.io spec and was an intentional architectural decision.
- **Add a note at the top of `visual-companion.md`** warning about the path — rejected, agents would still copy the wrong path from the code blocks below the note.

## Does this PR contain multiple unrelated changes?

No. Single file, single issue.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found that address script paths. PR #693 (remove bundled node_modules, CLOSED) and PR #700 (portable shebangs, CLOSED) touched the brainstorm server area but not this specific issue.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code (Windows / Git Bash) | 2.1.101 | Claude Sonnet | us.anthropic.claude-sonnet-4-6 |

## Evaluation

- Initial prompt: user asked to use visual brainstorming companion, accepted the offer, agent failed to find `start-server.sh`
- After fix: agent used `${CLAUDE_PLUGIN_ROOT}/skills/brainstorming/scripts/start-server.sh`, server started correctly, session proceeded
- The fix was verified in the same session that reproduced the bug — server launched successfully on the first attempt with the corrected path

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is a path fix in code blocks, not behavior-shaping prose. No skill wording was changed.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission