### PR TITLE
fix(using-git-worktrees): repair skipped Step 2 numbering

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -30,7 +30,7 @@ BRANCH=$(git branch --show-current)
 git rev-parse --show-superproject-working-tree 2>/dev/null
 ```
 
-**If `GIT_DIR != GIT_COMMON` (and not a submodule):** You are already in a linked worktree. Skip to Step 3 (Project Setup). Do NOT create another worktree.
+**If `GIT_DIR != GIT_COMMON` (and not a submodule):** You are already in a linked worktree. Skip to Step 2 (Project Setup). Do NOT create another worktree.
 
 Report with branch state:
 - On a branch: "Already in isolated workspace at `<path>` on branch `<name>`."
@@ -42,7 +42,7 @@ Has the user already indicated their worktree preference in your instructions? I
 
 > "Would you like me to set up an isolated worktree? It protects your current branch from changes."
 
-Honor any existing declared preference without asking. If the user declines consent, work in place and skip to Step 3.
+Honor any existing declared preference without asking. If the user declines consent, work in place and skip to Step 2.
 
 ## Step 1: Create Isolated Workspace
 
@@ -50,7 +50,7 @@ Honor any existing declared preference without asking. If the user declines cons
 
 ### 1a. Native Worktree Tools (preferred)
 
-The user has asked for an isolated workspace (Step 0 consent). Do you already have a way to create a worktree? It might be a tool with a name like `EnterWorktree`, `WorktreeCreate`, a `/worktree` command, or a `--worktree` flag. If you do, use it and skip to Step 3.
+The user has asked for an isolated workspace (Step 0 consent). Do you already have a way to create a worktree? It might be a tool with a name like `EnterWorktree`, `WorktreeCreate`, a `/worktree` command, or a `--worktree` flag. If you do, use it and skip to Step 2.
 
 Native tools handle directory placement, branch creation, and cleanup automatically. Using `git worktree add` when you have a native tool creates phantom state your harness can't see or manage.
 
@@ -111,7 +111,7 @@ cd "$path"
 
 **Sandbox fallback:** If `git worktree add` fails with a permission error (sandbox denial), tell the user the sandbox blocked worktree creation and you're working in the current directory instead. Then run setup and baseline tests in place.
 
-## Step 3: Project Setup
+## Step 2: Project Setup
 
 Auto-detect and run appropriate setup:
 
@@ -130,7 +130,7 @@ if [ -f pyproject.toml ]; then poetry install; fi
 if [ -f go.mod ]; then go mod download; fi
 ```
 
-## Step 4: Verify Clean Baseline
+## Step 3: Verify Clean Baseline
 
 Run tests to ensure workspace starts clean:
 


### PR DESCRIPTION
## What problem are you trying to solve?

`skills/using-git-worktrees/SKILL.md` presents a numbered workflow that jumps from `Step 1` to `Step 3`, then `Step 4`. That is the user-visible problem reported in #1508: an agent following the skill in order can reasonably wonder whether a Step 2 was accidentally omitted.

The active skill also had inline references telling agents to “skip to Step 3” for Project Setup, so simply changing headings would leave stale navigation text behind.

## What does this PR change?

Renumbers the active `using-git-worktrees` workflow so Project Setup is `Step 2` and Verify Clean Baseline is `Step 3`.

It also updates the three in-file “skip to Step 3” references that point at Project Setup so the headings and cross-references stay consistent.

Fixes https://github.com/obra/superpowers/issues/1508.

## Is this change appropriate for the core library?

Yes. `using-git-worktrees` is a core general-purpose Superpowers skill, and this fixes confusing navigation in the active skill text without adding project-specific behavior or third-party integration.

## What alternatives did you consider?

I considered adding new Step 2 content, but the surrounding worktree refactor already split the old create-workspace flow into Step 1a and Step 1b. There is no missing behavior here; the correct fix is a contiguous renumbering and cross-reference update.

I also considered updating historical design/plan documents that contain older Step 3/Step 4 text, but those are dated implementation artifacts. This PR intentionally limits the fix to the active skill file.

## Does this PR contain multiple unrelated changes?

No. This PR only changes `skills/using-git-worktrees/SKILL.md` to fix #1508.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1520

#1520 briefly included a partial fix for #1508, but maintainers narrowed it to the Cursor manifest cleanup for #1514 to preserve the one-issue-one-PR rule. This PR is the focused #1508 follow-up. I did not find an open direct duplicate for this issue.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Local shell/static text validation | zsh on macOS | n/a | n/a |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add harness support.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Not applicable. This PR does not add or modify a harness integration.

</details>

## Evaluation

- Initial prompt: Drew asked to fix #1508 after #1520 was narrowed to only #1514.
- Eval sessions after making the change: 0 runtime eval sessions. This is a navigation-numbering fix in a markdown skill file, not a behavior change.
- Before/after: before the change, a deterministic heading check reported `Step 0`, `Step 1`, `Step 3`, `Step 4`. After the change, it reports `Step 0`, `Step 1`, `Step 2`, `Step 3`, and a stale-reference check finds no remaining active `skip to Step 3` / `Step 4` references in `skills/using-git-worktrees/SKILL.md`.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is a mechanical numbering and cross-reference fix. I did not rewrite behavior-shaping sections, red flags, rationalization language, or the skill’s workflow semantics.

Verification run:

```text
OK: step headings exactly match
OK: no stale Project Setup / Verify Clean Baseline references
OK: diff whitespace clean
```

Commands used:

```bash
awk '/^## Step [0-9]+:/ { sub(/^## /, ""); print }' skills/using-git-worktrees/SKILL.md
rg -n 'Step 3 \(Project Setup\)|Step 3: Project Setup|skip to Step 3\b|Step 4 \(Verify Clean Baseline\)|Step 4: Verify Clean Baseline|\bStep 4\b' skills/using-git-worktrees/SKILL.md
git diff --check HEAD~1..HEAD -- skills/using-git-worktrees/SKILL.md
```

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed the complete one-file diff in Codex and explicitly approved opening this PR.
