### PR TITLE
[codex] replace Circle K signal with generic review guidance

### DIFF
--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -126,7 +126,7 @@ Push back when:
 - Reference working tests/code
 - Involve your human partner if architectural
 
-**If you feel hesitant to push back:** Name the tension plainly, then tell your human partner the technical concern you see. Honesty is more helpful than quiet compliance.
+**If you're uncomfortable pushing back out loud:** Name that tension, then tell your partner about the issue you've seen. They'll appreciate your honesty.
 
 ## Acknowledging Correct Feedback
 

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -126,8 +126,6 @@ Push back when:
 - Reference working tests/code
 - Involve your human partner if architectural
 
-**Signal if uncomfortable pushing back out loud:** "Strange things are afoot at the Circle K"
-
 ## Acknowledging Correct Feedback
 
 When feedback IS correct:

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -126,6 +126,8 @@ Push back when:
 - Reference working tests/code
 - Involve your human partner if architectural
 
+**If you feel hesitant to push back:** Name the tension plainly, then tell your human partner the technical concern you see. Honesty is more helpful than quiet compliance.
+
 ## Acknowledging Correct Feedback
 
 When feedback IS correct:


### PR DESCRIPTION
## What problem are you trying to solve?
The `receiving-code-review` skill included the personal phrase `Strange things are afoot at the Circle K` as an instruction for agents who feel uncomfortable pushing back out loud. Drew confirmed this phrase belongs in personal Claude/Codex instructions, not in public Superpowers core skill content.

Jesse also pointed out that the conditional itself is useful: if the model reaches that line, it likely already knows it feels hesitant about pushing back. The public core skill should preserve that behavioral escape hatch while removing the private phrase.

Tracking: SUP-246

Thanks @dantowne for reporting!

## What does this PR change?
Replaces the Circle K signal line in `skills/receiving-code-review/SKILL.md` with Jesse's plain-language guidance:

> If you're uncomfortable pushing back out loud: Name that tension, then tell your partner about the issue you've seen. They'll appreciate your honesty.

The surrounding guidance about when and how to push back on code review feedback is unchanged.

## Is this change appropriate for the core library?
Yes. Superpowers core should contain general-purpose agent workflow guidance, not maintainer-local or personal shorthand. This keeps the broadly useful behavior while removing the private convention, without adding dependencies, integrations, or new workflow surface.

## What alternatives did you consider?
I considered deleting the line entirely. That removed the private phrase, but it also removed a useful conditional for agents that are already feeling tension about pushing back.

I also briefly considered tightening Jesse's wording to use Superpowers' usual `human partner` phrasing and more technical framing. Drew asked to use Jesse's version for now, so this PR now keeps Jesse's wording directly.

## Does this PR contain multiple unrelated changes?
No. This PR contains one related change: replacing the personal Circle K signal with general-purpose review-pushback guidance.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #61, #129, #627, #812, #1443

Searches performed:
- Exact phrase searches for `Circle K` and `Strange things are afoot` across open and closed PRs found no duplicate removal/replacement PR.
- Broader `receiving-code-review` searches found prior/open PRs touching the same skill area, including #627, #812, and #1443, but they address review mechanics or other guidance rather than replacing this personal signal.
- Closed PRs #61 and #129 appeared in exact phrase search results because they copied broad skill content into other packaging/harness surfaces; neither is a duplicate of this replacement.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app | Not exposed in session | GPT-5 Codex | Not exposed in session |

## New harness support (required if this PR adds a new harness)
Not applicable. This PR does not add support for a new harness, IDE, CLI tool, or agent runner.

## Evaluation
- Initial prompt: Drew pointed at the exact blamed line in `skills/receiving-code-review/SKILL.md` and asked to remove the Circle K phrase from Superpowers because it belongs in personal Claude.md files, not public core.
- Follow-up prompt: Jesse suggested preserving the conditional with generic guidance to name the tension and tell the human partner about the issue.
- Final wording prompt: Drew asked to use Jesse's version for now.
- Eval sessions run after making the change: 0 live LLM eval sessions.
- Outcome change: Deterministic verification confirms the private phrase is gone and Jesse's replacement guidance is present. No live behavioral eval was run because this is a narrow wording replacement for a maintainer-local phrase, not a new skill or broad retuning.

Verification performed:
- Focused search after the latest wording update found Jesse's `If you're uncomfortable pushing back out loud` line.
- `rg -n "Strange things are afoot|Circle K|If you feel hesitant" .` returned no matches.
- `git diff --check` passed.
- `uv --project evals run pytest` passed: 128 tests.
- `bash tests/codex-plugin-sync/test-sync-to-codex-plugin.sh` passed.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

I used `superpowers:writing-skills` to check the skill-change workflow, but I did not complete adversarial pressure testing. This is intentionally disclosed rather than papered over: the change is a narrow replacement of personal/private phrasing with generic guidance, validated deterministically by repository search plus the relevant fast test suites.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed the original complete diff before PR creation, reviewed Jesse's replacement suggestion in the Codex thread, and then explicitly asked to use Jesse's version for now.
