### PR TITLE
docs: correct heading numbering in markdown

### DIFF
--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -275,7 +275,7 @@ wc -w skills/path/SKILL.md
 - `creating-skills`, `testing-skills`, `debugging-with-logs`
 - Active, describes the action you're taking
 
-### 4. Cross-Referencing Other Skills
+### 5. Cross-Referencing Other Skills
 
 **When writing documentation that references other skills:**
 


### PR DESCRIPTION
## What problem are you trying to solve?

A markdown heading number was incorrectly labeled, causing the section order to be inconsistent.

## What does this PR change?

Very small documentation-only adjustment:

- Fix heading numbering from `4` to `5`
- Keep markdown section ordering consistent

## Does this PR contain multiple unrelated changes?

No. This PR only includes a minor markdown numbering correction.

## Existing PRs
- [x] I have reviewed related PRs
- Related PRs: none found

## Human review
- [x] A human has reviewed the complete diff before submission