### PR TITLE
fix: route finishing PR creation by remote host

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -124,7 +124,22 @@ git branch -d <feature-branch>
 # Push branch
 git push -u origin <feature-branch>
 
-# Create PR
+# Detect hosting platform before creating the PR/MR
+REMOTE_URL=$(git remote get-url origin)
+```
+
+Use the remote host to choose the right creation tool:
+
+| Remote host | Action |
+|-------------|--------|
+| GitHub (`github.com` or GitHub Enterprise) | Use `gh pr create` |
+| GitLab (`gitlab.com` or self-hosted GitLab) | Use `glab mr create` |
+| Bitbucket (`bitbucket.org` or self-hosted Bitbucket) | Use `bb pr create` if available, otherwise print a manual PR/MR creation URL |
+| Unknown | Print a manual PR/MR creation URL and ask the user to open it |
+
+For GitHub:
+
+```bash
 gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Summary
 <2-3 bullets of what changed>
@@ -134,6 +149,22 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 EOF
 )"
 ```
+
+For GitLab:
+
+```bash
+glab mr create --title "<title>" --description "$(cat <<'EOF'
+## Summary
+<2-3 bullets of what changed>
+
+## Test Plan
+- [ ] <verification steps>
+EOF
+)"
+```
+
+For Bitbucket or unknown hosts, if the appropriate CLI is unavailable, print the
+manual PR/MR creation URL and tell the user which branch was pushed.
 
 **Do NOT clean up worktree** — user needs it alive to iterate on PR feedback.
 
@@ -225,6 +256,10 @@ git worktree prune  # Self-healing: clean up any stale registrations
 **Cleaning up harness-owned worktrees**
 - **Problem:** Removing a worktree the harness created causes phantom state
 - **Fix:** Only clean up worktrees under `.worktrees/` or `worktrees/`
+
+**Using GitHub CLI on non-GitHub remotes**
+- **Problem:** `gh pr create` fails on GitLab, Bitbucket, and self-hosted non-GitHub remotes
+- **Fix:** Check `git remote get-url origin` before creating a PR/MR. Use `gh pr create` for GitHub, `glab mr create` for GitLab, and a manual PR/MR creation URL when the platform or CLI is unknown
 
 **No confirmation for discard**
 - **Problem:** Accidentally delete work

--- a/tests/claude-code/README.md
+++ b/tests/claude-code/README.md
@@ -92,6 +92,13 @@ Tests skill content and requirements (~2 minutes):
 - Review loops documented
 - Task context provision documented
 
+#### test-finishing-platform-pr-create.sh
+Static regression test for the finishing-a-development-branch PR/MR path:
+- Requires remote-platform detection before creating a PR/MR
+- Keeps GitHub PR creation documented with `gh`
+- Documents GitLab MR creation with `glab`
+- Requires a manual fallback for unknown hosting platforms
+
 ### Integration Tests (use --integration flag)
 
 #### test-subagent-driven-development-integration.sh

--- a/tests/claude-code/run-skill-tests.sh
+++ b/tests/claude-code/run-skill-tests.sh
@@ -74,6 +74,7 @@ done
 # List of skill tests to run (fast unit tests)
 tests=(
     "test-worktree-path-policy.sh"
+    "test-finishing-platform-pr-create.sh"
     "test-subagent-driven-development.sh"
 )
 

--- a/tests/claude-code/test-finishing-platform-pr-create.sh
+++ b/tests/claude-code/test-finishing-platform-pr-create.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Regression check: finishing-a-development-branch must not assume every remote
+# is hosted on GitHub when creating a PR/MR.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+FINISHING_SKILL="$REPO_ROOT/skills/finishing-a-development-branch/SKILL.md"
+
+failures=0
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Fq "$pattern" "$file"; then
+        echo "  [PASS] $label"
+    else
+        echo "  [FAIL] $label"
+        echo "    Expected to find: $pattern"
+        echo "    In file: $file"
+        failures=$((failures + 1))
+    fi
+}
+
+echo "=== Finishing Branch PR Platform Test ==="
+echo ""
+
+assert_contains "$FINISHING_SKILL" "git remote get-url origin" "detects hosting platform from origin remote"
+assert_contains "$FINISHING_SKILL" "gh pr create" "keeps GitHub PR creation path"
+assert_contains "$FINISHING_SKILL" "glab mr create" "documents GitLab MR creation path"
+assert_contains "$FINISHING_SKILL" "Bitbucket" "documents Bitbucket as a non-GitHub host"
+assert_contains "$FINISHING_SKILL" "manual PR/MR creation URL" "falls back to manual URL for unknown hosts"
+assert_contains "$FINISHING_SKILL" "Using GitHub CLI on non-GitHub remotes" "warns against hardcoded gh usage"
+
+echo ""
+
+if [ "$failures" -gt 0 ]; then
+    echo "STATUS: FAILED ($failures failures)"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Summary

- Update `finishing-a-development-branch` Option 2 so it checks `git remote get-url origin` before creating a PR/MR.
- Keep the GitHub path with `gh pr create`, add a GitLab path with `glab mr create`, and document Bitbucket/unknown-host manual fallback.
- Add a static regression test and include it in the fast Claude Code skill test list.

Fixes #1609.

## Verification

RED before the skill change:

```bash
bash tests/claude-code/test-finishing-platform-pr-create.sh
# FAILED: missing remote detection, GitLab path, Bitbucket path, unknown-host fallback, and non-GitHub warning
```

GREEN after the skill change:

```bash
bash tests/claude-code/test-finishing-platform-pr-create.sh
bash tests/claude-code/test-worktree-path-policy.sh
bash -n tests/claude-code/test-finishing-platform-pr-create.sh tests/claude-code/run-skill-tests.sh
git diff --check
git diff --cached --check
```

All exited 0.

## Notes

- No `docs/superpowers/specs/*` or `docs/superpowers/plans/*` files are added.
- This PR changes skill instructions only; it does not add a new runtime dependency.
