### PR TITLE
docs: add README quickstart install links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Superpowers is a complete software development methodology for your coding agents, built on top of a set of composable skills and some initial instructions that make sure your agent uses them.
 
+## Quickstart
+
+Give your agent Superpowers: [Claude Code](#claude-code), [Codex CLI](#codex-cli), [Codex App](#codex-app), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [OpenCode](#opencode), [Cursor](#cursor), [GitHub Copilot CLI](#github-copilot-cli).
+
 ## How it works
 
 It starts from the moment you fire up your coding agent. As soon as it sees that you're building something, it *doesn't* just jump into trying to write code. Instead, it steps back and asks you what you're really trying to do. 
@@ -26,112 +30,126 @@ Thanks!
 
 ## Installation
 
-**Note:** Installation differs by platform. 
+Installation differs by harness. If you use more than one, install Superpowers separately for each one.
 
-### Claude Code Official Marketplace
+### Claude Code
 
 Superpowers is available via the [official Claude plugin marketplace](https://claude.com/plugins/superpowers)
 
-Install the plugin from Anthropic's official marketplace:
+#### Official Marketplace
 
-```bash
-/plugin install superpowers@claude-plugins-official
-```
+- Install the plugin from Anthropic's official marketplace:
 
-### Claude Code (Superpowers Marketplace)
+  ```bash
+  /plugin install superpowers@claude-plugins-official
+  ```
+
+#### Superpowers Marketplace
 
 The Superpowers marketplace provides Superpowers and some other related plugins for Claude Code.
 
-In Claude Code, register the marketplace first:
+- Register the marketplace:
 
-```bash
-/plugin marketplace add obra/superpowers-marketplace
-```
+  ```bash
+  /plugin marketplace add obra/superpowers-marketplace
+  ```
 
-Then install the plugin from this marketplace:
+- Install the plugin from this marketplace:
 
-```bash
-/plugin install superpowers@superpowers-marketplace
-```
+  ```bash
+  /plugin install superpowers@superpowers-marketplace
+  ```
 
-### OpenAI Codex CLI
+### Codex CLI
 
-- Open plugin search interface
+Superpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).
 
-```bash
-/plugins
-```
+- Open the plugin search interface:
 
-Search for Superpowers
+  ```bash
+  /plugins
+  ```
 
-```bash
-superpowers
-```
+- Search for Superpowers:
 
-Select `Install Plugin`
+  ```bash
+  superpowers
+  ```
 
-### OpenAI Codex App
+- Select `Install Plugin`.
+
+### Codex App
+
+Superpowers is available via the [official Codex plugin marketplace](https://github.com/openai/plugins).
 
 - In the Codex app, click on Plugins in the sidebar.
-- You should see `Superpowers` in the Coding section. 
+- You should see `Superpowers` in the Coding section.
 - Click the `+` next to Superpowers and follow the prompts.
 
+### Factory Droid
 
-### Cursor (via Plugin Marketplace)
+- Register the marketplace:
 
-In Cursor Agent chat, install from marketplace:
+  ```bash
+  droid plugin marketplace add https://github.com/obra/superpowers
+  ```
 
-```text
-/add-plugin superpowers
-```
+- Install the plugin:
 
-or search for "superpowers" in the plugin marketplace.
+  ```bash
+  droid plugin install superpowers@superpowers
+  ```
+
+### Gemini CLI
+
+- Install the extension:
+
+  ```bash
+  gemini extensions install https://github.com/obra/superpowers
+  ```
+
+- Update later:
+
+  ```bash
+  gemini extensions update superpowers
+  ```
 
 ### OpenCode
 
 OpenCode uses its own plugin install; install Superpowers separately even if you
 already use it in another harness.
 
-Tell OpenCode:
+- Tell OpenCode:
 
-```
-Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md
-```
+  ```
+  Fetch and follow instructions from https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/.opencode/INSTALL.md
+  ```
 
-**Detailed docs:** [docs/README.opencode.md](docs/README.opencode.md)
+- Detailed docs: [docs/README.opencode.md](docs/README.opencode.md)
+
+### Cursor
+
+- In Cursor Agent chat, install from marketplace:
+
+  ```text
+  /add-plugin superpowers
+  ```
+
+- Or search for "superpowers" in the plugin marketplace.
 
 ### GitHub Copilot CLI
 
-```bash
-copilot plugin marketplace add obra/superpowers-marketplace
-copilot plugin install superpowers@superpowers-marketplace
-```
+- Register the marketplace:
 
-### Gemini CLI
+  ```bash
+  copilot plugin marketplace add obra/superpowers-marketplace
+  ```
 
-```bash
-gemini extensions install https://github.com/obra/superpowers
-```
+- Install the plugin:
 
-To update:
-
-```bash
-gemini extensions update superpowers
-```
-
-### Factory Droid
-
-In Droid, register the marketplace:
-
-```bash
-droid plugin marketplace add https://github.com/obra/superpowers
-```
-
-Then install:
-
-```bash
-droid plugin install superpowers@superpowers
-```
+  ```bash
+  copilot plugin install superpowers@superpowers-marketplace
+  ```
 
 ## The Basic Workflow
 


### PR DESCRIPTION
## What problem are you trying to solve?

Drew and Jesse identified that the README installer section was harder to scan than it needed to be: the per-harness instructions existed, but there was no top-level Quickstart table of contents, Codex CLI and Codex App were grouped together even though they are separate apps, and the install steps mixed prose, bullets, and command blocks inconsistently. The user experience was that someone trying to install Superpowers for their agent had to visually parse the full install section instead of jumping directly to their harness.

## What does this PR change?

This adds a short Quickstart section near the top of the README with anchor links to each supported harness. It reorganizes the existing Installation section into separate harness sections, splits Codex CLI and Codex App, adds the official Codex plugin marketplace link, and normalizes install actions into bullet lists.

## Is this change appropriate for the core library?

Yes. This is README installation documentation for the general-purpose Superpowers project. It does not add skills, change behavior-shaping skill content, add dependencies, or introduce project-specific configuration.

## What alternatives did you consider?

We considered replacing the existing Installation section with Quickstart, but kept Installation as the detailed section so the README still has a full reference. We considered grouping Codex CLI and Codex App under one Codex heading, but split them because they are different apps with different install flows. We also considered grouping Cursor and GitHub Copilot CLI under "Other Harnesses," but promoted them to normal harness sections for consistency. Finally, we compared prose-only install steps with bullet lists and chose bullets because they are easier to scan across harnesses.

## Does this PR contain multiple unrelated changes?

No. This PR only reorganizes and clarifies README installation/quickstart documentation.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #610, #718, #1292, #400, #634

#610 added the Claude Code official marketplace instructions this README now keeps and nests under Claude Code. #718 was a broad README rewrite that was closed for vague motivation, unfilled template sections, and lack of human review; this PR is intentionally narrower, preserves the existing README voice/content, and fills the current template. #1292 and #400 are open harness-specific install-doc PRs for Antigravity and AdaL, not duplicates of this Quickstart/reorganization change. #634 adds a Claude Code verification checklist and is also not a duplicate.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app | Not exposed in session | Codex | GPT-5 |

## Evaluation
- What was the initial prompt you (or your human partner) used to start the session that led to this change?

  Drew asked to reorganize the README/per-harness installers with a Quickstart table of contents like: "Give your agent Superpowers: Claude Code, Codex, Factory Droids, Gemini CLI, Open Code."

- How many eval sessions did you run AFTER making the change?

  No agent behavior eval sessions were needed because this is README-only install documentation and does not modify `skills/**`.

- How did outcomes change compared to before the change?

  Before this change, the README moved directly from the intro into "How it works" and later had an Installation section with uneven heading levels and mixed prose/list formatting. After this change, readers get a Quickstart link row near the top, each harness has a matching install section, Codex CLI and Codex App are separate targets, and the install actions use consistent bullets.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
      Not applicable; this PR changes README installation documentation only and does not modify `skills/**`.
- [ ] This change was tested adversarially, not just on the happy path
      Not applicable to this README-only documentation reorganization. The validation was Markdown/anchor-focused.
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed the complete README diff in Codex before asking me to file this PR.
