### PR TITLE
fix(execute-plan): auto-redirect to executing-plans on invocation

### DIFF
--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -2,4 +2,6 @@
 description: "Deprecated - use the superpowers:executing-plans skill instead"
 ---
 
-Tell your human partner that this command is deprecated and will be removed in the next major release. They should ask you to use the "superpowers executing-plans" skill instead.
+Inform your human partner: "`superpowers:execute-plan` is deprecated and will be removed in the next major release. Forwarding to `superpowers:executing-plans` now."
+
+Then immediately invoke the `superpowers:executing-plans` skill using the Skill tool and follow it exactly.


### PR DESCRIPTION
## What problem are you trying to solve?

When `superpowers:execute-plan` is invoked, it only printed a deprecation message asking the human to manually re-invoke `superpowers:executing-plans`. This creates unnecessary friction — the user has to take an extra step after already invoking a skill.

## What does this PR change?

Updates `commands/execute-plan.md` so the old command notifies the human of the deprecation and immediately forwards execution to `superpowers:executing-plans` via the Skill tool. The old command now works transparently as a redirect.

## Is this change appropriate for the core library?

Yes — maintenance change to an existing deprecated command. Reduces friction for users on older setups without affecting users who already call `executing-plans` directly.

## What alternatives did you consider?

- Leaving the message-only behaviour: rejected, requires a manual extra step every time.
- Removing the command entirely: premature before the next major release.

## Does this PR contain multiple unrelated changes?

No. Single-file, single-concern change.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | latest | Claude Sonnet | claude-sonnet-4-5 |

## Evaluation

- Initial prompt: user invoked `superpowers:execute-plan`, received the deprecation message, then said "update the skill".
- Sessions tested after change: 1 (verified redirect fires correctly in the same session).
- Before: user received a static message and had to manually re-invoke the new skill.
- After: old command notifies and immediately forwards — zero extra steps.

## Rigor
- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing
- [x] This change was tested on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language)

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission