### PR TITLE
Fix skill descriptions to be trigger-condition only

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorming
-description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+description: "Use when about to create features, build components, add functionality, or modify behavior -- before any implementation work begins."
 ---
 
 # Brainstorming Ideas Into Designs

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-development-branch
-description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work.
 ---
 
 # Finishing a Development Branch

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable.
 ---
 
 # Code Review Reception

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback
+description: Use when starting feature work that needs isolation from the current workspace, or before executing implementation plans that should not affect the main working tree.
 ---
 
 # Using Git Worktrees

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-before-completion
-description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs.
 ---
 
 # Verification Before Completion


### PR DESCRIPTION
## Problem

Five skill descriptions were including behavioral instructions that belong inside the skill body, not in the picker description field. This caused agents to read the description and think they understood the skill without actually invoking it to get the real instructions.

## Fix

Trimmed descriptions to concise trigger-condition-only format ("Use when...") for:
- `brainstorming` -- removed "You MUST use this..." imperative and the "Explores user intent..." instruction
- `finishing-a-development-branch` -- removed "- guides completion..." trailing instruction
- `receiving-code-review` -- removed "- requires technical rigor..." trailing instruction
- `using-git-worktrees` -- removed "- ensures an isolated workspace..." trailing instruction
- `verification-before-completion` -- removed "- requires running verification commands..." trailing instruction

The full behavioral guidance remains intact inside each SKILL.md body where it belongs.