### PR TITLE
[codex] Preserve Codex marketplace metadata

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -36,6 +36,9 @@
       "I've got an idea for something I'd like to build.",
       "Let's add a feature to this project."
     ],
+    "websiteURL": "https://github.com/obra/superpowers",
+    "privacyPolicyURL": "https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement",
+    "termsOfServiceURL": "https://docs.github.com/en/site-policy/github-terms/github-terms-of-service",
     "brandColor": "#F59E0B",
     "composerIcon": "./assets/superpowers-small.svg",
     "logo": "./assets/app-icon.png",

--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -4,7 +4,8 @@
 #
 # Sync this superpowers checkout → prime-radiant-inc/openai-codex-plugins.
 # Clones the fork fresh into a temp dir, rsyncs tracked upstream plugin content
-# (including committed Codex files under .codex-plugin/ and assets/), commits,
+# (including committed Codex files under .codex-plugin/ and assets/), preserves
+# OpenAI-owned marketplace metadata already in the destination plugin, commits,
 # pushes a sync branch, and opens a PR.
 # Path/user agnostic — auto-detects upstream from script location.
 #
@@ -223,6 +224,7 @@ fi
 DEST="$DEST_REPO/$DEST_REL"
 PREVIEW_REPO="$DEST_REPO"
 PREVIEW_DEST="$DEST"
+SYNC_SOURCE=""
 
 overlay_destination_paths() {
   local repo="$1"
@@ -291,7 +293,7 @@ apply_to_preview_checkout() {
     mkdir -p "$PREVIEW_DEST"
   fi
 
-  rsync "${RSYNC_ARGS[@]}" "$UPSTREAM/" "$PREVIEW_DEST/"
+  rsync "${RSYNC_ARGS[@]}" "$SYNC_SOURCE/" "$PREVIEW_DEST/"
 }
 
 preview_checkout_has_changes() {
@@ -316,6 +318,36 @@ for pat in "${EXCLUDES[@]}"; do RSYNC_ARGS+=(--exclude="$pat"); done
 append_git_ignored_directory_excludes
 append_git_ignored_file_excludes
 
+copy_preserved_destination_metadata() {
+  local destination="$1"
+  local source="$2"
+  local path
+  local rel
+
+  [[ -d "$destination/skills" ]] || return 0
+
+  while IFS= read -r -d '' path; do
+    rel="${path#"$destination"/}"
+    mkdir -p "$source/$(dirname "$rel")"
+    cp -p "$path" "$source/$rel"
+  done < <(find "$destination/skills" -path '*/agents/openai.yaml' -type f -print0)
+}
+
+prepare_sync_source() {
+  local destination="$1"
+
+  [[ -n "$CLEANUP_DIR" ]] || CLEANUP_DIR="$(mktemp -d)"
+
+  SYNC_SOURCE="$CLEANUP_DIR/source-overlay"
+  rm -rf "$SYNC_SOURCE"
+  mkdir -p "$SYNC_SOURCE"
+
+  rsync "${RSYNC_ARGS[@]}" "$UPSTREAM/" "$SYNC_SOURCE/" >/dev/null
+  copy_preserved_destination_metadata "$destination" "$SYNC_SOURCE"
+}
+
+prepare_sync_source "$PREVIEW_DEST"
+
 # =============================================================================
 # Dry run preview (always shown)
 # =============================================================================
@@ -331,7 +363,7 @@ if [[ $BOOTSTRAP -eq 1 ]]; then
 fi
 echo ""
 echo "=== Preview (rsync --dry-run) ==="
-rsync "${RSYNC_ARGS[@]}" --dry-run --itemize-changes "$UPSTREAM/" "$PREVIEW_DEST/"
+rsync "${RSYNC_ARGS[@]}" --dry-run --itemize-changes "$SYNC_SOURCE/" "$PREVIEW_DEST/"
 echo "=== End preview ==="
 echo ""
 
@@ -368,7 +400,7 @@ echo "Syncing upstream content..."
 if [[ $BOOTSTRAP -eq 1 ]]; then
   mkdir -p "$DEST"
 fi
-rsync "${RSYNC_ARGS[@]}" "$UPSTREAM/" "$DEST/"
+rsync "${RSYNC_ARGS[@]}" "$SYNC_SOURCE/" "$DEST/"
 
 # Bail early if nothing actually changed
 cd "$DEST_REPO"

--- a/tests/codex-plugin-sync/test-sync-to-codex-plugin.sh
+++ b/tests/codex-plugin-sync/test-sync-to-codex-plugin.sh
@@ -73,6 +73,19 @@ assert_matches() {
     fi
 }
 
+assert_not_matches() {
+    local haystack="$1"
+    local pattern="$2"
+    local description="$3"
+
+    if printf '%s' "$haystack" | grep -Eq -- "$pattern"; then
+        fail "$description"
+        echo "    did not expect to match: $pattern"
+    else
+        pass "$description"
+    fi
+}
+
 assert_path_absent() {
     local path="$1"
     local description="$2"
@@ -244,6 +257,22 @@ EOF
     commit_fixture "$repo" "Initial destination fixture"
 }
 
+add_openai_agent_metadata_fixture() {
+    local repo="$1"
+
+    mkdir -p "$repo/plugins/superpowers/skills/example/agents"
+
+    cat > "$repo/plugins/superpowers/skills/example/agents/openai.yaml" <<'EOF'
+interface:
+  display_name: "Example"
+  short_description: "Destination-owned OpenAI metadata"
+EOF
+
+    git -C "$repo" add plugins/superpowers/skills/example/agents/openai.yaml
+
+    commit_fixture "$repo" "Add OpenAI agent metadata fixture"
+}
+
 dirty_tracked_destination_skill() {
     local repo="$1"
 
@@ -261,6 +290,7 @@ write_synced_destination_fixture() {
         "$repo/plugins/superpowers/.codex-plugin" \
         "$repo/plugins/superpowers/.private-journal" \
         "$repo/plugins/superpowers/assets" \
+        "$repo/plugins/superpowers/skills/example/agents" \
         "$repo/plugins/superpowers/skills/example"
 
     cat > "$repo/plugins/superpowers/.codex-plugin/plugin.json" <<EOF
@@ -282,12 +312,19 @@ EOF
 Fixture content.
 EOF
 
+    cat > "$repo/plugins/superpowers/skills/example/agents/openai.yaml" <<'EOF'
+interface:
+  display_name: "Example"
+  short_description: "Destination-owned OpenAI metadata"
+EOF
+
     printf 'tracked keep\n' > "$repo/plugins/superpowers/.private-journal/keep.txt"
 
     git -C "$repo" add \
         plugins/superpowers/.codex-plugin/plugin.json \
         plugins/superpowers/assets/app-icon.png \
         plugins/superpowers/assets/superpowers-small.svg \
+        plugins/superpowers/skills/example/agents/openai.yaml \
         plugins/superpowers/skills/example/SKILL.md \
         plugins/superpowers/.private-journal/keep.txt
 
@@ -415,6 +452,7 @@ main() {
     local help_output
     local script_source
     local dirty_skill_path
+    local noop_openai_metadata_path
 
     echo "=== Test: sync-to-codex-plugin dry-run regression ==="
 
@@ -443,6 +481,7 @@ main() {
 
     init_repo "$dest"
     write_destination_fixture "$dest"
+    add_openai_agent_metadata_fixture "$dest"
     checkout_fixture_branch "$dest" "$dest_branch"
     dirty_tracked_destination_skill "$dest"
 
@@ -490,6 +529,7 @@ main() {
     preview_section="$(printf '%s\n' "$preview_output" | sed -n '/^=== Preview (rsync --dry-run) ===$/,/^=== End preview ===$/p')"
     stale_preview_section="$(printf '%s\n' "$stale_preview_output" | sed -n '/^=== Preview (rsync --dry-run) ===$/,/^=== End preview ===$/p')"
     dirty_skill_path="$dirty_apply_dest/plugins/superpowers/skills/example/SKILL.md"
+    noop_openai_metadata_path="$noop_apply_dest/plugins/superpowers/skills/example/agents/openai.yaml"
 
     echo ""
     echo "Preview assertions..."
@@ -505,6 +545,7 @@ main() {
     assert_not_contains "$preview_output" "Overlay file (.codex-plugin/plugin.json) will be regenerated" "Preview omits overlay regeneration note"
     assert_not_contains "$preview_output" "Assets (superpowers-small.svg, app-icon.png) will be seeded from" "Preview omits assets seeding note"
     assert_contains "$preview_section" "skills/example/SKILL.md" "Preview reflects dirty tracked destination file"
+    assert_not_matches "$preview_section" "\\*deleting +skills/example/agents/openai\\.yaml" "Preview preserves destination-owned OpenAI agent metadata"
     assert_current_branch "$dest" "$dest_branch" "Preview leaves destination checkout on its original branch"
     assert_branch_absent "$dest" "sync/superpowers-*" "Preview does not create sync branch in destination checkout"
 
@@ -542,6 +583,9 @@ Locally modified fixture content." "Dirty local apply preserves tracked working-
     assert_contains "$noop_apply_output" "No changes — embedded plugin was already in sync with upstream" "Clean no-op local apply reports no changes"
     assert_current_branch "$noop_apply_dest" "$noop_apply_dest_branch" "Clean no-op local apply leaves destination checkout on its original branch"
     assert_branch_absent "$noop_apply_dest" "sync/superpowers-*" "Clean no-op local apply does not create sync branch in destination checkout"
+    assert_file_equals "$noop_openai_metadata_path" "interface:
+  display_name: \"Example\"
+  short_description: \"Destination-owned OpenAI metadata\"" "Clean no-op local apply preserves OpenAI agent metadata"
 
     echo ""
     echo "Missing manifest assertions..."


### PR DESCRIPTION
## What problem are you trying to solve?

While working through PRI-1367 section 2, we found two pieces of Codex marketplace drift between this repository and the embedded plugin that gets published through the OpenAI plugin repository.

First, the local `.codex-plugin/plugin.json` manifest did not include the URL metadata fields already present in the OpenAI-side manifest. That meant future syncs from this repository could regress marketplace metadata.

Second, the sync script treated destination-owned OpenAI marketplace metadata under `skills/*/agents/openai.yaml` as stale files because Jesse does not want those OpenAI-specific files committed to this source repository. In practice, a sync preview/apply would try to delete valid OpenAI-side metadata simply because it is intentionally maintained in the destination plugin repo.

## What does this PR change?

This adds the Codex plugin manifest URL fields to `.codex-plugin/plugin.json`. It also updates `scripts/sync-to-codex-plugin.sh` to build a temporary sync overlay that copies existing destination `skills/*/agents/openai.yaml` files into the sync source before previewing or applying changes, so destination-owned OpenAI metadata is preserved. The sync regression test now covers preview and no-op apply preservation of that metadata.

## Is this change appropriate for the core library?

Yes. This is not a new domain-specific skill, project-specific configuration, or third-party integration. It is maintenance for the repository's existing Codex plugin packaging and sync infrastructure, which is how the core Superpowers plugin is mirrored into the Codex plugin marketplace flow.

## What alternatives did you consider?

One option was to commit the `skills/*/agents/openai.yaml` files directly to this repository, but that would put OpenAI-owned marketplace metadata into the source repo even though Jesse does not want those files here. Another option was to rely on manual edits in the destination plugin repo after every sync, but that keeps the sync path fragile and easy to regress. I also evaluated protecting the files with rsync filter rules, but the local OpenBSD-compatible `rsync` behavior did not support the intended protect pattern reliably in this script's existing cross-platform shape. The overlay approach keeps this repo as source of truth for Superpowers-owned files while preserving destination-owned OpenAI metadata during sync.

## Does this PR contain multiple unrelated changes?

No. The manifest URL fields and `openai.yaml` preservation are both part of the same Codex marketplace sync cleanup: preventing local source-of-truth syncs from regressing metadata that the OpenAI plugin destination needs.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1261, #1180, #1165

No duplicate PR was found. #1261 made the sync script use committed Codex plugin files, #1180 seeded `interface.defaultPrompt`, and #1165 mirrored the initial Codex plugin tooling. This PR follows that same packaging path by preserving destination-owned marketplace metadata and adding missing manifest URL fields.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI | 0.124.0 | GPT-5 | Current Codex session model; exact provider ID not surfaced by CLI |

## Evaluation

- What was the initial prompt you (or your human partner) used to start the session that led to this change?

  Drew asked to continue through Linear issue PRI-1367, specifically section 2 around Codex marketplace file cleanup, then asked whether the sync script had a dry run, whether the OpenAI plugin repo/fork was in sync, what drift existed, and how to handle OpenAI-owned `openai.yaml` files without committing them to this repository.

- How many eval sessions did you run AFTER making the change?

  Zero agent-behavior eval sessions. This change does not modify behavior-shaping skill content. It changes packaging metadata and sync tooling, so the relevant evaluation is the shell regression test suite for the sync script.

- How did outcomes change compared to before the change?

  Before this change, the sync preview attempted to delete destination-owned `skills/example/agents/openai.yaml` metadata in the regression fixture. After this change, the preview no longer reports that deletion and a clean no-op apply preserves the OpenAI metadata file. The manifest URL fields are also now present locally, so future syncs will not drop them from the Codex plugin manifest.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is not a skills change. The regression test covers dry-run preview, dirty destination apply failure, clean no-op apply, missing manifest handling, bootstrap preview behavior, ignored tracked files, ignored untracked files, stale ignored destination deletion, and preservation of destination-owned OpenAI metadata.

Verification run:

```sh
bash -n scripts/sync-to-codex-plugin.sh tests/codex-plugin-sync/test-sync-to-codex-plugin.sh
python3 -m json.tool .codex-plugin/plugin.json >/dev/null
git diff --check HEAD~1..HEAD
bash tests/codex-plugin-sync/test-sync-to-codex-plugin.sh
```

The sync regression test completed with `PASS`.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
