### PR TITLE
test(skill-triggering): add pipefail so failed tests fail run-all.sh

### DIFF
--- a/tests/skill-triggering/run-all.sh
+++ b/tests/skill-triggering/run-all.sh
@@ -2,7 +2,7 @@
 # Run all skill triggering tests
 # Usage: ./run-all.sh
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROMPTS_DIR="$SCRIPT_DIR/prompts"


### PR DESCRIPTION
Fixing an issue with `run-all.sh`. If any of the `run-test.sh` failed, run-all.sh still showed all tests passed.

run-all.sh used `if cmd | tee log; then` to record per-skill output. Without `pipefail`, the pipeline's exit status is tee's (always 0), so failed tests were rolled up as passed in the summary.

Adding `set -eo pipefail` makes the pipeline fail when run-test.sh fails, which propagates to the if/else and into the PASSED/FAILED counters.


