### PR TITLE
docs: add Antigravity install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ To update:
 gemini extensions update superpowers
 ```
 
+### Google Antigravity
+
+- Clone this repository to `~/.agents/superpowers` (or the location of your choice):
+
+  ```bash
+  git clone https://github.com/obra/superpowers.git ~/.agents/superpowers
+  ```
+
+- In Antigravity, open Antigravity -> Settings -> Antigravity Settings -> Customizations -> Skill Custom Paths.
+- Add `~/.agents/superpowers` (or your chosen checkout path) as a global skills path.
+- Verify the setup by asking Antigravity whether it can access `superpowers:brainstorming`.
+
 ### Factory Droid
 
 In Droid, register the marketplace:


### PR DESCRIPTION
## What problem are you trying to solve?

Users are asking how to use Superpowers with Google Antigravity (#270), but the README does not currently give them a simple supported setup path. Earlier Antigravity attempts either added installers, copied/forked skill content, or focused on symlink-based setup. Drew verified that Antigravity can discover the existing Superpowers skills by adding a Superpowers checkout through Antigravity's Skill Custom Paths setting, so the README should document that smaller path.

## What does this PR change?

This adds a Google Antigravity section to the README. It tells users to clone Superpowers to `~/.agents/superpowers` by default, or another location they choose, add that checkout in Antigravity -> Settings -> Antigravity Settings -> Customizations -> Skill Custom Paths, and verify that `superpowers:brainstorming` is available.

## Is this change appropriate for the core library?

Yes. This is harness installation documentation for using the existing general-purpose Superpowers skills in Antigravity. It does not add new skill content, fork or rewrite existing skills, add dependencies, or add project-specific configuration.

## What alternatives did you consider?

We reviewed the broader Antigravity integration work in #192, but that approach is larger than needed for the currently verified path. We also reviewed custom/forked Antigravity skill ports such as #682, which maintainers rejected because they duplicate and adapt the core skills. We considered documenting fixed-directory copy or symlink installs, but Antigravity's Skill Custom Paths setting avoids copying skill content and keeps updates as a normal `git pull`. We also checked whether the existing Gemini CLI extension install could be reused, but Antigravity does not appear to consume Gemini CLI extensions as Antigravity skills.

## Does this PR contain multiple unrelated changes?

No. This PR only adds Antigravity installation instructions to `README.md`.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #192, #682, #535, #550, #281, #488, #264

#192 is the active broader Antigravity integration discussion. This PR is intentionally narrower: README-only documentation for the Skill Custom Paths setup Drew verified locally, without installers or custom skill copies. #682 was closed because it introduced custom versions of the skills; this PR preserves the existing core skill files. #535, #550, #281, #488, and #264 are earlier Antigravity/Gemini documentation or integration attempts; this PR documents the current Antigravity Skill Custom Paths UI path instead of those older copy/symlink-first approaches.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Google Antigravity | 1.23.2 (local app bundle; VS Code OSS 1.107.0) | Gemini | Gemini 3.1 Pro (High) |

## Evaluation
- What was the initial prompt you (or your human partner) used to start the session that led to this change?

  Drew asked us to follow up on PRI-1367 Antigravity support, review #192/block5 and the existing PR, and research whether Antigravity could use the existing Superpowers skill layout without adding another symlink-based install.

- How many eval sessions did you run AFTER making the change?

  No new skill-behavior eval sessions were needed after the README edit because this PR does not change skill behavior. Before documenting the path, Drew manually configured Antigravity with a Superpowers checkout path and verified in Antigravity chat that `superpowers:brainstorming` was discovered from `skills/brainstorming/SKILL.md`.

- How did outcomes change compared to before the change?

  Before this change, Antigravity users had to piece together setup from issues and prior PRs. After this change, the README gives a short clone, configure, and verify path for the setup that was manually confirmed.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
      Not applicable; this PR changes README installation documentation only and does not modify `skills/**`.
- [ ] This change was tested adversarially, not just on the happy path
      Not applicable to this README-only install documentation change. The documented path is based on a manual Antigravity smoke test plus prior-art review.
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed the complete README diff in Codex before asking me to file this PR.
