### PR TITLE
fix(cursor): run sessionStart via run-hook.cmd on Windows

### DIFF
--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -3,7 +3,7 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "./hooks/session-start"
+        "command": "./hooks/run-hook.cmd session-start"
       }
     ]
   }


### PR DESCRIPTION
## Problem
On Windows, \hooks-cursor.json\ pointed at the extensionless bash \session-start\ script. The OS/Cursor hook runner often does not execute it as bash, so the file is opened in the default app (editor) or triggers an **Open with** dialog on each new Agent chat (\sessionStart\).

## Change
Use the existing \un-hook.cmd\ dispatcher (same as Claude Code \hooks.json\) so Git Bash runs \session-start\ and prints JSON as intended.

## Verification
- Ran \un-hook.cmd session-start\ with \CURSOR_PLUGIN_ROOT\ set; stdout is valid JSON with \dditional_context\.


Made with [Cursor](https://cursor.com)