### PR TITLE
fix: make visual companion idle timeout configurable

### DIFF
--- a/skills/brainstorming/scripts/server.cjs
+++ b/skills/brainstorming/scripts/server.cjs
@@ -81,6 +81,14 @@ const CONTENT_DIR = path.join(SESSION_DIR, 'content');
 const STATE_DIR = path.join(SESSION_DIR, 'state');
 let ownerPid = process.env.BRAINSTORM_OWNER_PID ? Number(process.env.BRAINSTORM_OWNER_PID) : null;
 
+const DEFAULT_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+function getIdleTimeoutMs(value = process.env.BRAINSTORM_IDLE_TIMEOUT_MS) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return DEFAULT_IDLE_TIMEOUT_MS;
+  return parsed;
+}
+
 const MIME_TYPES = {
   '.html': 'text/html', '.css': 'text/css', '.js': 'application/javascript',
   '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg',
@@ -246,7 +254,7 @@ function broadcast(msg) {
 
 // ========== Activity Tracking ==========
 
-const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const IDLE_TIMEOUT_MS = getIdleTimeoutMs();
 let lastActivity = Date.now();
 
 function touchActivity() {
@@ -316,7 +324,7 @@ function startServer() {
     try { process.kill(ownerPid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
   }
 
-  // Check every 60s: exit if owner process died or idle for 30 minutes
+  // Check every 60s: exit if owner process died or the session is idle.
   const lifecycleCheck = setInterval(() => {
     if (!ownerAlive()) shutdown('owner process exited');
     else if (Date.now() - lastActivity > IDLE_TIMEOUT_MS) shutdown('idle timeout');
@@ -340,7 +348,8 @@ function startServer() {
     const info = JSON.stringify({
       type: 'server-started', port: Number(PORT), host: HOST,
       url_host: URL_HOST, url: 'http://' + URL_HOST + ':' + PORT,
-      screen_dir: CONTENT_DIR, state_dir: STATE_DIR
+      screen_dir: CONTENT_DIR, state_dir: STATE_DIR,
+      idle_timeout_ms: IDLE_TIMEOUT_MS
     });
     console.log(info);
     fs.writeFileSync(path.join(STATE_DIR, 'server-info'), info + '\n');
@@ -351,4 +360,4 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };
+module.exports = { computeAcceptKey, encodeFrame, decodeFrame, getIdleTimeoutMs, OPCODES };

--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start the brainstorm server and output connection info
-# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--foreground] [--background]
+# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--idle-timeout-minutes <minutes>] [--foreground] [--background]
 #
 # Starts server on a random high port, outputs JSON with URL.
 # Each session gets its own directory to avoid conflicts.
@@ -11,6 +11,8 @@
 #   --host <bind-host>    Host/interface to bind (default: 127.0.0.1).
 #                         Use 0.0.0.0 in remote/containerized environments.
 #   --url-host <host>     Hostname shown in returned URL JSON.
+#   --idle-timeout-minutes <minutes>
+#                         Override inactivity timeout (default: 120).
 #   --foreground          Run server in the current terminal (no backgrounding).
 #   --background          Force background mode (overrides Codex auto-foreground).
 
@@ -22,6 +24,7 @@ FOREGROUND="false"
 FORCE_BACKGROUND="false"
 BIND_HOST="127.0.0.1"
 URL_HOST=""
+IDLE_TIMEOUT_MINUTES=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project-dir)
@@ -34,6 +37,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --url-host)
       URL_HOST="$2"
+      shift 2
+      ;;
+    --idle-timeout-minutes)
+      IDLE_TIMEOUT_MINUTES="$2"
       shift 2
       ;;
     --foreground|--no-daemon)
@@ -50,6 +57,15 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+IDLE_TIMEOUT_MS=""
+if [[ -n "$IDLE_TIMEOUT_MINUTES" ]]; then
+  if ! [[ "$IDLE_TIMEOUT_MINUTES" =~ ^[0-9]+$ ]] || [[ "$IDLE_TIMEOUT_MINUTES" -eq 0 ]]; then
+    echo "{\"error\": \"--idle-timeout-minutes must be a positive integer\"}"
+    exit 1
+  fi
+  IDLE_TIMEOUT_MS=$((IDLE_TIMEOUT_MINUTES * 60 * 1000))
+fi
 
 if [[ -z "$URL_HOST" ]]; then
   if [[ "$BIND_HOST" == "127.0.0.1" || "$BIND_HOST" == "localhost" ]]; then
@@ -107,16 +123,26 @@ if [[ -z "$OWNER_PID" || "$OWNER_PID" == "1" ]]; then
   OWNER_PID="$PPID"
 fi
 
+SERVER_ENV=(
+  BRAINSTORM_DIR="$SESSION_DIR"
+  BRAINSTORM_HOST="$BIND_HOST"
+  BRAINSTORM_URL_HOST="$URL_HOST"
+  BRAINSTORM_OWNER_PID="$OWNER_PID"
+)
+if [[ -n "$IDLE_TIMEOUT_MS" ]]; then
+  SERVER_ENV+=(BRAINSTORM_IDLE_TIMEOUT_MS="$IDLE_TIMEOUT_MS")
+fi
+
 # Foreground mode for environments that reap detached/background processes.
 if [[ "$FOREGROUND" == "true" ]]; then
   echo "$$" > "$PID_FILE"
-  env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs
+  env "${SERVER_ENV[@]}" node server.cjs
   exit $?
 fi
 
 # Start server, capturing output to log file
 # Use nohup to survive shell exit; disown to remove from job table
-nohup env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs > "$LOG_FILE" 2>&1 &
+nohup env "${SERVER_ENV[@]}" node server.cjs > "$LOG_FILE" 2>&1 &
 SERVER_PID=$!
 disown "$SERVER_PID" 2>/dev/null
 echo "$SERVER_PID" > "$PID_FILE"

--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -91,11 +91,12 @@ scripts/start-server.sh \
 ```
 
 Use `--url-host` to control what hostname is printed in the returned URL JSON.
+Use `--idle-timeout-minutes` when a session may sit idle for longer than the 2-hour default.
 
 ## The Loop
 
 1. **Check server is alive**, then **write HTML** to a new file in `screen_dir`:
-   - Before each write, check that `$STATE_DIR/server-info` exists. If it doesn't (or `$STATE_DIR/server-stopped` exists), the server has shut down — restart it with `start-server.sh` before continuing. The server auto-exits after 30 minutes of inactivity.
+   - Before each write, check that `$STATE_DIR/server-info` exists. If it doesn't (or `$STATE_DIR/server-stopped` exists), the server has shut down — restart it with `start-server.sh` before continuing. The server auto-exits after 2 hours of inactivity by default; restart with `--idle-timeout-minutes` if the session needs a longer window.
    - Use semantic filenames: `platform.html`, `visual-style.html`, `layout.html`
    - **Never reuse filenames** — each screen gets a fresh file
    - Use your file-creation tool — **never use cat/heredoc** (dumps noise into terminal)

--- a/tests/brainstorm-server/server.test.js
+++ b/tests/brainstorm-server/server.test.js
@@ -16,6 +16,7 @@ const path = require('path');
 const assert = require('assert');
 
 const SERVER_PATH = path.join(__dirname, '../../skills/brainstorming/scripts/server.cjs');
+const { getIdleTimeoutMs } = require(SERVER_PATH);
 const TEST_PORT = 3334;
 const TEST_DIR = '/tmp/brainstorm-test';
 const CONTENT_DIR = path.join(TEST_DIR, 'content');
@@ -112,6 +113,26 @@ async function runTests() {
       assert.strictEqual(info.port, TEST_PORT);
       assert.strictEqual(info.screen_dir, CONTENT_DIR, 'screen_dir should point to content/');
       assert.strictEqual(info.state_dir, STATE_DIR, 'state_dir should point to state/');
+      assert.strictEqual(info.idle_timeout_ms, 2 * 60 * 60 * 1000, 'should report default idle timeout');
+      return Promise.resolve();
+    });
+
+    await test('defaults idle timeout to 2 hours', () => {
+      assert.strictEqual(getIdleTimeoutMs(undefined), 2 * 60 * 60 * 1000);
+      assert.strictEqual(getIdleTimeoutMs(''), 2 * 60 * 60 * 1000);
+      return Promise.resolve();
+    });
+
+    await test('accepts positive BRAINSTORM_IDLE_TIMEOUT_MS values', () => {
+      assert.strictEqual(getIdleTimeoutMs('900000'), 900000);
+      assert.strictEqual(getIdleTimeoutMs('1'), 1);
+      return Promise.resolve();
+    });
+
+    await test('ignores invalid BRAINSTORM_IDLE_TIMEOUT_MS values', () => {
+      assert.strictEqual(getIdleTimeoutMs('0'), 2 * 60 * 60 * 1000);
+      assert.strictEqual(getIdleTimeoutMs('-1'), 2 * 60 * 60 * 1000);
+      assert.strictEqual(getIdleTimeoutMs('not-a-number'), 2 * 60 * 60 * 1000);
       return Promise.resolve();
     });
 
@@ -407,6 +428,19 @@ async function runTests() {
       assert(template.includes('indicator-text'), 'Should have indicator text');
       assert(template.includes('<!-- CONTENT -->'), 'Should have content placeholder');
       assert(template.includes('frame-content'), 'Should have content container');
+      return Promise.resolve();
+    });
+
+    // ========== start-server.sh Configuration ==========
+    console.log('\n--- start-server.sh Configuration ---');
+
+    await test('start-server.sh exposes idle timeout configuration', () => {
+      const script = fs.readFileSync(
+        path.join(__dirname, '../../skills/brainstorming/scripts/start-server.sh'), 'utf-8'
+      );
+      assert(script.includes('--idle-timeout-minutes'), 'Should document idle timeout flag');
+      assert(script.includes('IDLE_TIMEOUT_MINUTES'), 'Should parse timeout minutes');
+      assert(script.includes('BRAINSTORM_IDLE_TIMEOUT_MS'), 'Should pass timeout to server process');
       return Promise.resolve();
     });
 


### PR DESCRIPTION
## What problem are you trying to solve?

Issue #1237 reports that the visual companion server silently exits after 30 minutes of inactivity during brainstorming. From the user's side the browser becomes unreachable, while the agent can keep referring to the stale URL as if the companion is still live. That breaks longer brainstorming sessions where a user may pause to think, talk with someone, or do parallel work.

Current `dev` hardcodes the timeout in `skills/brainstorming/scripts/server.cjs`:

```js
const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
```

The start script has no launch-time override, and the visual companion guide documents the 30-minute timeout as fixed behavior.

## What does this PR change?

This PR raises the default idle timeout to 2 hours and makes it configurable:

- `server.cjs` now reads a positive `BRAINSTORM_IDLE_TIMEOUT_MS` override, falls back to a 2-hour default, and includes `idle_timeout_ms` in the startup JSON / `state/server-info`.
- `start-server.sh` accepts `--idle-timeout-minutes <minutes>`, validates it as a positive integer, and passes the converted millisecond value to the server.
- `visual-companion.md` documents the 2-hour default and the new override flag.
- `server.test.js` covers the new default, override parsing, invalid values, startup JSON, and start-script exposure.

## Is this change appropriate for the core library?

Yes. This is core visual companion runtime behavior, applies across projects and harnesses, and does not add dependencies or integrate any third-party service. It addresses a real observed Superpowers visual companion failure mode rather than project-specific configuration.

## What alternatives did you consider?

1. Remove the idle timeout entirely. I rejected that because the timeout still protects users from orphaned local servers if the owner process check is unavailable or disabled.
2. Add a tombstone page at the last URL. That would improve UX but is a broader browser/server behavior change; this PR keeps to the smallest fix for the observed premature expiry.
3. Add a hard skill-process step requiring agents to check `server-info` before every mention of the URL. The guide already tells agents to check server liveness before writing; strengthening behavior-shaping prose would require more adversarial eval. This PR instead fixes the runtime timeout that caused the reported 45-minute session to break.

## Does this PR contain multiple unrelated changes?

No. All changes support one behavior: visual companion sessions should not silently expire after only 30 minutes, and longer sessions should be configurable at launch.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

I searched all open and closed PRs for:

- `1237 visual companion timeout expires inactivity server stopped`
- `visual companion idle timeout`
- `brainstorm companion timeout`

No existing PR addressing this timeout/configurability issue was found.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Local shell / Node test runtime | Node v22.14.0; npm test in `tests/brainstorm-server` | N/A | Runtime and script tests only |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add or modify harness support.

## Evaluation

Initial prompt/context: during issue triage, #1237 was selected as the next high-value issue because it has a concrete reported user failure and no duplicate PR. The goal was to keep the fix narrow: runtime timeout behavior, not a broad skill-flow rewrite.

Baseline before implementation:

After adding tests first, `npm test` in `tests/brainstorm-server` failed because `state/server-info` did not include `idle_timeout_ms`; expected `7200000`, actual was `undefined`. This confirmed the test covered the missing runtime behavior.

After implementation:

```bash
npm test
```

Result: `29 passed, 0 failed`.

Additional verification:

```bash
node tests/brainstorm-server/ws-protocol.test.js
```

Result: `31 passed, 0 failed`.

```bash
skills/brainstorming/scripts/start-server.sh --project-dir /tmp/brainstorm-idle-timeout-pr-test --idle-timeout-minutes 5 --background
```

The returned startup JSON included `"idle_timeout_ms":300000`; the test server was then stopped with `stop-server.sh`.

```bash
skills/brainstorming/scripts/start-server.sh --idle-timeout-minutes 0
skills/brainstorming/scripts/start-server.sh --idle-timeout-minutes abc
```

Both returned `{"error": "--idle-timeout-minutes must be a positive integer"}` and exited non-zero.

```bash
bash -n skills/brainstorming/scripts/start-server.sh skills/brainstorming/scripts/stop-server.sh
git diff --check
```

Both passed.

I also ran `bash tests/brainstorm-server/windows-lifecycle.test.sh`; it fails on current `dev` before reaching this change's behavior because the test script points at `skills/brainstorming/scripts/server.js`, while the current server file is `server.cjs`. That pre-existing test drift is handled separately in #1592, so I did not bundle it into this PR.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This PR changes runtime code and a factual visual companion guide line. It does not alter the `brainstorming` skill's hard gates, rationalization tables, or process rules. I used the RED/GREEN discipline from `superpowers:writing-skills` for the skill-adjacent doc update: write failing runtime/script tests first, implement the minimum runtime behavior, then update the guide to match the new behavior. I did not run adversarial multi-session evals because this PR does not attempt to change agent decision policy.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

The complete diff was shown before submission. The human partner previously instructed me to treat shown diffs as reviewed for these PRs unless they say otherwise.
