### PR TITLE
docs(dispatching-parallel-agents): document single-message-N-blocks mechanic

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -73,6 +73,43 @@ Task("Fix tool-approval-race-conditions.test.ts failures")
 // All three run concurrently
 ```
 
+#### Mechanics — How Parallel Actually Happens
+
+**Parallel execution requires N Task tool_use blocks in a SINGLE assistant message.** Multiple messages = sequential, even if you intended parallel.
+
+This is the underlying API behavior: when one assistant turn emits multiple `tool_use` blocks, the runtime executes them concurrently. When tool calls are split across multiple turns, each turn waits for the previous one to complete before issuing the next — that's sequential dispatch, not parallel.
+
+**Correct (parallel — 1 message, N blocks):**
+
+```
+[assistant turn 1]
+  Task("Fix file A")
+  Task("Fix file B")
+  Task("Fix file C")
+[assistant turn 2 observes all 3 results]
+```
+
+All three execute concurrently. Total wall-clock ≈ max(A, B, C).
+
+**Wrong (sequential despite intent — N messages, 1 block each):**
+
+```
+[assistant turn 1] Task("Fix file A")
+[wait for A to complete]
+[assistant turn 2] Task("Fix file B")  ← runs AFTER A
+[wait for B to complete]
+[assistant turn 3] Task("Fix file C")  ← runs AFTER B
+```
+
+This is sequential. Total wall-clock = A + B + C.
+
+**Self-verify before claiming parallel:**
+1. Count assistant turns in your batch — should be **1**.
+2. Count Task tool_use blocks in that single turn — should be **N** (the count you intended).
+3. If you have N turns each with 1 Task, you dispatched sequentially. Consolidate into one turn.
+
+This is a common error: thinking "I'll launch 3 Task calls" mentally maps to 3 separate API calls if you're not careful. Always emit them in one turn for true parallelism.
+
 ### 4. Review and Integrate
 
 When agents return:


### PR DESCRIPTION
## Problem

The skill body shows the parallel-dispatch code pattern (3 `Task()` calls + comment `// All three run concurrently`) but never explicitly documents the **underlying mechanic** that makes parallel work:

> Parallel execution requires N `Task` tool_use blocks in a **single assistant message**. Multiple messages = sequential, even if you intended parallel.

Models reading this skill consistently miss this rule and dispatch tasks across separate turns while narrating the result as "parallel". The dispatch is functionally sequential because each turn waits for the previous one's tool result before emitting the next.

## Empirical example

A recent multi-fix session attempted 2 file-disjoint fixes:
- Turn 1: `Task("Fix file A")` → wait for result
- Turn 2 (56s later): `Task("Fix file B")` → wait for result
- Then narrated: "2 parallel subagents launched"

Total wall-clock = A + B (sequential), not max(A, B) (parallel). The "parallel" claim was incorrect because the underlying API mechanic was misunderstood.

The rule is standard Claude API behavior (`disable_parallel_tool_use: false` is the default) — multiple `tool_use` blocks in one assistant message execute concurrently. See [Anthropic API docs § Implement tool use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use) for the official reference.

## Change

Pure additive documentation. No removals, no logic changes. ~37 new lines inserted right after step 3 (Dispatch in Parallel) in the skill body, before step 4 (Review and Integrate).

New subsection **\"Mechanics — How Parallel Actually Happens\"** covers:

1. The single-message-N-blocks rule (1 paragraph)
2. ✅ Correct vs ❌ Wrong contrast with explicit turn-by-turn diagrams
3. 3-step self-verify checklist (count turns → count blocks → reconcile)

The intent is to convert an unwritten API behavior into an explicit skill teaching, so future models invoking this skill understand the mechanic, not just the example formatting.

## No regression risk

- Documentation only — no behavior change
- No removals — existing content untouched
- Inserted between existing H3 sections — Markdown structure unchanged
- Cross-reference to Anthropic API doc included for canonical authority

## Test plan
- [ ] Render preview on GitHub — confirm new subsection appears between step 3 and step 4
- [ ] Verify code blocks formatting (3 fenced blocks added — typescript, plain, plain)
- [ ] Confirm no unintended changes outside the inserted subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)