### PR TITLE
fix(tdd): link testing anti-patterns reference

### DIFF
--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -356,7 +356,7 @@ Never fix bugs without a test.
 
 ## Testing Anti-Patterns
 
-When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+When adding mocks or test utilities, read [testing-anti-patterns.md](testing-anti-patterns.md) to avoid common pitfalls:
 - Testing mock behavior instead of real behavior
 - Adding test-only methods to production classes
 - Mocking without understanding dependencies


### PR DESCRIPTION
## What problem are you trying to solve?

`skills/test-driven-development/SKILL.md` tells agents to read `@testing-anti-patterns.md` before adding mocks or test utilities. That `@...md` form is not a resolvable markdown link and can cause an agent to treat the filename as literal text or guess the intended path.

Issue #1529 reports the concrete user-visible confusion: the referenced file exists as `skills/test-driven-development/testing-anti-patterns.md`, but the active skill points to it with an ambiguous `@` prefix.

## What does this PR change?

Replaces the ambiguous `@testing-anti-patterns.md` reference with a normal relative markdown link to `testing-anti-patterns.md`.

Fixes #1529.

## Is this change appropriate for the core library?

Yes. `test-driven-development` is a core Superpowers skill, and this makes its existing local reference unambiguous for all users without adding project-specific behavior, third-party dependencies, or new workflow semantics.

## What alternatives did you consider?

I considered documenting an `@<filename>` convention, but that would create a new reference style for a single line and would still leave agents needing to learn that convention. A plain relative markdown link matches the existing fix already present on `dev` for the similar `writing-skills` reference to `testing-skills-with-subagents.md`.

## Does this PR contain multiple unrelated changes?

No. This PR only fixes one local markdown reference in `skills/test-driven-development/SKILL.md`.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for #1529 or the `@testing-anti-patterns.md` reference

I searched open and closed PRs for #1529, `testing-anti-patterns`, and `@testing-anti-patterns`. Several historical broad skill PRs touched the TDD skill or the anti-patterns reference file, but I did not find a direct duplicate of this focused link fix.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Local shell/static markdown validation | zsh on macOS | n/a | n/a |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add or modify harness support.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Not applicable. This PR does not add or modify a harness integration.

</details>

## Evaluation

- Initial prompt: Drew asked to fix #1529 after confirming the `@testing-anti-patterns.md` reference was real on both `main` and `dev`.
- Eval sessions after making the change: 0 runtime eval sessions. This is a mechanical markdown-link correction, not a behavior-shaping skill rewrite.
- Before/after: before the change, `rg -n '@[A-Za-z0-9_.-]+\.md|read @' -S skills/test-driven-development skills/writing-skills` found the TDD `@testing-anti-patterns.md` reference. After the change, the same command finds no unresolved `@...md` references in those active skill files, and `rg -n 'read \[testing-anti-patterns\.md\]\(testing-anti-patterns\.md\)' skills/test-driven-development/SKILL.md` confirms the relative link.

Verification commands run:

```bash
rg -n '@[A-Za-z0-9_.-]+\.md|read @' -S skills/test-driven-development skills/writing-skills
rg -n 'read \[testing-anti-patterns\.md\]\(testing-anti-patterns\.md\)' skills/test-driven-development/SKILL.md
git diff --check origin/dev...HEAD
```

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is a mechanical link correction in an existing sentence. I read `superpowers:test-driven-development`, `superpowers:writing-skills`, and `superpowers:verification-before-completion`, but did not run adversarial pressure testing because the PR does not change skill behavior or tuned language.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed the complete one-line diff in Codex and explicitly approved opening this PR against `dev`.