### PR TITLE
feat: lifecycle event hooks for external plugin authors

### DIFF
--- a/docs/superpowers/lifecycle-events.md
+++ b/docs/superpowers/lifecycle-events.md
@@ -1,0 +1,133 @@
+# Superpowers Lifecycle Events (Plugin Author Reference)
+
+Superpowers core fires lifecycle events at well-defined moments during plan and task workflows. Plugin authors subscribe by dropping shell scripts into a registered directory.
+
+## Quick start
+
+1. Create a directory for your plugin's hook scripts:
+   ```bash
+   mkdir -p ~/.config/my-plugin/hooks
+   ```
+
+2. Add an executable hook script for the event you care about:
+   ```bash
+   cat > ~/.config/my-plugin/hooks/TaskClaimed.sh <<'EOF'
+   #!/usr/bin/env bash
+   echo "Task $SP_TASK_NUMBER claimed in $SP_PLAN_PATH" >&2
+   EOF
+   chmod +x ~/.config/my-plugin/hooks/TaskClaimed.sh
+   ```
+
+3. Register the dir in your shell rc:
+   ```bash
+   export SUPERPOWERS_HOOK_DIRS="$HOME/.config/my-plugin/hooks${SUPERPOWERS_HOOK_DIRS:+:$SUPERPOWERS_HOOK_DIRS}"
+   ```
+
+4. Restart your agent session. The hook fires automatically when a task is claimed.
+
+## How dispatch works
+
+When core wants to emit an event, it calls:
+
+```bash
+$SUPERPOWERS_ROOT/scripts/emit-hook.sh <EventName> [key=value ...]
+```
+
+`emit-hook.sh` then:
+
+1. Reads `$SUPERPOWERS_HOOK_DIRS` (colon-separated, like `$PATH`). If unset/empty, exits 0 immediately.
+2. Translates each `key=value` arg into an `SP_<KEY>` env var (key uppercased; values may contain `=`).
+3. For each registered dir in order, runs `<dir>/<EventName>.sh` if it exists and is executable.
+4. Hooks run sequentially, never in parallel. Stdin is `/dev/null`; stdout is discarded; stderr is captured and surfaced.
+5. Plugin failures (nonzero exit, timeout, missing exec bit) log a warning to stderr but never propagate. `emit-hook.sh` always exits 0.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `SUPERPOWERS_HOOK_DIRS` | unset (no plugins) | Colon-separated list of plugin hook directories. |
+| `SUPERPOWERS_HOOK_TIMEOUT` | `10` | Seconds before a hook script is killed. Integer only. |
+
+## Event catalog
+
+### `PlanWritten`
+
+Fired by `writing-plans` skill after self-review passes.
+
+| Env var | Description |
+|---|---|
+| `SP_PLAN_PATH` | Absolute path to the plan markdown file |
+| `SP_PLAN_TITLE` | H1 heading from the plan |
+
+**Plugin guidance:** plugins may mutate the plan file at this point (e.g., add a `**Refs:** xxx` line to each task body). The implementer prompt sends full task body text, so plan-level enrichment propagates naturally to subagent prompts.
+
+### `TaskClaimed`
+
+Fired when a task transitions to in_progress in `executing-plans` and `subagent-driven-development`.
+
+| Env var | Description |
+|---|---|
+| `SP_PLAN_PATH` | Plan the task belongs to |
+| `SP_TASK_NUMBER` | Integer matching `### Task N:` heading in plan |
+| `SP_TASK_TITLE` | Task heading text |
+
+### `TaskCompleted`
+
+Fired when a task reaches completed state. Same payload as `TaskClaimed`.
+
+### `BlockedOnHuman`
+
+Fired when a task cannot proceed and needs human resolution.
+
+| Env var | Description |
+|---|---|
+| `SP_PLAN_PATH` | Plan the task belongs to |
+| `SP_TASK_NUMBER` | Integer matching `### Task N:` heading in plan |
+| `SP_TASK_TITLE` | Task heading text |
+| `SP_REASON` | Free-text explanation of the block |
+
+## Failure modes
+
+| Condition | Behavior |
+|---|---|
+| `SUPERPOWERS_HOOK_DIRS` unset/empty | Silent no-op |
+| Hook script not present | Silent skip; continue |
+| Hook script not executable | Warning logged; skip |
+| Hook script exits nonzero | Warning logged; continue |
+| Hook script exceeds timeout | Killed (SIGTERM, then SIGKILL after 1s); warning logged; continue |
+| `timeout(1)` / `gtimeout(1)` not available | One-time warning; hooks run unbounded |
+
+## Writing a plugin: example
+
+A minimal plugin that logs every event to a file:
+
+```
+~/.config/my-plugin/hooks/
+├── PlanWritten.sh
+├── TaskClaimed.sh
+├── TaskCompleted.sh
+└── BlockedOnHuman.sh
+```
+
+Each script could simply be:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+event_name="$(basename "$0" .sh)"
+echo "[$(date -u +%FT%TZ)] $event_name plan=$SP_PLAN_PATH task=${SP_TASK_NUMBER:-} reason=${SP_REASON:-}" \
+  >> "$HOME/.config/my-plugin/events.log"
+```
+
+Plugins that don't care about an event simply don't ship a script for it. Multiple plugins coexist by registering multiple dirs in `SUPERPOWERS_HOOK_DIRS`.
+
+## Stability and forward compatibility
+
+- New events may be added in future releases. Plugins ignore events they don't subscribe to.
+- New env vars may be added to existing event payloads. Plugins ignore vars they don't read.
+- Existing env var names will not change without a major version bump.
+- The `SP_*` prefix is reserved for core. Plugins should not rely on or set their own `SP_*` env vars.
+
+## See also
+
+- [Lifecycle Events Design Spec](specs/2026-05-02-lifecycle-events-design.md)

--- a/docs/superpowers/lifecycle-events.md
+++ b/docs/superpowers/lifecycle-events.md
@@ -27,11 +27,14 @@ Superpowers core fires lifecycle events at well-defined moments during plan and 
 
 ## How dispatch works
 
-When core wants to emit an event, it calls:
+When core wants to emit an event, the calling skill resolves the script path through a harness fallback chain and invokes:
 
 ```bash
-$SUPERPOWERS_ROOT/scripts/emit-hook.sh <EventName> [key=value ...]
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" <EventName> [key=value ...]
 ```
+
+`CLAUDE_PLUGIN_ROOT` is set by Claude Code; `CURSOR_PLUGIN_ROOT` by Cursor; users on other harnesses (Codex, Gemini, OpenCode) should export `SUPERPOWERS_ROOT` themselves. If none is set, the emit is silently skipped — no error.
 
 `emit-hook.sh` then:
 

--- a/docs/superpowers/plans/2026-05-02-lifecycle-events.md
+++ b/docs/superpowers/plans/2026-05-02-lifecycle-events.md
@@ -1,0 +1,1218 @@
+# Lifecycle Events Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a minimum-surface lifecycle event API to Superpowers core so plugin authors can mirror plan/task lifecycle without forking skills. Four events (`PlanWritten`, `TaskClaimed`, `TaskCompleted`, `BlockedOnHuman`), one shell event-bus script, one env-var registry.
+
+**Architecture:** Core ships a single bash script (`scripts/emit-hook.sh`) that skills invoke at lifecycle points. The script reads `$SUPERPOWERS_HOOK_DIRS` (colon-separated), scans each dir for `<EventName>.sh`, and runs matching scripts with payload data exported as `SP_*` env vars. Failures are logged but never propagate. Three core skills get small additive emit blocks marked with `<!-- BEGIN lifecycle:Event -->` comments.
+
+**Spec:** [docs/superpowers/specs/2026-05-02-lifecycle-events-design.md](../specs/2026-05-02-lifecycle-events-design.md)
+
+**Tech Stack:** Bash 4+, coreutils `timeout` (or `gtimeout` on macOS), no other dependencies. Tests use the existing `*.test.sh` convention from `tests/brainstorm-server/windows-lifecycle.test.sh`.
+
+---
+
+## File Structure
+
+**Created:**
+- `scripts/emit-hook.sh` — the event dispatcher (~60 LOC bash)
+- `tests/lifecycle-events/emit-hook.test.sh` — bash test suite (~250 LOC)
+- `docs/superpowers/lifecycle-events.md` — plugin author reference doc (~150 LOC)
+
+**Modified:**
+- `skills/writing-plans/SKILL.md` — add 1 emit block
+- `skills/executing-plans/SKILL.md` — add 3 emit blocks
+- `skills/subagent-driven-development/SKILL.md` — add 3 emit blocks
+
+---
+
+## Chunk 1: emit-hook.sh + tests
+
+The event dispatcher and its test suite. Built incrementally TDD-style: each task adds one new behavior with its tests.
+
+### Task 1: Bootstrap test harness + skeleton script
+
+**Files:**
+- Create: `tests/lifecycle-events/emit-hook.test.sh`
+- Create: `scripts/emit-hook.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/lifecycle-events/emit-hook.test.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Tests for scripts/emit-hook.sh — the lifecycle event dispatcher.
+#
+# Usage:
+#   bash tests/lifecycle-events/emit-hook.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${SUPERPOWERS_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+EMIT_HOOK="$REPO_ROOT/scripts/emit-hook.sh"
+
+passed=0
+failed=0
+
+# Per-test scratch dir; cleaned between tests
+TEST_DIR=""
+
+setup_test() {
+  TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/emit-hook-test-XXXXXX")"
+}
+
+teardown_test() {
+  if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+    rm -rf "$TEST_DIR"
+  fi
+  unset TEST_DIR SUPERPOWERS_HOOK_DIRS SUPERPOWERS_HOOK_TIMEOUT
+}
+
+trap teardown_test EXIT
+
+pass() {
+  echo "  PASS: $1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  echo "    $2"
+  failed=$((failed + 1))
+}
+
+# ========== Tests ==========
+
+echo ""
+echo "=== emit-hook.sh tests ==="
+echo ""
+
+# Test: unset HOOK_DIRS is a silent no-op
+setup_test
+unset SUPERPOWERS_HOOK_DIRS
+out="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1)"
+rc=$?
+if [[ "$rc" -eq 0 && -z "$out" ]]; then
+  pass "unset HOOK_DIRS: silent no-op"
+else
+  fail "unset HOOK_DIRS: silent no-op" "rc=$rc out='$out'"
+fi
+teardown_test
+
+# ========== Summary ==========
+echo ""
+echo "=== Results: $passed passed, $failed failed ==="
+[[ "$failed" -eq 0 ]]
+```
+
+Make it executable:
+
+```bash
+chmod +x tests/lifecycle-events/emit-hook.test.sh
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: FAIL — `scripts/emit-hook.sh` does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/emit-hook.sh`:
+
+```bash
+#!/usr/bin/env bash
+# emit-hook.sh — Lifecycle event dispatcher for Superpowers plugins.
+#
+# Usage: emit-hook.sh <EventName> [key=value ...]
+#
+# Reads $SUPERPOWERS_HOOK_DIRS (colon-separated, like $PATH). For each
+# dir, runs <dir>/<EventName>.sh if it exists and is executable, with
+# key=value pairs translated to SP_<KEY> env vars (uppercased).
+#
+# Failures (nonzero exit, timeout, missing exec bit) log a warning to
+# stderr and skip to the next dir. emit-hook.sh always exits 0.
+
+set -uo pipefail
+
+# Always exit 0; never propagate plugin failures to caller.
+trap 'exit 0' EXIT
+
+if [[ $# -lt 1 ]]; then
+  echo "[hook warn] emit-hook.sh: missing event name" >&2
+  exit 0
+fi
+
+# Silent no-op if no plugins are registered.
+if [[ -z "${SUPERPOWERS_HOOK_DIRS:-}" ]]; then
+  exit 0
+fi
+
+# Further behavior added in Task 2.
+exit 0
+```
+
+Make it executable:
+
+```bash
+chmod +x scripts/emit-hook.sh
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: `PASS: unset HOOK_DIRS: silent no-op` and `Results: 1 passed, 0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/emit-hook.sh tests/lifecycle-events/emit-hook.test.sh
+git commit -m "feat(lifecycle): emit-hook skeleton + first test
+
+scripts/emit-hook.sh exits silently when SUPERPOWERS_HOOK_DIRS is
+unset. Test harness lives in tests/lifecycle-events/."
+```
+
+---
+
+### Task 2: Dir scanning + hook execution + env var translation
+
+**Files:**
+- Modify: `scripts/emit-hook.sh`
+- Modify: `tests/lifecycle-events/emit-hook.test.sh`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/lifecycle-events/emit-hook.test.sh` after the existing test (and before the Summary section):
+
+```bash
+# Test: hook script not present in registered dir → silent skip
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+out="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1)"
+rc=$?
+if [[ "$rc" -eq 0 && -z "$out" ]]; then
+  pass "missing hook script: silent skip"
+else
+  fail "missing hook script: silent skip" "rc=$rc out='$out'"
+fi
+teardown_test
+
+# Test: hook script runs and sees SP_* env vars
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "plan_path=$SP_PLAN_PATH plan_title=$SP_PLAN_TITLE" > "$SP_TEST_LOG"
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+log_file="$TEST_DIR/log"
+"$EMIT_HOOK" PlanWritten \
+  plan_path=/tmp/foo.md \
+  plan_title="My Feature" \
+  test_log="$log_file" >/dev/null 2>&1
+if [[ -f "$log_file" ]] && grep -q "plan_path=/tmp/foo.md plan_title=My Feature" "$log_file"; then
+  pass "hook runs with SP_* env vars exported"
+else
+  fail "hook runs with SP_* env vars exported" "log_file=$log_file contents='$(cat "$log_file" 2>/dev/null)'"
+fi
+teardown_test
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: First two pass (skeleton + missing hook); third fails because no execution logic exists yet (the log file is never written).
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the body of `scripts/emit-hook.sh` (everything after the unset HOOK_DIRS check) with:
+
+```bash
+event_name="$1"; shift
+
+# Translate key=value args to SP_<KEY> env vars (key uppercased).
+declare -a env_assignments=()
+for arg in "$@"; do
+  if [[ "$arg" != *"="* ]]; then
+    echo "[hook warn] emit-hook.sh: malformed arg '$arg' (expected key=value)" >&2
+    continue
+  fi
+  key="${arg%%=*}"
+  val="${arg#*=}"
+  upper_key="SP_$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+  env_assignments+=("$upper_key=$val")
+done
+
+# Iterate dirs in registration order; sequential per dir.
+IFS=':' read -ra dirs <<< "$SUPERPOWERS_HOOK_DIRS"
+for dir in "${dirs[@]}"; do
+  [[ -z "$dir" ]] && continue
+  hook_script="$dir/${event_name}.sh"
+
+  [[ ! -e "$hook_script" ]] && continue
+
+  if [[ ! -x "$hook_script" ]]; then
+    echo "[hook warn] $event_name in $dir: not executable" >&2
+    continue
+  fi
+
+  env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+done
+
+exit 0
+```
+
+The full file should now be:
+
+```bash
+#!/usr/bin/env bash
+# emit-hook.sh — Lifecycle event dispatcher for Superpowers plugins.
+#
+# Usage: emit-hook.sh <EventName> [key=value ...]
+#
+# Reads $SUPERPOWERS_HOOK_DIRS (colon-separated, like $PATH). For each
+# dir, runs <dir>/<EventName>.sh if it exists and is executable, with
+# key=value pairs translated to SP_<KEY> env vars (uppercased).
+#
+# Failures (nonzero exit, timeout, missing exec bit) log a warning to
+# stderr and skip to the next dir. emit-hook.sh always exits 0.
+
+set -uo pipefail
+
+trap 'exit 0' EXIT
+
+if [[ $# -lt 1 ]]; then
+  echo "[hook warn] emit-hook.sh: missing event name" >&2
+  exit 0
+fi
+
+if [[ -z "${SUPERPOWERS_HOOK_DIRS:-}" ]]; then
+  exit 0
+fi
+
+event_name="$1"; shift
+
+declare -a env_assignments=()
+for arg in "$@"; do
+  if [[ "$arg" != *"="* ]]; then
+    echo "[hook warn] emit-hook.sh: malformed arg '$arg' (expected key=value)" >&2
+    continue
+  fi
+  key="${arg%%=*}"
+  val="${arg#*=}"
+  upper_key="SP_$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+  env_assignments+=("$upper_key=$val")
+done
+
+IFS=':' read -ra dirs <<< "$SUPERPOWERS_HOOK_DIRS"
+for dir in "${dirs[@]}"; do
+  [[ -z "$dir" ]] && continue
+  hook_script="$dir/${event_name}.sh"
+
+  [[ ! -e "$hook_script" ]] && continue
+
+  if [[ ! -x "$hook_script" ]]; then
+    echo "[hook warn] $event_name in $dir: not executable" >&2
+    continue
+  fi
+
+  env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+done
+
+exit 0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: 3 PASSed, 0 failed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/emit-hook.sh tests/lifecycle-events/emit-hook.test.sh
+git commit -m "feat(lifecycle): dir scanning + hook execution + env vars
+
+emit-hook.sh now scans SUPERPOWERS_HOOK_DIRS, locates matching
+<EventName>.sh files, and runs them with key=value args translated
+to SP_<KEY> env vars."
+```
+
+---
+
+### Task 3: Failure handling — nonzero exit and missing exec bit
+
+**Files:**
+- Modify: `scripts/emit-hook.sh`
+- Modify: `tests/lifecycle-events/emit-hook.test.sh`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/lifecycle-events/emit-hook.test.sh` (before Summary):
+
+```bash
+# Test: hook exits nonzero → warning logged, emit-hook still exits 0
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+err="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1 1>/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 && "$err" == *"PlanWritten"* && "$err" == *"exit 7"* ]]; then
+  pass "nonzero exit: warning logged, emit-hook exits 0"
+else
+  fail "nonzero exit" "rc=$rc err='$err'"
+fi
+teardown_test
+
+# Test: hook script not executable → warning logged, skip
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+# Intentionally NOT chmod +x
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+err="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1 1>/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 && "$err" == *"not executable"* ]]; then
+  pass "not executable: warning logged"
+else
+  fail "not executable" "rc=$rc err='$err'"
+fi
+teardown_test
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: First three pass; "nonzero exit" fails (no warning emitted yet); "not executable" passes (already implemented in Task 2).
+
+- [ ] **Step 3: Write the implementation**
+
+In `scripts/emit-hook.sh`, replace the line:
+
+```bash
+  env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+```
+
+with:
+
+```bash
+  env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+  rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    echo "[hook warn] $event_name in $dir: exit $rc" >&2
+  fi
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: 5 passed, 0 failed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/emit-hook.sh tests/lifecycle-events/emit-hook.test.sh
+git commit -m "feat(lifecycle): warn on hook failures, never propagate
+
+Nonzero hook exit codes log a warning but emit-hook still exits 0.
+Non-executable hook scripts produce a warning and are skipped."
+```
+
+---
+
+### Task 4: Timeout enforcement (10s default + override)
+
+**Files:**
+- Modify: `scripts/emit-hook.sh`
+- Modify: `tests/lifecycle-events/emit-hook.test.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/lifecycle-events/emit-hook.test.sh` (before Summary):
+
+```bash
+# Test: hook exceeds timeout → killed, warning logged
+# Use SUPERPOWERS_HOOK_TIMEOUT=1 to keep the test fast.
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+sleep 30
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+export SUPERPOWERS_HOOK_TIMEOUT=1
+start_ts=$(date +%s)
+err="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1 1>/dev/null)"
+rc=$?
+elapsed=$(( $(date +%s) - start_ts ))
+if [[ "$rc" -eq 0 && "$err" == *"timed out"* && "$elapsed" -lt 5 ]]; then
+  pass "timeout: hook killed and warning logged (elapsed=${elapsed}s)"
+else
+  fail "timeout" "rc=$rc elapsed=${elapsed}s err='$err'"
+fi
+teardown_test
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: Existing tests pass; "timeout" test FAILS or hangs for ~30s. If it hangs, kill it (`Ctrl+C`); confirm no timeout enforcement exists yet.
+
+- [ ] **Step 3: Write the implementation**
+
+In `scripts/emit-hook.sh`, add this near the top (after the `set -uo pipefail` line):
+
+```bash
+readonly DEFAULT_TIMEOUT=10
+
+# Resolve timeout command (Linux: timeout; macOS w/ coreutils: gtimeout).
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+```
+
+Replace the hook execution block:
+
+```bash
+  env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+  rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    echo "[hook warn] $event_name in $dir: exit $rc" >&2
+  fi
+```
+
+with:
+
+```bash
+  hook_timeout="${SUPERPOWERS_HOOK_TIMEOUT:-$DEFAULT_TIMEOUT}"
+
+  if [[ -n "$TIMEOUT_CMD" ]]; then
+    env "${env_assignments[@]}" \
+      "$TIMEOUT_CMD" --kill-after=1 "$hook_timeout" "$hook_script" </dev/null >/dev/null
+    rc=$?
+    if [[ "$rc" -eq 124 || "$rc" -eq 137 ]]; then
+      echo "[hook warn] $event_name in $dir: timed out after ${hook_timeout}s" >&2
+    elif [[ "$rc" -ne 0 ]]; then
+      echo "[hook warn] $event_name in $dir: exit $rc" >&2
+    fi
+  else
+    # No timeout(1) available — run unbounded with one-time warning.
+    if [[ -z "${EMIT_HOOK_TIMEOUT_WARNED:-}" ]]; then
+      echo "[hook warn] timeout(1) not available; hooks run unbounded" >&2
+      EMIT_HOOK_TIMEOUT_WARNED=1
+      export EMIT_HOOK_TIMEOUT_WARNED
+    fi
+    env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      echo "[hook warn] $event_name in $dir: exit $rc" >&2
+    fi
+  fi
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: 6 passed, 0 failed. The timeout test should complete in ~1-2 seconds, not 30.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/emit-hook.sh tests/lifecycle-events/emit-hook.test.sh
+git commit -m "feat(lifecycle): enforce 10s default hook timeout
+
+Hooks that exceed SUPERPOWERS_HOOK_TIMEOUT (default 10s) are killed
+via timeout(1)/gtimeout(1) with a warning. Falls back to unbounded
+execution + one-time warning if neither tool is available."
+```
+
+---
+
+### Task 5: stdio + multi-dir + key=value edge cases
+
+**Files:**
+- Modify: `tests/lifecycle-events/emit-hook.test.sh`
+
+This task adds tests for behaviors that the existing implementation already supports — verifying they actually work as designed. No implementation changes expected.
+
+- [ ] **Step 1: Write the tests**
+
+Append to `tests/lifecycle-events/emit-hook.test.sh` (before Summary):
+
+```bash
+# Test: hook stdin is /dev/null (read returns empty)
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+read -r line || true
+echo "stdin_was='$line'" > "$SP_OUT"
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+echo "should-not-reach-hook" | "$EMIT_HOOK" PlanWritten out="$TEST_DIR/out" >/dev/null 2>&1
+if grep -q "stdin_was=''" "$TEST_DIR/out"; then
+  pass "hook stdin redirected to /dev/null"
+else
+  fail "hook stdin redirected to /dev/null" "got: $(cat "$TEST_DIR/out" 2>/dev/null)"
+fi
+teardown_test
+
+# Test: hook stdout is discarded
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "this-should-not-be-visible"
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+out="$("$EMIT_HOOK" PlanWritten plan_path=x 2>/dev/null)"
+if [[ -z "$out" ]]; then
+  pass "hook stdout discarded"
+else
+  fail "hook stdout discarded" "got: '$out'"
+fi
+teardown_test
+
+# Test: multiple registered dirs run sequentially in order
+setup_test
+mkdir -p "$TEST_DIR/h1" "$TEST_DIR/h2"
+cat > "$TEST_DIR/h1/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "h1" >> "$SP_LOG"
+EOF
+cat > "$TEST_DIR/h2/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "h2" >> "$SP_LOG"
+EOF
+chmod +x "$TEST_DIR/h1/PlanWritten.sh" "$TEST_DIR/h2/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/h1:$TEST_DIR/h2"
+"$EMIT_HOOK" PlanWritten log="$TEST_DIR/seq.log" >/dev/null 2>&1
+if [[ "$(cat "$TEST_DIR/seq.log")" == $'h1\nh2' ]]; then
+  pass "multiple dirs run sequentially in order"
+else
+  fail "multiple dirs sequential" "got: $(cat "$TEST_DIR/seq.log")"
+fi
+teardown_test
+
+# Test: key=value with literal '=' in value preserved
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$SP_REASON" > "$SP_OUT"
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+"$EMIT_HOOK" PlanWritten reason="error: foo=bar baz=qux" out="$TEST_DIR/r.out" >/dev/null 2>&1
+if [[ "$(cat "$TEST_DIR/r.out")" == "error: foo=bar baz=qux" ]]; then
+  pass "key=value preserves literal '=' in value"
+else
+  fail "key=value preserves '='" "got: '$(cat "$TEST_DIR/r.out")'"
+fi
+teardown_test
+
+# Test: missing event name → warning logged, exits 0
+setup_test
+err="$("$EMIT_HOOK" 2>&1 1>/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 && "$err" == *"missing event name"* ]]; then
+  pass "missing event name: warning logged, exits 0"
+else
+  fail "missing event name" "rc=$rc err='$err'"
+fi
+teardown_test
+```
+
+- [ ] **Step 2: Run tests to verify all pass**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: 11 passed, 0 failed. If any fail, the prior implementation has a gap — fix in `scripts/emit-hook.sh`.
+
+- [ ] **Step 3: Verify edge cases manually**
+
+Run a quick sanity check from the repo root:
+
+```bash
+mkdir -p /tmp/sp-hook-smoke
+cat > /tmp/sp-hook-smoke/PlanWritten.sh <<'EOF'
+#!/usr/bin/env bash
+echo "got plan_path=$SP_PLAN_PATH" >&2
+EOF
+chmod +x /tmp/sp-hook-smoke/PlanWritten.sh
+
+SUPERPOWERS_HOOK_DIRS=/tmp/sp-hook-smoke \
+  ./scripts/emit-hook.sh PlanWritten plan_path=/tmp/foo.md plan_title="Smoke Test"
+```
+
+Expected stderr: `got plan_path=/tmp/foo.md`
+
+Cleanup:
+
+```bash
+rm -rf /tmp/sp-hook-smoke
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/lifecycle-events/emit-hook.test.sh
+git commit -m "test(lifecycle): cover stdio, multi-dir, kv parsing edges"
+```
+
+---
+
+## Chunk 2: Skill integration
+
+Add small additive emit blocks at the lifecycle points identified in the spec. Each block uses the existing `<!-- BEGIN ... -->` / `<!-- END ... -->` comment convention.
+
+### Task 6: Add PlanWritten emit block to writing-plans skill
+
+**Files:**
+- Modify: `skills/writing-plans/SKILL.md` (insertion point: after the "Self-Review" section, before "Execution Handoff")
+
+- [ ] **Step 1: Read the current skill and identify the insertion point**
+
+Run: `grep -n "^## " skills/writing-plans/SKILL.md`
+
+Expected output includes lines like:
+```
+... ## Self-Review
+... ## Execution Handoff
+```
+
+Note the line number where `## Execution Handoff` begins. The new block goes immediately before that heading.
+
+- [ ] **Step 2: Insert the emit block**
+
+Add this block after the Self-Review section, immediately before the `## Execution Handoff` heading in `skills/writing-plans/SKILL.md`:
+
+````markdown
+<!-- BEGIN lifecycle:PlanWritten -->
+## Lifecycle Event: PlanWritten
+
+After self-review passes, emit the `PlanWritten` lifecycle event so any registered plugins (e.g., a Beads mirror) can react. This is a no-op when no plugins are installed (`SUPERPOWERS_HOOK_DIRS` unset).
+
+Resolve the script path and emit:
+
+```bash
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" PlanWritten \
+  plan_path="<absolute-plan-path>" \
+  plan_title="<plan H1 title>"
+```
+
+Substitute `<absolute-plan-path>` with the path you just saved the plan to, and `<plan H1 title>` with the H1 heading from the plan file. Plugins receive these as `$SP_PLAN_PATH` and `$SP_PLAN_TITLE`.
+<!-- END lifecycle:PlanWritten -->
+
+````
+
+- [ ] **Step 3: Verify the block parses cleanly and the file still loads as a skill**
+
+Run: `grep -c "BEGIN lifecycle\|END lifecycle" skills/writing-plans/SKILL.md`
+
+Expected: `2` (one BEGIN, one END).
+
+Run: `grep -A2 "^---$" skills/writing-plans/SKILL.md | head -5`
+
+Expected: shows the YAML frontmatter — confirms the file structure wasn't damaged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/writing-plans/SKILL.md
+git commit -m "feat(lifecycle): emit PlanWritten in writing-plans skill
+
+Adds a small additive block that fires the PlanWritten lifecycle
+event after self-review passes. No-op when SUPERPOWERS_HOOK_DIRS
+is unset; the legacy markdown-only flow is unchanged."
+```
+
+---
+
+### Task 7: Add task-state emit blocks to executing-plans skill
+
+**Files:**
+- Modify: `skills/executing-plans/SKILL.md` (3 insertion points within Step 2)
+
+- [ ] **Step 1: Identify insertion points**
+
+Run: `grep -n "^### Step 2\|Mark as completed\|Mark as in_progress\|BLOCKED" skills/executing-plans/SKILL.md`
+
+You should find references to task state transitions in Step 2: "Execute Tasks". The current Step 2 reads roughly:
+
+```
+For each task:
+1. Mark as in_progress
+2. Execute steps
+3. Run verifications as specified
+4. Mark as completed
+```
+
+The three emit blocks attach to: "Mark as in_progress", "Mark as completed", and the implicit BLOCKED escalation.
+
+- [ ] **Step 2: Insert the three emit blocks**
+
+In `skills/executing-plans/SKILL.md`, replace the Step 2 list:
+
+```markdown
+For each task:
+
+1. Mark as in_progress
+2. Execute steps
+3. Run verifications as specified
+4. Mark as completed
+```
+
+with:
+
+````markdown
+For each task:
+
+1. Mark as in_progress
+   <!-- BEGIN lifecycle:TaskClaimed -->
+   **Lifecycle event:** also emit `TaskClaimed`:
+   ```bash
+   SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+   [[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" TaskClaimed \
+     plan_path="<absolute-plan-path>" \
+     task_number="<N>" \
+     task_title="<task heading>"
+   ```
+   No-op when `SUPERPOWERS_HOOK_DIRS` is unset.
+   <!-- END lifecycle:TaskClaimed -->
+
+2. Execute steps
+3. Run verifications as specified
+4. Mark as completed
+   <!-- BEGIN lifecycle:TaskCompleted -->
+   **Lifecycle event:** also emit `TaskCompleted`:
+   ```bash
+   SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+   [[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" TaskCompleted \
+     plan_path="<absolute-plan-path>" \
+     task_number="<N>" \
+     task_title="<task heading>"
+   ```
+   <!-- END lifecycle:TaskCompleted -->
+
+If a task cannot proceed and needs human resolution:
+
+<!-- BEGIN lifecycle:BlockedOnHuman -->
+**Lifecycle event:** emit `BlockedOnHuman` before stopping:
+```bash
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" BlockedOnHuman \
+  plan_path="<absolute-plan-path>" \
+  task_number="<N>" \
+  task_title="<task heading>" \
+  reason="<short explanation of the block>"
+```
+<!-- END lifecycle:BlockedOnHuman -->
+
+````
+
+- [ ] **Step 3: Verify the file integrity**
+
+Run: `grep -c "BEGIN lifecycle\|END lifecycle" skills/executing-plans/SKILL.md`
+
+Expected: `6` (3 BEGIN, 3 END).
+
+Run: `head -10 skills/executing-plans/SKILL.md`
+
+Expected: shows YAML frontmatter intact (`---`, `name:`, `description:`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/executing-plans/SKILL.md
+git commit -m "feat(lifecycle): emit Task* events in executing-plans
+
+Adds three additive blocks for TaskClaimed, TaskCompleted, and
+BlockedOnHuman at the corresponding state-transition points in
+Step 2. No behavior change when SUPERPOWERS_HOOK_DIRS is unset."
+```
+
+---
+
+### Task 8: Add task-state emit blocks to subagent-driven-development skill
+
+**Files:**
+- Modify: `skills/subagent-driven-development/SKILL.md` (3 insertion points around the per-task loop)
+
+- [ ] **Step 1: Identify insertion points**
+
+Run: `grep -n "in_progress\|completed\|BLOCKED\|implementer.*report" skills/subagent-driven-development/SKILL.md | head -20`
+
+The skill describes a per-task loop with state transitions matching `executing-plans`. Find the lines near the per-task in_progress mark, the per-task completed mark, and the BLOCKED handling section.
+
+- [ ] **Step 2: Add the emit blocks**
+
+Find the section in `skills/subagent-driven-development/SKILL.md` describing the per-task loop. Near the line marking a task in_progress, insert this block (immediately after the existing in_progress mark instruction):
+
+````markdown
+<!-- BEGIN lifecycle:TaskClaimed -->
+**Lifecycle event:** also emit `TaskClaimed`:
+```bash
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" TaskClaimed \
+  plan_path="<absolute-plan-path>" \
+  task_number="<N>" \
+  task_title="<task heading>"
+```
+No-op when `SUPERPOWERS_HOOK_DIRS` is unset.
+<!-- END lifecycle:TaskClaimed -->
+````
+
+Near the line marking a task completed (after both reviews pass), insert:
+
+````markdown
+<!-- BEGIN lifecycle:TaskCompleted -->
+**Lifecycle event:** also emit `TaskCompleted`:
+```bash
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" TaskCompleted \
+  plan_path="<absolute-plan-path>" \
+  task_number="<N>" \
+  task_title="<task heading>"
+```
+<!-- END lifecycle:TaskCompleted -->
+````
+
+In the "Handling Implementer Status" / BLOCKED section (find via `grep -n "BLOCKED" skills/subagent-driven-development/SKILL.md`), add immediately before the existing escalation guidance:
+
+````markdown
+<!-- BEGIN lifecycle:BlockedOnHuman -->
+**Lifecycle event:** before escalating, emit `BlockedOnHuman`:
+```bash
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" BlockedOnHuman \
+  plan_path="<absolute-plan-path>" \
+  task_number="<N>" \
+  task_title="<task heading>" \
+  reason="<short explanation of the block>"
+```
+<!-- END lifecycle:BlockedOnHuman -->
+````
+
+- [ ] **Step 3: Verify the file integrity**
+
+Run: `grep -c "BEGIN lifecycle\|END lifecycle" skills/subagent-driven-development/SKILL.md`
+
+Expected: `6` (3 BEGIN, 3 END).
+
+Run: `head -10 skills/subagent-driven-development/SKILL.md`
+
+Expected: shows YAML frontmatter intact.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/subagent-driven-development/SKILL.md
+git commit -m "feat(lifecycle): emit Task* events in subagent-driven-development
+
+Adds TaskClaimed, TaskCompleted, and BlockedOnHuman emit blocks at
+the corresponding per-task transitions in the SDD loop. No behavior
+change when SUPERPOWERS_HOOK_DIRS is unset."
+```
+
+---
+
+## Chunk 3: Documentation + verification
+
+### Task 9: Write the lifecycle-events reference doc
+
+**Files:**
+- Create: `docs/superpowers/lifecycle-events.md`
+
+- [ ] **Step 1: Write the reference doc**
+
+Create `docs/superpowers/lifecycle-events.md`:
+
+````markdown
+# Superpowers Lifecycle Events (Plugin Author Reference)
+
+Superpowers core fires lifecycle events at well-defined moments during plan and task workflows. Plugin authors subscribe by dropping shell scripts into a registered directory.
+
+## Quick start
+
+1. Create a directory for your plugin's hook scripts:
+   ```bash
+   mkdir -p ~/.config/my-plugin/hooks
+   ```
+
+2. Add an executable hook script for the event you care about:
+   ```bash
+   cat > ~/.config/my-plugin/hooks/TaskClaimed.sh <<'EOF'
+   #!/usr/bin/env bash
+   echo "Task $SP_TASK_NUMBER claimed in $SP_PLAN_PATH" >&2
+   EOF
+   chmod +x ~/.config/my-plugin/hooks/TaskClaimed.sh
+   ```
+
+3. Register the dir in your shell rc:
+   ```bash
+   export SUPERPOWERS_HOOK_DIRS="$HOME/.config/my-plugin/hooks${SUPERPOWERS_HOOK_DIRS:+:$SUPERPOWERS_HOOK_DIRS}"
+   ```
+
+4. Restart your agent session. The hook fires automatically when a task is claimed.
+
+## How dispatch works
+
+When core wants to emit an event, it calls:
+
+```bash
+$SUPERPOWERS_ROOT/scripts/emit-hook.sh <EventName> [key=value ...]
+```
+
+`emit-hook.sh` then:
+
+1. Reads `$SUPERPOWERS_HOOK_DIRS` (colon-separated, like `$PATH`). If unset/empty, exits 0 immediately.
+2. Translates each `key=value` arg into an `SP_<KEY>` env var (key uppercased; values may contain `=`).
+3. For each registered dir in order, runs `<dir>/<EventName>.sh` if it exists and is executable.
+4. Hooks run sequentially, never in parallel. Stdin is `/dev/null`; stdout is discarded; stderr is captured and surfaced.
+5. Plugin failures (nonzero exit, timeout, missing exec bit) log a warning to stderr but never propagate. `emit-hook.sh` always exits 0.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `SUPERPOWERS_HOOK_DIRS` | unset (no plugins) | Colon-separated list of plugin hook directories. |
+| `SUPERPOWERS_HOOK_TIMEOUT` | `10` | Seconds before a hook script is killed. Integer only. |
+
+## Event catalog
+
+### `PlanWritten`
+
+Fired by `writing-plans` skill after self-review passes.
+
+| Env var | Description |
+|---|---|
+| `SP_PLAN_PATH` | Absolute path to the plan markdown file |
+| `SP_PLAN_TITLE` | H1 heading from the plan |
+
+**Plugin guidance:** plugins may mutate the plan file at this point (e.g., add a `**Refs:** xxx` line to each task body). The implementer prompt sends full task body text, so plan-level enrichment propagates naturally to subagent prompts.
+
+### `TaskClaimed`
+
+Fired when a task transitions to in_progress in `executing-plans` and `subagent-driven-development`.
+
+| Env var | Description |
+|---|---|
+| `SP_PLAN_PATH` | Plan the task belongs to |
+| `SP_TASK_NUMBER` | Integer matching `### Task N:` heading in plan |
+| `SP_TASK_TITLE` | Task heading text |
+
+### `TaskCompleted`
+
+Fired when a task reaches completed state. Same payload as `TaskClaimed`.
+
+### `BlockedOnHuman`
+
+Fired when a task cannot proceed and needs human resolution.
+
+| Env var | Description |
+|---|---|
+| `SP_PLAN_PATH` | Plan the task belongs to |
+| `SP_TASK_NUMBER` | Integer matching `### Task N:` heading in plan |
+| `SP_TASK_TITLE` | Task heading text |
+| `SP_REASON` | Free-text explanation of the block |
+
+## Failure modes
+
+| Condition | Behavior |
+|---|---|
+| `SUPERPOWERS_HOOK_DIRS` unset/empty | Silent no-op |
+| Hook script not present | Silent skip; continue |
+| Hook script not executable | Warning logged; skip |
+| Hook script exits nonzero | Warning logged; continue |
+| Hook script exceeds timeout | Killed (SIGTERM, then SIGKILL after 1s); warning logged; continue |
+| `timeout(1)` / `gtimeout(1)` not available | One-time warning; hooks run unbounded |
+
+## Writing a plugin: example
+
+A minimal plugin that logs every event to a file:
+
+```
+~/.config/my-plugin/hooks/
+├── PlanWritten.sh
+├── TaskClaimed.sh
+├── TaskCompleted.sh
+└── BlockedOnHuman.sh
+```
+
+Each script could simply be:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+event_name="$(basename "$0" .sh)"
+echo "[$(date -u +%FT%TZ)] $event_name plan=$SP_PLAN_PATH task=${SP_TASK_NUMBER:-} reason=${SP_REASON:-}" \
+  >> "$HOME/.config/my-plugin/events.log"
+```
+
+Plugins that don't care about an event simply don't ship a script for it. Multiple plugins coexist by registering multiple dirs in `SUPERPOWERS_HOOK_DIRS`.
+
+## Stability and forward compatibility
+
+- New events may be added in future releases. Plugins ignore events they don't subscribe to.
+- New env vars may be added to existing event payloads. Plugins ignore vars they don't read.
+- Existing env var names will not change without a major version bump.
+- The `SP_*` prefix is reserved for core. Plugins should not rely on or set their own `SP_*` env vars.
+
+## See also
+
+- [Lifecycle Events Design Spec](specs/2026-05-02-lifecycle-events-design.md)
+````
+
+- [ ] **Step 2: Verify the doc renders cleanly**
+
+Run: `head -3 docs/superpowers/lifecycle-events.md`
+
+Expected: First line is `# Superpowers Lifecycle Events (Plugin Author Reference)`.
+
+Run: `wc -l docs/superpowers/lifecycle-events.md`
+
+Expected: ~120-180 lines.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/lifecycle-events.md
+git commit -m "docs: add lifecycle events plugin author reference
+
+Documents the event catalog (PlanWritten, TaskClaimed, TaskCompleted,
+BlockedOnHuman), the emit-hook.sh dispatch contract, configuration
+env vars, failure modes, and a minimal example plugin layout."
+```
+
+---
+
+### Task 10: End-to-end verification with stub plugin
+
+**Files:**
+- No source files modified
+- Creates and removes a temp stub plugin
+
+This is a manual verification task — no test code is committed. Confirms the end-to-end path: plugin install → events fire during a real plan flow.
+
+- [ ] **Step 1: Run the unit test suite end-to-end**
+
+Run: `bash tests/lifecycle-events/emit-hook.test.sh`
+
+Expected: 11 passed, 0 failed.
+
+- [ ] **Step 2: Build a stub plugin in a temp dir**
+
+```bash
+STUB_DIR="$(mktemp -d)/stub-plugin/hooks"
+mkdir -p "$STUB_DIR"
+LOG_FILE="$(mktemp)"
+
+for evt in PlanWritten TaskClaimed TaskCompleted BlockedOnHuman; do
+  cat > "$STUB_DIR/$evt.sh" <<EOF
+#!/usr/bin/env bash
+echo "[\$(date -u +%FT%TZ)] $evt plan=\$SP_PLAN_PATH task=\${SP_TASK_NUMBER:-} reason=\${SP_REASON:-}" >> "$LOG_FILE"
+EOF
+  chmod +x "$STUB_DIR/$evt.sh"
+done
+
+echo "Stub plugin: $STUB_DIR"
+echo "Log file:    $LOG_FILE"
+```
+
+- [ ] **Step 3: Manually fire each event via emit-hook.sh**
+
+```bash
+export SUPERPOWERS_HOOK_DIRS="$STUB_DIR"
+export SUPERPOWERS_ROOT="$(pwd)"
+
+"$SUPERPOWERS_ROOT/scripts/emit-hook.sh" PlanWritten \
+  plan_path=/tmp/foo.md plan_title="Stub Test"
+
+"$SUPERPOWERS_ROOT/scripts/emit-hook.sh" TaskClaimed \
+  plan_path=/tmp/foo.md task_number=1 task_title="First task"
+
+"$SUPERPOWERS_ROOT/scripts/emit-hook.sh" TaskCompleted \
+  plan_path=/tmp/foo.md task_number=1 task_title="First task"
+
+"$SUPERPOWERS_ROOT/scripts/emit-hook.sh" BlockedOnHuman \
+  plan_path=/tmp/foo.md task_number=2 task_title="Second task" \
+  reason="Need API credentials"
+
+echo ""
+echo "=== Event log ==="
+cat "$LOG_FILE"
+```
+
+Expected: 4 lines in the log, one per event, with correct `plan=`, `task=`, and `reason=` fields populated.
+
+- [ ] **Step 4: Verify the no-plugins case is silent**
+
+```bash
+unset SUPERPOWERS_HOOK_DIRS
+out="$("$SUPERPOWERS_ROOT/scripts/emit-hook.sh" PlanWritten plan_path=/tmp/x 2>&1)"
+echo "rc=$? out='$out'"
+```
+
+Expected: `rc=0 out=''`
+
+- [ ] **Step 5: Cleanup**
+
+```bash
+rm -rf "$STUB_DIR" "$LOG_FILE"
+unset SUPERPOWERS_HOOK_DIRS SUPERPOWERS_ROOT
+```
+
+- [ ] **Step 6: Verify no uncommitted changes remain**
+
+```bash
+git status
+```
+
+Expected: working tree clean. (The verification doesn't commit anything; just confirms the system works end-to-end.)
+
+---
+
+## Done
+
+After Task 10:
+
+- All 11 unit tests pass
+- 4 events fire correctly with payloads
+- No-plugins case is silent
+- Skill blocks are additive (no rewrites)
+- Reference doc is published
+
+The PR is ready for human review against the maintainer guidelines in `CLAUDE.md`. Before opening the PR:
+
+1. Search both open and closed PRs at `obra/superpowers` for prior lifecycle-event / plugin-API attempts; reference findings in PR description.
+2. Fully complete every section of `.github/PULL_REQUEST_TEMPLATE.md`.
+3. Show the full diff to your human partner for explicit approval before submission.

--- a/docs/superpowers/specs/2026-05-02-lifecycle-events-design.md
+++ b/docs/superpowers/specs/2026-05-02-lifecycle-events-design.md
@@ -1,0 +1,261 @@
+# Lifecycle Events for Plugin Authors
+
+**Date:** 2026-05-02
+**Status:** Draft (spec self-review complete; pending user approval)
+**Branch:** `lifecycle-events`
+
+## Problem
+
+A Beads integration was prototyped on the `beads-integration` branch and rejected from upstream as direct integration — domain-specific tools belong in standalone plugins. To rebuild Beads (or any future workflow plugin) without forking core skills, plugin authors need a small set of lifecycle hooks they can listen to.
+
+This spec defines the minimum-surface lifecycle event API: 4 events, one shell-based event bus, one env-var registry. Plugin authors drop hook scripts; core fires events. Core knows nothing about specific plugins.
+
+## Goals
+
+- Plugin authors can mirror plan/task lifecycle into their own systems without forking skills
+- Zero impact on the legacy markdown-only flow when no plugins are installed
+- Plugin failures never block the agent's normal workflow
+- Tiny core surface: <100 LOC of new shell, <50 LOC of skill-markdown additions, <200 LOC of docs
+- Forward-compatible — events can be added or payloads enriched without breaking existing plugins
+
+## Non-Goals
+
+- Plugin discovery via manifest files (defer until 3+ plugins exist)
+- Structured/nested payloads (env vars only; defer JSON-on-stdin until an event needs it)
+- Plugin → agent return path (hooks are pure observers)
+- Cross-plugin coordination or dependency management
+- Sandboxing or isolation of plugin code (plugins run with user permissions; this is a trust boundary the user opted into when adding the dir to `SUPERPOWERS_HOOK_DIRS`)
+
+## Architecture
+
+Two new core artifacts:
+
+1. **`scripts/emit-hook.sh`** — one bash script (~50 lines). Skills call it at lifecycle moments. It scans `$SUPERPOWERS_HOOK_DIRS` for matching plugin scripts and runs them with payload data set as env vars.
+2. **`SUPERPOWERS_HOOK_DIRS`** — colon-separated list of directories (like `$PATH`) the user adds to their shell rc. Each plugin documents one dir to register. Unset = silent no-op.
+
+Skills get small additive emit blocks at lifecycle points, marked with `<!-- LIFECYCLE: EventName -->` comment markers for searchability and future maintainability.
+
+```
+                    ┌────────────────────┐
+                    │ skill calls:       │
+                    │ emit-hook.sh \     │
+                    │   PlanWritten ...  │
+                    └─────────┬──────────┘
+                              │
+                              ▼
+                    ┌────────────────────┐
+                    │ emit-hook.sh:      │
+                    │ - parse kv args    │
+                    │ - export SP_*      │
+                    │ - scan HOOK_DIRS   │
+                    │ - run matching     │
+                    │   <Event>.sh files │
+                    └─────────┬──────────┘
+                              │
+                ┌─────────────┴─────────────┐
+                ▼                           ▼
+        ┌──────────────┐            ┌──────────────┐
+        │ plugin-A/    │            │ plugin-B/    │
+        │ PlanWritten  │            │ PlanWritten  │
+        │   .sh        │            │   .sh        │
+        └──────────────┘            └──────────────┘
+            (sequential per dir, failures isolated)
+```
+
+## Event Catalog
+
+All event payloads are passed as env vars with the `SP_` prefix when invoking the plugin's hook script. The plugin's script filename matches the event name with a `.sh` extension (e.g., `PlanWritten.sh`).
+
+### `PlanWritten`
+
+- **Fired by:** `writing-plans` skill, immediately after self-review passes
+- **Payload:**
+  - `SP_PLAN_PATH` — absolute path to the plan markdown file
+  - `SP_PLAN_TITLE` — H1 heading from the plan (the feature name)
+- **Plugin guidance:** plugins may mutate the plan file at this point (e.g., add a `**Refs:** xxx` line to each task body). The implementer prompt sends full task body text from the plan, so any plan-level enrichment propagates naturally to subagent prompts without core needing a separate prompt-injection mechanism.
+
+### `TaskClaimed`
+
+- **Fired by:** `executing-plans` and `subagent-driven-development` when a task transitions to in_progress
+- **Payload:**
+  - `SP_PLAN_PATH` — plan the task belongs to
+  - `SP_TASK_NUMBER` — integer matching `### Task N:` heading in plan
+  - `SP_TASK_TITLE` — task heading text
+
+### `TaskCompleted`
+
+- **Fired by:** same skills, when a task reaches completed state
+- **Payload:** same shape as `TaskClaimed`
+
+### `BlockedOnHuman`
+
+- **Fired by:** same skills, when a task cannot proceed and requires human resolution
+- **Payload:** same shape as `TaskClaimed` plus `SP_REASON` (free-text string explaining the block)
+
+## emit-hook.sh contract
+
+Invocation:
+
+```
+emit-hook.sh <EventName> [key=value ...]
+```
+
+Behavior:
+
+- Translates `key=value` args to `SP_<KEY>` env vars (key uppercased; literal `=` separates key from value; values may contain `=` characters).
+- Iterates each path in `SUPERPOWERS_HOOK_DIRS` (colon-separated; like `$PATH`). Unset/empty → silent exit 0.
+- For each dir: if `<dir>/<EventName>.sh` exists and is executable, runs it with the env vars set.
+- Each hook script runs with a 5-second timeout. The user can override via `SUPERPOWERS_HOOK_TIMEOUT` (integer seconds).
+- Plugin script's stderr is captured and prefixed in core's stderr log; stdout is discarded.
+- Failures (nonzero exit, timeout, missing exec bit) → log `[hook warn] <EventName> in <dir>: <reason>` to stderr and continue to the next dir.
+- emit-hook.sh always exits 0. The agent's lifecycle step never fails because of a plugin.
+
+## Skill integration points
+
+| Skill file | Insertion point | Event |
+|---|---|---|
+| `skills/writing-plans/SKILL.md` | After "Self-Review" section, before "Execution Handoff" | `PlanWritten` |
+| `skills/executing-plans/SKILL.md` | Step 2: when marking task in_progress | `TaskClaimed` |
+| `skills/executing-plans/SKILL.md` | Step 2: when marking task completed | `TaskCompleted` |
+| `skills/executing-plans/SKILL.md` | Step 2: BLOCKED status escalation | `BlockedOnHuman` |
+| `skills/subagent-driven-development/SKILL.md` | Per-task in_progress transition | `TaskClaimed` |
+| `skills/subagent-driven-development/SKILL.md` | Per-task completed transition | `TaskCompleted` |
+| `skills/subagent-driven-development/SKILL.md` | Implementer reports BLOCKED | `BlockedOnHuman` |
+
+Each insertion is a small additive block (no existing prose is rewritten):
+
+````markdown
+<!-- LIFECYCLE: TaskClaimed -->
+**Lifecycle event:** after marking the task in_progress, emit:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT:-$SUPERPOWERS_ROOT}/scripts/emit-hook.sh" TaskClaimed \
+  plan_path="$plan_path" task_number="$n" task_title="$title"
+```
+
+When `SUPERPOWERS_HOOK_DIRS` is unset, this is a no-op — the legacy flow is unaffected.
+<!-- END LIFECYCLE -->
+````
+
+## Plugin author contract
+
+A plugin is a directory containing executable hook scripts named after the events it cares about. Example minimal plugin:
+
+```
+~/.config/superpowers-beads/
+└── hooks/
+    ├── PlanWritten.sh         (chmod +x)
+    ├── TaskClaimed.sh
+    ├── TaskCompleted.sh
+    └── BlockedOnHuman.sh
+```
+
+User registers the plugin by adding to their shell rc:
+
+```bash
+export SUPERPOWERS_HOOK_DIRS="$HOME/.config/superpowers-beads/hooks${SUPERPOWERS_HOOK_DIRS:+:$SUPERPOWERS_HOOK_DIRS}"
+```
+
+Hook script template:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+# Available env vars: $SP_PLAN_PATH, $SP_TASK_NUMBER, $SP_TASK_TITLE
+echo "TaskClaimed: task $SP_TASK_NUMBER in $SP_PLAN_PATH" >&2
+# do plugin-specific work here
+```
+
+Plugins that don't care about an event simply don't ship a script for it. Multiple plugins coexist by registering multiple dirs in `SUPERPOWERS_HOOK_DIRS`.
+
+## Failure modes
+
+| Condition | Behavior |
+|---|---|
+| `SUPERPOWERS_HOOK_DIRS` unset or empty | silent no-op; emit-hook exits 0 |
+| Hook script not present in a registered dir | silent skip; continue to next dir |
+| Hook script exists but not executable | warning logged; skip |
+| Hook script exits nonzero | warning logged; continue to next dir |
+| Hook script exceeds timeout | killed with SIGTERM, then SIGKILL after 1s grace; warning logged; continue |
+| Hook script writes to stdout | discarded |
+| Hook script writes to stderr | captured and prefixed in core's stderr stream |
+| `emit-hook.sh` itself fails to start | the calling skill block uses `|| true` to absorb; agent continues |
+
+## Testing
+
+`scripts/tests/emit-hook.test.sh` — bash test suite covering:
+
+- Unset `HOOK_DIRS` → emit-hook exits 0, no output
+- Empty dir registered → emit-hook exits 0, no output
+- Mock plugin with `PlanWritten.sh` → script runs, sees `SP_PLAN_PATH` and `SP_PLAN_TITLE`
+- Mock plugin script exits 1 → emit-hook exits 0, warning on stderr
+- Mock plugin script sleeps past timeout → killed, emit-hook exits 0, warning on stderr
+- Two dirs registered with same event → both run sequentially, both see env vars
+- Key=value parsing: values containing `=` (e.g., `reason="error: foo=bar"`) preserved correctly
+
+Manual end-to-end:
+
+- Build a stub `mock-plugin/` with hook scripts that append to a log file
+- Run a real `writing-plans` + `executing-plans` flow on a tiny throwaway plan
+- Verify log file contains expected sequence: `PlanWritten` → `TaskClaimed` → `TaskCompleted`
+
+## Out of scope (roadmap, not this PR)
+
+These wait for concrete motivating use cases:
+
+- **6 additional events** from prior brainstorming: `BrainstormCompleted`, `DesignSaved`, `WorktreeCreated`, `ReviewFindingCreated`, `EpicCompleted`, `BranchFinished` — each waits for a real plugin that needs it
+- **JSON-on-stdin payload format** — wait for an event that needs nested data
+- **Manifest-based plugin discovery** — wait for ecosystem of 3+ plugins
+- **Plugin → agent return channel** (stdout-capture filter pattern) — wait for an event that genuinely cannot use plan-mutation as the data path
+- **Programmatic plugin registry** (`superpowers plugins list/install/remove`) — premature without ecosystem
+
+## PR strategy
+
+- **Branch:** `lifecycle-events` (already pushed to fork at `cdub615/superpowers`)
+- **Target:** `obra/superpowers` `main`
+- **Title:** `feat: lifecycle event hooks for plugin authors`
+- **Approach:** single-problem PR, additive only, small diff
+- **Required PR template sections:**
+  - Problem statement: forked Beads integration; cannot rebuild as plugin without these hooks
+  - Existing PRs search: must search both open and closed PRs for prior attempts at lifecycle events / plugin APIs and reference them
+  - Per-event motivation: each of the 4 events ties to a specific Beads use case (in `beads-integration` branch)
+  - Test plan: bash test suite + manual end-to-end with stub plugin
+  - Roadmap section: 6 deferred events listed with explicit "wait for motivating use case"
+- **Anticipated diff size:**
+  - `scripts/emit-hook.sh` — ~50 LOC
+  - `scripts/tests/emit-hook.test.sh` — ~80 LOC
+  - `docs/superpowers/lifecycle-events.md` — ~150 LOC reference doc
+  - 3 skill files — ~10 LOC additive each (~30 LOC total)
+  - **Total: ~310 LOC, all additive, zero rewrites**
+
+## Risks
+
+**Maintainer rejection (94% rejection rate is real):**
+
+- Mitigation: only 4 events, each tied to a real use case (Beads); roadmap is explicitly deferred
+- Mitigation: PR template fully completed; existing PRs searched; human review of complete diff before submission
+- Mitigation: diff is purely additive — no existing prose modified
+
+**Skill content scrutiny:**
+
+- The project flags PRs that modify skill content without eval evidence
+- Mitigation: skill changes are **additive blocks**, not rewrites of existing prose
+- Mitigation: each block is a no-op when no plugins are installed (zero behavior change for default users) — explicitly documented in PR description
+- Mitigation: skill blocks include `<!-- LIFECYCLE -->` markers so reviewers can see exactly what changed
+
+**Cross-harness compatibility:**
+
+- Path resolution uses `${CLAUDE_PLUGIN_ROOT:-$SUPERPOWERS_ROOT}` — works for Claude Code; needs validation on at least one other harness
+- Mitigation: test on Cursor or another harness before submission; report results in PR's environment table
+
+**Misuse of stdin/stdout:**
+
+- A plugin script that reads stdin or writes large stdout could surprise users
+- Mitigation: emit-hook.sh redirects stdin from /dev/null and discards plugin stdout; documented in plugin author contract
+
+## Open questions for user review
+
+1. Is `SUPERPOWERS_HOOK_DIRS` the right env var name? Alternatives: `SP_HOOK_DIRS`, `SUPERPOWERS_PLUGINS`, `SUPERPOWERS_HOOK_PATH`. The chosen name is explicit and parallel to `SUPERPOWERS_BEADS` and `SUPERPOWERS_ROOT`.
+2. Default timeout of 5s — sufficient for most plugins, or should it be 10s/30s?
+3. Should plugin hooks run in parallel (background, wait-all) or sequentially per dir? Sequential is simpler and preserves ordering across dirs; parallel adds complexity for marginal benefit.
+4. Should the LIFECYCLE marker be `<!-- LIFECYCLE: -->` or follow the existing `<!-- BEGIN/END beads -->` convention used in `beads-integration`? Matching the existing convention may improve consistency.

--- a/docs/superpowers/specs/2026-05-02-lifecycle-events-design.md
+++ b/docs/superpowers/specs/2026-05-02-lifecycle-events-design.md
@@ -183,7 +183,7 @@ Plugins that don't care about an event simply don't ship a script for it. Multip
 
 ## Testing
 
-`scripts/tests/emit-hook.test.sh` — bash test suite covering:
+`tests/lifecycle-events/emit-hook.test.sh` — bash test suite covering:
 
 - Unset `HOOK_DIRS` → emit-hook exits 0, no output
 - Empty dir registered → emit-hook exits 0, no output
@@ -222,11 +222,11 @@ These wait for concrete motivating use cases:
   - Test plan: bash test suite + manual end-to-end with stub plugin
   - Roadmap section: 6 deferred events listed with explicit "wait for motivating use case"
 - **Anticipated diff size:**
-  - `scripts/emit-hook.sh` — ~50 LOC
-  - `scripts/tests/emit-hook.test.sh` — ~80 LOC
-  - `docs/superpowers/lifecycle-events.md` — ~150 LOC reference doc
-  - 3 skill files — ~10 LOC additive each (~30 LOC total)
-  - **Total: ~310 LOC, all additive, zero rewrites**
+  - `scripts/emit-hook.sh` — ~90 LOC (includes timeout enforcement)
+  - `tests/lifecycle-events/emit-hook.test.sh` — ~235 LOC
+  - `docs/superpowers/lifecycle-events.md` — ~133 LOC reference doc
+  - 3 skill files — ~99 LOC additive total (writing-plans 17 + executing-plans 38 + subagent-driven-development 44)
+  - **Total: ~557 LOC, all additive, zero rewrites of existing prose**
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-05-02-lifecycle-events-design.md
+++ b/docs/superpowers/specs/2026-05-02-lifecycle-events-design.md
@@ -1,7 +1,7 @@
 # Lifecycle Events for Plugin Authors
 
 **Date:** 2026-05-02
-**Status:** Draft (spec self-review complete; pending user approval)
+**Status:** Approved
 **Branch:** `lifecycle-events`
 
 ## Problem
@@ -33,7 +33,7 @@ Two new core artifacts:
 1. **`scripts/emit-hook.sh`** — one bash script (~50 lines). Skills call it at lifecycle moments. It scans `$SUPERPOWERS_HOOK_DIRS` for matching plugin scripts and runs them with payload data set as env vars.
 2. **`SUPERPOWERS_HOOK_DIRS`** — colon-separated list of directories (like `$PATH`) the user adds to their shell rc. Each plugin documents one dir to register. Unset = silent no-op.
 
-Skills get small additive emit blocks at lifecycle points, marked with `<!-- LIFECYCLE: EventName -->` comment markers for searchability and future maintainability.
+Skills get small additive emit blocks at lifecycle points, marked with paired `<!-- BEGIN lifecycle:EventName -->` / `<!-- END lifecycle:EventName -->` comments — matching the existing convention used by `<!-- BEGIN beads -->` blocks in the `beads-integration` branch.
 
 ```
                     ┌────────────────────┐
@@ -105,7 +105,7 @@ Behavior:
 - Translates `key=value` args to `SP_<KEY>` env vars (key uppercased; literal `=` separates key from value; values may contain `=` characters).
 - Iterates each path in `SUPERPOWERS_HOOK_DIRS` (colon-separated; like `$PATH`). Unset/empty → silent exit 0.
 - For each dir: if `<dir>/<EventName>.sh` exists and is executable, runs it with the env vars set.
-- Each hook script runs with a 5-second timeout. The user can override via `SUPERPOWERS_HOOK_TIMEOUT` (integer seconds).
+- Each hook script runs with a 10-second timeout. The user can override via `SUPERPOWERS_HOOK_TIMEOUT` (integer seconds).
 - Plugin script's stderr is captured and prefixed in core's stderr log; stdout is discarded.
 - Failures (nonzero exit, timeout, missing exec bit) → log `[hook warn] <EventName> in <dir>: <reason>` to stderr and continue to the next dir.
 - emit-hook.sh always exits 0. The agent's lifecycle step never fails because of a plugin.
@@ -125,7 +125,7 @@ Behavior:
 Each insertion is a small additive block (no existing prose is rewritten):
 
 ````markdown
-<!-- LIFECYCLE: TaskClaimed -->
+<!-- BEGIN lifecycle:TaskClaimed -->
 **Lifecycle event:** after marking the task in_progress, emit:
 
 ```bash
@@ -134,7 +134,7 @@ Each insertion is a small additive block (no existing prose is rewritten):
 ```
 
 When `SUPERPOWERS_HOOK_DIRS` is unset, this is a no-op — the legacy flow is unaffected.
-<!-- END LIFECYCLE -->
+<!-- END lifecycle:TaskClaimed -->
 ````
 
 ## Plugin author contract
@@ -241,7 +241,7 @@ These wait for concrete motivating use cases:
 - The project flags PRs that modify skill content without eval evidence
 - Mitigation: skill changes are **additive blocks**, not rewrites of existing prose
 - Mitigation: each block is a no-op when no plugins are installed (zero behavior change for default users) — explicitly documented in PR description
-- Mitigation: skill blocks include `<!-- LIFECYCLE -->` markers so reviewers can see exactly what changed
+- Mitigation: skill blocks include paired `<!-- BEGIN lifecycle:Event -->` / `<!-- END lifecycle:Event -->` markers so reviewers can see exactly what changed (matches the `<!-- BEGIN beads -->` convention)
 
 **Cross-harness compatibility:**
 
@@ -253,9 +253,9 @@ These wait for concrete motivating use cases:
 - A plugin script that reads stdin or writes large stdout could surprise users
 - Mitigation: emit-hook.sh redirects stdin from /dev/null and discards plugin stdout; documented in plugin author contract
 
-## Open questions for user review
+## Decisions locked
 
-1. Is `SUPERPOWERS_HOOK_DIRS` the right env var name? Alternatives: `SP_HOOK_DIRS`, `SUPERPOWERS_PLUGINS`, `SUPERPOWERS_HOOK_PATH`. The chosen name is explicit and parallel to `SUPERPOWERS_BEADS` and `SUPERPOWERS_ROOT`.
-2. Default timeout of 5s — sufficient for most plugins, or should it be 10s/30s?
-3. Should plugin hooks run in parallel (background, wait-all) or sequentially per dir? Sequential is simpler and preserves ordering across dirs; parallel adds complexity for marginal benefit.
-4. Should the LIFECYCLE marker be `<!-- LIFECYCLE: -->` or follow the existing `<!-- BEGIN/END beads -->` convention used in `beads-integration`? Matching the existing convention may improve consistency.
+- Env var name: `SUPERPOWERS_HOOK_DIRS` (parallel to `SUPERPOWERS_BEADS`, `SUPERPOWERS_ROOT`)
+- Default hook timeout: **10 seconds** (override via `SUPERPOWERS_HOOK_TIMEOUT`)
+- Hook execution model: **sequential per dir, sequential across dirs** — preserves ordering, simpler, sufficient for low-frequency lifecycle events
+- Comment marker style: **`<!-- BEGIN lifecycle:EventName -->` / `<!-- END lifecycle:EventName -->`** — matches the `<!-- BEGIN beads -->` convention

--- a/scripts/emit-hook.sh
+++ b/scripts/emit-hook.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# emit-hook.sh — Lifecycle event dispatcher for Superpowers plugins.
+#
+# Usage: emit-hook.sh <EventName> [key=value ...]
+#
+# Reads $SUPERPOWERS_HOOK_DIRS (colon-separated, like $PATH). For each
+# dir, runs <dir>/<EventName>.sh if it exists and is executable, with
+# key=value pairs translated to SP_<KEY> env vars (uppercased).
+#
+# Failures (nonzero exit, timeout, missing exec bit) log a warning to
+# stderr and skip to the next dir. emit-hook.sh always exits 0.
+
+set -uo pipefail
+
+# Always exit 0; never propagate plugin failures to caller.
+trap 'exit 0' EXIT
+
+if [[ $# -lt 1 ]]; then
+  echo "[hook warn] emit-hook.sh: missing event name" >&2
+  exit 0
+fi
+
+# Silent no-op if no plugins are registered.
+if [[ -z "${SUPERPOWERS_HOOK_DIRS:-}" ]]; then
+  exit 0
+fi
+
+# Further behavior added in Task 2.
+exit 0

--- a/scripts/emit-hook.sh
+++ b/scripts/emit-hook.sh
@@ -20,10 +20,37 @@ if [[ $# -lt 1 ]]; then
   exit 0
 fi
 
-# Silent no-op if no plugins are registered.
 if [[ -z "${SUPERPOWERS_HOOK_DIRS:-}" ]]; then
   exit 0
 fi
 
-# Further behavior added in Task 2.
+event_name="$1"; shift
+
+declare -a env_assignments=()
+for arg in "$@"; do
+  if [[ "$arg" != *"="* ]]; then
+    echo "[hook warn] emit-hook.sh: malformed arg '$arg' (expected key=value)" >&2
+    continue
+  fi
+  key="${arg%%=*}"
+  val="${arg#*=}"
+  upper_key="SP_$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+  env_assignments+=("$upper_key=$val")
+done
+
+IFS=':' read -ra dirs <<< "$SUPERPOWERS_HOOK_DIRS"
+for dir in "${dirs[@]}"; do
+  [[ -z "$dir" ]] && continue
+  hook_script="$dir/${event_name}.sh"
+
+  [[ ! -e "$hook_script" ]] && continue
+
+  if [[ ! -x "$hook_script" ]]; then
+    echo "[hook warn] $event_name in $dir: not executable" >&2
+    continue
+  fi
+
+  env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+done
+
 exit 0

--- a/scripts/emit-hook.sh
+++ b/scripts/emit-hook.sh
@@ -51,6 +51,10 @@ for dir in "${dirs[@]}"; do
   fi
 
   env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+  rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    echo "[hook warn] $event_name in $dir: exit $rc" >&2
+  fi
 done
 
 exit 0

--- a/scripts/emit-hook.sh
+++ b/scripts/emit-hook.sh
@@ -12,6 +12,16 @@
 
 set -uo pipefail
 
+readonly DEFAULT_TIMEOUT=10
+
+# Resolve timeout command (Linux: timeout; macOS w/ coreutils: gtimeout).
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+
 # Always exit 0; never propagate plugin failures to caller.
 trap 'exit 0' EXIT
 
@@ -50,10 +60,29 @@ for dir in "${dirs[@]}"; do
     continue
   fi
 
-  env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
-  rc=$?
-  if [[ "$rc" -ne 0 ]]; then
-    echo "[hook warn] $event_name in $dir: exit $rc" >&2
+  hook_timeout="${SUPERPOWERS_HOOK_TIMEOUT:-$DEFAULT_TIMEOUT}"
+
+  if [[ -n "$TIMEOUT_CMD" ]]; then
+    env "${env_assignments[@]}" \
+      "$TIMEOUT_CMD" --kill-after=1 "$hook_timeout" "$hook_script" </dev/null >/dev/null
+    rc=$?
+    if [[ "$rc" -eq 124 || "$rc" -eq 137 ]]; then
+      echo "[hook warn] $event_name in $dir: timed out after ${hook_timeout}s" >&2
+    elif [[ "$rc" -ne 0 ]]; then
+      echo "[hook warn] $event_name in $dir: exit $rc" >&2
+    fi
+  else
+    # No timeout(1) available — run unbounded with one-time warning.
+    if [[ -z "${EMIT_HOOK_TIMEOUT_WARNED:-}" ]]; then
+      echo "[hook warn] timeout(1) not available; hooks run unbounded" >&2
+      EMIT_HOOK_TIMEOUT_WARNED=1
+      export EMIT_HOOK_TIMEOUT_WARNED
+    fi
+    env "${env_assignments[@]}" "$hook_script" </dev/null >/dev/null
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      echo "[hook warn] $event_name in $dir: exit $rc" >&2
+    fi
   fi
 done
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -24,10 +24,33 @@ Load plan, review critically, execute all tasks, report when complete.
 ### Step 2: Execute Tasks
 
 For each task:
+
 1. Mark as in_progress
+   <!-- BEGIN lifecycle:TaskClaimed -->
+   **Lifecycle event:** also emit `TaskClaimed`:
+   ```bash
+   SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+   [[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" TaskClaimed \
+     plan_path="<absolute-plan-path>" \
+     task_number="<N>" \
+     task_title="<task heading>"
+   ```
+   No-op when `SUPERPOWERS_HOOK_DIRS` is unset.
+   <!-- END lifecycle:TaskClaimed -->
+
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
 4. Mark as completed
+   <!-- BEGIN lifecycle:TaskCompleted -->
+   **Lifecycle event:** also emit `TaskCompleted`:
+   ```bash
+   SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+   [[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" TaskCompleted \
+     plan_path="<absolute-plan-path>" \
+     task_number="<N>" \
+     task_title="<task heading>"
+   ```
+   <!-- END lifecycle:TaskCompleted -->
 
 ### Step 3: Complete Development
 
@@ -45,6 +68,21 @@ After all tasks complete and verified:
 - Verification fails repeatedly
 
 **Ask for clarification rather than guessing.**
+
+<!-- BEGIN lifecycle:BlockedOnHuman -->
+**Lifecycle event:** before stopping, emit `BlockedOnHuman`:
+
+```bash
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" BlockedOnHuman \
+  plan_path="<absolute-plan-path>" \
+  task_number="<N>" \
+  task_title="<task heading>" \
+  reason="<short explanation of the block>"
+```
+
+No-op when `SUPERPOWERS_HOOK_DIRS` is unset.
+<!-- END lifecycle:BlockedOnHuman -->
 
 ## When to Revisit Earlier Steps
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -99,6 +99,50 @@ Use the least powerful model that can handle each role to conserve cost and incr
 - Touches multiple files with integration concerns → standard model
 - Requires design judgment or broad codebase understanding → most capable model
 
+## Lifecycle Events
+
+The controller emits lifecycle events at key state transitions so registered plugins can react. Each block below is a no-op when `SUPERPOWERS_HOOK_DIRS` is unset; the legacy TodoWrite-only flow is unchanged.
+
+Resolve the script path once at start of run:
+
+```bash
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+```
+
+<!-- BEGIN lifecycle:TaskClaimed -->
+**TaskClaimed** — emit when transitioning a task to in_progress (before dispatching the implementer subagent):
+
+```bash
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" TaskClaimed \
+  plan_path="<absolute-plan-path>" \
+  task_number="<N>" \
+  task_title="<task heading>"
+```
+<!-- END lifecycle:TaskClaimed -->
+
+<!-- BEGIN lifecycle:TaskCompleted -->
+**TaskCompleted** — emit when marking the task complete in TodoWrite (after both spec and code-quality reviews approve):
+
+```bash
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" TaskCompleted \
+  plan_path="<absolute-plan-path>" \
+  task_number="<N>" \
+  task_title="<task heading>"
+```
+<!-- END lifecycle:TaskCompleted -->
+
+<!-- BEGIN lifecycle:BlockedOnHuman -->
+**BlockedOnHuman** — emit before escalating a BLOCKED implementer status (see "Handling Implementer Status" below):
+
+```bash
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" BlockedOnHuman \
+  plan_path="<absolute-plan-path>" \
+  task_number="<N>" \
+  task_title="<task heading>" \
+  reason="<short explanation of the block>"
+```
+<!-- END lifecycle:BlockedOnHuman -->
+
 ## Handling Implementer Status
 
 Implementer subagents report one of four statuses. Handle each appropriately:

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -131,6 +131,23 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 
+<!-- BEGIN lifecycle:PlanWritten -->
+## Lifecycle Event: PlanWritten
+
+After self-review passes, emit the `PlanWritten` lifecycle event so any registered plugins (e.g., a Beads mirror) can react. This is a no-op when no plugins are installed (`SUPERPOWERS_HOOK_DIRS` unset).
+
+Resolve the script path and emit:
+
+```bash
+SP_ROOT="${CLAUDE_PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT:-${SUPERPOWERS_ROOT:-}}}"
+[[ -n "$SP_ROOT" ]] && "$SP_ROOT/scripts/emit-hook.sh" PlanWritten \
+  plan_path="<absolute-plan-path>" \
+  plan_title="<plan H1 title>"
+```
+
+Substitute `<absolute-plan-path>` with the path you just saved the plan to, and `<plan H1 title>` with the H1 heading from the plan file. Plugins receive these as `$SP_PLAN_PATH` and `$SP_PLAN_TITLE`.
+<!-- END lifecycle:PlanWritten -->
+
 ## Execution Handoff
 
 After saving the plan, offer execution choice:

--- a/tests/lifecycle-events/emit-hook.test.sh
+++ b/tests/lifecycle-events/emit-hook.test.sh
@@ -150,6 +150,90 @@ else
 fi
 teardown_test
 
+# Test: hook stdin is /dev/null (read returns empty)
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+read -r line || true
+echo "stdin_was='$line'" > "$SP_OUT"
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+echo "should-not-reach-hook" | "$EMIT_HOOK" PlanWritten out="$TEST_DIR/out" >/dev/null 2>&1
+if grep -q "stdin_was=''" "$TEST_DIR/out"; then
+  pass "hook stdin redirected to /dev/null"
+else
+  fail "hook stdin redirected to /dev/null" "got: $(cat "$TEST_DIR/out" 2>/dev/null)"
+fi
+teardown_test
+
+# Test: hook stdout is discarded
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "this-should-not-be-visible"
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+out="$("$EMIT_HOOK" PlanWritten plan_path=x 2>/dev/null)"
+if [[ -z "$out" ]]; then
+  pass "hook stdout discarded"
+else
+  fail "hook stdout discarded" "got: '$out'"
+fi
+teardown_test
+
+# Test: multiple registered dirs run sequentially in order
+setup_test
+mkdir -p "$TEST_DIR/h1" "$TEST_DIR/h2"
+cat > "$TEST_DIR/h1/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "h1" >> "$SP_LOG"
+EOF
+cat > "$TEST_DIR/h2/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "h2" >> "$SP_LOG"
+EOF
+chmod +x "$TEST_DIR/h1/PlanWritten.sh" "$TEST_DIR/h2/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/h1:$TEST_DIR/h2"
+"$EMIT_HOOK" PlanWritten log="$TEST_DIR/seq.log" >/dev/null 2>&1
+if [[ "$(cat "$TEST_DIR/seq.log")" == $'h1\nh2' ]]; then
+  pass "multiple dirs run sequentially in order"
+else
+  fail "multiple dirs sequential" "got: $(cat "$TEST_DIR/seq.log")"
+fi
+teardown_test
+
+# Test: key=value with literal '=' in value preserved
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$SP_REASON" > "$SP_OUT"
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+"$EMIT_HOOK" PlanWritten reason="error: foo=bar baz=qux" out="$TEST_DIR/r.out" >/dev/null 2>&1
+if [[ "$(cat "$TEST_DIR/r.out")" == "error: foo=bar baz=qux" ]]; then
+  pass "key=value preserves literal '=' in value"
+else
+  fail "key=value preserves '='" "got: '$(cat "$TEST_DIR/r.out")'"
+fi
+teardown_test
+
+# Test: missing event name → warning logged, exits 0
+setup_test
+err="$("$EMIT_HOOK" 2>&1 1>/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 && "$err" == *"missing event name"* ]]; then
+  pass "missing event name: warning logged, exits 0"
+else
+  fail "missing event name" "rc=$rc err='$err'"
+fi
+teardown_test
+
 # ========== Summary ==========
 echo ""
 echo "=== Results: $passed passed, $failed failed ==="

--- a/tests/lifecycle-events/emit-hook.test.sh
+++ b/tests/lifecycle-events/emit-hook.test.sh
@@ -128,6 +128,28 @@ else
 fi
 teardown_test
 
+# Test: hook exceeds timeout → killed, warning logged
+# Use SUPERPOWERS_HOOK_TIMEOUT=1 to keep the test fast.
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+sleep 30
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+export SUPERPOWERS_HOOK_TIMEOUT=1
+start_ts=$(date +%s)
+err="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1 1>/dev/null)"
+rc=$?
+elapsed=$(( $(date +%s) - start_ts ))
+if [[ "$rc" -eq 0 && "$err" == *"timed out"* && "$elapsed" -lt 5 ]]; then
+  pass "timeout: hook killed and warning logged (elapsed=${elapsed}s)"
+else
+  fail "timeout" "rc=$rc elapsed=${elapsed}s err='$err'"
+fi
+teardown_test
+
 # ========== Summary ==========
 echo ""
 echo "=== Results: $passed passed, $failed failed ==="

--- a/tests/lifecycle-events/emit-hook.test.sh
+++ b/tests/lifecycle-events/emit-hook.test.sh
@@ -92,6 +92,42 @@ else
 fi
 teardown_test
 
+# Test: hook exits nonzero → warning logged, emit-hook still exits 0
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+err="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1 1>/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 && "$err" == *"PlanWritten"* && "$err" == *"exit 7"* ]]; then
+  pass "nonzero exit: warning logged, emit-hook exits 0"
+else
+  fail "nonzero exit" "rc=$rc err='$err'"
+fi
+teardown_test
+
+# Test: hook script not executable → warning logged, skip
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+# Intentionally NOT chmod +x
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+err="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1 1>/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 && "$err" == *"not executable"* ]]; then
+  pass "not executable: warning logged"
+else
+  fail "not executable" "rc=$rc err='$err'"
+fi
+teardown_test
+
 # ========== Summary ==========
 echo ""
 echo "=== Results: $passed passed, $failed failed ==="

--- a/tests/lifecycle-events/emit-hook.test.sh
+++ b/tests/lifecycle-events/emit-hook.test.sh
@@ -58,6 +58,40 @@ else
 fi
 teardown_test
 
+# Test: hook script not present in registered dir → silent skip
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+out="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1)"
+rc=$?
+if [[ "$rc" -eq 0 && -z "$out" ]]; then
+  pass "missing hook script: silent skip"
+else
+  fail "missing hook script: silent skip" "rc=$rc out='$out'"
+fi
+teardown_test
+
+# Test: hook script runs and sees SP_* env vars
+setup_test
+mkdir -p "$TEST_DIR/hooks"
+cat > "$TEST_DIR/hooks/PlanWritten.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "plan_path=$SP_PLAN_PATH plan_title=$SP_PLAN_TITLE" > "$SP_TEST_LOG"
+EOF
+chmod +x "$TEST_DIR/hooks/PlanWritten.sh"
+export SUPERPOWERS_HOOK_DIRS="$TEST_DIR/hooks"
+log_file="$TEST_DIR/log"
+"$EMIT_HOOK" PlanWritten \
+  plan_path=/tmp/foo.md \
+  plan_title="My Feature" \
+  test_log="$log_file" >/dev/null 2>&1
+if [[ -f "$log_file" ]] && grep -q "plan_path=/tmp/foo.md plan_title=My Feature" "$log_file"; then
+  pass "hook runs with SP_* env vars exported"
+else
+  fail "hook runs with SP_* env vars exported" "log_file=$log_file contents='$(cat "$log_file" 2>/dev/null)'"
+fi
+teardown_test
+
 # ========== Summary ==========
 echo ""
 echo "=== Results: $passed passed, $failed failed ==="

--- a/tests/lifecycle-events/emit-hook.test.sh
+++ b/tests/lifecycle-events/emit-hook.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Tests for scripts/emit-hook.sh — the lifecycle event dispatcher.
+#
+# Usage:
+#   bash tests/lifecycle-events/emit-hook.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${SUPERPOWERS_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+EMIT_HOOK="$REPO_ROOT/scripts/emit-hook.sh"
+
+passed=0
+failed=0
+
+# Per-test scratch dir; cleaned between tests
+TEST_DIR=""
+
+setup_test() {
+  TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/emit-hook-test-XXXXXX")"
+}
+
+teardown_test() {
+  if [[ -n "${TEST_DIR:-}" && -d "$TEST_DIR" ]]; then
+    rm -rf "$TEST_DIR"
+  fi
+  unset TEST_DIR SUPERPOWERS_HOOK_DIRS SUPERPOWERS_HOOK_TIMEOUT
+}
+
+trap teardown_test EXIT
+
+pass() {
+  echo "  PASS: $1"
+  passed=$((passed + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  echo "    $2"
+  failed=$((failed + 1))
+}
+
+# ========== Tests ==========
+
+echo ""
+echo "=== emit-hook.sh tests ==="
+echo ""
+
+# Test: unset HOOK_DIRS is a silent no-op
+setup_test
+unset SUPERPOWERS_HOOK_DIRS
+out="$("$EMIT_HOOK" PlanWritten plan_path=/tmp/x 2>&1)"
+rc=$?
+if [[ "$rc" -eq 0 && -z "$out" ]]; then
+  pass "unset HOOK_DIRS: silent no-op"
+else
+  fail "unset HOOK_DIRS: silent no-op" "rc=$rc out='$out'"
+fi
+teardown_test
+
+# ========== Summary ==========
+echo ""
+echo "=== Results: $passed passed, $failed failed ==="
+[[ "$failed" -eq 0 ]]


### PR DESCRIPTION
> Addresses #1442 (which I opened to propose this lifecycle-events surface). The issue lays out the motivating use case in more detail; this PR is the v1 implementation.

## What problem are you trying to solve?

I built a Beads integration as a fork of Superpowers (visible on my fork at [cdub615/superpowers:beads-integration](https://github.com/cdub615/superpowers/tree/beads-integration)). To make it shippable as a standalone plugin — which is what this project's contributor guidelines say domain-specific tools should be — the integration needs to react to plan/task lifecycle moments without modifying core skills. Today there's no supported mechanism for that, so the integration forks three core skills (`writing-plans`, `executing-plans`, `subagent-driven-development`) to add inline `bd` calls. That's the maintenance burden every workflow plugin author hits.

The specific failure mode: when I tried to extract the integration into a standalone plugin, I had nowhere to attach. The plan-mirror logic needs to fire after `writing-plans`' self-review passes; the `bd update --claim` logic needs to fire when a task transitions to in_progress; the close logic needs to fire on completion; the `bd update --status blocked` needs to fire on BLOCKED. With no hook mechanism, the only way to wire any of those is to edit the skill files. The fork branch is the proof.

I filed #1442 to propose this lifecycle-events surface; this PR is the implementation of the v1 subset of that proposal.

## What does this PR change?

Adds a minimum-surface lifecycle event API:

- New `scripts/emit-hook.sh` (~90 LOC bash) — dispatches events to plugin shell scripts found in `$SUPERPOWERS_HOOK_DIRS` (colon-separated, like `$PATH`).
- 4 events emitted from existing core skills via additive markdown blocks: `PlanWritten`, `TaskClaimed`, `TaskCompleted`, `BlockedOnHuman`. Each block is wrapped in `<!-- BEGIN lifecycle:Event -->` / `<!-- END lifecycle:Event -->` markers and is a no-op when `SUPERPOWERS_HOOK_DIRS` is unset.
- Payloads pass as `SP_<KEY>` env vars (e.g., `SP_PLAN_PATH`, `SP_TASK_NUMBER`, `SP_REASON`).
- 10s default hook timeout (`SUPERPOWERS_HOOK_TIMEOUT` override). Plugin failures (timeout, nonzero exit, missing exec bit) log a warning but never propagate — `emit-hook.sh` always exits 0.
- New `docs/superpowers/lifecycle-events.md` plugin author reference.
- New `tests/lifecycle-events/emit-hook.test.sh` — 11 tests covering every documented behavior and failure mode.

Total diff: ~600 LOC, all additive, zero rewrites of existing skill prose.

This is a deliberate v1 subset of the 10 events proposed in #1442 — only the 4 events with a concrete consumer (the Beads integration) are included. The other 6 (`BrainstormCompleted`, `DesignSaved`, `WorktreeCreated`, `ReviewFindingCreated`, `EpicCompleted`, `BranchFinished`) are documented in the spec as roadmap items, each waiting for a real plugin that needs them. This avoids speculative additions per the project's "no theoretical fixes" rule.

## Is this change appropriate for the core library?

Yes — this is general-purpose plugin infrastructure, not a domain-specific skill. It benefits all users by giving them a sanctioned way to extend Superpowers' lifecycle without modifying core, which directly aligns with the contributor guidelines ("domain-specific tools belong in standalone plugins").

No third-party dependencies. No domain-specific content. No new domain skills. The Beads use case is mentioned only as evidence that the problem is real; the events themselves are agnostic to any specific consumer. Other consumers #1442 enumerates: Linear/Jira/GitHub Issues sync, Slack/email notifications, per-epic cost controls, CI pre-validation, team-level workflow telemetry — none of which can be built today without forking.

## What alternatives did you consider?

1. **Direct integration of each plugin into core** — what my fork currently does. Doesn't scale; every plugin author hits the same wall and either forks or gives up.
2. **JSON-on-stdin payloads instead of env vars** — overkill for v1. Current events have flat key/value payloads (paths, ids, free-text reasons). Plugins re-read the canonical artifact (the plan file) from `$SP_PLAN_PATH` if they need richer structure. Roadmap item if/when an event genuinely needs nested data.
3. **Manifest-based plugin discovery (YAML/TOML)** — adds a parser and a discovery convention to core. Deferred until ecosystem maturity (3+ plugins). For v1, env-var path list (familiar from `$PATH`) is the smallest possible discovery surface.
4. **Filter events with a return channel** — would let plugins inject text back into agent prompts. Rejected because it makes core aware of plugin output shape and complicates the contract. Pure observers are sufficient: plugins that need to enrich prompts mutate the plan file in `PlanWritten`, and the implementer prompt naturally picks up the mutation since it sends full task body text.
5. **All ten events from #1442 in v1** — explicitly deferred to keep the PR scoped to events with proven consumers.

## Does this PR contain multiple unrelated changes?

No. Single feature: shell-based lifecycle event hooks for external plugin observers. The 13 commits are scoped TDD increments of one design (skeleton → dispatch → failure handling → timeout → edge tests → 3 skill emit points → reference doc → spec/doc fixes from review).

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art

**Most relevant prior art:**

- **#1224** (open, no maintainer response yet) — `feat: add lifecycle extension system for user-defined workflow hooks` by @jhochenbaum. Same problem space (lifecycle hooks at workflow events), genuinely different mechanism. I want to surface the comparison up front so the maintainer can choose how the project wants to handle this:

  | | #1224 | this PR |
  |---|---|---|
  | Plugin author writes | A Claude skill (markdown + YAML frontmatter) | A shell script |
  | Invocation site | `Skill` tool inside the agent's call graph | External process via Bash |
  | Discovery | YAML manifest at `~/.superpowers/extensions.yaml` and `.superpowers/extensions.yaml` | `$SUPERPOWERS_HOOK_DIRS` (colon-separated dirs) |
  | Plugin runs in agent's loop | Yes — extension output is visible to the agent's reasoning | No — fire-and-forget side effect, no return path |
  | Events | 7 (`post-brainstorm`, `post-plan`, `pre-task`, `post-task`, `post-execution`, `post-review`, `pre-finish`) | 4 (`PlanWritten`, `TaskClaimed`, `TaskCompleted`, `BlockedOnHuman`) |
  | Best fit for | In-agent extensions: compound-learning, security audit, compliance check — work that *participates* in the agent's reasoning | External observers: state mirrors, audit logs, dashboards, issue trackers — work that *records* what the agent did |

  The two approaches solve adjacent problems. #1224's design is an excellent fit for the use cases listed in its PR body (extensions that read agent context and contribute to its reasoning). This PR's design is the right fit for use cases like Beads (mirror plan/task state to an external database) where the plugin work happens *after* the agent has moved on and shouldn't pollute the agent's call graph.

  Honest position: if the maintainer wants only one mechanism, #1224 is the more general design. I'd rather see it land than nothing. But if external-observer hooks are seen as complementary infrastructure, this PR's design is genuinely simpler for that use case (no manifest parser, no Skill tool integration, no agent-graph participation). I'm happy to coordinate with @jhochenbaum if there's a unified approach worth pursuing.

- **#943** (open) — post-execution iteration skill. Referenced in #1224 as motivation. Not a direct conflict; it's a candidate consumer that either #1224 or this PR could enable.
- **#1107** — plugin architecture (skill directory organization). Different scope.
- **#1128 / #1129** — context provider via MCP. Different scope.

**Related issue:** #1442 (this PR's motivating issue, opened by me).

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.126 | Claude Opus 4.7 (1M) | claude-opus-4-7 |

Cross-harness validation (Cursor, Codex, Gemini, OpenCode) was not run — the script's harness fallback chain (`CLAUDE_PLUGIN_ROOT` → `CURSOR_PLUGIN_ROOT` → `SUPERPOWERS_ROOT`) follows the existing precedent from `hooks/session-start` and other scripts but should be validated on at least one non-Claude-Code harness before merge. Happy to run that if requested.

## New harness support (required if this PR adds a new harness)

N/A — does not add a new harness.

## Evaluation

- **Initial prompt:** "review the beads-integration branch and look at what events we'd need to expose in order to create a standalone plugin that would replicate the functionality in that branch."
- **Sessions run:** Single end-to-end session via SDD: brainstorming → spec design (with 4 explicit decision gates) → plan writing → 10-task execution loop with per-task spec compliance + code-quality reviews → final whole-implementation review → spec/doc fixes from review feedback.
- **Outcome:** 11/11 unit tests pass; 4 events fire correctly with correct payloads in end-to-end stub-plugin verification; no-plugins case is silent (`SUPERPOWERS_HOOK_DIRS` unset → rc=0, empty output).
- **Before/after:** Before this change, my Beads integration on `beads-integration` requires direct edits to `writing-plans/SKILL.md`, `executing-plans/SKILL.md`, `subagent-driven-development/SKILL.md`, plus injecting prompt-template content into `subagent-driven-development/implementer-prompt.md` — that's 79+ lines of skill modifications a fork has to maintain. After this change, that same plugin can ship as a standalone directory of shell scripts the user adds to `$SUPERPOWERS_HOOK_DIRS`, with zero edits to core. Default user behavior is identical in both cases — when no plugins are installed, the lifecycle blocks are conditional no-ops.

## Rigor

- [x] **Skills change discipline:** Each emit block is purely additive (paired `<!-- BEGIN lifecycle:Event -->` / `<!-- END lifecycle:Event -->` markers; `git diff` against base shows zero `-` content lines in `skills/`). No rewording of existing prose. No modifications to Red Flags / rationalization tables / "human partner" language / behavior-shaping content. The added blocks all open with the no-op-when-unset note so an agent reading them on a default install knows to skip.
- [x] **Tested adversarially, not just happy path:** the test suite covers every documented failure mode — unset `HOOK_DIRS`, missing hook script, non-executable hook, hook exits nonzero, hook exceeds timeout, missing event name, multi-dir ordering, stdin/stdout isolation, key=value with literal `=` in value, malformed args. Pre-impl test runs confirmed each TDD test failed for the expected reason before the implementation landed.
- [x] **Did not modify carefully-tuned content:** verified by `git diff` — the skill changes touch only inserted blocks; the existing Red Flags tables, rationalization checklists, "human partner" framings, and any agent-behavior-shaping prose are byte-for-byte unchanged.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission. The work was developed via Subagent-Driven Development with per-task spec + code-quality reviews, a final whole-implementation review, and explicit human approval at every decision gate (design choices, scope, alternatives, mechanism, payload format, event naming, marker style, timeout policy, and pre-submission positioning against #1224).