### PR TITLE
feat: add workflow chain encoding to skill descriptions + skill graph health check

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -3,6 +3,7 @@
  *
  * Injects superpowers bootstrap context via system prompt transform.
  * Auto-registers skills directory via config hook (no symlinks needed).
+ * Validates skill graph integrity at startup and surfaces warnings.
  */
 
 import path from 'path';
@@ -46,11 +47,77 @@ const normalizePath = (p, homeDir) => {
   return path.resolve(normalized);
 };
 
+// Expected skills that must exist for the workflow graph to be consistent.
+// Update this list when adding/removing skills from the repository.
+const EXPECTED_SKILLS = [
+  'brainstorming',
+  'dispatching-parallel-agents',
+  'executing-plans',
+  'finishing-a-development-branch',
+  'receiving-code-review',
+  'requesting-code-review',
+  'subagent-driven-development',
+  'systematic-debugging',
+  'test-driven-development',
+  'using-git-worktrees',
+  'using-superpowers',
+  'verification-before-completion',
+  'writing-plans',
+  'writing-skills',
+];
+
+// Validate that all expected skills exist on disk.
+// Returns { missing: string[], extra: string[] }
+const validateSkillGraph = (skillsDir) => {
+  const missing = [];
+  const extra = [];
+
+  // Check expected skills
+  for (const name of EXPECTED_SKILLS) {
+    const skillFile = path.join(skillsDir, name, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) {
+      missing.push(name);
+    }
+  }
+
+  // Check for unexpected skill directories (not in EXPECTED_SKILLS)
+  try {
+    const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory() && !EXPECTED_SKILLS.includes(entry.name)) {
+        const hasSkillMd = fs.existsSync(path.join(skillsDir, entry.name, 'SKILL.md'));
+        if (hasSkillMd) {
+          extra.push(entry.name);
+        }
+      }
+    }
+  } catch {
+    // skillsDir may not exist yet
+  }
+
+  return { missing, extra };
+};
+
 export const SuperpowersPlugin = async ({ client, directory }) => {
   const homeDir = os.homedir();
   const superpowersSkillsDir = path.resolve(__dirname, '../../skills');
   const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
   const configDir = envConfigDir || path.join(homeDir, '.config/opencode');
+
+  // Run skill graph health check at startup
+  const healthCheck = validateSkillGraph(superpowersSkillsDir);
+  const hasWarnings = healthCheck.missing.length > 0 || healthCheck.extra.length > 0;
+  if (hasWarnings) {
+    if (healthCheck.missing.length > 0) {
+      console.warn(`[superpowers] ⚠️ Missing skills: ${healthCheck.missing.join(', ')}`);
+    }
+    if (healthCheck.extra.length > 0) {
+      console.warn(`[superpowers] ℹ️ Unregistered skills (not in EXPECTED_SKILLS): ${healthCheck.extra.join(', ')}`);
+    }
+    console.warn('[superpowers] Run `git pull` in the superpowers directory or update EXPECTED_SKILLS in the plugin to fix.');
+  } else {
+    console.log('[superpowers] ✅ Skill graph validated: all 14 skills present, no orphans');
+  }
 
   // Helper to generate bootstrap content
   const getBootstrapContent = () => {
@@ -105,8 +172,15 @@ ${toolMapping}
       if (!firstUser || !firstUser.parts.length) return;
       // Only inject once
       if (firstUser.parts.some(p => p.type === 'text' && p.text.includes('EXTREMELY_IMPORTANT'))) return;
+
+      // Build health warning if skills are missing
+      let healthWarning = '';
+      if (hasWarnings && healthCheck.missing.length > 0) {
+        healthWarning = `\n\n<SUPERPOWERS_HEALTH_WARNING>\n⚠️ Skill graph inconsistency detected: ${healthCheck.missing.length} skill(s) missing — ${healthCheck.missing.map(s => `\`${s}\``).join(', ')}. Workflow links referencing these skills may be broken. Inform the user and suggest running \`git pull\` in the superpowers directory or checking skill installation.\n</SUPERPOWERS_HEALTH_WARNING>`;
+      }
+
       const ref = firstUser.parts[0];
-      firstUser.parts.unshift({ ...ref, type: 'text', text: bootstrap });
+      firstUser.parts.unshift({ ...ref, type: 'text', text: bootstrap + healthWarning });
     }
   };
 };

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorming
-description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+description: "You MUST use this before any creative work. Explores intent, requirements, design. Chain: upstream→product-requirements(if no PRD); parallel→mcu-selection(if embedded); downstream→writing-plans(HARD GATE: design approved→plans only, no code). Skip if: ≤3 files or mechanical change"
 ---
 
 # Brainstorming Ideas Into Designs

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatching-parallel-agents
-description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
+description: "Use when facing 2+ independent tasks that can be worked on without shared state. Chain: downstream→verification-before-completion(verify each agent result). Anti-pattern: dispatch on related failures, shared state, or exploratory debugging. Focus: one problem domain per agent, specific scope and output"
 ---
 
 # Dispatching Parallel Agents

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: executing-plans
-description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
+description: "Execute plan inline with batch checkpoints. Chain: requires→using-git-worktrees; uses→careful,freeze,karpathy-guidelines; downstream→finishing-a-development-branch. Alternative→subagent-driven-development(same-session,subagent-per-task)"
 ---
 
 # Executing Plans

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-development-branch
-description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+description: "Implementation done, tests pass, decide how to integrate. Chain: called by→subagent-driven-development,executing-plans; verifies via→verification-before-completion,requesting-code-review; pairs with→using-git-worktrees(cleanup). 4 options: merge, PR, keep, discard"
 ---
 
 # Finishing a Development Branch

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+description: "Use when receiving code review feedback, before implementing suggestions. Chain: pairs with→requesting-code-review; upstream→finishing-a-development-branch(review before merge). Verify before implementing. Push back with technical reasoning if wrong. No performative agreement"
 ---
 
 # Code Review Reception

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requesting-code-review
-description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+description: "Use when completing tasks, implementing major features, or before merging. Chain: comes after→verification-before-completion; leads to→receiving-code-review; upstream→finishing-a-development-branch. Template-based review with specific criteria categories"
 ---
 
 # Requesting Code Review

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-driven-development
-description: Use when executing implementation plans with independent tasks in the current session
+description: "Execute plan with fresh subagent per task + two-stage review. Chain: requires→using-git-worktrees; uses→test-driven-development,careful,freeze,karpathy-guidelines; downstream→finishing-a-development-branch. Preferred over executing-plans for same-session work"
 ---
 
 # Subagent-Driven Development

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systematic-debugging
-description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+description: "Use on ANY bug/failure/unexpected behavior BEFORE proposing fixes. Chain: invoke freeze first(lock scope→fault module), careful(if hw register/flash ops); Phase4→TDD(create failing test),verification(confirm fix). 4 phases: root cause→pattern→hypothesis→implementation. 3+ failed fixes→question architecture"
 ---
 
 # Systematic Debugging

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Use when implementing any feature or bugfix, before writing implementation code
+description: "Write test first, watch it fail, then minimal code to pass. RED→GREEN→REFACTOR. Chain: RED input←test-cases(if generated from PRD); downstream→verification-before-completion(confirm green); also used by→systematic-debugging(Phase4),subagent-driven-development. Iron Law: NO code without failing test first"
 ---
 
 # Test-Driven Development (TDD)

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification
+description: "Use when starting feature work needing isolation or before executing implementation plans. Chain: required by→subagent-driven-development,executing-plans; pairs with→finishing-a-development-branch(worktree cleanup). Creates isolated workspace away from main branch"
 ---
 
 # Using Git Worktrees

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-superpowers
-description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+description: "Session entry point. Route: new project→product-requirements→brainstorming→writing-plans; feature→brainstorming; bug→systematic-debugging+freeze+careful; embedded→mcu-selection; traceability→sparv; See workflow-graph.md"
 ---
 
 <SUBAGENT-STOP>

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-before-completion
-description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+description: "MANDATORY before claiming done/fixed/passing. Run verification commands, confirm output, then claim. Chain: triggered by→TDD(confirm green),systematic-debugging(confirm fix),finishing-a-development-branch(pre-merge). Iron Law: NO completion claims without fresh verification evidence"
 ---
 
 # Verification Before Completion

--- a/skills/workflow-graph.md
+++ b/skills/workflow-graph.md
@@ -1,0 +1,80 @@
+# Superpowers Workflow Graph
+
+This file defines the workflow linkage between all superpowers skills. Referenced by `using-superpowers`.
+
+## Primary Workflow (New Project / Major Feature)
+
+```
+using-superpowers (entry point)
+        │
+        ▼
+brainstorming ←─ product-requirements (if no PRD)
+        │              │
+   mcu-selection       │ (PRD)
+   (if embedded)       │
+        │              ▼
+        │         test-cases
+        │              │
+        ▼              │
+writing-plans ◄────────┘
+        │
+        ├──► subagent-driven-development (recommended)
+        │         │
+        │    using-git-worktrees
+        │    careful / freeze / karpathy-guidelines
+        │    test-driven-development ← test-cases
+        │    verification-before-completion
+        │    requesting-code-review → receiving-code-review
+        │         │
+        │         ▼
+        │    finishing-a-development-branch
+        │
+        └──► executing-plans (alternative)
+                  │
+             (same quality chain as above)
+```
+
+## Debugging Branch
+
+```
+systematic-debugging (on any bug/failure)
+        │
+        ├── freeze (lock scope to fault module FIRST)
+        ├── careful (if hw register / flash operations)
+        │
+        ▼ Phase 1-3: Root cause investigation
+        │
+        ▼ Phase 4: Implementation
+        ├── test-driven-development (create failing test)
+        │     └── test-cases (if available, use as RED input)
+        └── verification-before-completion (confirm fix)
+```
+
+## Test Chain (Requirements → Verification)
+
+```
+product-requirements
+        │ (acceptance criteria)
+        ▼
+test-cases (generate structured test cases)
+        │ (test case list)
+        ├──► test-driven-development (RED: use as first failing tests)
+        └──► verification-before-completion (GREEN: all must pass)
+```
+
+## Skill Development Branch
+
+```
+writing-skills (TDD for documentation) ◄──► skill-creator (evaluate, benchmark, optimize)
+```
+
+## Entry Routing
+
+| Task type | Route to | Skip when |
+|-----------|----------|-----------|
+| New project, unclear requirements | `product-requirements` → `brainstorming` | Task scope ≤3 files AND no new hardware |
+| Feature to add, requirements clear | `brainstorming` | Mechanical change (rename, config) |
+| Bug / test failure | `systematic-debugging` + `freeze` | Never skip |
+| Embedded/hardware project | `mcu-selection` during `brainstorming` | MCU already chosen |
+| Need new capability | `find-skills` → `skill-install` | N/A |
+| Create/edit a skill | `writing-skills` → `skill-creator` | N/A |

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: Use when you have a spec or requirements for a multi-step task, before touching code
+description: "Convert spec/requirements to step-by-step implementation plan. Chain: upstream←brainstorming,product-requirements,mcu-selection; downstream→subagent-driven-development|executing-plans+test-cases. Zero-context assumption, 2-5min tasks"
 ---
 
 # Writing Plans

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-skills
-description: Use when creating new skills, editing existing skills, or verifying skills work before deployment
+description: "TDD for process docs: write failing test→write skill→refactor. Chain: complementary with→skill-creator(evaluate,benchmark,optimize). Also used by→skill-install(validates skill quality). Applies same RED→GREEN→REFACTOR cycle to documentation as code"
 ---
 
 # Writing Skills


### PR DESCRIPTION
## Summary

Two enhancements to improve cross-skill workflow coordination, especially for platforms without plugin-level injection (e.g. Claude Code, Codex):

### 1. Workflow Chain Encoding in Skill Descriptions

Encodes upstream/downstream skill linkage directly into each skill's frontmatter description field. This makes workflow relationships **crop-resistant** — even when LLM context is heavily pruned, the description (being short metadata) survives truncation and continues guiding skill discovery.

**Pattern:** Each skill description now includes Chain: upstream←X; downstream→Y encoding.

**Example (before):**
`
description: Use on ANY bug/failure/unexpected behavior BEFORE proposing fixes.
`

**Example (after):**  
`
description: Use on ANY bug/failure/unexpected behavior BEFORE proposing fixes. Chain: invoke freeze first(lock scope→fault module), careful(if hw registers/flash ops); Phase4→test-driven-development(failing test), verification-before-completion(confirm fix). NEVER skip. Signal words: bug,failure,error,crash,regression
`

This covers all 14 superpowers skills with proper chain encoding, following the design from Claude Code's self-review of workflow linkage gaps.

### 2. Skill Graph Health Check in Plugin

Adds a alidateSkillGraph() function to superpowers.js that:
- Compares actual skill directories against an EXPECTED_SKILLS allowlist
- Detects missing skills (broken junction, deleted directory)
- Detects unregistered skills (new skill not in allowlist)
- Emits warnings via **dual channels**: console.warn for terminal visibility + SUPERPOWERS_HEALTH_WARNING injection for LLM context awareness
- Runs automatically on plugin load

This ensures the skill graph integrity is verified at startup, catching configuration drift early.

### Files Changed (16 files, +169/-15 lines)

- **14 skill SKILL.md files**: Added chain encoding to description frontmatter
- **skills/workflow-graph.md** (new): Visual workflow graph for documentation
- **.opencode/plugins/superpowers.js**: Added alidateSkillGraph() + EXPECTED_SKILLS allowlist + dual-channel health warnings

### Testing

- Positive test: All 14 skills present → ll 14 skills present in graph 
- Negative test: Renamed skill → Detected Missing: brainstorming + Unregistered: brainstorming_test_backup
- Plugin loads and executes health check successfully on OpenCode startup