### PR TITLE
feat: add subagent-model-reconciliation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ already use it in another harness.
 - **using-git-worktrees** - Parallel development branches
 - **finishing-a-development-branch** - Merge/PR decision workflow
 - **subagent-driven-development** - Fast iteration with two-stage review (spec compliance, then code quality)
+- **subagent-model-reconciliation** - Confirm subagents will run on a mid-tier model rather than silently inheriting a top-tier orchestrator model
 
 **Meta**
 - **writing-skills** - Create new skills following best practices (includes testing methodology)

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -65,11 +65,15 @@ Each agent gets:
 
 ### 3. Dispatch in Parallel
 
+Before the first dispatch, run **superpowers:subagent-model-reconciliation** so each parallel agent runs on the appropriate mid-tier model for the current provider rather than silently inheriting a top-tier orchestrator model. Cache the user's answer and pass `model:` on every dispatch in the fan-out.
+
 ```typescript
-// In Claude Code / AI environment
-Task("Fix agent-tool-abort.test.ts failures")
-Task("Fix batch-completion-behavior.test.ts failures")
-Task("Fix tool-approval-race-conditions.test.ts failures")
+// In Claude Code / AI environment.
+// `<mid-tier model for current provider>` is the model chosen during
+// reconciliation — looked up at decision time, not hardcoded here.
+Task("Fix agent-tool-abort.test.ts failures",                   model: <mid-tier model for current provider>)
+Task("Fix batch-completion-behavior.test.ts failures",          model: <mid-tier model for current provider>)
+Task("Fix tool-approval-race-conditions.test.ts failures",      model: <mid-tier model for current provider>)
 // All three run concurrently
 ```
 
@@ -171,6 +175,11 @@ After agents return:
 2. **Check for conflicts** - Did agents edit same code?
 3. **Run full suite** - Verify all fixes work together
 4. **Spot check** - Agents can make systematic errors
+
+## Integration
+
+**Required before dispatch:**
+- **superpowers:subagent-model-reconciliation** — confirms which model the parallel agents will run on so they don't silently inherit a top-tier orchestrator model. Run once before the fan-out and cache the answer for the rest of the dispatch batch.
 
 ## Real-World Impact
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -21,7 +21,13 @@ Load plan, review critically, execute all tasks, report when complete.
 3. If concerns: Raise them with your human partner before starting
 4. If no concerns: Create TodoWrite and proceed
 
-### Step 2: Execute Tasks
+### Step 2: Reconcile Subagent Model (if dispatching subagents)
+
+If executing this plan involves dispatching subagents — even one — run **superpowers:subagent-model-reconciliation** before the first dispatch. That skill confirms with the user which model each subagent should run on (looked up at decision time for whichever provider you're on) and pins `model:` on every dispatch in this flow. Cache the answer for the rest of plan execution.
+
+If the plan is going to be executed entirely inline (no subagents), skip this step.
+
+### Step 3: Execute Tasks
 
 For each task:
 1. Mark as in_progress
@@ -29,7 +35,7 @@ For each task:
 3. Run verifications as specified
 4. Mark as completed
 
-### Step 3: Complete Development
+### Step 4: Complete Development
 
 After all tasks complete and verified:
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
@@ -67,4 +73,5 @@ After all tasks complete and verified:
 **Required workflow skills:**
 - **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one or verifies existing)
 - **superpowers:writing-plans** - Creates the plan this skill executes
+- **superpowers:subagent-model-reconciliation** - Pins `model:` on subagent dispatches when the plan involves any subagent (skip if execution is fully inline)
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -31,7 +31,7 @@ HEAD_SHA=$(git rev-parse HEAD)
 
 **2. Dispatch code reviewer subagent:**
 
-Use Task tool with `general-purpose` type, fill template at `code-reviewer.md`
+Use Task tool with `general-purpose` type, fill template at `code-reviewer.md`. Pass `model:` explicitly — code review is mid-tier work and should not silently inherit a top-tier orchestrator model. If you haven't already run **superpowers:subagent-model-reconciliation** for this flow, do so now to pick the right mid-tier model for the current provider and cache the answer.
 
 **Placeholders:**
 - `{DESCRIPTION}` - Brief summary of what you built

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -101,6 +101,14 @@ Use the least powerful model that can handle each role to conserve cost and incr
 - Touches multiple files with integration concerns → standard model
 - Requires design judgment or broad codebase understanding → most capable model
 
+### Reconciliation Before First Dispatch
+
+Before dispatching the first implementer subagent, run **superpowers:subagent-model-reconciliation**. That skill detects whether the orchestrator is on a top-tier model, looks up the current mid-tier model for the provider you're running on (Sonnet for Claude, the current "fast" tier for OpenAI/Codex, Flash for Gemini, etc.), confirms with the user, and pins `model:` on every subsequent dispatch in this flow.
+
+Do this **once** per plan execution and cache the answer — don't re-ask before each task.
+
+If the harness you're on doesn't support per-dispatch model selection, that skill will tell you to surface the gap to the user; don't pretend the work is reconciled when it isn't.
+
 ## Handling Implementer Status
 
 Implementer subagents report one of four statuses. Handle each appropriately:
@@ -269,6 +277,7 @@ Done!
 **Required workflow skills:**
 - **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one or verifies existing)
 - **superpowers:writing-plans** - Creates the plan this skill executes
+- **superpowers:subagent-model-reconciliation** - Pins `model:` on subagent dispatches so they don't inherit a top-tier orchestrator model
 - **superpowers:requesting-code-review** - Code review template for reviewer subagents
 - **superpowers:finishing-a-development-branch** - Complete development after all tasks
 

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -8,6 +8,7 @@ Use this template when dispatching a code quality reviewer subagent.
 
 ```
 Task tool (general-purpose):
+  model: <mid-tier model for current provider — set during subagent-model-reconciliation>
   Use template at requesting-code-review/code-reviewer.md
 
   DESCRIPTION: [task summary, from implementer's report]

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -5,6 +5,7 @@ Use this template when dispatching an implementer subagent.
 ```
 Task tool (general-purpose):
   description: "Implement Task N: [task name]"
+  model: <mid-tier model for current provider — set during subagent-model-reconciliation>
   prompt: |
     You are implementing Task N: [task name]
 

--- a/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -7,6 +7,7 @@ Use this template when dispatching a spec compliance reviewer subagent.
 ```
 Task tool (general-purpose):
   description: "Review spec compliance for Task N"
+  model: <mid-tier model for current provider — set during subagent-model-reconciliation>
   prompt: |
     You are reviewing whether an implementation matches its specification.
 

--- a/skills/subagent-model-reconciliation/SKILL.md
+++ b/skills/subagent-model-reconciliation/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: subagent-model-reconciliation
+description: Use after planning is complete and before dispatching any subagent — confirms subagents will run on an appropriate mid-tier model rather than silently inheriting the orchestrator's top-tier model
+---
+
+# Subagent Model Reconciliation
+
+## Overview
+
+When the orchestrator is running on a top-tier model (the most capable model the current provider offers), subagents dispatched without an explicit model parameter will frequently inherit that same top-tier model. That is almost never what you want for implementer, spec-reviewer, code-quality-reviewer, or `Explore`-style subagents — those are mid-tier-appropriate roles. Burning top-tier inference on rote work is slow and expensive, and the orchestrator's own context can be churned for no quality gain.
+
+**Core principle:** The orchestrator decides the model for each subagent. Don't let a subagent silently inherit a top-tier model just because dispatch syntax allowed it.
+
+This skill is provider-agnostic. It works for any harness that supports per-subagent model selection (Claude Code, Codex, Copilot CLI, Gemini CLI, etc.) and for any provider's model lineup (Anthropic, OpenAI, Google, etc.).
+
+## When to Use
+
+Run this reconciliation step:
+
+- **After** planning / spec writing is complete (e.g., after `writing-plans` finishes).
+- **Before** the first subagent dispatch in `subagent-driven-development`, `dispatching-parallel-agents`, `executing-plans`, or any other flow that fans out to subagents.
+- **Once** per plan execution — cache the user's answer for the rest of the run.
+
+Skip this skill when:
+
+- The current harness does not support per-subagent model selection (the orchestrator and subagents always run on the same model). In that case, model choice is a session-start concern, not a dispatch-time concern.
+- The orchestrator is already on a mid-tier or smaller model. There is nothing to reconcile.
+
+## The Reconciliation Step
+
+```dot
+digraph reconciliation {
+    "Planning complete" [shape=doublecircle];
+    "Detect orchestrator model" [shape=box];
+    "On a top-tier model?" [shape=diamond];
+    "No reconciliation needed" [shape=box];
+    "Look up provider's current mid-tier" [shape=box];
+    "Differs from current?" [shape=diamond];
+    "Ask user to confirm" [shape=box];
+    "Cache answer for plan execution" [shape=box];
+    "Pass model: explicitly on every dispatch" [shape=box];
+    "Dispatch subagents" [shape=doublecircle];
+
+    "Planning complete" -> "Detect orchestrator model";
+    "Detect orchestrator model" -> "On a top-tier model?";
+    "On a top-tier model?" -> "No reconciliation needed" [label="no"];
+    "On a top-tier model?" -> "Look up provider's current mid-tier" [label="yes"];
+    "Look up provider's current mid-tier" -> "Differs from current?";
+    "Differs from current?" -> "No reconciliation needed" [label="no"];
+    "Differs from current?" -> "Ask user to confirm" [label="yes"];
+    "Ask user to confirm" -> "Cache answer for plan execution";
+    "Cache answer for plan execution" -> "Pass model: explicitly on every dispatch";
+    "No reconciliation needed" -> "Dispatch subagents";
+    "Pass model: explicitly on every dispatch" -> "Dispatch subagents";
+}
+```
+
+### Step 1: Detect the orchestrator's current model
+
+Most harnesses expose this in the system prompt or via a built-in environment lookup. If you genuinely cannot determine the current model, ask the user — don't guess. A wrong assumption here defeats the whole reconciliation.
+
+### Step 2: Decide whether reconciliation is needed
+
+If the orchestrator is on a **top-tier model** for the current provider (the provider's most capable production model), reconciliation is needed. Otherwise, skip this skill.
+
+The category — top-tier vs. mid-tier vs. small — is what matters, not the exact name. Provider lineups shift quickly; what was "top-tier" six months ago may be "mid-tier" today.
+
+### Step 3: Look up the provider's current mid-tier model
+
+**Do not rely on training-data memory for the model name.** Look it up at decision time:
+
+- Web search for the provider's current model lineup.
+- Check the provider's own documentation or pricing page.
+- Check the harness's documentation for the canonical model identifier string.
+
+The mid-tier model is the one that's appropriate for implementer / reviewer / `Explore` subagents — fast and cheap enough that running many of them is reasonable, capable enough to handle bounded, well-specified tasks. Examples (correct as of writing, but verify at runtime — these change):
+
+- Anthropic: Sonnet sits below Opus and above Haiku.
+- OpenAI: the current "fast" general-purpose tier sits below the flagship reasoning model.
+- Google: the current Flash tier sits below the flagship Pro tier.
+
+Do not hardcode any of those names into your dispatch. Look them up.
+
+### Step 4: Confirm with the user if it differs
+
+If the looked-up mid-tier model is different from the orchestrator's current model, surface the choice to the user before dispatching:
+
+> I'm orchestrating on `<orchestrator_model>`. For implementer / reviewer / Explore subagents, the appropriate mid-tier on `<provider>` looks to be `<looked_up_model>` — that's what I'd recommend so we don't burn top-tier inference on rote work. Use `<looked_up_model>` for subagents? **[yes / no — stay on `<orchestrator_model>` / different — name another]**
+
+Wait for an answer. Do not dispatch in the meantime.
+
+### Step 5: Cache the answer for the duration of plan execution
+
+Once the user picks a model (or confirms staying on the orchestrator's), use that choice for **every** subsequent subagent dispatch in this plan execution. Do not re-prompt before each task. The user's answer applies to:
+
+- All implementer dispatches
+- All reviewer dispatches (spec compliance, code quality)
+- All `Explore` / research dispatches
+- All parallel fan-out dispatches
+
+If the plan's nature changes mid-execution (e.g., the user asks you to switch to a fundamentally different kind of work), it's reasonable to re-run reconciliation — but treat that as the exception, not the default.
+
+### Step 6: Pass `model:` explicitly on every dispatch
+
+Every Agent / Task / equivalent dispatch in the flow must carry an explicit model parameter. The exact syntax depends on the harness — see the **Harness Syntax** section below — but the discipline is the same: don't rely on inheritance.
+
+The one exception is the orchestrator → orchestrator case (a sub-flow that genuinely should stay on the orchestrator's model). Even then, prefer making the choice explicit so a future reader doesn't have to infer it.
+
+## Harness Syntax
+
+Different harnesses expose model selection differently. Confirm against your harness's current documentation; the names below are illustrative only.
+
+- **Claude Code** — `Task(..., subagent_type: "...", model: "<model-id>")` or `Agent(..., model: "<model-id>")`. The `model:` field overrides the agent definition's frontmatter and any inheritance from the parent.
+- **Codex** — see the Codex tool reference for the dispatch tool's `model` parameter.
+- **Copilot CLI / Gemini CLI / others** — check the harness's subagent tool documentation for the equivalent field.
+
+If your harness genuinely lacks a per-dispatch model parameter, this skill cannot be applied as written — surface that to the user and stop. Don't pretend the dispatch is reconciled when it isn't.
+
+## Briefing Subagents Without a Model Field
+
+If you must dispatch on a harness that lacks per-dispatch model selection, tell the user during reconciliation. The fallback is for the user to start the harness on the desired mid-tier model and run the orchestration there — not for the orchestrator to silently push top-tier work onto every subagent.
+
+## Anti-Patterns
+
+- ❌ Hardcoding `model: "sonnet"` (or any other specific name) in a skill, plan, or prompt template. Provider lineups shift; the specific name will rot.
+- ❌ Skipping reconciliation because "I think I know what the mid-tier is." Look it up. Memory of the lineup is wrong often enough to matter.
+- ❌ Re-asking the user before every dispatch. Cache the answer once per plan run.
+- ❌ Letting subagents inherit silently because the dispatch syntax made it easy. The default is *explicit*.
+- ❌ Running reconciliation *before* planning. The plan's shape can change which model is appropriate; reconcile after the plan is fixed.
+
+## Integration
+
+**Required before any subagent dispatch in:**
+
+- `subagent-driven-development` — fires once before the first implementer dispatch
+- `dispatching-parallel-agents` — fires once before the parallel fan-out
+- `executing-plans` — fires once before invoking subagent dispatches in the plan
+- Any custom flow that dispatches subagents
+
+**Pairs with:**
+
+- `writing-plans` — reconciliation runs *after* `writing-plans` finishes, before any executor skill picks up.
+- `using-superpowers` — the bootstrap that surfaces this skill at the right moment.


### PR DESCRIPTION
## What problem are you trying to solve?

When an orchestrator runs on a top-tier model (Opus on Claude, the flagship reasoning model on OpenAI/Codex, Pro on Gemini, etc.), subagents dispatched by the existing executor skills frequently inherit that same top-tier model. Implementer / spec-reviewer / code-quality-reviewer / `Explore` subagents are mid-tier-appropriate roles, so this burns top-tier inference on rote work — slow and expensive, with no quality gain.

The gap is that none of the existing executor skills pin a model on dispatch. Verified against superpowers 5.1.0:

```
$ grep -rE "subagent_type|model:|sonnet|haiku|opus" skills/
# zero matches across all 14 SKILL.md files
```

Concretely: an Opus orchestrator running `subagent-driven-development` will dispatch implementer subagents that also run on Opus unless the orchestrator manually adds `model:` on every dispatch. None of the skills tell it to do that.

## What does this PR change?

Adds a new shared skill, `subagent-model-reconciliation`, that fires once after planning is complete and before the first subagent dispatch. It detects the orchestrator's current model, looks up the current mid-tier model for the provider at decision time, asks the user to confirm, caches the answer for the rest of the plan run, and pins `model:` on every subsequent dispatch. The three executor skills (`subagent-driven-development`, `dispatching-parallel-agents`, `executing-plans`) and `requesting-code-review` are updated to invoke this step; the dispatch example in `dispatching-parallel-agents` and the prompt templates in `subagent-driven-development` are updated to show `model:` on each Task call.

## Is this change appropriate for the core library?

I think so — it is general-purpose, not project-specific, and not third-party. It applies to every Superpowers user whose harness supports per-dispatch model selection (Claude Code, Codex, Copilot CLI, etc.) and whose orchestrator runs on the provider's top tier. That's a large fraction of real usage. It is not a new domain skill or workflow tool integration; it is plumbing that closes a default-inheritance gap in the existing executor skills. The README contributing notes mention the project doesn't generally accept *new* skills, so I'd be equally happy to inline the reconciliation behavior into each executor skill if that's preferred — see "What alternatives did you consider?" below.

## What alternatives did you consider?

1. **Inline reconciliation into each executor skill** instead of a new shared skill. Cleaner surface area (one fewer skill in the library), at the cost of duplicating the lookup-and-confirm prose three times. Picked the shared-skill approach because the rule applies identically to every fan-out flow and is likely to evolve as harnesses change. Easy to fold back into the executor skills if maintainers prefer.
2. **Hardcode model names** like `model: "sonnet"`. Rejected — Superpowers ships across providers and provider lineups shift fast. The skill instead names categories (top-tier / mid-tier) and instructs the agent to look up the current name at decision time, with the dispatch examples using a placeholder (`<mid-tier model for current provider>`) rather than a literal name.
3. **Set the model at session start** (don't reconcile at dispatch time). Rejected because the orchestrator and subagents need different models — running the whole session on mid-tier gives up the orchestrator's planning quality, and running the whole session on top-tier is exactly the failure mode this PR addresses.
4. **Do nothing and let the user pass `model:` themselves.** Rejected because the gap is silent: the orchestrator only notices after the bill arrives. The discipline needs to live in the skill prose.

## Does this PR contain multiple unrelated changes?

No — single concern: subagent model selection. The README entry, the new skill, and the executor-skill updates are all part of wiring this one behavior in. I have not touched the Red Flags tables, rationalizations, or "human partner" language.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found searching for "model" / "subagent_type" / "sonnet" / "reconciliation" in titles. (If a maintainer knows of prior work I missed, happy to rebase or close.)

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.x (current) | Opus | claude-opus-4-7 |

## New harness support

Not applicable — no harness added.

## Evaluation

**Honest disclosure: this PR is opened in DRAFT and has not been adversarially eval'd yet.** I'm publishing it now to get maintainer feedback on the approach (shared skill vs. inlined; provider-agnostic prose vs. concrete examples) before investing in the full pressure-test cycle that `writing-skills` calls for. Specifically:

- I have NOT run baseline scenarios with subagents to confirm the "agent silently inherits top-tier" failure mode triggers reliably without this skill.
- I have NOT run pressure scenarios with the skill present to confirm the agent reliably looks up the mid-tier model rather than guessing from training data.
- The change has been reviewed inline by me but has not gone through `requesting-code-review`.

If the approach looks right, I'll add the eval evidence before this leaves draft. If the approach is wrong, the eval work would be wasted on the wrong design.

Open questions for upstream maintainers:

1. Shared skill or inlined? (See alternative #1 above.)
2. The skill currently tells the agent to "stop and surface to the user" if the harness lacks per-dispatch model selection. Is that the right fallback, or should it silently no-op?
3. Should the reconciliation step also fire from `writing-plans` (so the plan itself records the chosen model)? Currently it fires only from the executor skills.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing — **NOT YET, see Evaluation above. Will complete before leaving draft.**
- [ ] This change was tested adversarially — **NOT YET.**
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement — confirmed, none of those were touched.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission — Patrick Saul (the human partner) is reviewing this draft before it is marked ready.