### PR TITLE
Add Skills宝 as a Chinese install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Then install the plugin from this marketplace:
 /plugin install superpowers@superpowers-marketplace
 ```
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ### OpenAI Codex CLI
 
 - Open plugin search interface


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This fits the marketplace installation flow and gives Chinese users a faster entry point to the skills catalog.