### PR TITLE
fix(hooks): probe per-user Git for Windows and Scoop bash before PATH fallback

### DIFF
--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -26,8 +26,22 @@ if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
     "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
     exit /b %ERRORLEVEL%
 )
+REM Per-user Git for Windows installer (Standalone Installer "Only for me")
+if exist "%LOCALAPPDATA%\Programs\Git\bin\bash.exe" (
+    "%LOCALAPPDATA%\Programs\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+REM Scoop user installs (e.g. `scoop install git`)
+if exist "%USERPROFILE%\scoop\apps\git\current\usr\bin\bash.exe" (
+    "%USERPROFILE%\scoop\apps\git\current\usr\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
 
-REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
+REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin).
+REM Note: on systems where Git Bash is not installed in any of the standard
+REM locations above, `where bash` may resolve to C:\Windows\System32\bash.exe
+REM (the WSL launcher), which fails on Windows-style script paths. The
+REM explicit probes above must therefore be exhausted first.
 where bash >nul 2>nul
 if %ERRORLEVEL% equ 0 (
     bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9


### PR DESCRIPTION
## What problem are you trying to solve?

On Windows installs where Git Bash is **not** in `C:\Program Files\Git\` or `C:\Program Files (x86)\Git\` — for example, the per-user "Only for me" Git for Windows installer (`%LOCALAPPDATA%\Programs\Git`) or the Scoop `git` package (`%USERPROFILE%\scoop\apps\git\current\usr\bin`) — `hooks/run-hook.cmd` skips both standard probes and falls through to `where bash`.

On a stock Windows 10/11 install, the first `bash` returned by `where bash` is `C:\Windows\System32\bash.exe` — the WSL launcher. WSL's `bash` cannot execute Windows-style script paths like `C:\Users\<name>\.cursor\plugins\...\hooks\session-start` and immediately fails with:

```
/bin/bash: C:\Users\...\hooks\session-start: No such file or directory
```

`run-hook.cmd` exits 0 because that's the original `where bash`-fallback behavior, so the **`SessionStart` hook silently fails** and Superpowers' `using-superpowers` bootstrap context is never injected into the session. From the user's perspective skills auto-trigger inconsistently or not at all, with no surfaced error.

This was reported and reproduced live on Cursor + Windows 11 + PowerShell 7 with Git installed via Scoop. It also matches the symptom previously reported in #912 (closed as "covered by #1054"), which fixed `hooks-cursor.json` invocation but did **not** address the bash-discovery failure inside `run-hook.cmd` itself.

Reproduction (PowerShell, Scoop-only Git):

```powershell
$env:CURSOR_PLUGIN_ROOT = "<plugin-root>"
& "$env:CURSOR_PLUGIN_ROOT\hooks\run-hook.cmd" session-start
# /bin/bash: <plugin-root>\hooks\session-start: No such file or directory
# EXIT=0   <-- silent failure, hook never produced JSON
```

After the patch:

```
{
  "additional_context": "<EXTREMELY_IMPORTANT>\nYou have superpowers..."
EXIT=0  (5920 chars of valid JSON)
```

## What does this PR change?

Adds two explicit `if exist` probes between the existing system-wide Git for Windows checks and the `where bash` fallback, in the Windows CMD branch of `hooks/run-hook.cmd`:

1. `%LOCALAPPDATA%\Programs\Git\bin\bash.exe` — Git for Windows "Only for me" / per-user installer.
2. `%USERPROFILE%\scoop\apps\git\current\usr\bin\bash.exe` — Scoop `git` package.

Also adds a comment to the `where bash` fallback explaining the WSL-launcher trap (`C:\Windows\System32\bash.exe`), so future maintainers understand why explicit probes must be exhausted first.

## Is this change appropriate for the core library?

Yes. `run-hook.cmd` is the core hook entry point used by **every** Superpowers user on Windows (Claude Code, Cursor, Codex, Copilot CLI, OpenCode). Per-user Git for Windows installations and Scoop installs are both first-party-supported Git distributions on Windows, and the latter is the default `winget`-recommended path for many developers who don't have admin rights. The fix is 12 lines of `if exist` blocks, no new dependencies, no skill/content changes, and no behavior change for users who already work today.

## What alternatives did you consider?

1. **Skip `C:\Windows\System32\bash.exe` inside the `where bash` fallback.** This would also fix the symptom and additionally cover obscure Git Bash install locations (e.g. MSYS2, Cygwin under `C:\msys64\usr\bin`). However it requires `setlocal enabledelayedexpansion` plus a `for /f`/`findstr` loop, materially expanding the diff and conflicting on the same lines as open PR #1175. I deliberately kept this PR narrow — explicit probes only — so it can land cleanly alongside #1175 and so the change is trivially reviewable. A WSL-skip can follow up if maintainer wants.
2. **Detect `bash` via `git --exec-path` or `git config --get pathspec`.** Requires `git` to be on PATH and adds a process spawn per hook invocation. Probing well-known directories with `if exist` is cheaper, deterministic, and parallel to how the existing code already works.
3. **Document the requirement and ask Scoop/per-user users to add `C:\Program Files\Git` symlinks.** Not actionable — most affected users have no admin rights (which is why they used a per-user installer in the first place).

## Does this PR contain multiple unrelated changes?

No. Single concern: extending the explicit-probe list in `run-hook.cmd` so SessionStart hooks succeed on common per-user Git Bash installs. One file changed, +15/-1 lines.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1054 (merged — fixed `hooks-cursor.json` invocation), #1175 (open — fixes `%~1` quoting on spaced paths), #1250, #1280 (closed dups of #1054). No PR addresses bash discovery beyond the two `Program Files` paths.

#1175 also touches `run-hook.cmd` but on different lines (the `bash` invocation arguments, not the probe list). The diffs are textually adjacent but functionally orthogonal — both fixes are needed.

Related issues: #871 (closed), #912 (closed), #1449 (closed), #1142 (open). #912 in particular described the WSL-launcher-on-PATH symptom and was closed as "covered by #1054"; the present PR closes the residual gap that #1054 did not touch.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Cursor | 3.2.16 (Windows 11) | Claude (Opus 4.7 via Cursor) | n/a |

Manual end-to-end on the affected machine:

- **Before patch:** `run-hook.cmd session-start` → bash from `C:\Windows\System32\bash.exe` (WSL) → `No such file or directory`, exit 0, no JSON. SessionStart silently fails. Cursor additionally pops the Windows "Open with…" dialog every session because `hooks-cursor.json` in superpowers 5.0.7 still invokes the extensionless `./hooks/session-start` directly (this latter symptom is fixed in 5.1.0 by #1054).
- **After patch (with 5.1.0's `hooks-cursor.json` already in place):** `run-hook.cmd session-start` → Scoop bash at `%USERPROFILE%\scoop\apps\git\current\usr\bin\bash.exe` → exit 0, 5920 chars of valid JSON containing `additional_context` with the full `using-superpowers` skill. Cursor session start no longer pops the dialog and `using-superpowers` auto-loads.

Verified the existing happy path still works: on a separate Windows 11 box with `C:\Program Files\Git\bin\bash.exe` present, the first `if exist` still wins and the new probes are never reached (early `exit /b`).

## Evaluation

- **Initial prompt that surfaced the bug:** A user starting a Cursor session on Windows 11 with Scoop-installed Git reported the Windows "Open with…" dialog on every session and absent superpowers context. Investigation showed two layered failures: (a) `hooks-cursor.json` calling extensionless `./hooks/session-start` directly (fixed upstream by #1054 in 5.1.0), and (b) after manually applying the 5.1.0 fix, `run-hook.cmd` still failing because `where bash` hits the WSL launcher.
- **Sessions after the change:** 3 Cursor session starts (cold start, post-`/clear`, post-auto-compact). All three produced valid JSON, exit 0, and the bootstrap context appeared in the agent system prompt as evidenced by the agent recognizing `superpowers:using-superpowers` skill on the first user message without any explicit invocation.
- **Outcome:** Before the change, SessionStart was a silent no-op for this configuration; after, it is reliable. The probes are inert for any configuration that already worked.

## Rigor

- [ ] If this is a skills change: N/A — this is a hook-infrastructure fix, not a skills change.
- [x] Tested adversarially: (a) machine with both `C:\Program Files\Git` and Scoop Git → standard probe wins, no regression; (b) Scoop-only machine → Scoop probe wins, hook works; (c) machine with no Git Bash at all → falls through to `where bash`, hits WSL, original silent-failure behavior preserved (no new regression introduced); (d) per-user Git installer at `%LOCALAPPDATA%\Programs\Git` → probe wins (verified by manually relocating Git for Windows on a test box).
- [x] No carefully-tuned behavior-shaping content was modified.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

The fix and PR body were drafted with AI assistance (Cursor). The contributor read the full diff and PR body line-by-line, ran the before/after reproduction on the affected machine, and is responsible for the change.
