### PR TITLE
[codex] docs: clarify OpenCode install caveats

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -14,9 +14,13 @@ Add superpowers to the `plugin` array in your `opencode.json` (global or project
 }
 ```
 
-Restart OpenCode. That's it — the plugin auto-installs and registers all skills.
+Restart OpenCode. The plugin installs through OpenCode's plugin manager and
+registers all skills.
 
 Verify by asking: "Tell me about your superpowers"
+
+OpenCode uses its own plugin install. If you also use Claude Code, Codex, or
+another harness, install Superpowers separately for each one.
 
 ## Migrating from the old symlink-based install
 
@@ -46,7 +50,10 @@ use skill tool to load superpowers/brainstorming
 
 ## Updating
 
-Superpowers updates automatically when you restart OpenCode.
+OpenCode installs Superpowers through a git-backed package spec. Some OpenCode
+and Bun versions pin that resolved git dependency in a lockfile or cache, so a
+restart may not pick up the newest Superpowers commit. If updates do not appear,
+clear OpenCode's package cache or reinstall the plugin.
 
 To pin a specific version:
 
@@ -63,6 +70,26 @@ To pin a specific version:
 1. Check logs: `opencode run --print-logs "hello" 2>&1 | grep -i superpowers`
 2. Verify the plugin line in your `opencode.json`
 3. Make sure you're running a recent version of OpenCode
+
+### Windows install issues
+
+Some Windows OpenCode builds have upstream installer issues with git-backed
+plugin specs, including cache paths for `git+https` URLs and Bun not finding
+`git.exe` even when it works in a normal terminal. If OpenCode cannot install
+the plugin, try installing with system npm and pointing OpenCode at the local
+package:
+
+```powershell
+npm install superpowers@git+https://github.com/obra/superpowers.git --prefix "$HOME\.config\opencode"
+```
+
+Then use the installed package path in `opencode.json`:
+
+```json
+{
+  "plugin": ["~/.config/opencode/node_modules/superpowers"]
+}
+```
 
 ### Skills not found
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ or search for "superpowers" in the plugin marketplace.
 
 ### OpenCode
 
+OpenCode uses its own plugin install; install Superpowers separately even if you
+already use it in another harness.
+
 Tell OpenCode:
 
 ```

--- a/docs/README.opencode.md
+++ b/docs/README.opencode.md
@@ -12,9 +12,13 @@ Add superpowers to the `plugin` array in your `opencode.json` (global or project
 }
 ```
 
-Restart OpenCode. The plugin auto-installs via Bun and registers all skills automatically.
+Restart OpenCode. The plugin installs through OpenCode's plugin manager and
+registers all skills.
 
 Verify by asking: "Tell me about your superpowers"
+
+OpenCode uses its own plugin install. If you also use Claude Code, Codex, or
+another harness, install Superpowers separately for each one.
 
 ### Migrating from the old symlink-based install
 
@@ -78,7 +82,10 @@ Create project-specific skills in `.opencode/skills/` within your project.
 
 ## Updating
 
-Superpowers updates automatically when you restart OpenCode. The plugin is re-installed from the git repository on each launch.
+OpenCode installs Superpowers through a git-backed package spec. Some OpenCode
+and Bun versions pin that resolved git dependency in a lockfile or cache, so a
+restart may not pick up the newest Superpowers commit. If updates do not appear,
+clear OpenCode's package cache or reinstall the plugin.
 
 To pin a specific version, use a branch or tag:
 
@@ -111,6 +118,26 @@ Skills written for Claude Code are automatically adapted for OpenCode:
 1. Check OpenCode logs: `opencode run --print-logs "hello" 2>&1 | grep -i superpowers`
 2. Verify the plugin line in your `opencode.json` is correct
 3. Make sure you're running a recent version of OpenCode
+
+### Windows install issues
+
+Some Windows OpenCode builds have upstream installer issues with git-backed
+plugin specs, including cache paths for `git+https` URLs and Bun not finding
+`git.exe` even when it works in a normal terminal. If OpenCode cannot install
+the plugin, try installing with system npm and pointing OpenCode at the local
+package:
+
+```powershell
+npm install superpowers@git+https://github.com/obra/superpowers.git --prefix "$HOME\.config\opencode"
+```
+
+Then use the installed package path in `opencode.json`:
+
+```json
+{
+  "plugin": ["~/.config/opencode/node_modules/superpowers"]
+}
+```
 
 ### Skills not found
 


### PR DESCRIPTION
## What problem are you trying to solve?

OpenCode users have been hitting install and update behavior that the current docs do not accurately prepare them for. The docs currently say the plugin auto-installs, that restart is enough, and that Superpowers updates automatically on restart, but recent OpenCode reports show real edge cases:

- #1242 and #1068 report Windows failures resolving the `git+https` plugin spec into cache/package paths.
- #1111 reports OpenCode/Bun on Windows failing to find `git.exe`, with users sharing a system-npm workaround.
- #942 reports OpenCode/Bun pinning the git dependency in a lockfile/cache, so restart does not necessarily update Superpowers.
- #954 shows user confusion about whether Claude Code and OpenCode need separate Superpowers installs.

This PR makes the docs less overconfident and gives users a concrete fallback when the OpenCode installer path fails.

## What does this PR change?

This updates the README and OpenCode docs to clarify that OpenCode needs its own Superpowers install, softens the install/update language, and adds a Windows troubleshooting note with the system-npm workaround and local package plugin path.

## Is this change appropriate for the core library?

Yes. OpenCode is a supported Superpowers harness, and these docs are the core installation path for that harness. This does not add dependencies, introduce a new harness, or promote a third-party project; it documents known behavior around the existing OpenCode install path.

## What alternatives did you consider?

I considered reviving #704 / PRI-766, but that PR targeted the older symlink and `OPENCODE_CONFIG_DIR` docs and was closed as obsolete after the native OpenCode plugin install landed. I also considered changing plugin behavior, but the current issues are installer/update caveats and user-facing documentation gaps; changing behavior would be larger and should wait for the separate PRI-1369 OpenCode integration-test work.

## Does this PR contain multiple unrelated changes?

No. All changes are part of the same OpenCode install-doc cleanup: separate install expectations, update caveats, and Windows installer troubleshooting.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related issues: #1068, #1111, #1242, #942, #954
- Related PRs: #704, #753, #981, #1232, #1241, #1247

#704 is the closest prior docs PR, but it was closed as obsolete because the OpenCode install flow moved to the native plugin path. #753 introduced the native plugin install approach this PR now documents more carefully. #1232 handled bootstrap caching and is not an install-doc patch. #981 is a separate skill naming/bootstrap guidance PR that still needs real OpenCode verification. #1241 and #1247 touch plugin behavior/refactoring and should wait for the PRI-1369 baseline.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop | not exposed in UI | GPT-5 | not exposed in UI |

## Evaluation
- What was the initial prompt you (or your human partner) used to start the session that led to this change?

Drew asked to triage the remaining OpenCode issues/PRs under PRI-1367 while PRI-1369 was being implemented separately, then approved the small-value docs cleanup path after reviewing the recommendation.

- How many eval sessions did you run AFTER making the change?

0 runtime eval sessions. This is a documentation-only change. I verified the committed Markdown diff with `git diff --check HEAD~1..HEAD`.

- How did outcomes change compared to before the change?

Before: the docs implied restart was enough for install/update and did not mention known Windows OpenCode/Bun installer failures or the separate-install expectation.

After: the docs describe the install/update path more carefully, provide a Windows fallback command, and clarify that OpenCode uses its own Superpowers install even if another harness already has Superpowers installed.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
  - Not applicable: this PR does not modify any skill content.
- [ ] This change was tested adversarially, not just on the happy path
  - Not applicable as a runtime claim: this is a docs-only patch. The text was checked against the reported failure modes in #1068, #1111, #1242, #942, and #954.
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed the complete diff in the Codex session and explicitly approved opening this PR.
