### PR TITLE
fix: handle spaced test paths in find-polluter

### DIFF
--- a/skills/systematic-debugging/find-polluter.sh
+++ b/skills/systematic-debugging/find-polluter.sh
@@ -19,14 +19,13 @@ echo "Test pattern: $TEST_PATTERN"
 echo ""
 
 # Get list of test files
-TEST_FILES=$(find . -path "$TEST_PATTERN" | sort)
-TOTAL=$(echo "$TEST_FILES" | wc -l | tr -d ' ')
+TOTAL=$(find . -path "$TEST_PATTERN" | sort | wc -l | tr -d ' ')
 
 echo "Found $TOTAL test files"
 echo ""
 
 COUNT=0
-for TEST_FILE in $TEST_FILES; do
+while IFS= read -r TEST_FILE; do
   COUNT=$((COUNT + 1))
 
   # Skip if pollution already exists
@@ -56,7 +55,7 @@ for TEST_FILE in $TEST_FILES; do
     echo "  cat $TEST_FILE         # Review test code"
     exit 1
   fi
-done
+done < <(find . -path "$TEST_PATTERN" | sort)
 
 echo ""
 echo "✅ No polluter found - all tests clean!"

--- a/tests/systematic-debugging/test-find-polluter.sh
+++ b/tests/systematic-debugging/test-find-polluter.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+mkdir -p "$TEST_DIR/tests" "$TEST_DIR/fake-bin"
+touch "$TEST_DIR/tests/space name.test.js"
+
+cat > "$TEST_DIR/fake-bin/npm" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" != "test" ]]; then
+  echo "unexpected npm command: $*" >&2
+  exit 2
+fi
+shift
+
+if [[ "$#" -eq 1 && "$1" == "./tests/space name.test.js" ]]; then
+  touch pollution
+fi
+SCRIPT
+chmod +x "$TEST_DIR/fake-bin/npm"
+
+cd "$TEST_DIR"
+set +e
+PATH="$TEST_DIR/fake-bin:$PATH" bash "$REPO_ROOT/skills/systematic-debugging/find-polluter.sh" pollution './tests/*.test.js' > output.txt 2>&1
+status=$?
+set -e
+
+if [[ "$status" -ne 1 ]]; then
+  echo "Expected find-polluter.sh to exit 1 after finding the polluter, got $status"
+  cat output.txt
+  exit 1
+fi
+
+if ! grep -Fq "Test: ./tests/space name.test.js" output.txt; then
+  echo "Expected output to identify the full test path with spaces"
+  cat output.txt
+  exit 1
+fi
+
+echo "PASS find-polluter handles test paths with spaces"


### PR DESCRIPTION
## What problem are you trying to solve?

`skills/systematic-debugging/find-polluter.sh` currently stores `find` output in a scalar and iterates with `for TEST_FILE in $TEST_FILES`. A test path containing whitespace is split into multiple iterations, so the script can run the wrong path and miss the polluting test.

This reproduces the third finding in #1446 with a focused shell regression test.

## What does this PR change?

The script now reads sorted `find` output line-by-line with `while IFS= read -r TEST_FILE`, preserving spaces in test file paths. A regression test creates a fake test path named `./tests/space name.test.js` and verifies the full path is passed to `npm test`.

## Is this change appropriate for the core library?

Yes. This fixes a general-purpose debugging utility shipped with the core systematic-debugging skill. It is not project-specific, domain-specific, or tied to a third-party service.

## What alternatives did you consider?

Leaving the script as-is would keep paths with spaces broken. Using `xargs` would require careful delimiter handling and would be less direct than preserving the existing one-test-at-a-time loop.

## Does this PR contain multiple unrelated changes?

No. It only fixes `find-polluter.sh` path handling and adds a regression test for that behavior.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #599; no open duplicate found for `find-polluter`

#599 was a closed bundled hardening PR that mentioned `find-polluter` among unrelated changes. This PR is different: it is a single-purpose fix for the path-splitting bug with a focused regression test.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex API | not surfaced in session | GPT-5 | current Codex session model |

## New harness support (required if this PR adds a new harness)

Not applicable; this PR does not add a new harness.

## Evaluation
- What was the initial prompt you (or your human partner) used to start the session that led to this change?

  Research the repository, identify a small acceptable PR candidate, and submit a well-scoped contribution if possible.

- How many eval sessions did you run AFTER making the change?

  0 agent-behavior eval sessions; this is a shell utility bugfix, not behavior-shaping skill text.

- How did outcomes change compared to before the change?

  Before, the regression test showed `./tests/space name.test.js` was split into `./tests/space` and `name.test.js`, causing the polluter to be missed. After, the full path is preserved and the polluter is detected.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is not a skill-content change. It changes a shell helper script and adds a regression test.

Verification:

```bash
bash tests/systematic-debugging/test-find-polluter.sh
bash -n skills/systematic-debugging/find-polluter.sh tests/systematic-debugging/test-find-polluter.sh
```

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
