### PR TITLE
Make `using-superpowers` manual-invoke (disable-model-invocation: true)

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: using-superpowers
-description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+description: Reference for how to find and use superpowers skills via the Skill tool. Invoke explicitly to load the skill-discovery rules and red-flag table.
+disable-model-invocation: true
 ---
 
 <SUBAGENT-STOP>


### PR DESCRIPTION
Closes #1456

## What

Adds `disable-model-invocation: true` to `skills/using-superpowers/SKILL.md` and updates the description to reflect that the skill is now manually-invoked.

## Why

`using-superpowers` currently auto-injects its full ~5.4KB / ~1,300 tokens content into the system context at the start of every Claude Code session because its description (`"Use when starting any conversation..."`) matches every conversation. For users who actively use superpowers skills (TDD, brainstorming, debugging-systematically, etc.), the meta-skill content doesn't need to be in context to find the other skills — they're discoverable via the standard Skill registry.

The v5.0.7 release notes show you already care about this kind of cost (the OpenCode `experimental.chat.messages.transform` fix for #750). This applies the same principle to Claude Code.

## Trade-off (worth flagging)

Claude no longer sees the "MUST invoke Skill tool BEFORE any response" rule and the red-flag table by default. Users who want the enforcement back can invoke the skill explicitly:

```
/superpowers:using-superpowers
```

If you'd rather preserve some default guidance, two alternatives I floated in #1456:

1. **Replace the full inject with a 1-line pointer** (~20 tokens):
   > "Run `/superpowers:using-superpowers` for guidance on finding and using superpowers skills."
2. **Use `sessionStart: true` + `pathPatterns`** (the pattern Vercel's `knowledge-update` uses) so it only injects when the project shows signs of code work.

Happy to adjust this PR if you'd prefer either alternative.

## Verification

- The other superpowers skills (TDD, brainstorming, debugging, etc.) still appear in the standard skill registry and remain invokable via the Skill tool — confirmed in a fresh session.
- `disable-model-invocation: true` is documented at https://code.claude.com/docs/en/skills.md as the standard way to mark a skill manual-only.