### PR TITLE
fix(claude-plugin): declare bundled skills path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,5 +16,6 @@
     "collaboration",
     "best-practices",
     "workflows"
-  ]
+  ],
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary
- add the missing `skills` entry to `.claude-plugin/plugin.json`
- point Claude Code at the bundled `./skills/` directory so marketplace installs can discover the shipped skills

## Why
Issue #1479 reports that the Claude Code manifest does not declare a skills path, which prevents bundled skills from being discovered even though they exist on disk.

## Verification
- parsed `.claude-plugin/plugin.json` successfully after the change
- confirmed the manifest now exposes `skills: ./skills/`
- ran `git diff --check`