### PR TITLE
Clarify simplification review in workflow gates

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -27,7 +27,8 @@ For each task:
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
-4. Mark as completed
+4. At review checkpoints, run spec compliance first, then simplification/code quality only after spec compliance passes and verification is green
+5. Mark as completed
 
 ### Step 3: Complete Development
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -7,7 +7,7 @@ description: Use when completing tasks, implementing major features, or before m
 
 Dispatch a code reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
 
-**Core principle:** Review early, review often.
+**Core principle:** Review at meaningful checkpoints before issues cascade. In plan execution, run spec compliance first; only then run simplification/code-quality review.
 
 ## When to Request Review
 
@@ -72,10 +72,23 @@ You: [Fix progress indicators]
 [Continue to Task 3]
 ```
 
+## Simplification Review
+
+Use this as the standard code-quality review rubric after spec compliance passes and verification is green.
+
+**Default:** one reviewer checks all three lenses:
+- **Reuse:** existing utilities/helpers/patterns that should replace new code; duplicated functionality; hand-rolled string/path/env/type-guard logic.
+- **Quality:** redundant state, parameter sprawl, copy-paste variation, leaky abstractions, stringly typed code, unnecessary wrappers, comments that explain WHAT or narrate the task instead of non-obvious WHY.
+- **Efficiency:** redundant work, missed safe concurrency, hot-path bloat, recurring no-op updates, TOCTOU existence checks, leaks/unbounded data, overly broad reads/loads.
+
+**Escalate to parallel focused reviewers** for large diffs, risky refactors, performance-sensitive work, or final pre-merge review: dispatch reuse, quality, and efficiency reviewers concurrently against the same git range, then aggregate findings.
+
 ## Integration with Workflows
 
 **Subagent-Driven Development:**
 - Review after EACH task
+- First run spec compliance review
+- Then run simplification/code-quality review only after spec compliance passes and verification is green
 - Catch issues before they compound
 - Fix before moving to next task
 

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -37,11 +37,13 @@ Task tool (general-purpose):
     - Are deviations justified improvements, or problematic departures?
     - Is all planned functionality present?
 
-    **Code quality:**
+    **Simplification / Code quality:**
+    - Reuse: existing utilities/helpers/patterns instead of duplicated or hand-rolled code?
+    - Quality: no redundant state, parameter sprawl, copy-paste variation, leaky abstractions, stringly typing, unnecessary wrappers, or low-value comments?
+    - Efficiency: no redundant work, missed safe concurrency, hot-path bloat, no-op update churn, TOCTOU checks, leaks, or overly broad reads/loads?
     - Clean separation of concerns?
     - Proper error handling?
     - Type safety where applicable?
-    - DRY without premature abstraction?
     - Edge cases handled?
 
     **Architecture:**

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -5,11 +5,11 @@ description: Use when executing implementation plans with independent tasks in t
 
 # Subagent-Driven Development
 
-Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then code quality review.
+Execute plan by dispatching fresh subagent per task, with two-stage review after each: spec compliance review first, then simplification/code-quality review.
 
 **Why subagents:** You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
 
-**Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration
+**Core principle:** Fresh subagent per task + two-stage review (spec then simplification/quality) = high quality, fast iteration
 
 **Continuous execution:** Do not pause to check in with your human partner between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are: BLOCKED status you cannot resolve, ambiguity that genuinely prevents progress, or all tasks complete. "Should I continue?" prompts and progress summaries waste their time — they asked you to execute the plan, so execute it.
 
@@ -36,7 +36,7 @@ digraph when_to_use {
 **vs. Executing Plans (parallel session):**
 - Same session (no context switch)
 - Fresh subagent per task (no context pollution)
-- Two-stage review after each task: spec compliance first, then code quality
+- Two-stage review after each task: spec compliance first, then simplification/code quality
 - Faster iteration (no human-in-loop between tasks)
 
 ## The Process
@@ -54,8 +54,8 @@ digraph process {
         "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [shape=box];
         "Spec reviewer subagent confirms code matches spec?" [shape=diamond];
         "Implementer subagent fixes spec gaps" [shape=box];
-        "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
-        "Code quality reviewer subagent approves?" [shape=diamond];
+        "Dispatch simplification/code-quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
+        "Simplification/code-quality reviewer subagent approves?" [shape=diamond];
         "Implementer subagent fixes quality issues" [shape=box];
         "Mark task complete in TodoWrite" [shape=box];
     }
@@ -74,11 +74,11 @@ digraph process {
     "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" -> "Spec reviewer subagent confirms code matches spec?";
     "Spec reviewer subagent confirms code matches spec?" -> "Implementer subagent fixes spec gaps" [label="no"];
     "Implementer subagent fixes spec gaps" -> "Dispatch spec reviewer subagent (./spec-reviewer-prompt.md)" [label="re-review"];
-    "Spec reviewer subagent confirms code matches spec?" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="yes"];
-    "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
-    "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
-    "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
-    "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
+    "Spec reviewer subagent confirms code matches spec?" -> "Dispatch simplification/code-quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="yes"];
+    "Dispatch simplification/code-quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Simplification/code-quality reviewer subagent approves?";
+    "Simplification/code-quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
+    "Implementer subagent fixes quality issues" -> "Dispatch simplification/code-quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
+    "Simplification/code-quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
     "Mark task complete in TodoWrite" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
@@ -123,7 +123,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 
 - `./implementer-prompt.md` - Dispatch implementer subagent
 - `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
-- `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
+- `./code-quality-reviewer-prompt.md` - Dispatch simplification/code-quality reviewer subagent
 
 ## Example Workflow
 
@@ -153,7 +153,7 @@ Implementer: "Got it. Implementing now..."
 [Dispatch spec compliance reviewer]
 Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
 
-[Get git SHAs, dispatch code quality reviewer]
+[Get git SHAs, dispatch simplification/code-quality reviewer]
 Code reviewer: Strengths: Good test coverage, clean. Issues: None. Approved.
 
 [Mark Task 1 complete]
@@ -181,7 +181,7 @@ Implementer: Removed --json flag, added progress reporting
 [Spec reviewer reviews again]
 Spec reviewer: ✅ Spec compliant now
 
-[Dispatch code quality reviewer]
+[Dispatch simplification/code-quality reviewer]
 Code reviewer: Strengths: Solid. Issues (Important): Magic number (100)
 
 [Implementer fixes]
@@ -222,7 +222,7 @@ Done!
 
 **Quality gates:**
 - Self-review catches issues before handoff
-- Two-stage review: spec compliance, then code quality
+- Two-stage review: spec compliance, then simplification/code quality
 - Review loops ensure fixes actually work
 - Spec compliance prevents over/under-building
 - Code quality ensures implementation is well-built
@@ -237,7 +237,7 @@ Done!
 
 **Never:**
 - Start implementation on main/master branch without explicit user consent
-- Skip reviews (spec compliance OR code quality)
+- Skip reviews (spec compliance OR simplification/code quality)
 - Proceed with unfixed issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Make subagent read plan file (provide full text instead)
@@ -246,7 +246,7 @@ Done!
 - Accept "close enough" on spec compliance (spec reviewer found issues = not done)
 - Skip review loops (reviewer found issues = implementer fixes = review again)
 - Let implementer self-review replace actual review (both are needed)
-- **Start code quality review before spec compliance is ✅** (wrong order)
+- **Start simplification/code-quality review before spec compliance is ✅** (wrong order)
 - Move to next task while either review has open issues
 
 **If subagent asks questions:**

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -1,10 +1,14 @@
-# Code Quality Reviewer Prompt Template
+# Simplification / Code Quality Reviewer Prompt Template
 
-Use this template when dispatching a code quality reviewer subagent.
+Use this template when dispatching the post-spec-compliance quality reviewer.
 
-**Purpose:** Verify implementation is well-built (clean, tested, maintainable)
+**Purpose:** Verify implementation is well-built: reusable, clean, tested, maintainable, and efficient.
 
-**Only dispatch after spec compliance review passes.**
+**Only dispatch after spec compliance review passes and verification is green.**
+
+## Default: One Reviewer, Three Lenses
+
+For normal task-sized changes, dispatch one reviewer and explicitly ask it to review the diff through all three simplification lenses: reuse, quality, and efficiency.
 
 ```
 Task tool (general-purpose):
@@ -14,12 +18,28 @@ Task tool (general-purpose):
   PLAN_OR_REQUIREMENTS: Task N from [plan-file]
   BASE_SHA: [commit before task]
   HEAD_SHA: [current commit]
+
+  EXTRA REVIEW FOCUS:
+  Run a simplification review through these lenses:
+  1. Reuse: existing utilities/helpers/patterns that should replace new code; duplicated functionality; hand-rolled string/path/env/type-guard logic.
+  2. Quality: redundant state; parameter sprawl; copy-paste variations; leaky abstractions; stringly-typed code where constants/unions exist; unnecessary wrappers; comments that explain WHAT or narrate the task instead of non-obvious WHY.
+  3. Efficiency: redundant computation/I/O/API calls; missed safe concurrency; hot-path bloat; recurring no-op updates without change detection; TOCTOU existence checks; leaks/unbounded data; overly broad reads/loads.
 ```
 
-**In addition to standard code quality concerns, the reviewer should check:**
+**In addition to the simplification lenses, the reviewer should check:**
 - Does each file have one clear responsibility with a well-defined interface?
 - Are units decomposed so they can be understood and tested independently?
 - Is the implementation following the file structure from the plan?
 - Did this implementation create new files that are already large, or significantly grow existing files? (Don't flag pre-existing file sizes — focus on what this change contributed.)
 
-**Code reviewer returns:** Strengths, Issues (Critical/Important/Minor), Assessment
+## Escalation: Parallel Focused Reviewers
+
+For large diffs, risky refactors, performance-sensitive work, or final pre-merge review, dispatch three read-only reviewers concurrently against the same git range:
+
+1. **Reuse reviewer** — searches for existing utilities, helpers, and codebase patterns that should replace new code.
+2. **Quality reviewer** — looks for redundant state, parameter sprawl, copy-paste, leaky abstractions, stringly typing, unnecessary wrappers, and low-value comments.
+3. **Efficiency reviewer** — looks for avoidable work, missed concurrency, hot-path bloat, no-op updates, TOCTOU checks, leaks, and overly broad operations.
+
+Aggregate findings after all three complete. Fix valid findings; note false positives briefly and move on.
+
+**Reviewer returns:** Strengths, Issues (Critical/Important/Minor), Assessment


### PR DESCRIPTION
## What problem are you trying to solve?
During a Softpowers workflow discussion, we noticed that the existing review gate said "code quality" but did not make the most useful cleanup pass concrete. In practice, after a task passes spec review, the next reviewer needs to check three distinct failure modes that generic code-quality wording can miss: duplicated helpers/patterns, hacky implementation quality issues, and avoidable efficiency problems. Without that rubric, agents can run a nominal quality review while missing hand-rolled utilities, redundant state, polling no-op churn, TOCTOU checks, or comments that narrate the task instead of explaining non-obvious constraints.

## What does this PR change?
This PR turns the existing post-spec code-quality gate into a simplification/code-quality review with three explicit lenses: reuse, quality, and efficiency. It keeps the default fluid by using one reviewer for normal task-sized diffs, while adding an escalation path to three parallel read-only reviewers for large, risky, performance-sensitive, or final pre-merge reviews.

## Is this change appropriate for the core library?
Yes. This is a general workflow-quality improvement for Softpowers' existing implementation and review skills. It is not project-specific, team-specific, tool-specific, or dependent on any third-party service; it applies to any codebase using the core review workflow.

## What alternatives did you consider?
I considered adding a separate standalone `simplify` skill or an additional mandatory review gate. I rejected that because it would add ceremony and increase review spam. Folding the rubric into the existing code-quality gate preserves the current workflow shape: spec compliance first, then one quality/simplification review. I also considered always launching three reviewers, but kept that only as an escalation path for large/risky/final reviews so normal tasks stay lightweight.

## Does this PR contain multiple unrelated changes?
No. All changes update the same review workflow concept: the post-spec quality review rubric and when to escalate it to focused parallel reviewers.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #613, #738, #865, #1299

#613 adds hard gates to prevent review skipping in subagent-driven-development. This PR is narrower: it does not add new hard-gate structure; it clarifies what the existing quality review should check.

#738 proposes a fresh-eyes final review for cross-task issues. This PR is complementary: it improves the reuse/quality/efficiency rubric for the existing quality review and adds focused parallel review only for large/risky/final cases.

#865 proposes a blind spec-only final review. This PR does not add blind review or change spec-review semantics; it only improves the implementation-quality pass after spec compliance.

#1299 merged code-reviewer template consolidation. This PR builds on that direction by updating the self-contained review template rather than reintroducing a separate agent source of truth.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Pi coding agent harness | local API session, exact version not exposed | DeepSeek reviewer subagents | deepseek-v4-pro |
| Pi coding agent harness | local API session, exact version not exposed | Main coding agent | API model for this session, exact ID not exposed |

## Evaluation
- What was the initial prompt you (or your human partner) used to start the session that led to this change?
  - "I really like those skills instructions /home/brice/.agents/skills-backup/simplify i wonder how we could integrate them into softpowers at which step ?"
- How many eval sessions did you run AFTER making the change?
  - Four read-only reviewer eval sessions: old instructions vs new instructions for a normal post-spec task review, and old instructions vs new instructions for a large/risky final pre-merge review.
- How did outcomes change compared to before the change?
  - Baseline normal task review dispatched one generic code-quality reviewer and focused on single responsibility, decomposition, file structure, and file size. It did not naturally produce the intended concrete reuse/quality/efficiency rubric; it interpreted "reuse" as template reuse and "efficiency" as workflow efficiency rather than code-level efficiency.
  - New normal task review dispatched one simplification/code-quality reviewer and explicitly checked reuse (existing utilities/helpers/patterns and hand-rolled path/string/env/type-guard logic), quality (redundant state, parameter sprawl, leaky abstractions, low-value comments), and efficiency (redundant I/O/API calls, hot-path bloat, no-op update churn, TOCTOU checks, leaks, overly broad reads/loads). It also stated the spec-compliance + green-verification prerequisite.
  - Baseline large/risky final review selected one final reviewer and reported that no parallel escalation was obvious.
  - New large/risky final review selected three parallel focused reviewers (reuse, quality, efficiency) and identified the escalation as explicit because the scenario hit both "large diff" and "final pre-merge review" triggers.

## Rigor

- [x] If this is a skills change: I used `softpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Eval scenarios used pressure from ambiguity and scale:

1. Normal phase/task gate after tests green and spec reviewer approval, with a diff containing a new path normalization helper, a polling store update, and comments narrating what changed. Expected behavior: one reviewer, but with concrete reuse/quality/efficiency lenses and green-verification prerequisite.
2. Large risky final pre-merge review with cross-cutting changes across many files. Expected behavior: parallel read-only focused reviewers for reuse, quality, and efficiency.

Results:
- Old normal instructions: one generic code-quality reviewer; concrete reuse/quality/efficiency checks were not produced correctly.
- New normal instructions: one reviewer with explicit reuse, quality, and efficiency lenses; no unnecessary parallelism.
- Old final instructions: one reviewer; no obvious parallel escalation path.
- New final instructions: three parallel read-only reviewers with the expected focused responsibilities.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
