### PR TITLE
@mhat reported that his claude got confused about 'debugging' being n…

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -102,15 +102,15 @@ These thoughts mean STOP—you're rationalizing:
 
 When multiple skills could apply, use this order:
 
-1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
+1. **Process skills first** (brainstorming, systematic-debugging) - these determine HOW to approach the task
 2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
 
 "Let's build X" → brainstorming first, then implementation skills.
-"Fix this bug" → debugging first, then domain-specific skills.
+"Fix this bug" → systematic-debugging first, then domain-specific skills.
 
 ## Skill Types
 
-**Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline.
+**Rigid** (TDD, systematic-debugging): Follow exactly. Don't adapt away discipline.
 
 **Flexible** (patterns): Adapt principles to context.
 


### PR DESCRIPTION
@mhat's claude reported:

```
Honest answer, and I'll separate the two because they have different causes — one I can trace in context, one I mostly can't.  superpowers:debugging — traceable. The SessionStart hook injected the full text of the superpowers:using-superpowers skill. Two things in that text fed the guess:

  1. The hook introduced it as "your superpowers:using-superpowers skill" — so I had a confirmed example of the superpowers: namespace prefix.
  2. The skill body names "debugging" as a skill, twice:
  ▎ "Process skills first (brainstorming, debugging)"
  ▎ "'Fix this bug' → debugging first, then domain-specific skills."
```