### PR TITLE
Fix OpenCode package file whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,10 @@
   "name": "superpowers",
   "version": "5.1.0",
   "type": "module",
-  "main": ".opencode/plugins/superpowers.js"
+  "main": ".opencode/plugins/superpowers.js",
+  "files": [
+    ".opencode/plugins/superpowers.js",
+    "assets/",
+    "skills/"
+  ]
 }

--- a/tests/opencode/run-tests.sh
+++ b/tests/opencode/run-tests.sh
@@ -61,6 +61,7 @@ done
 tests=(
     "test-plugin-loading.sh"
     "test-bootstrap-caching.sh"
+    "test-package-files.sh"
 )
 
 # Integration tests (require OpenCode)

--- a/tests/opencode/test-package-files.sh
+++ b/tests/opencode/test-package-files.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Test: OpenCode package contents
+# Verifies the git-backed package only ships runtime files.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "=== Test: OpenCode Package Files ==="
+
+pack_json="$(npm pack --dry-run --json "$ROOT_DIR")"
+
+PACK_JSON="$pack_json" node <<'NODE'
+const data = JSON.parse(process.env.PACK_JSON);
+const files = data[0].files.map((file) => file.path);
+
+const forbiddenPrefixes = [
+  '.claude-plugin/',
+  '.codex-plugin/',
+  '.cursor-plugin/',
+  '.github/',
+  'docs/',
+  'hooks/',
+  'scripts/',
+  'tests/',
+];
+
+const requiredFiles = [
+  '.opencode/plugins/superpowers.js',
+  'assets/app-icon.png',
+  'assets/superpowers-small.svg',
+  'skills/using-superpowers/SKILL.md',
+  'skills/brainstorming/scripts/server.cjs',
+  'package.json',
+  'README.md',
+  'LICENSE',
+];
+
+const failures = [];
+
+for (const prefix of forbiddenPrefixes) {
+  if (files.some((file) => file.startsWith(prefix))) {
+    failures.push(`package includes forbidden path prefix: ${prefix}`);
+  }
+}
+
+for (const file of requiredFiles) {
+  if (!files.includes(file)) {
+    failures.push(`package is missing required file: ${file}`);
+  }
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) console.error(`  [FAIL] ${failure}`);
+  process.exit(1);
+}
+NODE
+
+echo "  [PASS] Package contains only OpenCode runtime files"
+echo ""
+echo "=== All package file tests passed ==="


### PR DESCRIPTION
## What problem are you trying to solve?
OpenCode installs Superpowers from the git-backed npm package spec documented in `docs/README.opencode.md`:

```json
{
  "plugin": ["superpowers@git+https://github.com/obra/superpowers.git"]
}
```

In a clean OpenCode 1.14.48 run using that plugin spec, the resolved package landed at:

`~/.cache/opencode/packages/superpowers@git+https:/github.com/obra/superpowers.git/node_modules/superpowers`

That package included repo and harness files that OpenCode does not need at runtime, including `.github/`, `docs/`, `hooks/`, `scripts/`, `tests/`, `.claude-plugin/`, `.codex-plugin/`, and `.cursor-plugin/`. `npm pack --dry-run --json git+https://github.com/obra/superpowers.git` reproduced the same issue and warned that no `.npmignore` was present, so npm fell back to `.gitignore`.

## What does this PR change?
This PR adds a `package.json` `files` whitelist for the OpenCode npm package so only the plugin entrypoint, assets, and skills are packed. It also adds an OpenCode packaging regression test that rejects top-level repo/test/docs/hook/harness files while ensuring required runtime files and nested skill scripts remain present.

## Is this change appropriate for the core library?
Yes. This is core packaging infrastructure for the documented OpenCode install path. It is not project-specific, does not add a new skill, and does not integrate a third-party service.

## What alternatives did you consider?
I considered adding `.npmignore`, but that is easier to accidentally drift because it must blacklist every non-runtime path. A `files` whitelist is smaller and makes the intended runtime artifact explicit.

I also considered excluding all `scripts/` paths, but that would break skill-owned scripts such as `skills/brainstorming/scripts/server.cjs`. The whitelist keeps `skills/` intact and only removes top-level non-runtime paths.

## Does this PR contain multiple unrelated changes?
No. The package whitelist and the regression test cover one packaging boundary issue.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for OpenCode package contents / npm pack whitelist

Searches reviewed included `npmignore`, `npm pack`, `package size`, `package.json files`, and `opencode package files`. Related-but-different OpenCode PRs included OpenCode plugin loading/caching/docs changes; they did not address package contents.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| OpenCode | 1.14.48 | OpenAI | gpt-5.4 |
| npm | 10.9.4 | n/a | n/a |

## New harness support (required if this PR adds a new harness)

Not applicable. This does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Not applicable. This PR does not add a new harness.

</details>

## Evaluation
- Initial prompt: compare what Superpowers installs for Codex and OpenCode, especially skills and hooks; then verify whether the OpenCode package bloat was reproducible.
- Eval sessions after the change: 3 packaging/runtime checks.
- Before: `npm pack --dry-run --json git+https://github.com/obra/superpowers.git` produced 145 entries and included top-level `.github/`, `docs/`, `hooks/`, `scripts/`, and `tests/` paths. OpenCode also resolved the git plugin into cache with those same non-runtime paths.
- After: local `npm pack --dry-run --json` produces 52 entries: `.opencode/plugins/superpowers.js`, `assets/`, `skills/`, `package.json`, `README.md`, and `LICENSE`. OpenCode successfully loaded the local package path and initialized skills.

Verification run:

```bash
bash tests/opencode/test-package-files.sh
npm pack --dry-run --json
OPENCODE_CONFIG_DIR=/tmp/opencode/superpowers-pr-local opencode run --print-logs "Tell me about your superpowers"
```

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is not a skills content change. The regression test includes negative checks for forbidden top-level paths and positive checks for required runtime files, including nested skill scripts.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission