### PR TITLE
writing-skills: add Script vs Prose guidance

### DIFF
--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -371,6 +371,53 @@ pptx/
 ```
 When: Reference material too large for inline
 
+## Script vs Prose
+
+This is a per-step decision during skill authoring, distinct from the per-skill decision in "When to Create a Skill" above (which asks whether to write a skill at all, vs ship a standalone tool).
+
+Skills often mix deterministic steps (data gathering, format conversion, pattern matching) with judgment calls (architecture decisions, risk assessment, priority ranking). Putting both in prose wastes agent reasoning on mechanical work and introduces inconsistency.
+
+**Decision rule:** If a step produces the same output given the same input regardless of who runs it, extract it to a script. Reserve prose for steps that require context, judgment, or adaptation.
+
+| Step Type | Belongs In | Examples |
+|-----------|-----------|----------|
+| **Deterministic** | Script (bash/python) | Collect configs, detect patterns, parse JSON, count occurrences, diff files |
+| **Judgment** | Prose (SKILL.md) | Decide if pattern is intentional, evaluate risk, choose between approaches |
+| **Hybrid** | Script generates report → prose interprets | Audit tools, code analysis, migration planning |
+
+### Pattern: Script + Prose Pipeline
+
+```
+script (gather) → script (analyze) → agent (interpret + decide) → agent (apply)
+```
+
+The skill document orchestrates: it tells the agent WHEN to run each script, WHAT the output means, and WHERE judgment is needed.
+
+````markdown
+### Step 1: Gather Data (scripted)
+```bash
+bash path/to/gather.sh | python3 path/to/analyze.py
+```
+
+### Step 2: Review Report
+Scripts handle: [deterministic parts].
+Agent handles: [judgment calls requiring context].
+````
+
+### Concrete Example: Permissions Audit
+
+A skill that audits project permissions for redundancy splits cleanly:
+- **Deterministic** (script): scan settings files, parse JSON, expand globs, compute subset relationships across permission lists
+- **Judgment** (prose): decide whether a covered entry is intentionally project-specific or should be folded into a user-level glob
+
+Without this split, the agent re-derives subset detection via LLM each run, burning tokens on work a 30-line `analyze.py` does deterministically.
+
+### When NOT to Extract
+
+- Steps that need conversation context or codebase-specific knowledge
+- One-liners that are clearer inline than in a separate file
+- Logic that changes per-project (put adaptation guidance in prose instead)
+
 ## The Iron Law (Same as TDD)
 
 ```
@@ -627,6 +674,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 - [ ] Common mistakes section
 - [ ] No narrative storytelling
 - [ ] Supporting files only for tools or heavy reference
+- [ ] Each step reviewed: deterministic steps extracted to scripts (see Script vs Prose)
 
 **Deployment:**
 - [ ] Commit skill to git and push to your fork (if configured)


### PR DESCRIPTION
## What problem are you trying to solve?

While writing a permissions-audit skill, I followed `writing-skills` and produced a skill where every step was prose, including steps that were fully deterministic — file scanning, glob expansion, subset detection across two permission lists. An agent then executed that skill correctly, but performed all the comparison work via LLM reasoning. Subset detection between two permission lists is mechanical — it should be a script, not prose for an LLM to re-derive each run. I only caught this in self-review, after deploying the skill.

The closest existing guidance is the `When to Create a Skill` bullet at line 59:

> "Mechanical constraints (if it's enforceable with regex/validation, automate it—save documentation for judgment calls)"

That's a **per-skill** test ("should this whole problem be a skill, or should I just ship a tool?"). It does not fire **per step** while authoring, after the skill's scope is already fixed. An agent that has decided "yes, this should be a skill" then drops into step-by-step authoring with no further prompt to re-classify each step as deterministic vs judgment. The failure mode is silent: the skill looks correct, the agent appears to follow it, but the LLM is burning tokens on mechanical work it can't do consistently.

Issue: #1267

## What does this PR change?

Adds a **Script vs Prose** section to `skills/writing-skills/SKILL.md` between "File Organization" and "The Iron Law", and one corresponding item to the Quality Checks list. The section opens by explicitly distinguishing itself from the per-skill rule at line 59, then provides a step-level decision rule (same input → same output ⇒ script), a type-mapping table (Deterministic / Judgment / Hybrid), a pipeline pattern, a concrete permissions-audit worked example, and a "When NOT to Extract" guardrail.

## Is this change appropriate for the core library?

Yes. `writing-skills` is a general-purpose skill that applies to anyone authoring a skill in any harness, regardless of project, tool, or domain. The Script-vs-Prose distinction is a property of skills as a medium (deterministic logic generalizes across runs; judgment doesn't), not specific to any project. There are no third-party dependencies, no integrations with external services, and no reword of behavior-shaping content — the change is purely additive.

## What alternatives did you consider?

1. **Extend line 59 itself** — add ", and for steps within a skill, classify deterministic vs judgment" to the existing `When to Create a Skill` bullet. **Rejected** because that bullet is in a section answering "should I write a skill at all?" — a one-time, top-of-workflow question. The script-vs-prose decision recurs per step, after that question has been answered. Forcing both questions into one bullet weakens both: the per-skill carve-out gets diluted, and the per-step rule gets buried in a section the agent stops re-consulting once it commits to writing the skill.

2. **Extend "File Organization" with a "Script-bearing skill" subsection.** "File Organization" already shows a `pptx/` example with `scripts/` alongside SKILL.md. **Rejected** because that section answers *where files go on disk*, not *what content type each step should be*. An agent reading "File Organization" sees layout, not the decision rule.

3. **Add only the checklist item, no new section.** Smallest possible change. **Rejected** because a checklist item without a referent ("Each step reviewed: deterministic steps extracted to scripts") is a phrase the agent has to interpret with no anchor — exactly the failure mode the issue describes.

4. **Rewrite the existing "Skill Types" section to add a 4th type (Hybrid).** **Rejected** because Skill Types categorizes *whole skills*, not *steps*.

5. **Per #365, extract this guidance to a separate authoring-details file.** PR #365 ("Extract writing-skills appendices to separate reference doc") was closed. I did not contact maintainers to confirm whether that closure means "no further file splits" or "that specific extraction was done badly, try again." If maintainers prefer this section live in a separate file, happy to migrate — flag in review.

## Does this PR contain multiple unrelated changes?

No. Two edits in one file: one new section, one new checklist item that references it. The checklist item is non-functional without the section.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art

I searched closed and open PRs with queries: `writing-skills`, `script prose`, `deterministic`, `1267`, `automation`. Closest prior art:

- **#365 (closed)** — "Extract writing-skills appendices to separate reference doc". Different topic — proposed reorganizing the existing file by extracting reference material to a separate file. Did not introduce new content. Closed. (See alternative #5 above for how this PR relates.)
- **#797 (closed)** — "fix: improve prose consistency, remove unverifiable claims in writing-skills". Different topic — copy-edited existing wording. No new sections.
- **#588 (closed)** — "Skills audit: systematic improvement of all 16 skills". Bulk PR; closed.
- **#1028 (open)** — "docs(writing-skills): add YAML frontmatter quoting guidance". Different topic.
- **#949 (open)** — "docs: relax writing-skills guidance for Codex interop". Different topic — harness compatibility.

No PR addresses the script-vs-prose decision rule. No PR references issue #1267.

## Environment tested

| Harness         | Harness version | Model       | Model version/ID                |
|-----------------|-----------------|-------------|---------------------------------|
| Claude Code CLI | 2.1.119         | Claude Opus | claude-opus-4-7 (1M context)    |

## Evaluation

**Sessions run AFTER the change:** 4 (2 scenarios × 2 conditions, parallel A/B subagents).

**Methodology:** Each subagent received the same authoring task. The only variable was which version of `writing-skills/SKILL.md` it read (baseline = upstream/main, treatment = this PR). Both subagents authored a new SKILL.md from scratch and reported their authoring decisions, including whether they extracted any deterministic logic to supporting scripts and why.

**Two scenarios** (chosen to vary how obvious the deterministic/judgment split is):
1. `auditing-test-coverage-gaps` — measure → classify → prioritize → test. Tooling steps are thin (one-line wrappers around existing coverage tools). Judgment dominates.
2. `detecting-circular-imports` — detect cycles → analyze edges → break one. Detection is deterministic (madge / tsc); edge selection is judgment.

**Outcomes:**

| Scenario | Baseline behavior | Treatment behavior |
|---|---|---|
| coverage-gaps | Authored skill with coverage commands inlined as prose. Authoring note: "I didn't include a separate coverage analysis script. Why? The core skill is the *thinking pattern*, not the tooling." Did not engage with the script-vs-prose question at all. | Authored a structurally similar skill, but explicitly engaged the framework: cited "When NOT to Extract" guardrail, classified the deterministic parts as one-liner-tier, justified the choice. |
| circular-imports | Detection tools and analysis steps mixed in prose. No phase-level classification. | Explicit phase-level classification: "Phase 1 Step 1 includes `madge`, `tsc`, and Node flags because detecting cycles is deterministic, not judgment-based. Phase 2 is prose-only because analyzing *which* edge to break requires understanding the codebase, business constraints, and design philosophy." |

**What changed:** Treatment agents made the decision **visible and principled**. They cited the framework, classified content explicitly, and justified their choices.

**What did NOT change — and limits of this eval (honest disclosure):**

In both N=2 trials the treatment agent ultimately decided *not* to extract scripts. The deterministic logic in these scenarios was thin (one-liner tool invocations) and the "When NOT to Extract" guardrail correctly held. **The positive case — substantial deterministic logic actually triggering script extraction — was not directly observed in this eval.** The original motivating incident (the permissions-audit skill, where subset detection was the deterministic logic) is the historical RED that prompted this work; I did not re-run that exact scenario as a controlled before/after in this session.

I also do not claim the eval simulates realistic authoring pressure. LLMs in chat prompts cannot experience sunk-cost or authority pressure the way a human author can. Adding "you have one shot, no revisions" to a prompt is not equivalent to a 30-minute drift-and-rationalize cycle that's the real failure mode.

Reviewers should weight this accordingly: this eval shows the treatment agent's *reasoning is altered* (script-vs-prose is now a visible, explicit decision rather than an implicit one), and the guardrail does not produce false-positive extraction in two judgment-heavy scenarios. It does not by itself prove that an agent under pressure will extract scripts when they should.

**Iron Law disclosure.** The Iron Law in `writing-skills` says baseline (RED) must be observed *before* writing the skill. I wrote this section first, then ran differential A/B against the unmodified upstream. That is differential evidence, not strict RED-first TDD. The original permissions-audit incident in #1267 is the historical RED that triggered the issue, but I did not re-run it with both conditions in this session. If reviewers prefer the Iron Law be honored strictly, I can revert and re-do RED-first against the permissions-audit scenario.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

The first checkbox is left unchecked deliberately. I invoked `superpowers:writing-skills` and ran differential A/B (described in Evaluation), but I did not run the canonical pressure-testing playbook the skill defines for discipline-enforcing rules (combined time + sunk-cost + authority pressure with a baseline RED phase). My N=2 differential eval is honest evidence that the treatment changes agent reasoning, but it is not what the rigor box asks for. Marking it true would be wrong. If reviewers want the full pressure-test cycle before merging, I can do it on a follow-up.

The second box is checked because the eval explicitly looked for the failure mode (will the framework cause false-positive extraction on judgment-heavy tasks?), not just the success case.

The third box is checked because the change is purely additive: no existing words were modified. The Red Flags table, rationalization tables, and "human partner" language are untouched.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

---

**Submitting as draft for maintainer feedback** before marking ready, given the Iron Law disclosure above and the question in alternative #5 about file location.
