### PR TITLE
Little typo fix of unordered list

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -125,10 +125,10 @@ Return: Summary of what you found and what you fixed.
 
 ## When NOT to Use
 
-* **Related failures:** Fixing one might fix others - investigate together first
-* **Need full context:** Understanding requires seeing entire system
-* **Exploratory debugging:** You don't know what's broken yet
-* **Shared state:** Agents would interfere (editing same files, using same resources)
+- **Related failures:** Fixing one might fix others - investigate together first
+- **Need full context:** Understanding requires seeing entire system
+- **Exploratory debugging:** You don't know what's broken yet
+- **Shared state:** Agents would interfere (editing same files, using same resources)
 
 ## Real Example from Session
 

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -125,10 +125,10 @@ Return: Summary of what you found and what you fixed.
 
 ## When NOT to Use
 
-**Related failures:** Fixing one might fix others - investigate together first
-**Need full context:** Understanding requires seeing entire system
-**Exploratory debugging:** You don't know what's broken yet
-**Shared state:** Agents would interfere (editing same files, using same resources)
+* **Related failures:** Fixing one might fix others - investigate together first
+* **Need full context:** Understanding requires seeing entire system
+* **Exploratory debugging:** You don't know what's broken yet
+* **Shared state:** Agents would interfere (editing same files, using same resources)
 
 ## Real Example from Session
 


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

## What problem are you trying to solve?
Broken unordered list.

## What does this PR change?
Fix broken unordered list.

## Is this change appropriate for the core library?
Yes

## What alternatives did you consider?
I have just fixed typo in the obvious way.

## Does this PR contain multiple unrelated changes?
No

## Existing PRs
No, it is simple typo easy to fix.

## Environment tested

No

## New harness support (required if this PR adds a new harness)

No

## Evaluation
No

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [ x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

## Human review
- [x ] A human has reviewed the COMPLETE proposed diff before submission
