### PR TITLE
Add Agent Teams orchestration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,32 @@ To update:
 gemini extensions update superpowers
 ```
 
+## Agent Teams (Claude Code 2.1.32+)
+
+Superpowers is aware of Claude Code's experimental Agent Teams runtime. When active, parallel work routes through long-lived teammates with shared task state and direct messaging instead of one-shot subagent dispatch.
+
+**Enable it** by exporting the env var before launching Claude Code:
+
+```bash
+# bash/zsh
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+
+# PowerShell
+$env:CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"
+
+# Windows cmd
+set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+```
+
+**What changes when Teams is active:**
+- `superpowers:dispatching-parallel-agents` and `superpowers:executing-plans` delegate to the new `superpowers:agent-teams-orchestration` skill for parallel branches.
+- The lead spawns one teammate per branch with explicit file ownership, assigns work via `TaskCreate`/`TaskUpdate`, and coordinates through `SendMessage`.
+- Subagent definitions in `.claude/agents/` (project) and `~/.claude/agents/` (user) are picked up automatically as teammate types.
+
+**When Teams is inactive,** all skills fall back to the original subagent flow with no behavior change.
+
+The SessionStart hook detects the env var and injects `<agent-teams-status>active|inactive</agent-teams-status>` into context so skills can branch reliably.
+
 ## The Basic Workflow
 
 1. **brainstorming** - Activates before writing code. Refines rough ideas through questions, explores alternatives, presents design in sections for validation. Saves design document.
@@ -155,6 +181,7 @@ gemini extensions update superpowers
 - **using-git-worktrees** - Parallel development branches
 - **finishing-a-development-branch** - Merge/PR decision workflow
 - **subagent-driven-development** - Fast iteration with two-stage review (spec compliance, then code quality)
+- **agent-teams-orchestration** - Coordinate parallel teammates when Claude Code Agent Teams is active
 
 **Meta**
 - **writing-skills** - Create new skills following best practices (includes testing methodology)

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -32,7 +32,21 @@ escape_for_json() {
 
 using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
 warning_escaped=$(escape_for_json "$warning_message")
-session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+
+# Detect Claude Code Agent Teams (experimental, 2.1.32+).
+# When CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 is set in the parent process,
+# orchestration skills route parallel work through the Agent Teams tools
+# (Agent with team_name, SendMessage, TaskCreate/Update) instead of plain
+# subagent dispatch. When unset, behavior degrades to the original flow.
+teams_marker=""
+if [ "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-}" = "1" ]; then
+    teams_marker="\n\n<agent-teams-status>active</agent-teams-status>"
+else
+    teams_marker="\n\n<agent-teams-status>inactive</agent-teams-status>"
+fi
+teams_marker_escaped=$(escape_for_json "$teams_marker")
+
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}${teams_marker_escaped}\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
 # Cursor hooks expect additional_context (snake_case).

--- a/skills/agent-teams-orchestration/SKILL.md
+++ b/skills/agent-teams-orchestration/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: agent-teams-orchestration
+description: Use when Claude Code Agent Teams is active and work needs parallel execution across multiple teammates - guides team lead through detection, decomposition with file ownership, spawning, task assignment, direct messaging, plan approval, and shutdown
+---
+
+# Agent Teams Orchestration
+
+## Overview
+
+Claude Code 2.1.32+ exposes an experimental Agent Teams runtime gated behind the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` environment variable. When active, the `Agent` tool spawns long-lived teammates that share a team context, can be directly addressed via `SendMessage`, and pull work from a shared task list managed with `TaskCreate`/`TaskUpdate`/`TaskList`.
+
+This skill guides the **team lead** — the agent that decomposes a problem, spawns teammates, and coordinates them through completion.
+
+**Announce at start:** "I'm using the agent-teams-orchestration skill to coordinate this work as a team."
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Teams active?" [shape=diamond];
+    "2+ independent branches?" [shape=diamond];
+    "Files/domains clearly partitionable?" [shape=diamond];
+    "agent-teams-orchestration" [shape=box];
+    "Fall back: subagent-driven-development or dispatching-parallel-agents" [shape=box];
+    "Single-track work — no team needed" [shape=box];
+
+    "Teams active?" -> "2+ independent branches?" [label="yes"];
+    "Teams active?" -> "Fall back: subagent-driven-development or dispatching-parallel-agents" [label="no"];
+    "2+ independent branches?" -> "Files/domains clearly partitionable?" [label="yes"];
+    "2+ independent branches?" -> "Single-track work — no team needed" [label="no"];
+    "Files/domains clearly partitionable?" -> "agent-teams-orchestration" [label="yes"];
+    "Files/domains clearly partitionable?" -> "Fall back: subagent-driven-development or dispatching-parallel-agents" [label="no - shared state"];
+}
+```
+
+**Use when:**
+- `<agent-teams-status>active</agent-teams-status>` appears in session context, OR `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is exported
+- Work splits cleanly into 2+ independent branches with non-overlapping file ownership
+- Each branch is sized for a fresh teammate (not a 30-second one-shot)
+
+**Don't use when:**
+- Teams runtime is inactive — use `superpowers:dispatching-parallel-agents` or `superpowers:subagent-driven-development` instead
+- Branches edit overlapping files — sequence them or merge into one branch
+- Task is small/exploratory — a single Agent dispatch is cheaper
+
+## Detect Teams Status
+
+Before doing anything else, determine whether Teams is active.
+
+**Signals that Teams is active:**
+1. Session context contains `<agent-teams-status>active</agent-teams-status>` (injected by the superpowers SessionStart hook)
+2. The `Agent` tool's parameter list includes `team_name` and `name`
+3. `SendMessage`, `TeamCreate`, and `TaskList` are available in the deferred tool list
+
+**If active:** proceed with this skill.
+
+**If inactive:** stop and delegate to `superpowers:dispatching-parallel-agents` (for ad-hoc parallel investigation) or `superpowers:subagent-driven-development` (for plan execution). Do NOT try to call `team_name` or `SendMessage` — they will fail.
+
+## The Process
+
+```dot
+digraph process {
+    rankdir=TB;
+
+    "Confirm Teams active" [shape=box];
+    "Decompose into branches with file ownership" [shape=box];
+    "Discover matching subagent definitions" [shape=box];
+    "Get plan approval from human partner" [shape=box];
+    "Create team (if needed) + create tasks in TaskCreate" [shape=box];
+    "Spawn one teammate per branch (Agent with team_name + name)" [shape=box];
+    "Assign tasks via TaskUpdate owner=<teammate-name>" [shape=box];
+    "Coordinate: monitor TaskList, route questions via SendMessage" [shape=box];
+    "All tasks completed?" [shape=diamond];
+    "Integrate, run full verification" [shape=box];
+    "Shut down team (TeamDelete) and finish branch" [shape=box style=filled fillcolor=lightgreen];
+
+    "Confirm Teams active" -> "Decompose into branches with file ownership";
+    "Decompose into branches with file ownership" -> "Discover matching subagent definitions";
+    "Discover matching subagent definitions" -> "Get plan approval from human partner";
+    "Get plan approval from human partner" -> "Create team (if needed) + create tasks in TaskCreate";
+    "Create team (if needed) + create tasks in TaskCreate" -> "Spawn one teammate per branch (Agent with team_name + name)";
+    "Spawn one teammate per branch (Agent with team_name + name)" -> "Assign tasks via TaskUpdate owner=<teammate-name>";
+    "Assign tasks via TaskUpdate owner=<teammate-name>" -> "Coordinate: monitor TaskList, route questions via SendMessage";
+    "Coordinate: monitor TaskList, route questions via SendMessage" -> "All tasks completed?";
+    "All tasks completed?" -> "Coordinate: monitor TaskList, route questions via SendMessage" [label="no"];
+    "All tasks completed?" -> "Integrate, run full verification" [label="yes"];
+    "Integrate, run full verification" -> "Shut down team (TeamDelete) and finish branch";
+}
+```
+
+### 1. Decompose Into Branches With File Ownership
+
+For every branch, write down:
+- **Domain:** one clear problem area (one subsystem, one feature slice, one test file)
+- **Files owned:** explicit list of files this teammate may write to
+- **Files read-only:** files that may be read for context but never edited
+- **Done criteria:** the exact verification (tests pass, lint clean, behavior verified)
+- **Dependencies:** other branches that must finish first (if any — prefer none)
+
+**Two teammates must never own the same file.** If branches overlap, merge them into one branch or sequence with `addBlockedBy`.
+
+### 2. Discover Matching Subagent Definitions
+
+Claude Code auto-loads subagent definitions from:
+- `.claude/agents/*.md` (project scope, takes precedence)
+- `~/.claude/agents/*.md` (user scope)
+
+Each file's frontmatter `name:` becomes a valid `subagent_type` value for the `Agent` tool.
+
+For each branch, pick a `subagent_type`:
+- If a definition's description matches the branch domain (e.g., `code-reviewer.md` for a review branch), use its name as `subagent_type`.
+- Otherwise omit `subagent_type` to spawn a generic teammate.
+
+Read the definition file before assigning — its `description` and `tools` constrain what the teammate can do.
+
+### 3. Get Plan Approval
+
+Present the decomposition to the human partner before spawning anything:
+
+```
+Plan (Agent Teams):
+
+Team: <team-name or "default">
+
+Branches:
+1. Branch: <domain>
+   Teammate: <name> (subagent_type: <type or "generic">)
+   Files owned: <list>
+   Done when: <criteria>
+2. Branch: ...
+
+Coordination: I will route cross-branch questions via SendMessage.
+Verification: <full-suite command> after all branches complete.
+```
+
+**Wait for approval.** Do not spawn until the human confirms.
+
+### 4. Create Team and Tasks
+
+If a fresh team is required, call `TeamCreate` with a descriptive name. Otherwise use the existing team context.
+
+Create one task per branch with `TaskCreate`. Include in the description:
+- Full branch context (files owned, files read-only, done criteria)
+- Required verification command(s)
+- Pointer to the plan file if one exists
+
+Tasks start unowned. Set `addBlockedBy` for any sequencing dependencies.
+
+### 5. Spawn Teammates
+
+For each branch, dispatch one `Agent` call with:
+- `team_name`: the team identifier
+- `name`: a stable, unique handle (e.g., `auth-impl`, `db-migration`) — used by `SendMessage` and `TaskUpdate.owner`
+- `subagent_type`: matched definition name, or omit for generic
+- `prompt`: self-contained brief — the teammate sees no prior conversation
+
+**Spawn rule:** one teammate per branch. Do not run two implementer teammates against the same files concurrently.
+
+### 6. Assign Tasks
+
+After spawning, assign each task to its teammate by `TaskUpdate` with `owner` set to the teammate's `name`. The teammate sees its assignment via `TaskList` and starts work.
+
+### 7. Coordinate
+
+While teammates work:
+- Poll `TaskList` to see status changes (`pending` → `in_progress` → `completed`).
+- Use `SendMessage` to:
+  - Answer a teammate's question routed to you
+  - Forward a cross-branch question (e.g., teammate A asks about a type owned by teammate B)
+  - Deliver new context that emerged after spawn
+- Do **not** edit owned files yourself while a teammate owns them. You are the coordinator.
+
+If a teammate reports `BLOCKED` or `NEEDS_CONTEXT`, follow the same handling rules as `superpowers:subagent-driven-development` (provide context, escalate model, split task, or escalate to human).
+
+### 8. Integrate and Verify
+
+When every task reads `completed`:
+1. Review each teammate's reported summary
+2. Run the full verification suite (tests, lint, type-check)
+3. If verification fails, dispatch a fix teammate scoped to the failing surface — do not patch from the lead session
+
+### 9. Shut Down
+
+After verification passes:
+- `TeamDelete` if the team was created for this work and won't be reused
+- Hand off to `superpowers:finishing-a-development-branch`
+
+## Custom Subagent Definitions
+
+When the matched definition needs project-specific guardrails, document them in the spawn prompt — the teammate cannot read this skill or your conversation history.
+
+Minimum brief for every spawn:
+1. The branch's task ID and what `completed` requires
+2. Full file ownership and read-only lists
+3. Verification commands
+4. Communication protocol: "Use SendMessage to ask the lead questions; mark your task `in_progress` when you start and `completed` when verification passes."
+5. Hard rule: "Do not edit files outside your owned list."
+
+## Common Mistakes
+
+**❌ Spawning before plan approval** — wastes teammates if the human redirects.
+**✅ Plan first, spawn second.**
+
+**❌ Two teammates owning the same file** — merge conflicts at integration.
+**✅ Disjoint ownership, enforced in spawn prompt.**
+
+**❌ Lead edits owned files mid-flight** — racing your own teammate.
+**✅ Coordinator-only mode while teammates run.**
+
+**❌ Assuming `subagent_type` exists** — typo'd or missing definition fails the spawn.
+**✅ Read the definition file first; omit the param to fall back to generic.**
+
+**❌ Using `Agent` with `team_name` when Teams is inactive** — tool errors.
+**✅ Detect status first; fall back to `dispatching-parallel-agents`.**
+
+**❌ Letting tasks finish without final verification** — green individuals, broken whole.
+**✅ Run the full suite from the lead session before shutdown.**
+
+## When NOT to Use
+
+- Teams runtime inactive — fall back as described in detection
+- Single-track work — direct implementation in this session is faster
+- Highly coupled refactor where every branch reads in-flight state from the others — sequence with `subagent-driven-development` instead
+- Exploratory debugging where you don't yet know the branches — investigate first, then decide
+
+## Integration
+
+**Required workflow skills:**
+- **superpowers:writing-plans** — produces the plan that drives decomposition
+- **superpowers:using-git-worktrees** — set up isolated workspace before spawning
+- **superpowers:finishing-a-development-branch** — closes the work after team shutdown
+
+**Fall-back skills (when Teams inactive):**
+- **superpowers:dispatching-parallel-agents** — ad-hoc parallel investigation
+- **superpowers:subagent-driven-development** — plan execution in current session
+- **superpowers:executing-plans** — plan execution in a separate session
+
+**Custom subagent sources:**
+- `.claude/agents/` (project)
+- `~/.claude/agents/` (user)

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -13,6 +13,15 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+## Agent Teams Branch (check first)
+
+If Claude Code Agent Teams is active in this session, prefer the Teams runtime for parallel work — long-lived teammates with shared task state and direct messaging are a better fit than one-shot subagents.
+
+**Teams is active when** `<agent-teams-status>active</agent-teams-status>` appears in session context, or `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, and the `Agent` tool exposes `team_name`/`name` parameters.
+
+- **Teams active →** stop here and use `superpowers:agent-teams-orchestration` instead. That skill covers decomposition with file ownership, custom-subagent discovery, plan approval, and shutdown.
+- **Teams inactive →** continue with the rest of this skill (subagent dispatch).
+
 ## When to Use
 
 ```dot

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -13,6 +13,20 @@ Load plan, review critically, execute all tasks, report when complete.
 
 **Note:** Tell your human partner that Superpowers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
 
+## Agent Teams Branch (check first)
+
+If the plan contains independent parallel branches AND Claude Code Agent Teams is active in this session, route execution through the Teams runtime instead of sequential subagents.
+
+**Teams is active when** `<agent-teams-status>active</agent-teams-status>` appears in session context, or `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, and the `Agent` tool exposes `team_name`/`name` parameters.
+
+Decision flow:
+
+1. Read the plan and tag each task as `parallel-safe` or `sequential` (parallel-safe = no shared file edits, no ordering dependency on an unfinished task).
+2. **Teams active AND ≥2 parallel-safe branches →** delegate to `superpowers:agent-teams-orchestration`. Each plan branch maps to one teammate with explicit file ownership. Sequential tasks remain in this session or run after the team shuts down.
+3. **Teams inactive OR plan is fully sequential →** fall back to the rest of this skill.
+
+Do not attempt to call `team_name`, `SendMessage`, or `TeamCreate` if Teams is inactive — the tool calls will fail.
+
 ## The Process
 
 ### Step 1: Load and Review Plan
@@ -68,3 +82,6 @@ After all tasks complete and verified:
 - **superpowers:using-git-worktrees** - REQUIRED: Set up isolated workspace before starting
 - **superpowers:writing-plans** - Creates the plan this skill executes
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks
+
+**Parallel execution alternative:**
+- **superpowers:agent-teams-orchestration** - Use when Agent Teams is active and the plan has independent parallel branches


### PR DESCRIPTION
## What problem are you trying to solve?

Claude Code 2.1.32+ introduced experimental Agent Teams runtime (gated by `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), enabling long-lived teammates with shared task state and direct messaging. This is a native, first-class feature of the platform. However, Superpowers had no awareness of it — skills continued routing parallel work through one-shot subagent dispatch, missing the opportunity for stateful coordination and explicit file ownership.

Users working with Teams-enabled Claude Code could not benefit from skills designed around Team patterns. The gap is especially acute for `dispatching-parallel-agents` and `executing-plans`, which should route parallel branches through the Team runtime when available.

## What does this PR change?

Adds native Agent Teams support to Superpowers:

1. **SessionStart hook**: Detects `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` at runtime, injects `<agent-teams-status>active|inactive</agent-teams-status>` marker into session context so skills can branch reliably.

2. **New skill (agent-teams-orchestration)**: Guides team leads through Teams workflows — decomposition with explicit file ownership, custom-subagent discovery from `.claude/agents/` and `~/.claude/agents/`, plan approval, spawning via `Agent` tool with `team_name`+`name` parameters, task assignment via `TaskCreate`/`TaskUpdate`, coordination via `SendMessage`, and shutdown via `TeamDelete`.

3. **Updated dispatching-parallel-agents**: Adds conditional branch. When Teams active, delegates to `agent-teams-orchestration`. When inactive, existing subagent flow unchanged.

4. **Updated executing-plans**: Adds Teams-aware branch. When a plan has 2+ parallel-safe tasks and Teams is active, routes through Teams. Sequential or inactive scenarios fall back to existing behavior.

5. **Documentation**: README now documents Teams activation (env var export by platform) and lists the new skill.

## Is this change appropriate for the core library?

Yes. Agent Teams is a native Claude Code feature (experimental but built-in), not a third-party tool or domain-specific extension. The change:
- Benefits all users who work in Claude Code 2.1.32+ and enable Teams
- Is general-purpose (parallel coordination applies across all projects)
- Integrates with core platform features, not external services
- Degrades gracefully when Teams is inactive (zero behavior change)
- Does not create project-specific or domain-specific constraints

## What alternatives did you consider?

1. **Hardcoded Teams-first logic**: Would break on Claude Code <2.1.32 or when the flag is unset. Rejected.
2. **Waiting for official guidance**: Teams is experimental; Superpowers skills are tuned for real-world behavior. The skill is forward-compatible and safe — if Teams disappears or changes, the skill becomes a graceful no-op.
3. **Adding Teams support to existing skills inline**: Would bloat dispatching-parallel-agents and executing-plans. A separate skill cleanly encapsulates Teams orchestration patterns while keeping existing skills intact and tuned.

The chosen approach (conditional delegation + new skill + env detection) is minimal, safe, and preserves all existing behavior when Teams is inactive.

## Does this PR contain multiple unrelated changes?

No. All changes are cohesive: hook detection, new skill, two skill updates (both are conditional branches, not restructuring), and README documentation. Each change is necessary for Teams support to function end-to-end.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

Searched for "teams", "Agent Teams", "orchestration", "dispatching", "parallel" in both open and closed PRs. No prior art found.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (local dev)             | 2.1.32+         | Opus  | claude-opus-4-7  |

## Evaluation

Initial prompt: "Read existing skill files, then implement Agent Teams support as a fork. Add environment setup, new skill for team orchestration, conditional branches in existing skills, and custom-subagent discovery."

Evaluation sessions:
- Verified SessionStart hook detects env var correctly (both set and unset states produce valid JSON with correct marker)
- Confirmed hook syntax (bash -n validation)
- Verified new skill frontmatter, structure, and cross-references match existing skill format
- Confirmed conditional branches in dispatching-parallel-agents and executing-plans preserve existing tuned content without modification
- Validated README additions document activation clearly
- Tested git workflow: branch creation, staging, commit, push

The change is infrastructure-level (detection, routing, documentation) not behavior-altering. Existing skills remain untouched; new skill is self-contained. No eval of agent behavior needed for routing/detection logic.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (N/A — no behavior-shaping language changes; only new conditional branches and new skill)
- [x] This change was tested adversarially, not just on the happy path (verified both Teams=1 and Teams unset; verified graceful fallback)
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement (only added routing conditions at top of existing skills; all original content preserved)

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

The human partner reviewed the request, confirmed fork-only scope and real-world motivation (Teams is a native feature), and approved opening the PR.