### PR TITLE
fix: add missing `name` field to deprecated command frontmatter

### DIFF
--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,4 +1,5 @@
 ---
+name: brainstorm
 description: "Deprecated - use the superpowers:brainstorming skill instead"
 ---
 

--- a/commands/execute-plan.md
+++ b/commands/execute-plan.md
@@ -1,4 +1,5 @@
 ---
+name: execute-plan
 description: "Deprecated - use the superpowers:executing-plans skill instead"
 ---
 

--- a/commands/write-plan.md
+++ b/commands/write-plan.md
@@ -1,4 +1,5 @@
 ---
+name: write-plan
 description: "Deprecated - use the superpowers:writing-plans skill instead"
 ---
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three deprecated command files (`commands/brainstorm.md`, `commands/write-plan.md`, `commands/execute-plan.md`) are missing the required `name` field in their YAML frontmatter.

The Claude Code command schema requires a `name` field to register the canonical command name. Without it, command registration may fall back to the filename or fail entirely. Even though these are deprecation stubs whose only purpose is to redirect users to the successor skills, a malformed frontmatter entry can cause registration failures that surface as confusing errors or silent no-ops.

## Fix

Added the `name` field to each file's frontmatter:

- `commands/brainstorm.md` → `name: brainstorm`
- `commands/write-plan.md` → `name: write-plan`
- `commands/execute-plan.md` → `name: execute-plan`

The fix is minimal — one line added per file, matching the existing frontmatter style.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:e6271ab9a48cfc704cadc2dddfb17f509d1fa1cc5aba0d1ca068decee95d7346"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:c511375774402242cc32f0540b4931a7a616fc909387abef445c59f0911a85c3"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:75c3899150b26fd7000fafac18d2aea7e1915d1d2a675ba8a2ddaabac67cfcf6"}]}
nlpm-metadata-end -->