### PR TITLE
docs: add eval evidence guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ The general contribution process for Superpowers is below. Keep in mind that we 
 2. Switch to the 'dev' branch
 3. Create a branch for your work
 4. Follow the `writing-skills` skill for creating and testing new and modified skills
-5. Submit a PR, being sure to fill in the pull request template.
+5. Package your test and eval results using `docs/eval-evidence.md`
+6. Submit a PR, being sure to fill in the pull request template.
 
 Skill-behavior tests use the eval harness submodule at `evals/`. After cloning this repo, run `git submodule update --init evals`, then see `evals/README.md` for setup. Plugin-infrastructure tests live at `tests/` and run via the relevant `run-*.sh` or `npm test`.
 

--- a/docs/eval-evidence.md
+++ b/docs/eval-evidence.md
@@ -1,0 +1,162 @@
+# Eval Evidence for Superpowers PRs
+
+Superpowers changes are reviewed on evidence, not confidence. This guide
+describes the evidence packet to include in pull requests so reviewers can see
+what failed before, what changed after, and what limits still remain.
+
+This complements the pull request template and `skills/writing-skills/SKILL.md`.
+It does not replace skill testing, plugin tests, or harness transcripts.
+
+## Evidence Packet
+
+Use this structure in the PR `Evaluation` and `Rigor` sections.
+
+1. **Initial trigger**
+   - What user prompt, issue, transcript, or code path led to the change?
+   - What exact failure mode did you observe?
+
+2. **Baseline behavior**
+   - Show what happens before the change.
+   - For code bugs, include the failing command or regression test.
+   - For skill behavior, include the RED run or transcript summary.
+   - For docs-only changes, name the ambiguity or missing guidance the docs fix.
+
+3. **Change boundary**
+   - State what this PR changes and what it deliberately does not change.
+   - If the linked issue has multiple concerns, name the one concern this PR
+     addresses.
+
+4. **After behavior**
+   - Show the command, transcript, or check that demonstrates the new behavior.
+   - Prefer exact commands and short output summaries over prose claims.
+
+5. **Adversarial or edge evidence**
+   - For behavior-shaping skill changes, run pressure scenarios as described in
+     `skills/writing-skills/testing-skills-with-subagents.md`.
+   - For runtime code, include edge-case regression tests when practical.
+   - For docs-only changes, disclose that no behavioral eval was run unless one
+     actually was.
+
+6. **Verification commands**
+   - List the commands run immediately before opening the PR.
+   - Include failures honestly, especially if a failure is unrelated or caused by
+     local environment limits.
+
+7. **Limits and follow-ups**
+   - State what the evidence does not prove.
+   - Do not check rigor boxes that the evidence does not support.
+
+## Evidence by Change Type
+
+| Change type | Minimum evidence | Strong evidence |
+| --- | --- | --- |
+| Runtime bugfix | Failing regression or live repro, then passing regression | Negative control showing the test fails without the fix |
+| Hook or installer fix | Isolated fixture plus parser/exit-code check | Same fixture across affected harness variants |
+| Skill behavior change | RED baseline, GREEN run, pressure scenario | Multiple fresh sessions with transcript summaries |
+| Skill docs clarification | Before ambiguity plus after static checks | Fresh-session retrieval test showing the guidance is found |
+| New harness support | Required clean-session transcript from the PR template | Additional install/update/uninstall smoke checks |
+| Docs-only contributor guidance | Static checks plus clear before/after documentation gap | Reviewer checklist or example PR body using the guidance |
+
+## Templates
+
+### Runtime Bugfix
+
+```markdown
+## Evaluation
+
+Initial trigger: <issue or observed failure>
+
+Baseline:
+- Command: `<command>`
+- Result before fix: `<failure summary>`
+
+After:
+- Command: `<command>`
+- Result after fix: `<pass summary>`
+
+Adversarial or edge coverage:
+- `<edge case covered>`
+
+Limits:
+- `<what this does not cover>`
+```
+
+### Skill Behavior Change
+
+```markdown
+## Evaluation
+
+Initial trigger: <prompt or issue>
+
+RED baseline:
+- Scenario: <pressure scenario>
+- Observed failure: <verbatim or summarized transcript evidence>
+
+GREEN:
+- Scenario: <same scenario with changed skill>
+- Observed behavior: <how the agent now complies>
+
+Pressure testing:
+- Pressures used: <time pressure, authority pressure, sunk cost, etc.>
+- Result: <pass/fail summary>
+
+Limits:
+- <number of sessions, harnesses not tested, remaining risks>
+```
+
+### Docs-Only Guidance
+
+```markdown
+## Evaluation
+
+Initial trigger: <review gap, repeated PR issue, or missing guidance>
+
+Before:
+- Existing docs explain <what they already cover>
+- Missing piece: <what contributors still had to infer>
+
+After:
+- Added <file/section>
+- Linked from <entry point>
+
+Verification:
+- `<markdown/static check command>`
+
+Limits:
+- This does not prove behavior changes in live agent sessions.
+```
+
+## Common Mistakes
+
+**Claiming "works" without a baseline**
+
+Reviewers need to know what failed before. A passing command after the change is
+not enough when the test did not fail before the change.
+
+**Bundling unrelated evidence**
+
+Evidence should support the specific PR. If a command verifies a different
+issue or another PR, label it as contextual, not acceptance evidence.
+
+**Checking rigor boxes too broadly**
+
+If you did not run adversarial pressure testing, leave that box unchecked and
+explain why. Honest limits are better than overstated rigor.
+
+**Using transcript volume instead of findings**
+
+Do not paste huge transcripts into the PR body. Summarize the relevant moments
+and include enough exact wording to support the claim. For new harness support,
+follow the PR template and include the required complete transcript.
+
+**Treating docs-only changes as skill evals**
+
+Docs-only contributor guidance can be reviewed with static checks and clear
+examples. Do not claim live behavior evidence unless you ran live behavior evals.
+
+## Relationship to Existing Tests
+
+- Use `docs/testing.md` to choose and run plugin tests or skill behavior evals.
+- Use `skills/writing-skills/testing-skills-with-subagents.md` for pressure
+  testing behavior-shaping skill changes.
+- Use this document to package the resulting evidence for reviewers.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,3 +32,10 @@ uv run drill run triggering-test-driven-development -b claude
 ```
 
 Drill scenarios are slow (3-30+ minutes each) and run real LLM sessions. They are not part of CI today; the natural follow-up is a tiered model (fast subset on PR, full sweep nightly + on-demand).
+
+## Reporting Evidence in PRs
+
+After running tests or evals, package the results for reviewers using
+`docs/eval-evidence.md`. That guide explains how to summarize baseline
+behavior, after-change behavior, adversarial coverage, verification commands,
+and known limits in the pull request template.


### PR DESCRIPTION
## What problem are you trying to solve?

The PR template asks contributors to show evaluation, rigor, and adversarial evidence, and `writing-skills` explains RED/GREEN pressure testing for skill work. But contributors still have to infer how to package that evidence for reviewers across different change types.

That makes review harder than it needs to be: useful evidence can be buried in prose, a baseline can be missing, or a docs-only PR can overclaim behavior evidence it did not run. #1597 proposes standardizing this evidence before attempting larger workflow-state or preference features.

## What does this PR change?

Adds `docs/eval-evidence.md`, a contributor-facing guide for packaging PR evidence. It defines a reusable evidence packet, a change-type evidence matrix, and short templates for runtime bugfixes, skill behavior changes, and docs-only guidance. It also links the guide from the README contribution steps and `docs/testing.md`.

## Is this change appropriate for the core library?

Yes. This is contributor infrastructure for all Superpowers changes. It is not project-specific, harness-specific, or tied to a third-party service, and it does not change runtime or skill behavior.

## What alternatives did you consider?

1. **Put this directly in the PR template.** Rejected because the PR template is already long and should stay focused on required fields. A separate guide can include examples without making every PR body heavier.
2. **Put this inside `writing-skills`.** Rejected because the guidance applies to runtime bugs, hook/installer fixes, harness support, and docs-only contributor guidance, not only skill authorship.
3. **Wait for a workflow-state proposal.** Rejected because evaluation packaging is useful immediately and is a lower-risk first step before larger state/preference work.
4. **Do nothing.** Rejected because current evidence expectations exist, but the shape of a good evidence packet is still implicit.

## Does this PR contain multiple unrelated changes?

No. All changes support one concern: helping contributors present test and eval evidence in a reviewer-friendly format.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found that add an eval evidence guide or `docs/eval-evidence.md`

Related prior art and nearby work:

- #1473 contains a detailed evaluation section for a plan-review skill, but it does not add reusable contributor guidance.
- #1274 and #1512 are examples of PRs where evaluation/rigor disclosure matters, but they do not standardize the format for future contributors.
- #1597 is the RFC issue opened for sequencing eval evidence before workflow state and preferences.

Searches run included exact terms for `docs/eval-evidence.md`, `Eval Evidence for Superpowers PRs`, and `evidence packet`; no direct duplicate was found.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Local shell documentation checks | macOS zsh/bash | N/A | N/A |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add or modify harness support.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
N/A - this PR does not add a new harness.
```

</details>

## Evaluation

- Initial trigger: my human partner asked me to plan and execute the next useful feature direction for Superpowers. Discussions are disabled on the repository, so I opened #1597 as an RFC issue and then started with the lowest-risk first phase: contributor evidence guidance.
- Eval sessions after making the change: 0 live model eval sessions. This is docs-only contributor guidance, not behavior-shaping skill text.
- Before: README pointed contributors to `writing-skills`, the eval harness, and the PR template, but there was no focused guide that explained how to package baseline, after-change, adversarial, verification, and limits evidence for reviewers.
- After: `docs/eval-evidence.md` gives a standard evidence packet, change-type matrix, templates, and common mistakes; README and `docs/testing.md` link to it from the contribution/test flow.

Verification commands run:

```bash
git diff --cached --check
git diff --check HEAD~1 HEAD
test -f docs/eval-evidence.md
rg -n "docs/eval-evidence.md|Eval Evidence for Superpowers PRs|Reporting Evidence in PRs" README.md docs/testing.md docs/eval-evidence.md
```

All commands exited 0.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is a docs-only contributor guide. It does not modify skill behavior, Red Flags tables, rationalization guidance, or any prompt used by agents. The unchecked boxes are intentional because no live adversarial model eval was run or needed for a docs-only guide.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

The complete staged diff was shown before submission. The human partner previously instructed me to treat shown diffs as reviewed for these PRs unless they say otherwise.

Refs #1597.
