### PR TITLE
fix: remove stale agents/commands refs from .cursor-plugin/plugin.json

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -19,7 +19,5 @@
     "workflows"
   ],
   "skills": "./skills/",
-  "agents": "./agents/",
-  "commands": "./commands/",
   "hooks": "./hooks/hooks-cursor.json"
 }


### PR DESCRIPTION
## Summary

Remove stale `agents` and `commands` entries from `.cursor-plugin/plugin.json`.

Those directories no longer exist, and the Cursor manifest should match the current shipped plugin surface instead of pointing at deleted paths.

## Issue

Addresses #1514

## Testing

- `jq empty .cursor-plugin/plugin.json`
- `git diff --check`