### PR TITLE
brainstorming: require explicit user-facing-surface checks

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -88,8 +88,20 @@ digraph brainstorming {
 - Once you believe you understand what you're building, present the design
 - Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
 - Ask after each section whether it looks right so far
-- Cover: architecture, components, data flow, error handling, testing
+- Cover: architecture, components, data flow, error handling, testing, **user-facing surface** (see below)
 - Be ready to go back and clarify if something doesn't make sense
+
+**User-facing surface (REQUIRED for any feature a human will see or interact with):**
+
+A working endpoint and a rendering component is not the same as a usable feature. Every spec for a UI-touching feature MUST explicitly answer:
+
+1. **Discoverability** — How does the target user find this? Name the navigation entry, breadcrumb, link, or surfacing. "It's at `/admin/x`" is not an answer; users don't memorise URLs. If the answer is "no nav yet, will add later," the spec must include the nav as part of THIS feature, not a follow-up MR.
+2. **Empty / loading / error states** — What does the user see before data loads, when there is none, and when something fails? For each error path, write the exact copy the user will see. "Show an error" is not a spec; "Show 'Domain already exists in the blocklist.'" is.
+3. **Realistic-content edge cases** — If the feature renders content (article body, list of items, overlay), what happens at the realistic ends of the distribution? An overlay over a 1-paragraph stub is not the same as over a 5,000-word article. Specify what scale the design assumes and what degrades.
+4. **Copy redundancy / tone** — Read every user-visible string the feature ships. Does the same identity / call-to-action / disclaimer appear in two places? If yes, justify or remove. Does the tone match neighbouring features (formal vs casual, terse vs verbose)?
+5. **Permission gating from the user's view** — If the feature is role-gated, what does an unauthorised user see? A 403 page, a hidden nav item, a disabled control with a tooltip? Pick one explicitly.
+
+These are the failure modes that ship "technically correct" features that are unusable. Every UI spec MUST address all five before transitioning to writing-plans. Non-UI features (pure backend services, internal pipelines) can skip this section but should say so.
 
 **Design for isolation and clarity:**
 
@@ -120,6 +132,7 @@ After writing the spec document, look at it with fresh eyes:
 2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
 3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
 4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+5. **User-facing surface check (UI features only):** Does the spec answer all five points from the "User-facing surface" section above — discoverability (named nav entry), empty/loading/error states with exact copy, realistic-content edge cases, copy redundancy/tone, permission gating from user's view? A spec that ships "the page exists at /x/y" without saying how a user finds /x/y is incomplete. Add the missing surfaces to the spec; do not defer to "follow-up MR."
 
 Fix any issues inline. No need to re-review — just fix and move on.
 


### PR DESCRIPTION
## Summary

Adds a mandatory **User-facing surface** subsection to the design presentation phase of the brainstorming skill, plus a corresponding self-review check. Catches a recurring failure mode I keep hitting: shipping "technically correct" features that are unusable because the spec didn't enumerate the human-facing surface.

## Motivation

The current spec template covers architecture / components / data flow / error handling / testing — but does **not** explicitly require the spec to answer how a user *discovers* or *perceives* the feature. So specs end up dutifully describing routes and components while skipping nav links, exact error copy, redundant disclosures, and realistic-content edge cases. Implementation faithfully follows the spec, ships the gap, and the user finds it instead.

Concrete examples I've personally hit (and a colleague rightly called out today):

- Admin settings pages built at `/hub/settings/email-validation` with no sidebar entry — invisible until URL is memorised.
- Duplicate-detection error showing raw `API error 409: {"detail":"..."}` instead of the friendly copy intended.
- Email-gate overlay tested on placeholder seed content (1 paragraph, 0 H2s) so the visual effect didn't surface — but on real 5,000-word whitepapers it would.
- Widget identity declared in three places (header subtitle, greeting, GDPR disclosure), creating redundant copy.

These all share the same root cause: the spec didn't make me answer the question *before* writing-plans was invoked.

## Changes

### `skills/brainstorming/SKILL.md`

**1. Design presentation phase** — new mandatory subsection after the "Cover" line, with five explicit checks:

1. **Discoverability** — named nav entry / breadcrumb / link, not "it's at /admin/x". URL-only access is disqualifying. If the answer is "no nav yet," the spec must include the nav as part of THIS feature, not a follow-up MR.
2. **Empty / loading / error states** — exact copy for each, not "show an error".
3. **Realistic-content edge cases** — overlay over a 1-paragraph stub is not the same as over a 5000-word article; specify the scale the design assumes and what degrades.
4. **Copy redundancy / tone** — read every user-visible string the feature ships. Does the same identity / CTA / disclaimer appear in two places?
5. **Permission gating from user's view** — 403 page, hidden nav, disabled control with tooltip? Pick one.

Non-UI features (pure backend, internal pipelines) can opt out by saying so.

**2. Spec self-review** — gains a 5th check that verifies the section is filled in, with explicit anti-loophole language: *"Add the missing surfaces to the spec; do not defer to 'follow-up MR.'"*

## Testing

The skill is text instruction; no automated tests apply. I've already applied this guidance to in-flight work in my own codebase and the gap surfaced immediately on a re-review of the most recent design.

## Notes

- Diff is 14 insertions, 1 deletion. Surgical.
- Section was placed alongside the existing "Cover: architecture, components, data flow, error handling, testing" line so it's encountered at the same point in the workflow rather than as a tacked-on appendix.
- Anti-loophole language ("do not defer to 'follow-up MR'") is intentional — the failure mode is that it's tempting to ship the page first and add nav "next sprint."

🤖 Co-authored with Claude Opus 4.7 — I drafted the change in collaboration with my Claude Code session after a colleague (mike.chew) named the recurring pattern in plain language.