### PR TITLE
feat(skills): add n/total counter prefix to TodoWrite entries

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -19,7 +19,7 @@ Load plan, review critically, execute all tasks, report when complete.
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
 3. If concerns: Raise them with your human partner before starting
-4. If no concerns: Create TodoWrite and proceed
+4. If no concerns: Create TodoWrite with each entry named `step <n>/<total> <step text>` (n = 1-indexed position, total = count of `- [ ]` steps in plan) and proceed
 
 ### Step 2: Execute Tasks
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -58,7 +58,7 @@ digraph process {
         "Mark task complete in TodoWrite" [shape=box];
     }
 
-    "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
+    "Read plan, extract all tasks with full text, note context, create TodoWrite (entries named 'task <n>/<total> <task text>')" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent for entire implementation" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];


### PR DESCRIPTION
## What problem are you trying to solve?

Two problems the existing TodoWrite panel summary (`N pending · M completed`) does not solve:

1. **Similarly-named entries are visually indistinguishable.** A plan with `Implement endpoint`, `Implement endpoint validation`, `Implement endpoint tests` produces three rows that diverge late in the text — under horizontal truncation or quick scanning you cannot tell which is `in_progress`. `executing-plans` has the same issue at step granularity, since per-task local numbering flattens multi-task plans into repeated `Step 1`, `Step 2`, `Step 1`, `Step 2` rows.

2. **Row text appears outside the live panel** — subagent dispatch logs, scrollback, screenshots in bug reports, paste into PRs and chat. There the row text is the only handle. `Mozilla` or `deploy` cannot point at "the 50th of 50 tasks" without re-counting from the plan markdown; `task 50/50 Mozilla` carries its position into every surface.

Originally surfaced in a `subagent-driven-development` session on a multi-task plan where multiple `### Task` blocks shared a leading word.

## What does this PR change?

Two one-line edits prefixing TodoWrite entries with a labelled position:

- `executing-plans`: `step <n>/<total> <step text>`
- `subagent-driven-development`: `task <n>/<total> <task text>`

Before
<img width="400" height="550" alt="image" src="https://github.com/user-attachments/assets/efba93ee-bc9c-43f6-923a-86e3f1f23b08" />

After
<img width="400" height="350" alt="Screenshot from 2026-05-04 17-26-25" src="https://github.com/user-attachments/assets/70faa738-4059-4a7c-823d-3fa67a46b5e5" />

## Is this change appropriate for the core library?

Yes. Both skills are general-purpose execution skills in the documented core workflow (`writing-plans` → `executing-plans` / `subagent-driven-development` → `finishing-a-development-branch`). No domain, tool, or third-party coupling. No new dependencies, hooks, or tooling.

## What alternatives did you consider?

| Alternative | Rejected because |
|---|---|
| Encode totals in plan markdown via `writing-plans` | Plans get edited; authoritative count is the actual `- [ ]` / `### Task N` count at execution time. |
| Bracketed `[n/total] <name>` (no label) | Tested in an earlier iteration. Reads fine alone, noisy in lists, and indistinguishable from other bracketed leading text. The literal `step` / `task` label removes the need for surrounding glyphs. |
| Suffix `<name> [n/total]` | Defeats both pain points — eye lands on leading characters, truncation cuts there, log excerpts quote line starts. |

Format rationale (no brackets, no zero-padding, `/` separator) is in the accompanying spec doc.

## Does this PR contain multiple unrelated changes?

No. Both skills create TodoWrite entries from the same plan and inherit the same disambiguation problem; landing one without the other would render the same plan inconsistently. The single edit per skill is the same convention with only the granularity label differing (`task` vs `step`).

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #442, #166, #170, #171, #588, #808, #874, #1117, #520, #622, #1062 — none address TodoWrite entry-name shape.

Closest related: #442 (plan-level status frontmatter, different layer); #588 (skill-rename audit, not merged — confirms `TodoWrite` identifier should be preserved); #808 / #874 (plan-file checkbox sync, different artifact). Searched obra/superpowers PRs and issues with queries: `TodoWrite prefix`, `n/total`, `progress prefix`, `executing-plans TodoWrite`, `truncation TodoWrite`, `TodoWrite naming`, `task numbering`, `step numbering`, `[n/total]`, plus issue queries on `TodoWrite`, `progress visibility`, `terminal truncated`. Read #442, #166, #170, #171, #588, #808, #874, #1117, #520, #622, #1062, #212, #789, #1260 in full to confirm no overlap.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code (CLI) |  2.1.126 (Claude Code)  | Opus 4.7 (controller) + Haiku 4.5 (implementers) | `claude-opus-4-7` (1M ctx) / `claude-haiku-4-5-20251001` |

## New harness support

N/A — this PR does not add a new harness.

## Evaluation

**Initial prompt that led to this change:** A `subagent-driven-development` session on a multi-task plan where multiple `### Task` blocks shared a leading word. The panel summary read clearly, but identifying which similarly-named task an implementer subagent's reply was about required re-reading the plan markdown each time.

**Sessions run after the change:** Three on Claude Code, Opus 4.7 + Haiku 4.5:

| Session | Plan size | Result |
|---|---|---|
| `executing-plans` | 7 steps | Entries `1/7`–`7/7` emitted exactly. |
| `subagent-driven-development` | 3 tasks | Entries `1/3`–`3/3` emitted exactly. |
| `subagent-driven-development` | 50 tasks (final shape) | `task 1/50 Python` through `task 50/50 Mozilla`, in order, no gaps, no duplicates, 100% format compliance. 50 sequential Haiku dispatches, zero NEEDS_CONTEXT/BLOCKED escalations, all 50 completed. ≈70 s Haiku-side wall time. |

**How outcomes changed:** Panel summary unchanged (not the target). Two real differences:

1. **Disambiguation.** `Implement endpoint` / `… validation` / `… tests` rows that previously diverged late are now uniquely keyed on first characters as `task 12/47 …`, `task 13/47 …`, `task 14/47 …`. Confirmed at scale on the 50-task run where topics share leading words.
2. **Stable identifier outside the panel.** Same row text in logs / screenshots / paste is now self-identifying (`task 50/50 Mozilla` vs bare `Mozilla`).

No regressions in TDD discipline, commit cadence, review handoffs, or escalation behavior on these three sessions.

**Gaps:** Adversarial variants from the spec's eval plan (single-step plan; 30+ step plan; name containing `/`; text starting with literal `step` / `task`; mid-execution plan edit) and a second harness (Codex / Gemini CLI) — not yet run. Happy to run before merge if maintainers want.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing — **partial.** Spec drafted with the writing-skills mindset; happy-path acceptance at 3, 7, 50 entries on Claude Code on the final shape. Adversarial variants 1–5 not yet exercised (see Gaps above).
- [ ] This change was tested adversarially, not just on the happy path — **no, not yet.**
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement — diff modifies a numbered procedural step in `## The Process` of `executing-plans` and a node label in the process digraph of `subagent-driven-development`. Red Flags table, rationalization list, and "human partner" language unchanged. Verified via `git diff main...HEAD -- skills/`.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission