### PR TITLE
feat(brainstorming,writing-plans): propose parallel execution tracks by default

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -26,10 +26,11 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+6. **Add Parallel Execution Plan section** — for any spec with 2+ logically independent stories, propose how to split the work across parallel sessions and how the tracks merge. See the Parallel Execution Plan section below. Skip only on truly single-story specs.
+7. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+8. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+9. **User reviews written spec** — ask user to review the spec file before proceeding
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -88,7 +89,7 @@ digraph brainstorming {
 - Once you believe you understand what you're building, present the design
 - Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
 - Ask after each section whether it looks right so far
-- Cover: architecture, components, data flow, error handling, testing
+- Cover: architecture, components, data flow, error handling, testing, parallel execution plan (when 2+ stories)
 - Be ready to go back and clarify if something doesn't make sense
 
 **Design for isolation and clarity:**
@@ -103,6 +104,26 @@ digraph brainstorming {
 - Explore the current structure before proposing changes. Follow existing patterns.
 - Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.
 - Don't propose unrelated refactoring. Stay focused on what serves the current goal.
+
+## Parallel Execution Plan
+
+Bias toward proposing parallel tracks **by default** for any spec with 2+ logically independent stories. This is offense (ship faster), not defense (avoid conflicts). Many users run multiple Claude sessions concurrently; sequential specs leave throughput on the table.
+
+Include a top-level **"Parallel Execution Plan"** section in every PRD/spec that has 2+ stories you could plausibly hand to different engineers. The section MUST contain:
+
+1. **Track decomposition.** Break the stories into tracks that touch disjoint files / surfaces.
+   - **Safe parallel:** backend modules, new files, additive blueprints, separate DB tables, independent API endpoints.
+   - **Serial dependency:** shared template edits, shared modules under heavy churn, schema migrations everyone depends on.
+
+2. **Dependency graph.** State which tracks block which (e.g., "Track C UI depends on Track A endpoint shipping first"). If the tracks are fully independent, say so explicitly.
+
+3. **Merge plan.** Name what integrates the tracks at the end — usually a final stitch session that wires UI to backend, or a handoff stub like *"Track A complete, awaiting Track B's endpoint at /api/foo — wire the button to it once available."*
+
+4. **Session count estimate.** *"3 parallel sessions + 1 merge session ≈ 2× faster than sequential."*
+
+When a single PRD section spans multiple tracks (e.g., a feature where backend ships now and UI is deferred), embed an inline **"Parallel-safety / handoff status"** subsection inside that PRD section. List what's done in this build vs. what's queued for the next session, and which files each track touches. This way the next session picking up the work knows the boundary without re-reading the whole spec.
+
+**When to skip:** Truly single-story specs (one file, one bug, one tight feature). The moment a spec has 2+ logically independent pieces, include the section.
 
 ## After the Design
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -22,6 +22,31 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
 
+## Track Structure (parallel execution)
+
+If the spec includes a **Parallel Execution Plan** section (it should, for any 2+ story spec), organize tasks into tracks that mirror it. Tasks within a track run sequentially in one session; different tracks are dispatched to parallel sessions.
+
+```markdown
+## Track A: [Backend module] (independent)
+### Task A1: ...
+### Task A2: ...
+
+## Track B: [Frontend additions] (depends on Track A's `/api/foo`)
+### Task B1: ...
+
+## Merge: [Final stitch session]
+### Task M1: Wire Track B's button to Track A's `/api/foo`
+```
+
+Per-track requirements:
+
+- **Header dependency tag.** State `(independent)` or `(depends on Track X's <thing>)` next to each track name. The merge track runs after the tracks it integrates.
+- **Handoff stub on the last task of any parallel-safe track.** Name exactly what is and isn't done so a session in another track can read it and know the boundary. Example final-task note:
+  > *"Track A complete: `POST /api/items` shipped, returns 201 with `{id, created_at}`. Track B may now wire its `Create` button to this endpoint. No template files touched in this track."*
+- **No cross-track file edits.** If Task A3 and Task B2 both modify the same file, the tracks aren't actually parallel — collapse them into one track or move the shared edit into the merge track.
+
+Skip track structure only if the spec is genuinely single-story (one file, one bug, one tight feature) — those usually shouldn't need a multi-task plan in the first place.
+
 ## File Structure
 
 Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.


### PR DESCRIPTION
## Summary

Adds a **"Parallel Execution Plan"** section to the brainstorming skill and a **"Track Structure"** section to the writing-plans skill. Any spec covering 2+ logically independent stories now proactively proposes how to split the work across parallel sessions, instead of producing a sequential spec by default.

## Motivation

The current brainstorming flow produces sequential specs. For users running multiple Claude sessions concurrently, sequential specs leave throughput on the table — parallel-track analysis tends to surface only after the user explicitly asks _"can we parallelize this?"_. This change moves that analysis into the default spec output as offense (ship faster), not defense (avoid conflicts).

## What's in the brainstorming change

- New checklist step **"Add Parallel Execution Plan section"** between _Present design_ and _Write design doc_.
- Updated the design _"Cover:"_ list to include the parallel plan.
- New **"Parallel Execution Plan"** section defining the four required components:
  1. **Track decomposition** — break stories into tracks that touch disjoint files / surfaces. Backend modules, new files, additive blueprints, separate DB tables → safe parallel; shared template edits, shared modules, schema migrations everyone depends on → serial.
  2. **Dependency graph** — which tracks block which? Independent tracks said so explicitly.
  3. **Merge plan** — what stitches the tracks at the end; or a handoff stub.
  4. **Session count estimate** — _"3 parallel sessions + 1 merge ≈ 2× faster than sequential."_
- Inline **"Parallel-safety / handoff status"** subsection pattern for PRD sections that span multiple tracks (e.g. backend ships now, UI deferred to a later session).
- Explicit skip condition for genuinely single-story specs.

## What's in the writing-plans change

- New **"Track Structure (parallel execution)"** section between _Scope Check_ and _File Structure_.
- Plans organize tasks into tracks mirroring the spec's parallel plan. Tasks within a track run sequentially in one session; different tracks dispatch to parallel sessions.
- Per-track headers tag dependencies (`(independent)` or `(depends on Track X's <thing>)`).
- Last task of each parallel-safe track ends with a **handoff stub** naming exactly what shipped, so a parallel session can pick it up cleanly.
- **No cross-track file edits** rule: if two tracks both modify the same file, they aren't actually parallel — collapse or move the shared edit into the merge track.

## Validation

Ran a RED/GREEN test with two parallel subagents on an identical 2-story feature request (Flask audit-logging backend + admin dashboard UI):

- **RED** (no skill, free-form spec): subagent produced a sequential spec with **zero** parallel-execution section.
- **GREEN** (skill content provided): subagent produced a complete Parallel Execution Plan with **all four required components**, correctly identifying the backend + UI + tests as Tracks A/B/C with a merge session.

Skill content materially changes the spec output.

## Test plan

- [x] Brainstorming RED/GREEN validation via parallel subagents
- [x] Writing-plans content cross-referenced (track structure → handoff stub example)
- [ ] Reviewer sanity check — does the "offense not defense" framing land?
- [ ] Reviewer sanity check — is the four-component contract the right grain?