### PR TITLE
fix(brainstorming): cap WebSocket frame payloads

### DIFF
--- a/skills/brainstorming/scripts/server.cjs
+++ b/skills/brainstorming/scripts/server.cjs
@@ -7,6 +7,7 @@ const path = require('path');
 
 const OPCODES = { TEXT: 0x01, CLOSE: 0x08, PING: 0x09, PONG: 0x0A };
 const WS_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+const MAX_FRAME_PAYLOAD_BYTES = 10 * 1024 * 1024;
 
 function computeAcceptKey(clientKey) {
   return crypto.createHash('sha1').update(clientKey + WS_MAGIC).digest('base64');
@@ -53,8 +54,16 @@ function decodeFrame(buffer) {
     offset = 4;
   } else if (payloadLen === 127) {
     if (buffer.length < 10) return null;
-    payloadLen = Number(buffer.readBigUInt64BE(2));
+    const extendedLen = buffer.readBigUInt64BE(2);
+    if (extendedLen > BigInt(MAX_FRAME_PAYLOAD_BYTES)) {
+      throw new Error('WebSocket frame payload exceeds maximum allowed size');
+    }
+    payloadLen = Number(extendedLen);
     offset = 10;
+  }
+
+  if (payloadLen > MAX_FRAME_PAYLOAD_BYTES) {
+    throw new Error('WebSocket frame payload exceeds maximum allowed size');
   }
 
   const maskOffset = offset;
@@ -351,4 +360,4 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };
+module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES, MAX_FRAME_PAYLOAD_BYTES };

--- a/tests/brainstorm-server/ws-protocol.test.js
+++ b/tests/brainstorm-server/ws-protocol.test.js
@@ -329,6 +329,21 @@ function runTests() {
     assert.strictEqual(result.payload.length, 65536);
   });
 
+  test('rejects oversized 64-bit frames before payload allocation', () => {
+    const mask = Buffer.from([0x00, 0x00, 0x00, 0x00]);
+    const header = Buffer.alloc(14);
+    header[0] = 0x81; // FIN + TEXT
+    header[1] = 0x80 | 127; // masked, 64-bit length
+    header.writeBigUInt64BE(BigInt(ws.MAX_FRAME_PAYLOAD_BYTES) + 1n, 2);
+    mask.copy(header, 10);
+
+    assert.throws(
+      () => ws.decodeFrame(header),
+      /exceeds maximum allowed size/i,
+      'oversized advertised payload must be rejected from header alone'
+    );
+  });
+
   // ========== Close Frame with Status Code ==========
   console.log('\n--- Close Frame Details ---');
 


### PR DESCRIPTION
## What problem are you trying to solve?

Issue #1446 reports that `skills/brainstorming/scripts/server.cjs` trusts the 64-bit WebSocket payload length from a client frame and then allocates `Buffer.alloc(payloadLen)`. Because the brainstorm companion server listens on localhost, a local process or browser context can advertise a huge frame length and make the server attempt a very large allocation.

This PR addresses only that concrete payload-size allocation bug from #1446. It does not attempt to fix the other two unrelated items in the bundled issue.

## What does this PR change?

Adds a 10 MiB maximum WebSocket frame payload size, rejects oversized advertised payloads before allocation, and exports the limit for protocol tests. Adds a regression test that constructs an oversized 64-bit frame header and verifies `decodeFrame()` rejects it from the header alone.

## Is this change appropriate for the core library?

Yes. The brainstorm companion server is part of the core `brainstorming` skill, and this hardens its built-in zero-dependency WebSocket parser for all users. It is not project-specific, team-specific, or tied to a third-party integration.

## What alternatives did you consider?

I considered limiting only complete frames after `buffer.length >= totalLen`, but that still leaves the parser willing to wait for an enormous declared payload and keeps the bad length in control flow. Rejecting immediately after reading the extended length avoids the risky allocation path and makes the behavior explicit.

I also considered changing the server to use a WebSocket dependency, but Superpowers is intentionally dependency-light and this bug can be fixed locally in the existing parser.

## Does this PR contain multiple unrelated changes?

No. This PR only caps inbound brainstorm WebSocket frame payloads and adds protocol-level coverage for that limit.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1504, #1483

I searched open and closed PRs for `1446`, `escape_for_json`, `payload-size`, and `find-polluter`. I found #1504, which hardens a different brainstorm-server path (`handleMessage` null payload handling), and #1483, which addressed the separate `find-polluter.sh` spaced-path issue from #1446 and was closed. I did not find an open or merged PR that caps WebSocket frame payload length before allocation.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex local shell | Codex desktop | GPT-5 | Codex session |

System Node/npm on this machine is currently broken because Homebrew Node cannot load `/opt/homebrew/opt/llhttp/lib/libllhttp.9.3.dylib`. I used the Codex bundled Node runtime for the focused protocol test instead.

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add or modify harness support.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Not applicable. This PR does not add or modify a harness integration.

</details>

## Evaluation

- Initial prompt: the human partner asked to find a relevant issue in `obra/superpowers` and contribute. I reviewed open issues and PRs, rejected #1529 as duplicate because #1532 already merged the focused fix, then selected the WebSocket payload-size item from #1446.
- Eval sessions after making the change: 1 focused protocol test run.
- Before/after: before the change, `decodeFrame()` accepted a 64-bit advertised payload length and would use that length in `Buffer.alloc(payloadLen)` once enough bytes were buffered. After the change, lengths above `MAX_FRAME_PAYLOAD_BYTES` throw `WebSocket frame payload exceeds maximum allowed size` immediately after header decoding, before payload allocation.

Verification commands run:

```bash
/Users/rahul/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node tests/brainstorm-server/ws-protocol.test.js
git diff --check
```

Results:

```text
--- Results: 32 passed, 0 failed ---
```

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This PR changes parser code and a protocol test, not behavior-shaping skill prose. The regression test exercises an adversarial oversized 64-bit WebSocket frame header designed to trigger the reported allocation path.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

The complete two-file diff was shown in the Codex session and the human partner explicitly approved opening the PR.
