### PR TITLE
feat: add plan review cycle skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,15 @@ already use it in another harness.
 
 3. **writing-plans** - Activates with approved design. Breaks work into bite-sized tasks (2-5 minutes each). Every task has exact file paths, complete code, verification steps.
 
-4. **subagent-driven-development** or **executing-plans** - Activates with plan. Dispatches fresh subagent per task with two-stage review (spec compliance, then code quality), or executes in batches with human checkpoints.
+4. **plan-review-cycle** - Activates after a plan is written when your human partner wants independent verification before execution. Especially recommended for large plans, plans with many constraints, or plans that will be executed by subagents. Dispatches a fresh reviewer subagent, records each finding in a Plan Review Log, requires either an approved plan change or approved no-change rationale, and optionally repeats verification rounds until there are no open findings.
 
-5. **test-driven-development** - Activates during implementation. Enforces RED-GREEN-REFACTOR: write failing test, watch it fail, write minimal code, watch it pass, commit. Deletes code written before tests.
+5. **subagent-driven-development** or **executing-plans** - Activates with plan. Dispatches fresh subagent per task with two-stage review (spec compliance, then code quality), or executes in batches with human checkpoints.
 
-6. **requesting-code-review** - Activates between tasks. Reviews against plan, reports issues by severity. Critical issues block progress.
+6. **test-driven-development** - Activates during implementation. Enforces RED-GREEN-REFACTOR: write failing test, watch it fail, write minimal code, watch it pass, commit. Deletes code written before tests.
 
-7. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
+7. **requesting-code-review** - Activates between tasks. Reviews against plan, reports issues by severity. Critical issues block progress.
+
+8. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
 
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
 
@@ -183,6 +185,7 @@ already use it in another harness.
 **Collaboration** 
 - **brainstorming** - Socratic design refinement
 - **writing-plans** - Detailed implementation plans
+- **plan-review-cycle** - Independent plan verification loop with tracked finding dispositions before execution
 - **executing-plans** - Batch execution with checkpoints
 - **dispatching-parallel-agents** - Concurrent subagent workflows
 - **requesting-code-review** - Pre-review checklist

--- a/skills/plan-review-cycle/SKILL.md
+++ b/skills/plan-review-cycle/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: plan-review-cycle
+description: Use when an implementation plan has been written and needs independent verification, issue triage, documented finding dispositions, or repeated review before execution
+---
+
+# Plan Review Cycle
+
+## Quick Reference
+
+1. Dispatch a fresh reviewer.
+2. Record every finding in the Plan Review Log.
+3. Assign each finding a severity and status.
+4. For each finding, propose either `Resolved` or `No Plan Change`.
+5. Get human partner approval before changing the plan or closing a finding.
+6. Do not execute while `Critical`, `Major`, or `Minor` findings are `Open`.
+7. Recommend another review round after substantial plan changes.
+
+## Overview
+
+Run an independent verification loop for an existing implementation plan before execution begins. Every reviewer finding must be closed by either changing the plan or documenting why no plan change is needed.
+
+At the start, clearly state that you are running the plan-review-cycle to verify and refine the plan.
+
+Core invariant: **No reviewer finding disappears.** It is either resolved with a plan change or preserved with an explicit no-change rationale approved by your human partner.
+
+## When to Use
+
+Use this after a complete implementation plan exists and before implementation starts.
+
+Use when:
+
+- Your human partner asks for plan verification, plan review, a reviewer subagent, or another review round
+- A plan may have missing requirements, vague tasks, contradictions, or buildability risks
+- Review findings need to become tracked follow-up items
+- The plan should preserve rationale for issues intentionally left unchanged
+
+Do not use for:
+
+- Creating the initial implementation plan
+- Reviewing implemented code
+- Debugging a failing implementation
+- Replacing the inline self-review required by `superpowers:writing-plans`
+
+## Required Inputs
+
+- Plan file path
+- Spec, requirements, or design file path when available
+- Constraints, priorities, or non-goals from your human partner
+
+If the spec path is missing, explicitly ask for it before starting the review unless your human partner confirms to proceed without it.
+
+## Cycle
+
+1. Dispatch a fresh reviewer subagent.
+2. Ask the reviewer to identify only issues that would materially affect implementation, not completeness or polish. Do not list stylistic suggestions, minor preferences, or already-covered points.
+3. If the reviewer returns `Status: Approved` with no findings, skip directly to step 8.
+4. Convert each reviewer issue into a tracked finding.
+5. Present findings to your human partner as a checkbox summary ordered by severity.
+6. For each finding:
+   - present the concern and why it matters;
+   - ask your human partner for their thoughts before proposing anything;
+   - propose a concrete plan change or a no-change rationale;
+   - ask for approval;
+   - update the plan accordingly only after explicit approval.
+7. Ensure every finding is closed as either:
+   - `Resolved`, with plan changes recorded; or
+   - `No Plan Change`, with rationale recorded.
+8. Ask your human partner whether to run another review round.
+9. If yes, repeat the cycle with a fresh reviewer subagent.
+10. If no, ask whether to proceed to the next workflow step.
+
+## Reviewer Subagent Prompt
+
+Use `reviewer-prompt.md` from this skill when dispatching the reviewer. Fill in the plan path, spec path, and any constraints.
+
+The reviewer must ignore issues already closed in the Plan Review Log unless there is new evidence that invalidates the prior disposition.
+
+## Plan Review Log
+
+If the plan does not already contain a `Plan Review Log`, append one near the end of the plan after the implementation tasks and before any execution handoff notes.
+
+For each review round, add:
+
+```markdown
+### Review Round N
+
+**Reviewer:** subagent
+**Date:** YYYY-MM-DD
+**Spec reviewed:** `path/to/spec.md`
+**Plan reviewed:** `path/to/plan.md`
+
+#### Findings
+```
+
+For each finding:
+
+Finding IDs are scoped by review round. Use `R<N>-PRC<NNN>` where `N` is the review round number and `NNN` is the finding number within that round. Do not reuse IDs across rounds.
+
+```markdown
+##### Finding R<N>-PRC<NNN>: Short title
+
+**Status:** Open | Resolved | No Plan Change  
+**Severity:** Critical | Major | Minor | Advisory  
+**Location:** Plan section, task, or step
+
+**Reviewer concern:**  
+[What the reviewer flagged.]
+
+**Why it matters:**  
+[Implementation risk, ambiguity, missing requirement, contradiction, or other concrete impact.]
+
+**Decision:**  
+Change plan | No plan change
+
+**Plan changes made:**
+
+- [Task/section changed]
+- [Exact summary of modification]
+
+**Reason if no plan change:**  
+[Explicit rationale explaining why the original plan remains valid, why the issue is out of scope, or why the concern is intentionally deferred.]
+
+**Human partner approval:**  
+Approved | Rejected | Deferred
+```
+
+Delete unused placeholder lines. Do not leave template text in the plan.
+
+## Finding Disposition Rules
+
+Every reviewer finding starts as `Open`.
+
+A finding may be closed only when one of these is true:
+
+### Resolved
+
+The plan was changed. Record the reviewer concern, decision, exact plan sections or tasks changed, summary of the change, and approval from your human partner.
+
+### No Plan Change
+
+The plan was not changed. Record the reviewer concern, why the existing plan is already sufficient, out of scope, intentionally deferred, or superseded by another task, and approval from your human partner.
+
+Never silently discard a finding. Never decide a finding is invalid without documenting the rationale and getting approval from your human partner.
+
+Never update the plan unless your human partner explicitly confirms the disposition.  
+Do not partially update the plan while a finding is still under discussion.
+If operating in build mode, pause and wait for confirmation before making changes.
+
+## Severity Semantics
+
+- `Critical`: Blocks execution until resolved or explicitly closed as `No Plan Change` with human partner approval. Use for missing requirements, contradictions, unsafe paths, or tasks that cannot be executed.
+- `Major`: Blocks execution unless your human partner explicitly approves deferring or accepting the risk. Use for issues likely to cause rework or incorrect behavior.
+- `Minor`: Blocks execution until closed. Should be resolved or explicitly documented, but should not require large plan changes.
+- `Advisory`: Does not block execution. Record only if your human partner wants it tracked.
+
+Do not proceed to implementation while any `Critical`, `Major`, or `Minor` finding remains `Open`.
+
+## Human Partner Interaction
+
+After reviewer findings are returned, present a summary ordered by severity using checkbox syntax, then ask whether to begin:
+
+```text
+Review found N issue(s):
+
+- [ ] R<N>-PRC001 [Critical] Short title
+- [ ] R<N>-PRC002 [Major] Short title
+- [ ] R<N>-PRC003 [Minor] Short title
+- [ ] R<N>-PRC004 [Advisory] Short title
+
+Would you like to review the first item on the list?
+```
+
+For each finding, present the concern and why it matters, then ask:
+
+```text
+What are your thoughts on this? Do you see it the same way, or is there context I'm missing?
+```
+
+After the human responds, propose a concrete plan change or no-change rationale, then ask:
+
+```text
+Approve this disposition?
+```
+
+Once a finding is approved, mark its checkbox and move to the next item.
+
+If your human partner rejects a proposed disposition, keep the finding open and ask what outcome they want: revise the change, document no-change rationale, defer, or stop the review cycle.
+
+## Repeat Review Guidance
+
+Recommend another round when:
+
+- Critical or Major findings caused substantial plan changes
+- The plan structure changed significantly
+- New tasks, files, or dependencies were introduced
+- Multiple material issues were found
+
+Do not strongly recommend another round when:
+
+- The review returned no findings or only Advisory findings
+- Findings were closed as `No Plan Change` with clear rationale
+- Plan changes were small and localized
+
+Ask:
+
+```text
+All review findings are closed. Another verification round is [recommended/optional/not necessary]. Would you like to run another round?
+```
+
+If yes, start another review round, include the existing Plan Review Log in the reviewer instructions, and tell the reviewer not to repeat already-closed findings unless there is new evidence.
+
+If no, ask whether to proceed to the next step:
+
+```text
+Plan review cycle complete. Should we proceed to implementation with superpowers:subagent-driven-development or superpowers:executing-plans?
+```
+
+Do not start execution until your human partner confirms.
+
+## Red Flags
+
+Stop and fix if:
+
+- A reviewer finding is discussed but not recorded
+- A plan is unchanged but no rationale is documented
+- A finding is treated as "implicitly resolved" without explicit closure
+- The agent decides a finding is invalid without approval
+- A review round repeats already-closed findings without new evidence
+- Execution starts while findings remain open
+- The Plan Review Log contains unresolved template placeholders

--- a/skills/plan-review-cycle/reviewer-prompt.md
+++ b/skills/plan-review-cycle/reviewer-prompt.md
@@ -1,0 +1,73 @@
+# Plan Review Cycle Reviewer Prompt
+
+Use this template when dispatching a fresh subagent for a plan review cycle.
+
+```text
+You are a plan verification reviewer.
+
+Review the implementation plan against the spec and identify only findings that would materially affect implementation.
+
+Plan:
+[PLAN_FILE_PATH]
+
+Spec:
+[SPEC_FILE_PATH]
+
+Additional constraints or priorities from the human partner:
+[HUMAN_PARTNER_CONSTRAINTS]
+
+Review round number:
+[REVIEW_ROUND_NUMBER]
+
+Existing Plan Review Log, if any:
+[PLAN_REVIEW_LOG]
+
+Check for:
+- Missing spec requirements
+- Contradictions between tasks
+- Vague or non-actionable steps
+- Missing file paths, commands, or expected outcomes
+- TDD violations, where applicable
+- Tasks that cannot be executed independently
+- Hidden dependencies between tasks
+- Scope creep beyond the approved spec
+- Missing migration, compatibility, or rollback concerns where relevant
+- Missing verification steps
+
+Severity guide:
+- Critical: Missing requirements, contradictions, unsafe implementation paths, or tasks that cannot be executed
+- Major: Issues likely to cause rework, implementation confusion, or incomplete behavior
+- Minor: Issues worth addressing or documenting, but unlikely to derail implementation
+- Advisory: Non-blocking suggestions only
+
+Do not flag:
+- Minor wording preferences
+- Stylistic improvements
+- Nice-to-have enhancements
+- Issues already addressed in the Plan Review Log with a valid rationale
+
+Calibration:
+Only flag issues that would cause real problems during implementation. An implementer building the wrong thing or getting stuck is an issue. Minor wording, stylistic preferences, and nice-to-have suggestions are not.
+
+If the Plan Review Log already closes a finding as Resolved or No Plan Change, do not repeat that finding unless you have new evidence that the prior disposition is incorrect or incomplete.
+
+Output:
+
+## Plan Verification Review
+
+**Status:** Approved | Issues Found
+
+### Findings
+
+#### Finding R<REVIEW_ROUND_NUMBER>-PRC<NNN>: [short title]
+
+**Severity:** Critical | Major | Minor | Advisory
+**Location:** [plan section/task/step]
+**Concern:** [specific issue]
+**Why it matters:** [implementation risk]
+**Suggested resolution:** [concrete recommendation]
+
+### Recommendations
+
+- [Advisory suggestions only. These must not block approval.]
+```

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -131,6 +131,18 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 
+## Optional Plan Review Cycle
+
+After saving the plan and completing self-review, ask:
+
+"Would you like me to run an independent plan-review-cycle before execution? This is especially recommended for large plans, plans with many constraints, or plans that will be executed by subagents."
+
+If yes:
+
+**REQUIRED SUB-SKILL:** Use superpowers:plan-review-cycle
+
+Do not offer execution until the review cycle has no open findings. Every reviewer finding must either result in an approved plan change or be recorded in the plan with an approved no-change rationale from your human partner.
+
 ## Execution Handoff
 
 After saving the plan, offer execution choice:

--- a/tests/claude-code/README.md
+++ b/tests/claude-code/README.md
@@ -92,6 +92,14 @@ Tests skill content and requirements (~2 minutes):
 - Review loops documented
 - Task context provision documented
 
+#### test-plan-review-cycle.sh
+Tests skill content and requirements (~2 minutes):
+- Skill loading and accessibility
+- Fresh reviewer subagent requirement documented
+- Plan Review Log and No Plan Change dispositions documented
+- Human partner approval required before updating or leaving a finding unchanged
+- Repeated review loop and execution blocking requirements documented
+
 ### Integration Tests (use --integration flag)
 
 #### test-subagent-driven-development-integration.sh

--- a/tests/claude-code/run-skill-tests.sh
+++ b/tests/claude-code/run-skill-tests.sh
@@ -58,6 +58,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Tests:"
             echo "  test-subagent-driven-development.sh  Test skill loading and requirements"
+            echo "  test-plan-review-cycle.sh            Test plan review cycle skill loading and requirements"
             echo ""
             echo "Integration Tests (use --integration):"
             echo "  test-subagent-driven-development-integration.sh  Full workflow execution"
@@ -74,6 +75,7 @@ done
 # List of skill tests to run (fast unit tests)
 tests=(
     "test-subagent-driven-development.sh"
+    "test-plan-review-cycle.sh"
 )
 
 # Integration tests (slow, full execution)

--- a/tests/claude-code/test-plan-review-cycle.sh
+++ b/tests/claude-code/test-plan-review-cycle.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Test: plan-review-cycle skill requirements
+# Verifies that Claude understands the plan-review-cycle workflow and guardrails.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+
+echo "========================================"
+echo " Test: plan-review-cycle skill"
+echo "========================================"
+echo ""
+
+echo "[1/2] Testing skill loading and core workflow requirements..."
+output=$(run_claude "Use the plan-review-cycle skill. Describe the required workflow in concise bullets. Include these exact phrases where applicable: fresh reviewer subagent, Plan Review Log, No Plan Change, human partner, another review round, R1-PRC001, Critical, Major." 120)
+
+assert_contains "$output" "plan-review-cycle" "Skill name is referenced"
+assert_contains "$output" "fresh reviewer subagent" "Reviewer subagent requirement documented"
+assert_contains "$output" "Plan Review Log" "Plan Review Log requirement documented"
+assert_contains "$output" "No Plan Change" "No-change disposition documented"
+assert_contains "$output" "human partner" "Human partner approval language used"
+assert_contains "$output" "another review round" "Repeat review loop documented"
+assert_contains "$output" "R1-PRC001" "Round-scoped finding ID example documented"
+assert_contains "$output" "Critical" "Critical severity documented"
+assert_contains "$output" "Major" "Major severity documented"
+
+echo ""
+echo "[2/2] Testing anti-rationalization behavior for unchanged plans..."
+pressure_output=$(run_claude "Use the plan-review-cycle skill. A reviewer flagged a Critical issue, but I believe the plan is already correct. Can I just ignore the finding and continue to implementation? Answer with the required disposition behavior and include these exact phrases: Never silently discard, no-change rationale, approval from your human partner, Do not start execution." 120)
+
+assert_contains "$pressure_output" "Never silently discard" "Findings cannot be silently discarded"
+assert_contains "$pressure_output" "no-change rationale" "No-change rationale required"
+assert_contains "$pressure_output" "approval from your human partner" "Human partner approval required"
+assert_contains "$pressure_output" "Do not start execution" "Execution blocked until review cycle complete"
+
+echo ""
+echo "=== All plan-review-cycle tests passed ==="

--- a/tests/opencode/run-tests.sh
+++ b/tests/opencode/run-tests.sh
@@ -47,6 +47,7 @@ while [[ $# -gt 0 ]]; do
             echo "  test-bootstrap-caching.sh  Verify bootstrap content caching"
             echo "  test-tools.sh           Test use_skill and find_skills tools (integration)"
             echo "  test-priority.sh        Test skill priority resolution (integration)"
+            echo "  test-plan-review-cycle.sh Test plan-review-cycle skill behavior (integration)"
             exit 0
             ;;
         *)
@@ -67,6 +68,7 @@ tests=(
 integration_tests=(
     "test-tools.sh"
     "test-priority.sh"
+    "test-plan-review-cycle.sh"
 )
 
 # Add integration tests if requested

--- a/tests/opencode/test-plan-review-cycle.sh
+++ b/tests/opencode/test-plan-review-cycle.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Test: plan-review-cycle skill requirements in OpenCode
+# Verifies that OpenCode can load the skill and that the model reports the
+# core plan-review-cycle guardrails.
+# NOTE: These tests require OpenCode to be installed and configured.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+REAL_HOME="${HOME:-}"
+REAL_XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$REAL_HOME/.config}"
+REAL_OPENCODE_CONFIG_DIR="${OPENCODE_CONFIG_DIR:-$REAL_XDG_CONFIG_HOME/opencode}"
+
+echo "=== Test: OpenCode plan-review-cycle skill ==="
+
+source "$SCRIPT_DIR/setup.sh"
+trap cleanup_test_env EXIT
+
+if [ -d "$REAL_OPENCODE_CONFIG_DIR" ]; then
+    echo "Copying OpenCode config from: $REAL_OPENCODE_CONFIG_DIR"
+    if command -v rsync >/dev/null 2>&1; then
+        rsync -a --exclude '/plugins/' --exclude '/superpowers/' "$REAL_OPENCODE_CONFIG_DIR"/ "$OPENCODE_CONFIG_DIR"/
+    else
+        find "$REAL_OPENCODE_CONFIG_DIR" -mindepth 1 -maxdepth 1 ! -name plugins ! -name superpowers -exec cp -R {} "$OPENCODE_CONFIG_DIR"/ \;
+    fi
+else
+    echo "No real OpenCode config found at: $REAL_OPENCODE_CONFIG_DIR"
+fi
+
+if ! command -v opencode >/dev/null 2>&1; then
+    echo "  [SKIP] OpenCode not installed - skipping integration test"
+    echo "  To run this test, install OpenCode: https://opencode.ai"
+    exit 0
+fi
+
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD="gtimeout"
+else
+    echo "  [WARN] Neither timeout nor gtimeout found; OpenCode commands will run without a timeout"
+fi
+
+assert_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local test_name="$3"
+
+    if grep -qi "$pattern" "$file"; then
+        echo "  [PASS] $test_name"
+    else
+        echo "  [FAIL] $test_name"
+        echo "  Expected to find: $pattern"
+        echo "  Output was:"
+        head -200 "$file"
+        exit 1
+    fi
+}
+
+run_opencode_to_file() {
+    local prompt="$1"
+    local output_file="$2"
+    local timeout_seconds="${3:-120}"
+    local exit_code
+
+    set +e
+    if [ -n "$TIMEOUT_CMD" ]; then
+        "$TIMEOUT_CMD" "${timeout_seconds}s" opencode run --print-logs "$prompt" >"$output_file" 2>&1
+    else
+        opencode run --print-logs "$prompt" >"$output_file" 2>&1
+    fi
+    exit_code=$?
+    set -e
+
+    if [ "$exit_code" -ne 0 ]; then
+        if [ "$exit_code" -eq 124 ]; then
+            echo "  [FAIL] OpenCode timed out after ${timeout_seconds}s"
+        else
+            echo "  [FAIL] OpenCode returned non-zero exit code: $exit_code"
+        fi
+        echo "  Output was:"
+        head -200 "$output_file"
+        exit 1
+    fi
+}
+
+echo "Test 1: Loading plan-review-cycle skill and checking core workflow..."
+output_file_1="$(mktemp)"
+prompt_1="Use the use_skill tool to load superpowers:plan-review-cycle. Then summarize the required workflow in concise bullets. Include these exact phrases where applicable: plan-review-cycle, fresh reviewer subagent, Plan Review Log, No Plan Change, human partner, another review round, R1-PRC001, Critical, Major."
+run_opencode_to_file "$prompt_1" "$output_file_1" 120
+
+assert_file_contains "$output_file_1" "plan-review-cycle" "Skill name is referenced"
+assert_file_contains "$output_file_1" "fresh reviewer subagent" "Fresh reviewer subagent requirement documented"
+assert_file_contains "$output_file_1" "Plan Review Log" "Plan Review Log requirement documented"
+assert_file_contains "$output_file_1" "No Plan Change" "No-change disposition documented"
+assert_file_contains "$output_file_1" "human partner" "Human partner approval language used"
+assert_file_contains "$output_file_1" "another review round" "Repeat review loop documented"
+assert_file_contains "$output_file_1" "R1-PRC001" "Round-scoped finding ID example documented"
+assert_file_contains "$output_file_1" "Critical" "Critical severity documented"
+assert_file_contains "$output_file_1" "Major" "Major severity documented"
+
+echo ""
+echo "Test 2: Checking adversarial pressure behavior..."
+output_file_2="$(mktemp)"
+prompt_2="Use the use_skill tool to load superpowers:plan-review-cycle. A reviewer flagged a Critical issue, but I believe the plan is already correct. Can I just ignore the finding and continue to implementation? Answer with the required disposition behavior and include these exact phrases: Never silently discard, no-change rationale, approval from your human partner, Do not start execution."
+run_opencode_to_file "$prompt_2" "$output_file_2" 120
+
+assert_file_contains "$output_file_2" "Never silently discard" "Findings cannot be silently discarded"
+assert_file_contains "$output_file_2" "no-change rationale" "No-change rationale required"
+assert_file_contains "$output_file_2" "approval from your human partner" "Human partner approval required"
+assert_file_contains "$output_file_2" "Do not start execution" "Execution blocked until review cycle complete"
+
+rm -f "$output_file_1" "$output_file_2"
+
+echo ""
+echo "=== OpenCode plan-review-cycle test passed ==="


### PR DESCRIPTION
## What problem are you trying to solve?

I started working with AI using OpenCode for some personal projects and experiments.

I discovered Superpowers through Reddit and the Claude plugin ecosystem. I found it very useful because I was no longer relying only on state-of-the-art models, but also on structured workflows.

I started using the `brainstorming` skill to explore new feature ideas. However, I noticed that I often didn’t have the full picture of all the nuances, and models tend to rush toward creating a plan while skipping or under-exploring unclear parts.

At some point, I read this advice: before approving a plan, ask the model to identify what is still unclear and ask a few follow-up questions. I started doing this systematically, and it improved the planning phase.

Another approach I used was to take the generated plan, paste it into another LLM (Claude, ChatGPT, DeepSeek, etc.), ask for a review, then bring the findings back into OpenCode and address them.

Over time, this evolved into something more structured:

"I asked another model to review the document. For each point raised, create a sub-task and review it together."

Then, after discovering sub-agents, it became:

"Run a reviewer sub-agent on `@plans/myplan.md`. For each finding, create a task and let’s review it together."

I would repeat this several times until I was satisfied with the plan. I also had to explicitly tell the model to update the plan with rationale, so that future review rounds would not raise the same questions again.

## What does this PR change?

Adds a new `plan-review-cycle` skill and reviewer prompt.

The reviewer subagent is instructed to return a `Status: Approved | Issues Found` field, which the orchestrating agent uses to determine whether to enter the finding-processing loop.


The skill:

- dispatches a fresh reviewer subagent after an implementation plan is written;
- records findings in a `Plan Review Log`;
- includes a concise Quick Reference for the full review/disposition loop;
- uses round-scoped finding IDs such as `R1-PRC001`;
- defines severity semantics for `Critical`, `Major`, `Minor`, and `Advisory`;
- blocks execution while `Critical`, `Major`, or `Minor` findings remain `Open`;
- requires human partner approval before changing the plan or closing a finding as `No Plan Change`;
- provides guidance for when another review round is recommended, optional, or not necessary;
- instructs later review rounds not to repeat already-closed findings unless there is new evidence.

The core of the skill is the cycle:

1. Dispatch a fresh reviewer subagent.
2. Ask the reviewer to identify only issues that would materially affect implementation, not completeness or polish. Do not list stylistic suggestions, minor preferences, or already-covered points.
3. If the reviewer returns `Status: Approved` with no findings, skip directly to step 8.
4. Convert each reviewer issue into a tracked finding.
5. Present findings to your human partner as a checkbox summary ordered by severity.
6. For each finding:
   - present the concern and why it matters;
   - ask your human partner for their thoughts before proposing anything;
   - propose a concrete plan change or a no-change rationale;
   - ask for approval;
   - update the plan accordingly only after explicit approval.
7. Ensure every finding is closed as either:
   - `Resolved`, with plan changes recorded; or
   - `No Plan Change`, with rationale recorded.
8. Ask your human partner whether to run another review round.
9. If yes, repeat the cycle with a fresh reviewer subagent.
10. If no, ask whether to proceed to the next workflow step.


<img width="1115" height="2268" alt="Mermaid-preview" src="https://github.com/user-attachments/assets/db30c08b-a6b0-4b55-9eee-77e7663e093f" />


This PR also updates:

- `README.md`
  - adds `plan-review-cycle` to the Basic Workflow;
  - adds it to the Collaboration skills list.
- `skills/writing-plans/SKILL.md`
  - adds an optional handoff asking whether to run `plan-review-cycle` before execution;
  - notes that it is especially recommended for large plans, plans with many constraints, or plans that will be executed by subagents.
- `tests/claude-code/*`
  - adds Claude Code test coverage for the skill requirements.
- `tests/opencode/*`
  - adds OpenCode integration coverage for skill loading, core workflow reporting, and adversarial pressure behavior.


## Is this change appropriate for the core library?

Yes.

This is a general-purpose planning quality gate. It is not domain-specific, project-specific, harness-specific, or tied to a third-party tool. It applies to any implementation plan that may be reviewed before execution, especially plans that will be implemented by subagents.

The behavior is aligned with Superpowers’ existing process-oriented skills: make the agent slow down at high-leverage workflow boundaries, preserve human approval points, and prevent silent rationalization.

## What alternatives did you consider?

1. **Add this directly to `writing-plans`.**

   Rejected because plan review can be useful for any existing implementation plan, including manually written plans. It also needs to be repeatable independently after plan changes.

2. **Use a one-shot plan reviewer prompt only.**

   Rejected because one-shot review does not track finding disposition, severity, no-change rationale, or repeated review rounds.

3. **Keep findings only in chat.**

   Rejected because future reviewer subagents cannot see why an issue was resolved or intentionally left unchanged. A durable `Plan Review Log` prevents already-decided issues from being rediscovered indefinitely.

4. **Make every plan review mandatory.**

   Rejected because small/simple plans do not always need another review round. The skill is available as an explicit review gate and is especially recommended for large plans, plans with many constraints, or plans that will be executed by subagents.

## Does this PR contain multiple unrelated changes?

No.

All changes support the new `plan-review-cycle` skill, its handoff from `writing-plans`, and its test/documentation coverage.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art.
- [x] I also searched standalone issues for related prior art.

Related PRs / issues / prior art:

- #1010 proposed enhanced `writing-plans` review capabilities via an inline `Plan Audit -> Revise -> Consistency Check` workflow. This PR is related but different: it adds a separate `plan-review-cycle` skill using a fresh reviewer subagent, durable `Plan Review Log`, explicit `Open` / `Resolved` / `No Plan Change` dispositions, severity-based blocking, human partner approval, and repeat-review guidance.

- #1130 proposed an adversarial plan review step between `writing-plans` and `executing-plans`. This PR is related but different: it adds durable finding disposition, severity-based blocking, human partner approval, and repeat-review guidance rather than only a destructive review pass.

- #334 added document/spec/plan review loops. This PR builds on that area but adds a durable implementation-plan finding disposition cycle with round-scoped IDs, severity semantics, explicit `Resolved` / `No Plan Change` closure, human partner approval, and repeat-review guidance.

- #441 added architecture and file-size checks to spec, plan, and code-quality review loops. This PR does not add more review criteria; it adds the process for tracking and closing findings raised during plan review.

- #766 suggested plan review improvements for product-level gaps and intent-vs-implementation drift. This PR addresses the disposition/closure workflow for reviewer findings rather than adding new product-level review criteria.

- #895, #1233, and #1234 are related planning-quality issues. They focus on what implementation plans should contain or how plans should preserve spec/code context; this PR focuses on how independent review findings are tracked, approved, closed, or carried forward.

- #522 adjusted process-oriented skills to scale to task complexity. This PR follows the same principle by making another review round recommended, optional, or unnecessary based on finding severity and amount of plan change.

- #1285 is prior art for OpenCode integration tests. This PR follows the OpenCode test-suite pattern by adding an integration test that launches real OpenCode sessions through `tests/opencode/run-tests.sh`.

- #1299 is prior art for adding behavioral tests around review dispatch behavior, but it targets code review, not implementation-plan review disposition.

No duplicate PR implementing a durable `plan-review-cycle` finding-disposition skill was found.

## Environment tested

| Harness             |                           Harness version | Model | Model version/ID            |
| ------------------- | ----------------------------------------: | ----- | --------------------------- |
| OpenCode            |                                   1.14.33 | Hy3   | Not surfaced by test output |
| Shell static checks | macOS, Bash, GNU coreutils `timeout` 9.10 | N/A   | N/A                         |
| Claude Code         |                           Not run locally | N/A   | N/A                         |

Claude Code behavioral tests were not run locally because I do not have a valid Claude Code subscription plan. To provide a real harness eval, I added and ran an OpenCode integration test instead.

GNU `timeout` is available locally:

```text
timeout (GNU coreutils) 9.10
```

## Evaluation

**Initial prompt that started the session:**

> I usually launch a sub-agent to review generated plans. I want findings to become tracked tasks, and if no plan change is made, the reason should be documented in the plan so future review subagents do not raise the same issue again. After findings are closed, ask whether to run another review round.

**Eval sessions run after the change:**

- 1 targeted OpenCode integration eval (`test-plan-review-cycle.sh`)
- multiple iterative local runs while developing the test and skill (used for debugging and validation, not counted as distinct eval scenarios)

The formal acceptance eval for this PR is the OpenCode integration test described below.

### Outcome compared to before the change

Before this PR:

- reviewer findings were transient and often handled in chat;
- there was no enforced requirement to document why a finding was not addressed;
- future review rounds could re-raise the same issue with no awareness of prior decisions.

After this PR:

- every finding must be explicitly closed (`Resolved` or `No Plan Change`) or remain `Open`;
- no-change decisions require rationale and human partner approval;
- execution is blocked while blocking findings remain `Open`;
- future review rounds are explicitly instructed not to repeat already-closed findings without new evidence.

In practice, this changes plan review from an informal discussion into a repeatable and auditable workflow.

### 1. OpenCode integration eval

Command:

```bash
cd tests/opencode
./run-tests.sh --test test-plan-review-cycle.sh --verbose
```

OpenCode version:

```text
1.14.33
```

Result: PASS

Output summary:

```text
Test 1: Loading plan-review-cycle skill and checking core workflow...
  [PASS] Skill name is referenced
  [PASS] Fresh reviewer subagent requirement documented
  [PASS] Plan Review Log requirement documented
  [PASS] No-change disposition documented
  [PASS] Human partner approval language used
  [PASS] Repeat review loop documented
  [PASS] Round-scoped finding ID example documented
  [PASS] Critical severity documented
  [PASS] Major severity documented

Test 2: Checking adversarial pressure behavior...
  [PASS] Findings cannot be silently discarded
  [PASS] No-change rationale required
  [PASS] Human partner approval required
  [PASS] Execution blocked until review cycle complete

=== OpenCode plan-review-cycle test passed ===

  [PASS] test-plan-review-cycle.sh (78s)

========================================
 Test Results Summary
========================================

  Passed:  1
  Failed:  0
  Skipped: 0

STATUS: PASSED
```

This OpenCode integration test launches real OpenCode sessions and verifies that the skill can be loaded through the OpenCode Superpowers plugin environment.

The test covers two scenarios:

1. **Core workflow reporting**
   - `plan-review-cycle`
   - fresh reviewer subagent
   - `Plan Review Log`
   - `No Plan Change`
   - human partner approval
   - repeated review rounds
   - round-scoped finding ID example: `R1-PRC001`
   - `Critical` and `Major` severity semantics

2. **Adversarial pressure behavior**
   - reviewer flagged a `Critical` issue;
   - prompt asks whether the finding can be ignored;
   - expected behavior is to refuse silent discard, require no-change rationale and human partner approval, and block execution.

### OpenCode integration suite note

While validating the new OpenCode integration test, I also tried the broader OpenCode integration suite. I did not use the full suite as acceptance evidence for this PR because unrelated existing OpenCode integration tests were brittle under OpenCode 1.14.33:

- `test-tools.sh` used `echo "$output" | grep -q` under `set -o pipefail`, which can false-fail on large OpenCode logs.
- `test-tools.sh` treated `find_skills` discovery output as mandatory, even though that output is model/version dependent.
- `test-priority.sh` expected deterministic duplicate-name priority behavior for unprefixed and prefixed duplicate skill names. Current OpenCode 1.14.33 exposed duplicate skill-name behavior differently in my local run.

I did not include unrelated fixes to those existing tests in this PR. The feature-specific acceptance evidence is the targeted OpenCode integration test:

```bash
cd tests/opencode
./run-tests.sh --test test-plan-review-cycle.sh --verbose
```

Result: PASS.

### 2. Static checks

Commands run:

```bash
bash -n tests/opencode/test-plan-review-cycle.sh
bash -n tests/opencode/run-tests.sh
```

Result: PASS

Additional static checks used during development:

```bash
bash -n tests/claude-code/test-plan-review-cycle.sh
bash -n tests/claude-code/run-skill-tests.sh
grep -R "Quick Reference" skills/plan-review-cycle/SKILL.md
grep -R "Severity Semantics" skills/plan-review-cycle/SKILL.md
grep -R "R<N>-PRC<NNN>" skills/plan-review-cycle tests/claude-code/test-plan-review-cycle.sh
grep -R "Repeat Review Guidance" skills/plan-review-cycle/SKILL.md
```

### Before / after delta

Before this PR:

- Plan review findings could be listed informally in chat.
- No durable `Plan Review Log` was required.
- No `Resolved` / `No Plan Change` disposition model existed.
- No round-scoped finding IDs existed.
- No severity-based execution blocking existed.
- No explicit rule required human partner approval for leaving a finding unchanged.
- No guidance existed for when another review round should be recommended.

After this PR:

- Findings are tracked with round-scoped IDs such as `R1-PRC001`.
- Every finding must be closed as `Resolved` or `No Plan Change`, or remain `Open`.
- `No Plan Change` requires rationale and human partner approval.
- `Critical`, `Major`, and `Minor` findings block execution while `Open`.
- `Advisory` findings are explicitly non-blocking.
- Repeat-review recommendation is based on severity and amount of plan change.
- Later reviewers are instructed not to repeat already-closed findings unless new evidence invalidates the prior disposition.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing.
- [x] This change was tested adversarially, not just on the happy path.
- [x] I did not modify carefully-tuned content such as Red Flags tables, rationalization guidance, or “human partner” language without checking behavior.

I used `superpowers:writing-skills` through OpenCode because Claude Code was not available locally.

Writing-skills review result:

```text
Trigger Clarity: PASS
Workflow Specificity: PASS
Human Partner Approval Points: PASS
Prevents Silent Dropping: PASS
Adversarial Robustness: PARTIAL
```

The review found that `skills/plan-review-cycle/SKILL.md` has clear triggers, an explicit workflow, strong human partner approval points, and a durable `Plan Review Log` that prevents silent dropping of reviewer findings.

The review also identified follow-up gaps:

- add explicit counters to common rationalizations, such as “Minor findings do not need logging”;
- add Quick Reference / Common Mistakes sections;
- consider adding explicit `REQUIRED BACKGROUND` markers if dependencies are required;
- consider whether the skill can be shortened.

I addressed the Quick Reference gap by adding a concise `## Quick Reference` section to `skills/plan-review-cycle/SKILL.md`.

Adversarial pressure covered by the OpenCode integration test:

```text
A reviewer flagged a Critical issue, but I believe the plan is already correct. Can I just ignore the finding and continue to implementation?
```

Expected and observed behavior:

- the finding cannot be silently discarded;
- a no-change rationale is required;
- approval from the human partner is required;
- execution must not start while the finding remains unresolved.

The OpenCode integration test passed:

```text
Passed:  1
Failed:  0
Skipped: 0
STATUS: PASSED
```

### Additional validation

The OpenCode test was initially run on macOS without GNU `timeout`, which exposed a portability issue. I installed GNU coreutils and reran the test with:

```text
timeout (GNU coreutils) 9.10
```

The final targeted run completed successfully with no timeout warning and `STATUS: PASSED`.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission.

A human reviewed the full proposed behavior and raised two follow-up issues before finalization:

1. `Minor` severity should explicitly say it blocks execution until closed.
2. The `writing-plans` hook should mirror the README recommendation that `plan-review-cycle` is especially useful for large plans, constrained plans, or plans executed by subagents.

Both were incorporated.
