### PR TITLE
feat: add Antigravity CLI plugin support

### DIFF
--- a/.antigravity-plugin/ANTIGRAVITY.md
+++ b/.antigravity-plugin/ANTIGRAVITY.md
@@ -1,0 +1,2 @@
+@./skills/using-superpowers/SKILL.md
+@./skills/using-superpowers/references/antigravity-tools.md

--- a/.antigravity-plugin/INSTALL.md
+++ b/.antigravity-plugin/INSTALL.md
@@ -1,0 +1,23 @@
+# Installing Superpowers for Antigravity CLI
+
+## Installation
+
+1. Clone the superpowers repository:
+   ```bash
+   git clone https://github.com/obra/superpowers.git
+   cd superpowers
+   ```
+
+2. Run the install script matching your OS:
+   - **Windows:** Run in PowerShell:
+     ```powershell
+     .\scripts\install-antigravity.ps1
+     ```
+   - **macOS / Linux:** Run in Terminal:
+     ```bash
+     chmod +x ./scripts/install-antigravity.sh
+     ./scripts/install-antigravity.sh
+     ```
+
+3. Restart Antigravity CLI and ask:
+   > "Tell me about your superpowers."

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "superpowers",
+  "version": "5.1.0",
+  "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
+  "author": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "homepage": "https://github.com/obra/superpowers",
+  "repository": "https://github.com/obra/superpowers",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "tdd",
+    "debugging",
+    "collaboration",
+    "best-practices",
+    "workflows"
+  ],
+  "contextFileName": "ANTIGRAVITY.md"
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Superpowers is a complete software development methodology for your coding agent
 
 ## Quickstart
 
-Give your agent Superpowers: [Claude Code](#claude-code), [Codex CLI](#codex-cli), [Codex App](#codex-app), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [OpenCode](#opencode), [Cursor](#cursor), [GitHub Copilot CLI](#github-copilot-cli).
+Give your agent Superpowers: [Claude Code](#claude-code), [Codex CLI](#codex-cli), [Codex App](#codex-app), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [Antigravity CLI](#antigravity-cli), [OpenCode](#opencode), [Cursor](#cursor), [GitHub Copilot CLI](#github-copilot-cli).
 
 ## How it works
 
@@ -113,6 +113,25 @@ Superpowers is available via the [official Codex plugin marketplace](https://git
   ```bash
   gemini extensions update superpowers
   ```
+
+### Antigravity CLI
+
+- Clone the repository:
+  ```bash
+  git clone https://github.com/obra/superpowers.git
+  cd superpowers
+  ```
+
+- Run the installer matching your OS:
+  - **Windows (PowerShell):**
+    ```powershell
+    .\scripts\install-antigravity.ps1
+    ```
+  - **macOS / Linux (Bash):**
+    ```bash
+    chmod +x ./scripts/install-antigravity.sh
+    ./scripts/install-antigravity.sh
+    ```
 
 ### OpenCode
 

--- a/scripts/install-antigravity.ps1
+++ b/scripts/install-antigravity.ps1
@@ -1,0 +1,40 @@
+# Resolve repository root
+$repoRoot = (Get-Item "$PSScriptRoot\..").FullName
+$pluginsDir = "$HOME\.gemini\config\plugins\superpowers"
+
+if (Test-Path $pluginsDir) {
+    Write-Host "Removing existing superpowers plugin directory at $pluginsDir..."
+    Remove-Item -Recurse -Force $pluginsDir
+}
+
+Write-Host "Creating superpowers plugin directory at $pluginsDir..."
+New-Item -ItemType Directory -Path $pluginsDir -Force | Out-Null
+
+# Helper to link or copy
+function Link-Or-Copy {
+    param(
+        [string]$Src,
+        [string]$Dest,
+        [switch]$IsDirectory
+    )
+    try {
+        # Attempt symbolic link
+        New-Item -ItemType SymbolicLink -Path $Dest -Target $Src -Force -ErrorAction Stop | Out-Null
+        Write-Host "Created symbolic link: $Dest -> $Src"
+    } catch {
+        # Fallback to copy
+        Write-Warning "Symbolic link creation failed (Developer Mode might be disabled). Copying instead..."
+        if ($IsDirectory) {
+            Copy-Item -Path $Src -Destination $Dest -Recurse -Force | Out-Null
+        } else {
+            Copy-Item -Path $Src -Destination $Dest -Force | Out-Null
+        }
+        Write-Host "Copied: $Dest"
+    }
+}
+
+Link-Or-Copy -Src "$repoRoot\.antigravity-plugin\plugin.json" -Dest "$pluginsDir\plugin.json"
+Link-Or-Copy -Src "$repoRoot\.antigravity-plugin\ANTIGRAVITY.md" -Dest "$pluginsDir\ANTIGRAVITY.md"
+Link-Or-Copy -Src "$repoRoot\skills" -Dest "$pluginsDir\skills" -IsDirectory
+
+Write-Host "Superpowers plugin installed successfully for Antigravity!"

--- a/scripts/install-antigravity.sh
+++ b/scripts/install-antigravity.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGINS_DIR="$HOME/.gemini/config/plugins/superpowers"
+
+if [ -d "$PLUGINS_DIR" ] || [ -L "$PLUGINS_DIR" ]; then
+    echo "Removing existing superpowers plugin directory at $PLUGINS_DIR..."
+    rm -rf "$PLUGINS_DIR"
+fi
+
+echo "Creating superpowers plugin directory at $PLUGINS_DIR..."
+mkdir -p "$PLUGINS_DIR"
+
+# Link files
+ln -sf "$REPO_ROOT/.antigravity-plugin/plugin.json" "$PLUGINS_DIR/plugin.json"
+ln -sf "$REPO_ROOT/.antigravity-plugin/ANTIGRAVITY.md" "$PLUGINS_DIR/ANTIGRAVITY.md"
+ln -sf "$REPO_ROOT/skills" "$PLUGINS_DIR/skills"
+
+echo "Superpowers plugin installed successfully for Antigravity!"

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -19,7 +19,7 @@ This is not negotiable. This is not optional. You cannot rationalize your way ou
 
 Superpowers skills override default system prompt behavior, but **user instructions always take precedence**:
 
-1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
+1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, ANTIGRAVITY.md, AGENTS.md, direct requests) — highest priority
 2. **Superpowers skills** — override default system behavior where they conflict
 3. **Default system prompt** — lowest priority
 
@@ -37,7 +37,7 @@ If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "alw
 
 ## Platform Adaptation
 
-Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-tools.md` (Copilot CLI), `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
+Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-tools.md` (Copilot CLI), `references/codex-tools.md` (Codex), or `references/antigravity-tools.md` (Antigravity CLI) for tool equivalents. Gemini/Antigravity CLI users get the tool mapping loaded automatically via GEMINI.md/ANTIGRAVITY.md.
 
 # Using Skills
 

--- a/skills/using-superpowers/references/antigravity-tools.md
+++ b/skills/using-superpowers/references/antigravity-tools.md
@@ -1,0 +1,38 @@
+# Antigravity CLI Tool Mapping
+
+Skills use Claude Code tool names. When you encounter these in a skill, use your platform equivalent:
+
+| Skill references | Antigravity CLI equivalent |
+|-----------------|----------------------|
+| `Read` (file reading) | `view_file` |
+| `Write` (file creation) | `write_to_file` |
+| `Edit` (file editing) | `replace_file_content` / `multi_replace_file_content` |
+| `Bash` (run commands) | `run_command` |
+| `Grep` (search file content) | `grep_search` |
+| `Glob` (search files by name) | `glob` |
+| `TodoWrite` (task tracking) | `write_todos` (or task/todo comments) |
+| `Skill` tool (invoke a skill) | `activate_skill` |
+| `WebSearch` | `search_web` |
+| `WebFetch` | `read_url_content` |
+| `Task` tool (dispatch subagent) | `invoke_subagent` / `define_subagent` (see [Subagent support](#subagent-support)) |
+
+## Subagent support
+
+Antigravity CLI supports subagents natively via the `invoke_subagent` and `define_subagent` tools. Use these tools to delegate specific, independent tasks to subagents.
+
+When a skill says to dispatch a named agent type:
+1. Define the subagent type if not already defined using `define_subagent`.
+2. Invoke the subagent using `invoke_subagent` with the prompt template from the skill filled with appropriate task details.
+3. Communicate using `send_message` when needed.
+
+| Skill instruction | Antigravity CLI equivalent |
+|-------------------|----------------------|
+| `Task tool (superpowers:implementer)` | `invoke_subagent` with `implementer` role and filled prompt |
+| `Task tool (superpowers:spec-reviewer)` | `invoke_subagent` with `spec-reviewer` role and filled prompt |
+| `Task tool (superpowers:code-reviewer)` | `invoke_subagent` with `code-reviewer` role and filled prompt |
+| `Task tool (superpowers:code-quality-reviewer)` | `invoke_subagent` with `code-quality-reviewer` role and filled prompt |
+| `Task tool (general-purpose)` | `invoke_subagent` with task-specific role and prompt |
+
+### Parallel dispatch
+
+Antigravity CLI supports parallel subagent execution. When a skill asks you to dispatch multiple independent tasks in parallel, define/invoke the subagents concurrently by specifying multiple subagent objects in the `Subagents` array of a single `invoke_subagent` call.


### PR DESCRIPTION
## What problem are you trying to solve?
Users of Google Antigravity CLI (agy) have no official way to install 
Superpowers as a plugin. This PR adds native Antigravity CLI support so 
users can install the full Superpowers skills library in one step.

## What does this PR change?
- Adds `.antigravity-plugin/` folder with `plugin.json` manifest and 
  `ANTIGRAVITY.md` bootstrap (follows the same pattern as `.claude-plugin/`, 
  `.codex-plugin/`, `.cursor-plugin/`)
- Adds `skills/using-superpowers/references/antigravity-tools.md` mapping 
  Claude Code tool names to Antigravity CLI equivalents
- Adds `scripts/install-antigravity.ps1` (Windows) and 
  `scripts/install-antigravity.sh` (macOS/Linux) one-step installers that 
  symlink the plugin into `~/.gemini/config/plugins/superpowers/`
- Updates `README.md` to document the Antigravity CLI install path
- Updates `SKILL.md` to reference `ANTIGRAVITY.md` and `antigravity-tools.md`

## Is this change appropriate for the core library?
Yes. It follows the exact same pattern already used for Claude Code, Codex, 
Cursor, and OpenCode — a hidden subfolder containing platform-specific 
manifest files, with zero changes to the core skills content.

## What alternatives did you consider?
- Placing `plugin.json` at the repo root (rejected — violates the clean-root 
  convention established by existing plugin dirs)
- A separate standalone repo (rejected — creates a maintenance burden and 
  version drift)

## Does this PR contain multiple unrelated changes?
No. All changes are directly related to adding Antigravity CLI support.

## Existing PRs
I have reviewed all open AND closed PRs for duplicates or prior art.
No prior Antigravity CLI support PRs found.

## Environment tested
| Harness | Harness version | Model | Model version |
|---------|----------------|-------|---------------|
| Antigravity CLI (agy) | latest | Gemini | gemini-2.5-pro |

## Evaluation
- Initial prompt: "Add Antigravity CLI plugin support to superpowers"
- Eval sessions run after change: 1
- The plugin loads correctly and the `using-superpowers` skill is injected 
  at session start via the `ANTIGRAVITY.md` bootstrap

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission