### PR TITLE
将 14 个 skill description 翻译为简体中文

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorming
-description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+description: "在任何创造性工作之前你必须使用此技能——创建功能、构建组件、添加功能或修改行为。在实施之前探索用户意图、需求和设计。"
 ---
 
 # Brainstorming Ideas Into Designs

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatching-parallel-agents
-description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
+description: 当面临2个以上可独立完成、无需共享状态或顺序依赖的任务时使用
 ---
 
 # Dispatching Parallel Agents

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: executing-plans
-description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
+description: 当你有一个书面实施计划需要在独立会话中执行且含有审查检查点时使用
 ---
 
 # Executing Plans

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-development-branch
-description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+description: 当实施完成、所有测试通过，需要决定如何整合工作时使用——通过提供合并、PR或清理等结构化选项来指导开发工作的收尾
 ---
 
 # Finishing a Development Branch

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+description: 当收到代码审查反馈时、在实施建议之前使用，尤其当反馈看似不清晰或技术上存疑时——要求技术严谨与验证，而非表演式同意或盲目实施
 ---
 
 # Code Review Reception

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requesting-code-review
-description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+description: 在完成任务、实施主要功能或合并之前使用，以验证工作是否符合要求
 ---
 
 # Requesting Code Review

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-driven-development
-description: Use when executing implementation plans with independent tasks in the current session
+description: 在当前会话中执行含有独立任务的实施计划时使用
 ---
 
 # Subagent-Driven Development

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systematic-debugging
-description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+description: 当遇到任何bug、测试失败或意外行为时，在提出修复方案之前使用
 ---
 
 # Systematic Debugging

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Use when implementing any feature or bugfix, before writing implementation code
+description: 当实施任何功能或修复bug时，在编写实施代码之前使用
 ---
 
 # Test-Driven Development (TDD)

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback
+description: 当开始需要与当前工作区隔离的功能工作时使用，或在执行实施计划之前——确保通过原生工具或git worktree备用方案存在隔离的工作区
 ---
 
 # Using Git Worktrees

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-superpowers
-description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+description: 在任何对话开始时使用——建立如何查找和使用技能的规则，要求在包括澄清问题在内的任何回应之前必须调用Skill工具
 ---
 
 <SUBAGENT-STOP>

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-before-completion
-description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+description: 当准备声称工作已完成、已修复或已通过时，在提交或创建PR之前使用——需要运行验证命令并确认输出，然后才能声称成功；永远先验证后断言
 ---
 
 # Verification Before Completion

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: Use when you have a spec or requirements for a multi-step task, before touching code
+description: 当你有一个多步骤任务的规格说明或需求时，在编写代码之前使用
 ---
 
 # Writing Plans

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-skills
-description: Use when creating new skills, editing existing skills, or verifying skills work before deployment
+description: 当创建新技能、编辑现有技能或在部署前验证技能时使用
 ---
 
 # Writing Skills


### PR DESCRIPTION
## 概述

将 superpowers 插件下全部 14 个 skill 的 `description` frontmatter 字段从英文翻译为简体中文，便于中文用户在 Skill 工具提示中直接阅读技能用途说明。

## 变更内容

修改了以下 14 个 SKILL.md 文件，每个仅修改 description 字段（1 行变更）：

- `skills/brainstorming/SKILL.md`
- `skills/dispatching-parallel-agents/SKILL.md`
- `skills/executing-plans/SKILL.md`
- `skills/finishing-a-development-branch/SKILL.md`
- `skills/receiving-code-review/SKILL.md`
- `skills/requesting-code-review/SKILL.md`
- `skills/subagent-driven-development/SKILL.md`
- `skills/systematic-debugging/SKILL.md`
- `skills/test-driven-development/SKILL.md`
- `skills/using-git-worktrees/SKILL.md`
- `skills/using-superpowers/SKILL.md`
- `skills/verification-before-completion/SKILL.md`
- `skills/writing-plans/SKILL.md`
- `skills/writing-skills/SKILL.md`

## 测试计划

- [x] 确认 14 个文件的 description 字段均已翻译为中文
- 技能正文指令保持英文不变，不影响功能匹配