### PR TITLE
Require session transcript for new-harness PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,6 +50,45 @@ of human involvement will be closed without review.
 |-------------------------------------|-----------------|-------|------------------|
 |                                     |                 |       |                  |
 
+## New harness support (required if this PR adds a new harness)
+
+<!-- If this PR adds support for a new harness (IDE, CLI tool, agent
+     runner), you MUST include a session transcript proving the
+     integration actually works.
+
+     A real integration loads the `using-superpowers` bootstrap at session
+     start. The bootstrap is what causes skills to auto-trigger. Without
+     it, the skills are dead weight — present on disk but never invoked
+     at the right moments.
+
+     ACCEPTANCE TEST: Open a clean session in the new harness and send
+     exactly this user message:
+
+         Let's make a react todo list
+
+     A working integration auto-triggers the `brainstorming` skill before
+     any code is written. Paste the complete transcript below.
+
+     These are NOT real integrations and PRs that ship them will be closed:
+
+     - Manually copying skill files into the harness
+     - Wrapping with `npx skills` or similar at-runtime shims
+     - Anything that requires the user to opt in to skills per-session
+     - Anything where brainstorming does not auto-trigger on the test above
+
+     If you are not sure whether your integration loads the bootstrap at
+     session start, it does not.
+-->
+
+<details>
+<summary>Clean-session transcript for "Let's make a react todo list"</summary>
+
+```
+paste the complete transcript here
+```
+
+</details>
+
 ## Evaluation
 - What was the initial prompt you (or your human partner) used to start
   the session that led to this change?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,27 @@ PRs containing invented claims, fabricated problem descriptions, or hallucinated
 
 PRs containing multiple unrelated changes will be closed. Split them into separate PRs.
 
+## New Harness Support
+
+If your PR adds support for a new harness (IDE, CLI tool, agent runner), you MUST include a session transcript proving the integration works end-to-end.
+
+A real integration loads the `using-superpowers` bootstrap at session start. The bootstrap is what causes skills to auto-trigger at the right moments. Without it, the skills are dead weight — present on disk but never invoked.
+
+**The acceptance test.** Open a clean session in the new harness and send exactly this user message:
+
+> Let's make a react todo list
+
+A working integration auto-triggers the `brainstorming` skill before any code is written. Paste the complete transcript in the PR.
+
+**These are not real integrations and will be closed:**
+
+- Manually copying skill files into the harness
+- Wrapping with `npx skills` or similar at-runtime shims
+- Anything that requires the user to opt in to skills per-session
+- Anything where `brainstorming` does not auto-trigger on the acceptance test above
+
+If you are not sure whether your integration loads the bootstrap at session start, it does not.
+
 ## Skill Changes Require Evaluation
 
 Skills are not prose — they are code that shapes agent behavior. If you modify skill content:


### PR DESCRIPTION
## Summary
- Most new-harness PRs ship integrations that copy skill files or wrap with `npx skills` instead of loading the `using-superpowers` bootstrap at session start. Skills sit on disk but never auto-trigger.
- Add an acceptance test in the PR template and `CLAUDE.md` (also `AGENTS.md` via symlink): in a clean session in the new harness, the user message "Let's make a react todo list" must auto-trigger `brainstorming` before any code is written. Paste the transcript.
- List the disqualifiers explicitly: copying skill files, `npx skills` shims, per-session opt-in, anything where brainstorming does not auto-trigger.

## Test plan
- [ ] Skim the rendered PR template on the PR page to confirm the new section appears in the right place
- [ ] Skim the rendered `CLAUDE.md` on GitHub to confirm the new section reads cleanly between "Bundled unrelated changes" and "Skill Changes Require Evaluation"