### PR TITLE
feat: add skill.json metadata for Claude Code 2.1.142 skill discovery

### DIFF
--- a/scripts/generate-skill-json.sh
+++ b/scripts/generate-skill-json.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# 为缺少 skill.json 的 superpowers 技能自动生成元数据文件
+# 用法: bash generate-skill-json.sh [skills目录路径]
+# 默认: 脚本所在目录的 ../skills/
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_DIR="${1:-${SCRIPT_DIR}/../skills}"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+    echo "错误: 技能目录不存在: $SKILLS_DIR"
+    exit 1
+fi
+
+count=0
+
+for skill_dir in "$SKILLS_DIR"/*/; do
+    skill_name=$(basename "$skill_dir")
+    skill_md="${skill_dir}/SKILL.md"
+    skill_json="${skill_dir}/skill.json"
+
+    # 已有 skill.json 则跳过
+    if [ -f "$skill_json" ]; then
+        continue
+    fi
+
+    # 必须有 SKILL.md
+    if [ ! -f "$skill_md" ]; then
+        echo "警告: $skill_name 没有 SKILL.md，跳过"
+        continue
+    fi
+
+    # 提取 YAML frontmatter 中的 name 和 description
+    # 查找 --- 之间的内容
+    name=$(sed -n '/^---$/,/^---$/p' "$skill_md" | grep '^name:' | head -1 | sed 's/^name: *//')
+    desc=$(sed -n '/^---$/,/^---$/p' "$skill_md" | grep '^description:' | head -1 | sed 's/^description: *//')
+
+    if [ -z "$name" ]; then
+        echo "警告: $skill_name 的 SKILL.md 中没有 name 字段，跳过"
+        continue
+    fi
+
+    # 生成 skill.json
+    escaped_desc=$(echo "$desc" | sed 's/"/\\"/g')
+    cat > "$skill_json" << SKILLEOF
+{
+  "name": "$name",
+  "description": $escaped_desc,
+  "entry": "SKILL.md"
+}
+SKILLEOF
+
+    echo "已生成: $skill_json"
+    count=$((count + 1))
+done
+
+echo "完成: 生成 $count 个 skill.json 文件"

--- a/skills/brainstorming/skill.json
+++ b/skills/brainstorming/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "brainstorming",
+  "description": "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.",
+  "entry": "SKILL.md"
+}

--- a/skills/dispatching-parallel-agents/skill.json
+++ b/skills/dispatching-parallel-agents/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "dispatching-parallel-agents",
+  "description": "Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies",
+  "entry": "SKILL.md"
+}

--- a/skills/executing-plans/skill.json
+++ b/skills/executing-plans/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "executing-plans",
+  "description": "Use when you have a written implementation plan to execute in a separate session with review checkpoints",
+  "entry": "SKILL.md"
+}

--- a/skills/finishing-a-development-branch/skill.json
+++ b/skills/finishing-a-development-branch/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "finishing-a-development-branch",
+  "description": "Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup",
+  "entry": "SKILL.md"
+}

--- a/skills/receiving-code-review/skill.json
+++ b/skills/receiving-code-review/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "receiving-code-review",
+  "description": "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation",
+  "entry": "SKILL.md"
+}

--- a/skills/requesting-code-review/skill.json
+++ b/skills/requesting-code-review/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "requesting-code-review",
+  "description": "Use when completing tasks, implementing major features, or before merging to verify work meets requirements",
+  "entry": "SKILL.md"
+}

--- a/skills/subagent-driven-development/skill.json
+++ b/skills/subagent-driven-development/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "subagent-driven-development",
+  "description": "Use when executing implementation plans with independent tasks in the current session",
+  "entry": "SKILL.md"
+}

--- a/skills/systematic-debugging/skill.json
+++ b/skills/systematic-debugging/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "systematic-debugging",
+  "description": "Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes",
+  "entry": "SKILL.md"
+}

--- a/skills/test-driven-development/skill.json
+++ b/skills/test-driven-development/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-driven-development",
+  "description": "Use when implementing any feature or bugfix, before writing implementation code",
+  "entry": "SKILL.md"
+}

--- a/skills/using-git-worktrees/skill.json
+++ b/skills/using-git-worktrees/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "using-git-worktrees",
+  "description": "Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback",
+  "entry": "SKILL.md"
+}

--- a/skills/using-superpowers/skill.json
+++ b/skills/using-superpowers/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "using-superpowers",
+  "description": "Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions",
+  "entry": "SKILL.md"
+}

--- a/skills/verification-before-completion/skill.json
+++ b/skills/verification-before-completion/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "verification-before-completion",
+  "description": "Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always",
+  "entry": "SKILL.md"
+}

--- a/skills/writing-plans/skill.json
+++ b/skills/writing-plans/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "writing-plans",
+  "description": "Use when you have a spec or requirements for a multi-step task, before touching code",
+  "entry": "SKILL.md"
+}

--- a/skills/writing-skills/skill.json
+++ b/skills/writing-skills/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "writing-skills",
+  "description": "Use when creating new skills, editing existing skills, or verifying skills work before deployment",
+  "entry": "SKILL.md"
+}


### PR DESCRIPTION
## Problem

Claude Code 2.1.142 (released 2026-05-15) changed plugin skill discovery: skills without `skill.json` metadata files are silently not registered. 

Superpowers skills only have `SKILL.md` frontmatter — no `skill.json`. After the Claude Code auto-update, all 14 superpowers skills vanish from the available skills list. Skills from other plugins that include `skill.json` (e.g., arscontexta) continue to work.

## What This PR Does

- Adds `skill.json` for all 14 skills, extracting `name` and `description` from each SKILL.md's YAML frontmatter
- Adds `scripts/generate-skill-json.sh` — a regeneration script that scans for missing `skill.json` files and auto-generates them from SKILL.md frontmatter

## Reproduction

1. Install superpowers on Claude Code 2.1.142+
2. Type `/brainstorming` — skill not found
3. Check available skills — no superpowers skills listed
4. Apply this PR's skill.json files → skills reappear

## Testing

- Verified on Claude Code 2.1.142 (Windows 11)
- All 14 skills registered successfully after adding skill.json files