### PR TITLE
docs(subagent-driven-development): add Cost Discipline section

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -99,6 +99,32 @@ Use the least powerful model that can handle each role to conserve cost and incr
 - Touches multiple files with integration concerns → standard model
 - Requires design judgment or broad codebase understanding → most capable model
 
+## Cost Discipline
+
+**The orchestrator is on the most expensive model. Every orchestrator turn re-bills the accumulated session context. The dominant cost lever in long subagent-driven sessions is keeping mechanical work *out* of the orchestrator — not skipping reviews on trivial files.**
+
+**The drift trap.** Early in a session, dispatching subagents feels natural. As the session progresses and the orchestrator's context grows, "I'll just do this one inline because it's a 3-line edit" starts to feel faster than dispatching. It is faster — *for that single edit*. But:
+
+- The orchestrator session is on the most capable (most expensive) model.
+- Each new turn re-bills the entire growing context (with cache discount, but still at top tier).
+- The same edit on a fresh subagent costs ~1/5 as much because the subagent only sees the focused brief, not the session history.
+- Across a 20-task plan, drifting from "always dispatch" to "sometimes inline" can double total session cost.
+
+**The decision rule.** If the next action is to write code (any quantity, any file, any reason), dispatch a subagent. Reserve the orchestrator turn for: design tradeoffs, edge-case reasoning, debugging non-obvious issues, adversarial review, judgment calls.
+
+**Watch for the drift trigger.** "I'll just do this one inline because it's a 3-line edit / one tool call / a quick fix" — that thought *is* the failure mode. Dispatch anyway. Three lines on a subagent costs the same as 30 lines, and the subagent doesn't pollute the orchestrator's context.
+
+**This rule applies during post-review fixes too.** When a reviewer flags issues and the implementer subagent has already returned its result, the temptation is to apply the fixes inline ("just two small edits"). Dispatch a fix subagent every time, with the specific changes to apply.
+
+**Reservation list — orchestrator may edit inline ONLY when:**
+- Reverting a clearly broken subagent output where re-dispatching would take longer than the undo
+- Editing within a single tool call as part of demonstrating something interactively to the user
+- Updating session-level memory or scratch files (orchestrator state, not codebase work)
+
+**Self-check.** If the orchestrator has done >2 inline mechanical edits on the codebase in a single session, stop and explicitly ask whether you've drifted. If you have, dispatch the remaining work and resume orchestration mode.
+
+**Reviews are not the cost driver.** The per-task spec + quality reviews described above feel like overhead, but they're the cheap part — typically a few cents each on standard or cheap models. Skipping them to save cost is false economy. Skipping the inline-drift discipline is the real lever.
+
 ## Handling Implementer Status
 
 Implementer subagents report one of four statuses. Handle each appropriately:
@@ -246,6 +272,7 @@ Done!
 - Let implementer self-review replace actual review (both are needed)
 - **Start code quality review before spec compliance is ✅** (wrong order)
 - Move to next task while either review has open issues
+- **Edit code inline as the orchestrator** — even small mechanical edits, even "one tool call," even when "it would be faster than dispatching." See the Cost Discipline section above. The drift to inline edits is the dominant cost leak in long sessions.
 
 **If subagent asks questions:**
 - Answer clearly and completely


### PR DESCRIPTION
## Why

The skill's existing **Model Selection** section names the right model per task type but doesn't call out the dominant *failure mode* in long subagent-driven sessions: the orchestrator gradually drifting from "always dispatch a cheaper subagent" to "I'll just do this one inline because it's a 3-line edit." Each inline edit re-bills the orchestrator's growing session context at the most expensive tier, so the drift compounds turn-over-turn rather than staying flat.

In a 20-task implementation session I ran end-to-end recently, I started clean (T1-T10 all dispatched to Sonnet), then drifted into inline Opus edits for ~T11 onward and again for the post-review fix loop. Post-hoc accounting showed the inline drift was approximately **half** the total session cost. The fix would have been one consistent rule: *if the next action is to write code, dispatch a subagent.*

The skill's `## Red Flags` section already says **"If subagent fails task: Don't try to fix manually (context pollution)"** — but that rule is scoped only to the failure case, not to the much more common drift case where the orchestrator just *thinks* an edit is small enough to do inline. This PR widens that guidance.

## What this changes

1. **New `## Cost Discipline` section** between `Model Selection` and `Handling Implementer Status`. Names:
   - The drift trap and why it compounds (growing context × top-tier rebill)
   - The decision rule (`if write code → dispatch`)
   - The trigger phrase to watch for (`"I'll just do this one inline because…"`)
   - The post-review fix loop as the highest-risk drift surface
   - A reservation list of the few legitimate inline-edit cases (revert a broken subagent output, demonstrate interactively, update orchestrator-state files)
   - A self-check trigger (`>2 inline edits on the codebase → stop and ask if you've drifted`)
   - An explicit clarification that **per-task reviews are not the cost driver** — skipping reviews to "save cost" is false economy compared to fixing the inline-drift discipline

2. **One new bullet in `## Red Flags → Never:`** cross-referencing the new section, so an orchestrator scanning the Red Flags list catches the rule there too:

   > **Edit code inline as the orchestrator** — even small mechanical edits, even "one tool call," even when "it would be faster than dispatching." See the Cost Discipline section above. The drift to inline edits is the dominant cost leak in long sessions.

## What this does NOT change

No edits to the existing process flowchart, model-selection guidance, dispatch templates (implementer/spec-reviewer/code-quality-reviewer), the example workflow, or the integration list with other skills. The change is additive — clarifying an existing principle that the skill already gestured at, and naming the failure mode it most often shows up as.

## Style notes

Followed the surrounding section's voice and formatting: bolded lead, paragraph-then-bullets structure, periods inside quoted thought-bubbles. Section ordering puts `Cost Discipline` after `Model Selection` because the two compose ("which model" + "where the work runs") and a reader who's just made a model decision is exactly the audience that needs the discipline reminder next.

Happy to revise tone/length if it overshoots the skill's usual brevity bar — easy to trim.