### PR TITLE
docs(tdd): use backticked filename instead of @-prefix

### DIFF
--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -356,7 +356,7 @@ Never fix bugs without a test.
 
 ## Testing Anti-Patterns
 
-When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+When adding mocks or test utilities, read `testing-anti-patterns.md` to avoid common pitfalls:
 - Testing mock behavior instead of real behavior
 - Adding test-only methods to production classes
 - Mocking without understanding dependencies


### PR DESCRIPTION
Fixes #1529.

Line 359 of `skills/test-driven-development/SKILL.md` references `@testing-anti-patterns.md`. Nothing in this repo strips the `@` — there's no preamble convention for it, no skill loader that resolves it, and no other `@`-prefixed file reference in this SKILL.md. Every other internal file pointer here is either a bare filename or a backticked path, so the `@` reads as a mistake.

The actual file lives next to the SKILL at `skills/test-driven-development/testing-anti-patterns.md`.

This PR replaces the `@`-prefixed token with a backticked filename, matching the citation style used everywhere else in the same file:

```diff
- When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+ When adding mocks or test utilities, read `testing-anti-patterns.md` to avoid common pitfalls:
```

One line, one file. No behavior change — the surrounding section about mocks and test utilities is unchanged.

I checked the rest of the repo for the same pattern with `grep -nE '@[a-zA-Z0-9_-]+\.md'` and found exactly one other instance: `skills/writing-skills/SKILL.md` line 556 (`See @testing-skills-with-subagents.md`). I left that one alone — issue #1529 only names the TDD file, and `writing-skills/SKILL.md` is the kind of carefully-tuned content that probably wants its own discussion. Happy to file a follow-up if you want it fixed too.
