### PR TITLE
Add pi-review and pi-refine skills using pi-subagents

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,103 @@
+# Skills Dependencies
+
+This directory contains the skill library for Superpowers. Some skills depend on external pi packages to function.
+
+## Required External Packages
+
+### pi-subagents
+
+**Required by:** `pi-review`, `pi-refine`
+
+The `pi-subagents` package provides the `subagent()` tool and builtin agents (including `reviewer`) that these skills use to perform external code and document review.
+
+**Installation:**
+
+```bash
+npm install -g pi-subagents
+```
+
+Or follow the installation instructions for your specific pi distribution.
+
+**Verification:**
+
+After installation, verify it's working:
+
+```typescript
+subagent({ action: "list" });
+```
+
+This should list available builtin agents including `reviewer`, `scout`, `planner`, `worker`, and `oracle`.
+
+If you encounter issues:
+
+```typescript
+subagent({ action: "doctor" });
+```
+
+**Model Overrides:**
+
+The `reviewer` agent defaults to `openai-codex/gpt-5.5`. You can override this globally in `.pi/settings.json`:
+
+```json
+{
+  "subagents": {
+    "agentOverrides": {
+      "reviewer": {
+        "model": "deepseek/deepseek-v4-pro",
+        "thinking": "high"
+      }
+    }
+  }
+}
+```
+
+Or per-call:
+
+```typescript
+subagent({
+  agent: "reviewer",
+  model: "anthropic/claude-sonnet-4",
+  task: "...",
+});
+```
+
+## Optional External Packages
+
+### pi-intercom
+
+**Used by:** Any skill that launches async or forked subagents
+
+Provides inter-agent communication for coordination between parent and child agents. Not strictly required for `pi-review` or `pi-refine` since they use synchronous subagent calls, but useful for more complex multi-agent workflows.
+
+## Skills Index
+
+### Core Development
+
+- **brainstorming** - Socratic design refinement before coding
+- **writing-plans** - Detailed implementation planning
+- **executing-plans** - Batch execution with checkpoints
+- **subagent-driven-development** - Fast iteration with two-stage review
+
+### Testing & Quality
+
+- **test-driven-development** - RED-GREEN-REFACTOR enforcement
+- **systematic-debugging** - 4-phase root cause analysis
+- **verification-before-completion** - Confirm fixes actually work
+
+### Review & Refinement
+
+- **pi-review** - One-off code/design review via `reviewer` subagent _(requires pi-subagents)_
+- **pi-refine** - Iterative document refinement via `reviewer` subagent _(requires pi-subagents)_
+- **requesting-code-review** - Pre-review checklist
+- **receiving-code-review** - Handling feedback
+
+### Collaboration & Workflow
+
+- **dispatching-parallel-agents** - Concurrent subagent workflows
+- **using-git-worktrees** - Isolated development branches
+- **finishing-a-development-branch** - Merge/PR decisions
+
+### Meta
+
+- **using-superpowers** - Introduction to the skills system
+- **writing-skills** - Create and test new skills

--- a/skills/pi-refine/SKILL.md
+++ b/skills/pi-refine/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: pi-refine
+description: Use when iteratively refining a design doc, plan, or specification through repeated pi reviews until quality converges
+---
+
+# Pi Refine
+
+Iteratively refine a document through repeated `reviewer` subagent reviews until it converges on quality.
+
+**Core principle:** Review → filter → fix → re-review → repeat until clean.
+
+## Default Model
+
+The `reviewer` builtin agent defaults to `openai-codex/gpt-5.5`. If the user does not specify a model, use the builtin default. To override, pass `model` to the subagent call or set a persistent override in `.pi/settings.json`:
+
+```json
+{
+  "subagents": {
+    "agentOverrides": {
+      "reviewer": {
+        "model": "deepseek/deepseek-v4-pro"
+      }
+    }
+  }
+}
+```
+
+## When to Use
+
+- When you want a design doc or plan polished through iterative external review
+- After drafting a doc and before implementing it
+- When a doc needs thorough vetting but you want the process automated
+
+## Invocation
+
+The user may say things like "refine this doc with pi", "iterate on this plan", etc.
+
+## The Iteration Loop
+
+For each iteration (max 5):
+
+### Step 1: Dispatch Reviewer Subagent
+
+Send the document to the `reviewer` agent with fresh context and capture output:
+
+```typescript
+subagent({
+  agent: "reviewer",
+  task: `Below is the full text of a document to review. Review ONLY this text.
+
+Identify:
+1. Gaps, missing steps, or incorrect assumptions
+2. Logic errors, contradictions, or ordering problems
+3. Security, privacy, or authorization concerns
+4. Unclear or ambiguous sections
+
+Reference section/task/step numbers from the document. Organize by severity: critical, important, minor.`,
+  reads: [filePath],
+  output: `/tmp/pi-refine-iter-${iteration}.md`,
+});
+```
+
+Then read `/tmp/pi-refine-iter-${iteration}.md`.
+
+### Step 2: Triage Findings
+
+Categorize each finding into one of:
+
+**Fix** — Implement the change:
+
+- Genuine gaps, missing steps, or incorrect information
+- Logic errors, contradictions, or broken ordering
+- **Security concerns**: authentication, authorization, input validation, injection risks, secret handling
+- **Privacy concerns**: data exposure, logging PII, missing access controls, data retention issues
+- **Authorization concerns**: missing permission checks, privilege escalation paths, role boundary violations
+- Unclear sections that would confuse readers
+
+**Ignore** — Skip silently (do not ask the user):
+
+- **Hallucinations**: References to files, APIs, libraries, or features that don't exist in the project
+- **Trivial nits**: Formatting preferences, naming bikeshedding, stylistic opinions
+- **Scale-only concerns**: Rate limiting, sharding, horizontal scaling, load balancing, caching layers, distributed locking, high-availability patterns — anything only relevant at multi-user/SaaS scale. This is an internal product with a handful of users.
+- **Over-engineering**: Suggestions to add abstraction layers, plugin architectures, feature flags, or other complexity not justified by the current user base
+- **Redundant with prior iterations**: Issues already addressed in a previous iteration that the reviewer is re-raising
+
+**Ask the user** — When a finding is borderline:
+
+- It might be valid but you're not sure if it applies to this project
+- It's a design tradeoff where user preference matters
+- It suggests a significant architectural change that may or may not be wanted
+- Security/privacy concern that seems theoretical rather than practical for an internal tool
+
+Use `AskUserQuestion` for borderline items. Present the finding and your assessment, and let the user decide fix or ignore.
+
+### Step 3: Implement Fixes
+
+Apply all "Fix" changes to the document using Edit/Write tools. Make targeted, minimal edits — don't rewrite sections that aren't flagged.
+
+### Step 4: Check Convergence
+
+Converge eagerly. Exit the loop if **any** of these hold:
+
+1. **No fixes applied this iteration** — all findings were ignored or trivial.
+2. **Findings are language-only** — this iteration's findings are all wording/clarification/phrasing issues, with no new implementation gaps, logic errors, missing steps, security/privacy/authorization concerns, or test-adequacy concerns. Language polish has diminishing returns; once the reviewer stops surfacing real implementation issues, stop.
+3. **Diminishing returns signal** — findings are substantively similar to the prior iteration (same class of nit, different wording), even if technically new.
+
+**How to decide (#2):** For each finding, ask: "Would a reader acting on the current spec build the wrong thing, or just write prose a reviewer might phrase differently?" If every finding falls in the latter bucket, you're done. A single real implementation finding is enough to keep iterating; a stack of wording suggestions is not.
+
+When converging under #2 or #3, you may still apply one or two high-value findings before exiting (e.g., removing a leaked identifier, noting a version requirement) — the criterion is about _stopping the loop_, not _rejecting every remaining suggestion_. But don't apply the whole set of clarifications; that's the trap this rule exists to break.
+
+Otherwise, increment iteration counter and go back to Step 1.
+
+### Step 5: Update Plan Status
+
+If the document has a YAML-style header or metadata section, add or update a `Status: Refined` line in it. If the document has no clear header/metadata area, add a status line near the top of the document after the title:
+
+```
+**Status:** Refined
+```
+
+### Step 6: Report Summary
+
+After the loop ends (converged or hit 5-iteration cap), report a comprehensive summary to the user covering everything that was found and what was done about it:
+
+```
+## Refinement Summary
+
+**Iterations:** N
+**Converged:** yes/no
+
+### All Findings and Actions
+
+For each iteration, list every finding with its disposition:
+
+**Iteration 1:**
+- [FIXED] <finding description> → <what was changed>
+- [FIXED] <finding description> → <what was changed>
+- [IGNORED: hallucination] <finding description>
+- [IGNORED: scale-only] <finding description>
+- [ASKED USER → fixed/ignored] <finding description> → <outcome>
+
+**Iteration 2:**
+- [FIXED] <finding description> → <what was changed>
+- [IGNORED: nit] <finding description>
+...
+
+### Summary of Changes Made
+- Bullet list of all substantive changes across all iterations
+
+### Ignored (noise):
+- [brief list of ignored items grouped by category with counts]
+
+### Remaining (if hit cap):
+- [any unresolved items from the final review]
+```
+
+## Important Notes
+
+- Use a distinct output file per iteration (`/tmp/pi-refine-iter-1.md`, `-iter-2.md`, etc.) so you can reference earlier reviews.
+- If the reviewer raises the same issue across iterations after you've already fixed it, it may be hallucinating the problem. Ignore on the second occurrence.
+- The 5-iteration cap is a safety net. Most docs should converge in 1-2 iterations. If iteration 2 is producing only language polish, stop — the spec is done.
+- This skill is for document refinement. For one-off code or document review, use `pi-review` directly.
+- **Security/privacy/auth findings are always worth fixing** — even for internal tools, these protect against insider threats and accidental data exposure.
+- **Scalability/SaaS patterns are noise** — don't add complexity for hypothetical growth. Internal tools with a handful of users don't need production-grade infrastructure patterns.

--- a/skills/pi-review/SKILL.md
+++ b/skills/pi-review/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: pi-review
+description: Use when needing external code review of git changes or design document review before implementation, or when the user asks for a pi review
+---
+
+# Pi Review
+
+Use the `reviewer` subagent to get an independent review of code changes or design documents.
+
+## Default Model
+
+The `reviewer` builtin agent defaults to `openai-codex/gpt-5.5`. If the user does not specify a model, use the builtin default. To override, pass `model` to the subagent call or set a persistent override in `.pi/settings.json`:
+
+```json
+{
+  "subagents": {
+    "agentOverrides": {
+      "reviewer": {
+        "model": "deepseek/deepseek-v4-pro"
+      }
+    }
+  }
+}
+```
+
+## When to Use
+
+- When you want an independent second opinion on code or a design document
+- Before implementing a design doc — catch gaps and missing steps early
+- Before committing — review uncommitted changes
+- Before creating a PR — review branch changes
+- After a complex change — get independent review from a fresh context
+
+## Two Modes
+
+### 1. Design Doc Review
+
+Review a design document by dispatching the `reviewer` agent with the file in `reads`:
+
+```typescript
+subagent({
+  agent: "reviewer",
+  task: `Review ${filePath} for correctness, completeness, and potential issues. Focus on: async/await patterns, SQLite concurrency, Flask route safety, and whether the semaphore approach is appropriate for the resolver.`,
+  reads: [filePath],
+  output: "review-design.md",
+});
+```
+
+Then read `review-design.md` and present the findings.
+
+**Custom focus areas:** replace the prompt with project-specific focus bullets.
+
+### 2. Code Diff Review
+
+Review git changes by passing the diff in the task or letting the reviewer inspect it directly:
+
+```typescript
+// Let reviewer inspect the repo and diff directly
+subagent({
+  agent: "reviewer",
+  task: "Review the uncommitted changes in this repo for bugs, security vulnerabilities, missing error handling, and code quality issues. Inspect git diff directly.",
+  output: "review-diff.md",
+});
+```
+
+Or, for a specific base branch:
+
+```typescript
+subagent({
+  agent: "reviewer",
+  task: "Review the changes on the current branch compared to main for bugs, security vulnerabilities, missing error handling, and code quality issues. Inspect git diff main... directly.",
+  output: "review-branch.md",
+});
+```
+
+The `reviewer` agent has access to `bash`, `read`, and other tools, so it can run `git diff` itself and inspect files directly.
+
+### 3. Specific Commit Review
+
+```typescript
+subagent({
+  agent: "reviewer",
+  task: `Review commit ${sha} for bugs, security vulnerabilities, missing error handling, and code quality issues. Inspect the commit directly.`,
+  output: "review-commit.md",
+});
+```
+
+## Quick Reference
+
+| Want to review... | Approach                                                                 |
+| ----------------- | ------------------------------------------------------------------------ |
+| Design doc        | `subagent({ agent: "reviewer", reads: [file], task: "Review..." })`      |
+| Uncommitted work  | `subagent({ agent: "reviewer", task: "Review uncommitted changes..." })` |
+| Branch vs main    | `subagent({ agent: "reviewer", task: "Review changes vs main..." })`     |
+| Single commit     | `subagent({ agent: "reviewer", task: "Review commit <sha>..." })`        |
+
+## Context Mode
+
+- **Fresh context (default)** — the reviewer starts with minimal history and inspects the repo/diff directly. Best for adversarial code review.
+- **Forked context** — `context: "fork"` creates a branched child that inherits parent session history. Use only when you want the reviewer to understand the design decisions that led to the current code.
+
+```typescript
+// Fresh adversarial review (default)
+subagent({
+  agent: "reviewer",
+  task: "Review the auth module for security issues",
+});
+
+// Forked review with inherited context
+subagent({ agent: "reviewer", task: "Review my approach", context: "fork" });
+```
+
+## Review Output
+
+The `reviewer` agent can:
+
+- Identify bugs, security issues, and quality problems
+- Suggest fixes and improvements
+- Edit code directly when appropriate
+
+Capture structured output with the `output` parameter, then read it and present findings to the user organized by severity.
+
+## Related Skills
+
+- For iterative doc refinement (review → fix → re-review until clean), use `pi-refine` instead.


### PR DESCRIPTION
This PR adds two new review/refinement skills that leverage the pi-subagents package instead of shelling out to the external `pi` CLI.

## New Skills

### `pi-review`
One-off code/design review using the builtin `reviewer` subagent:
- Design doc review via `reads` parameter
- Code diff review by letting the reviewer inspect git state directly
- Supports both fresh (adversarial) and forked (context-aware) review contexts

### `pi-refine`
Iterative document refinement loop (max 5 iterations):
- Dispatches `reviewer` subagent per iteration
- Triages findings into Fix / Ignore / Ask-user categories
- Eager convergence: stops when only language polish remains
- Same security-first triage rules as the original skill

### `skills/README.md`
Documents external package dependencies:
- `pi-subagents` as required for pi-review and pi-refine
- Installation, verification, and model override instructions
- `pi-intercom` as optional for async workflows
- Skills index organized by category

## Key Changes from CLI-based Approach
- No external `pi` CLI dependency — everything stays in the pi tool ecosystem
- Reviewer agent can use `read`, `bash`, `ast_grep_search`, `lsp_navigation`, etc.
- Configurable model overrides via `.pi/settings.json` or per-call `model` parameter