### PR TITLE
fix: handle EPIPE on SessionStart hook stdout (Windows)

### DIFF
--- a/hooks/session-start
+++ b/hooks/session-start
@@ -45,13 +45,13 @@ session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the 
 # See: https://github.com/obra/superpowers/issues/571
 if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
   # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
-  printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
+  printf '{\n  "additional_context": "%s"\n}\n' "$session_context" | cat
 elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
   # Claude Code sets CLAUDE_PLUGIN_ROOT without COPILOT_CLI
-  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context"
+  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context" | cat
 else
   # Copilot CLI (sets COPILOT_CLI=1) or unknown platform — SDK standard format
-  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
+  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context" | cat
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

On Windows + Git Bash, the SessionStart hook prints a confusing diagnostic at every startup:

\`\`\`
printf: write error: Permission denied
/systematic-debugging
\`\`\`

The hook still completes and context still gets injected, but this noise surfaces at every Claude Code session start on Windows.

## Repro

- Windows 11 (NT 10.0.26200), Claude Code 2.1.x, Git for Windows bash 5.2
- superpowers 5.1.0 installed via the official marketplace
- Open any Claude Code session; observe the diagnostic printed before the first prompt

## Root cause

Git Bash / MSYS surfaces SIGPIPE/EPIPE on bash builtins as \`Permission denied\` (not \`Broken pipe\`). When Claude Code closes the hook's stdout pipe early, the bare \`printf\` calls fail and a fragment of the next JSON chunk (e.g. \`/systematic-debugging\`) becomes visible in the terminal before bash can suppress it.

## Fix

Pipe each \`printf\` through \`cat\`. \`cat\` is an external process whose SIGPIPE termination does not propagate to the parent script under \`set -euo pipefail\`. The partial-chunk diagnostic disappears because \`cat\` owns the failing write.

\`\`\`diff
-  printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
+  printf '{\n  "additional_context": "%s"\n}\n' "$session_context" | cat

-  printf '{\n  "hookSpecificOutput": ...}\n' "$session_context"
+  printf '{\n  "hookSpecificOutput": ...}\n' "$session_context" | cat

-  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
+  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context" | cat
\`\`\`

No behaviour change on macOS / Linux — the \`cat\` passthrough is transparent when stdout is not closed early. Preserves \`set -euo pipefail\` and the \`printf\`-based output (no heredoc regression, see #571).

## Verification

- Windows 11 + Git Bash 5.2 + Claude Code 2.1.x: diagnostic gone, context injection still works
- macOS 14 + bash 5.3 (Homebrew): no change, no hang, no regression on #571
- Linux + bash 5.x: no change

## Notes

- 3 LOC, one concern, no unrelated changes
- Not fork-specific — affects every Windows user of the plugin
- Pre-submission checklist: searched existing PRs/issues (none for this), confirmed real repro, change belongs in core, diff reviewed before submitting