### PR TITLE
docs: define plan status contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The Pi package loads the Superpowers skills and a small extension that injects t
 
 2. **using-git-worktrees** - Activates after design approval. Creates isolated workspace on new branch, runs project setup, verifies clean test baseline.
 
-3. **writing-plans** - Activates with approved design. Breaks work into bite-sized tasks (2-5 minutes each). Every task has exact file paths, complete code, verification steps.
+3. **writing-plans** - Activates with approved design. Breaks work into bite-sized tasks (2-5 minutes each). Every task has exact file paths, complete code, verification steps. Plans follow the [plan status contract](docs/plan-status.md), which defines how task progress and resume targets should be represented.
 
 4. **subagent-driven-development** or **executing-plans** - Activates with plan. Dispatches fresh subagent per task with two-stage review (spec compliance, then code quality), or executes in batches with human checkpoints.
 

--- a/docs/plan-status.md
+++ b/docs/plan-status.md
@@ -1,0 +1,143 @@
+# Plan Status Contract
+
+Superpowers plans are markdown files written for humans first. Agents should be
+able to recover progress from the same file without a new slash command, a
+separate state database, or brittle transcript parsing.
+
+This document defines the lightweight status contract for generated plans. It
+is intentionally small: task headings and step checkboxes are the durable state,
+with optional status notes for cases a checkbox cannot express.
+
+## Goals
+
+- Show which tasks are pending, in progress, done, blocked, or skipped.
+- Let a later session resume from the next unfinished task without reading an
+  entire long plan into context.
+- Keep plan files readable in plain markdown and GitHub.
+- Avoid adding a new command surface. Users should still be able to ask the
+  agent for status or continuation in ordinary language.
+
+## Non-Goals
+
+- This is not a task database.
+- This does not require parsing chat transcripts or tool logs.
+- This does not define a new slash command.
+- This does not make execution agents update status automatically yet.
+
+## Plan Structure
+
+Plan documents should keep the existing generated shape:
+
+```markdown
+# Feature Name Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One sentence.
+
+**Architecture:** Two or three sentences.
+
+**Tech Stack:** Key technologies.
+
+---
+
+### Task 1: First Component
+
+**Files:**
+- Create: `src/example.py`
+- Test: `tests/test_example.py`
+
+- [ ] **Step 1: Write the failing test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+```
+
+The status contract depends on:
+
+- The document header before the first task.
+- Stable task headings in the form `### Task N: Name`.
+- Checkbox steps under each task using `- [ ]` and `- [x]`.
+- Optional task metadata lines directly below the task heading.
+
+## Status Rules
+
+Agents should compute task status from the task body:
+
+| Status | Rule |
+| --- | --- |
+| `pending` | The task has no checked steps and no explicit `Status` line. |
+| `in_progress` | The task has a mix of checked and unchecked steps. |
+| `done` | Every required step checkbox in the task is checked. |
+| `blocked` | The task has `**Status:** blocked - reason`. |
+| `skipped` | The task has `**Status:** skipped - reason`. |
+
+Use `done`, not a separate `complete` spelling. Use `pending`, not `todo`, for
+not-started tasks.
+
+Explicit `blocked` and `skipped` status lines are authoritative when checkbox
+state is ambiguous. If every required checkbox is checked but the task still has
+an explicit `blocked` or `skipped` status line, agents should report the
+conflict instead of silently choosing one state.
+
+## Optional Metadata
+
+When checkbox state is not enough, agents may add metadata directly below the
+task heading:
+
+```markdown
+### Task 3: Migration
+
+**Status:** blocked - waiting for the API schema decision in issue #123
+**Evidence:** `npm test -- migration.test.ts`, failing on missing schema field
+**Next:** Re-run the schema generator after #123 is resolved.
+```
+
+Supported metadata:
+
+- `**Status:** blocked - reason`
+- `**Status:** skipped - reason`
+- `**Evidence:** command, file, commit, PR, or issue reference`
+- `**Next:** one concrete next action`
+
+Do not add metadata for ordinary `pending`, `in_progress`, or `done` tasks if
+checkboxes already describe the state.
+
+## Resume Target
+
+When asked to continue a plan, an agent should choose the resume target in this
+order:
+
+1. The first `in_progress` task.
+2. The first `pending` task.
+3. The first `blocked` task only if the blocker has been resolved.
+
+Within a task, resume at the first unchecked step. If every task is `done` or
+`skipped`, the agent should move to finishing the development branch instead of
+starting new implementation work.
+
+## Context-Frugal Reading
+
+For long plans, agents should avoid loading the whole file when the user only
+asks for status or continuation:
+
+1. Read the document header.
+2. Scan task headings and checkbox summaries.
+3. Read only the current resume target task in full.
+
+This keeps the workflow compatible with ordinary conversation while addressing
+large-plan context usage.
+
+## Eval Evidence
+
+Behavior changes that consume this contract should include fixtures for:
+
+- A fresh plan where every task is `pending`.
+- A partially completed plan with one `in_progress` task.
+- A plan with a `blocked` task and a later `pending` task.
+- A plan where every required task is `done`.
+- A stale status line that conflicts with checkbox state.
+
+The expected behavior should state which task and step the agent resumes from,
+and what it reports to the user.

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -17,17 +17,27 @@ Load plan, review critically, execute all tasks, report when complete.
 
 ### Step 1: Load and Review Plan
 1. Read plan file
-2. Review critically - identify any questions or concerns about the plan
-3. If concerns: Raise them with your human partner before starting
-4. If no concerns: Create todos for the plan items and proceed
+2. Apply the [plan status contract](../../docs/plan-status.md): scan task
+   headings, checkbox steps, and any `Status` / `Evidence` / `Next` metadata
+3. If continuing a partially executed plan, choose the resume target from the
+   first `in_progress` task, then the first `pending` task, then a `blocked`
+   task only if its blocker has been resolved
+4. Review critically - identify any questions or concerns about the plan or its
+   current status
+5. If concerns: Raise them with your human partner before starting
+6. If no concerns: Create todos for the remaining plan items and proceed
 
 ### Step 2: Execute Tasks
 
 For each task:
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
-3. Run verifications as specified
-4. Mark as completed
+3. Update the plan checkbox after each completed step when editing the plan file
+   is possible
+4. Run verifications as specified
+5. If blocked or skipped, add a `Status`, `Evidence`, and `Next` note using the
+   plan status contract
+6. Mark as completed
 
 ### Step 3: Complete Development
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -60,12 +60,12 @@ digraph process {
         "Mark task complete in todo list" [shape=box];
     }
 
-    "Read plan, extract all tasks with full text, note context, create todos" [shape=box];
+    "Read plan, apply status contract, extract remaining tasks with full text, note context, create todos" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent for entire implementation" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
-    "Read plan, extract all tasks with full text, note context, create todos" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Read plan, apply status contract, extract remaining tasks with full text, note context, create todos" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
     "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
     "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
@@ -85,6 +85,33 @@ digraph process {
     "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
 }
 ```
+
+## Plan Status
+
+Before dispatching subagents, the controller applies the
+[plan status contract](../../docs/plan-status.md):
+
+1. Scan task headings, checkbox steps, and any `Status` / `Evidence` / `Next`
+   metadata.
+2. If continuing a partially executed plan, resume from the first
+   `in_progress` task, then the first `pending` task, then a `blocked` task
+   only if its blocker has been resolved.
+3. Extract only the remaining task text needed for dispatch, while preserving
+   any earlier completed-task context that affects later work.
+4. Create todos for the remaining tasks, not for tasks that are already `done`
+   or `skipped`.
+
+The controller still provides full task text to each subagent. Do not make
+subagents read the full plan file.
+
+After each task is approved by both reviewers:
+
+1. Mark the task complete in the todo list.
+2. Update the plan checkboxes for that task when editing the plan file is
+   possible.
+3. If a task is blocked or skipped, add a `Status`, `Evidence`, and `Next` note
+   using the plan status contract before stopping or moving to the next valid
+   task.
 
 ## Model Selection
 
@@ -131,8 +158,9 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 You: I'm using Subagent-Driven Development to execute this plan.
 
 [Read plan file once: docs/superpowers/plans/feature-plan.md]
-[Extract all 5 tasks with full text and context]
-[Create todos for all tasks]
+[Apply the plan status contract]
+[Extract remaining tasks with full text and context]
+[Create todos for remaining tasks]
 
 Task 1: Hook installation script
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -60,6 +60,11 @@ This structure informs the task decomposition. Each task should produce self-con
 ---
 ```
 
+Plans should keep task headings and checkbox steps compatible with the
+[plan status contract](../../docs/plan-status.md). That contract lets later
+sessions report progress and resume from the next unfinished task without a
+new slash command or separate state file.
+
 ## Task Structure
 
 ````markdown


### PR DESCRIPTION
## Summary

- Add `docs/plan-status.md` with a lightweight markdown contract for plan task status.
- Define status derivation from task headings, checkbox steps, optional `Status` / `Evidence` / `Next` metadata, and conflict handling.
- Document context-frugal resume behavior without adding a new slash command or separate state store.
- Link the contract from the README and `writing-plans` skill.
- Connect `executing-plans` and `subagent-driven-development` to the contract so they scan existing status, resume from the right task, and update plan state when possible.

## Why

Refs #1599, #1075, #931, and #1597.

This keeps the user-facing model as ordinary conversation instead of adding a new slash command. The first PR stays docs/skill-instructions only: it gives reviewers a narrow contract and execution workflow to validate before any follow-up runtime or eval harness work.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `test -f docs/plan-status.md`
- `rg -ni "plan status contract|docs/plan-status.md|\.\./\.\./docs/plan-status.md|blocked|skipped" README.md skills/writing-plans/SKILL.md docs/plan-status.md`
- `rg -n "plan status contract|blocked.*resolved|remaining tasks|Do not make subagents read|current status" skills/executing-plans/SKILL.md skills/subagent-driven-development/SKILL.md docs/plan-status.md README.md`
