### PR TITLE
docs: add context pack handoff contract

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -60,12 +60,12 @@ digraph process {
         "Mark task complete in todo list" [shape=box];
     }
 
-    "Read plan, extract all tasks with full text, note context, create todos" [shape=box];
+    "Read plan, extract Context Pack and all tasks with full text, note context, create todos" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent for entire implementation" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
-    "Read plan, extract all tasks with full text, note context, create todos" -> "Dispatch implementer subagent (./implementer-prompt.md)";
+    "Read plan, extract Context Pack and all tasks with full text, note context, create todos" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
     "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
     "Answer questions, provide context" -> "Dispatch implementer subagent (./implementer-prompt.md)";
@@ -119,6 +119,22 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 
 **Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
 
+## Context Pack Handoff
+
+Plans created by `writing-plans` include a Context Pack near the top.
+
+Read the Context Pack once when you read the plan, preserve it in controller notes,
+and include the relevant Context Pack fields in each implementer and reviewer
+prompt.
+
+Use the Context Pack to keep dispatch efficient:
+- Do not make subagents rediscover repo structure, entrypoints, verification
+  commands, acceptance criteria, or constraints that planning already captured.
+- Forward only the parts that matter for the current task. The full task text
+  still owns the implementation details.
+- If execution discovers that a Context Pack assumption is wrong, stop that task
+  and resolve the mismatch before continuing.
+
 ## Prompt Templates
 
 - [implementer-prompt.md](implementer-prompt.md) - Dispatch implementer subagent
@@ -131,13 +147,13 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 You: I'm using Subagent-Driven Development to execute this plan.
 
 [Read plan file once: docs/superpowers/plans/feature-plan.md]
-[Extract all 5 tasks with full text and context]
+[Extract Context Pack and all 5 tasks with full text and context]
 [Create todos for all tasks]
 
 Task 1: Hook installation script
 
 [Get Task 1 text and context (already extracted)]
-[Dispatch implementation subagent with full task text + context]
+[Dispatch implementation subagent with full task text + relevant Context Pack fields]
 
 Implementer: "Before I begin - should the hook be installed at user or system level?"
 

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -16,6 +16,15 @@ Subagent (general-purpose):
 
     [Scene-setting: where this fits, dependencies, architectural context]
 
+    ## Context Pack
+
+    [Relevant Context Pack fields from the plan: files, entrypoints,
+    verification commands, acceptance criteria, constraints, and assumptions]
+
+    Treat this as the handoff contract from planning to execution. Use it to
+    stay inside the intended repo slice. If it conflicts with what you find in
+    the code, report NEEDS_CONTEXT or BLOCKED instead of guessing.
+
     ## Before You Begin
 
     If you have questions about:

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -57,8 +57,37 @@ This structure informs the task decomposition. Each task should produce self-con
 
 **Tech Stack:** [Key technologies/libraries]
 
+**Context Pack:**
+- Relevant files: [Small set of source, test, docs, and config paths execution agents should inspect or touch]
+- Entrypoints: [Commands, modules, APIs, UI paths, or workflows that define the behavior under change]
+- Verification commands: [Smallest useful commands that prove the planned change]
+- Acceptance criteria: [Observable outcomes reviewers can check]
+- Constraints: [Architecture, compatibility, performance, UX, migration, or ownership boundaries]
+- Open questions / assumptions: [Known uncertainties, assumptions, and what should stop execution if contradicted]
+
 ---
 ```
+
+## Context Pack Contract
+
+Every plan carries a concise Context Pack so execution agents can start with the
+right repo slice instead of rediscovering it.
+
+Do not document the whole repository. Capture only the context needed to execute
+and review this feature slice.
+
+The Context Pack is not a memory system, multi-file documentation mode, or
+replacement for the task body. It is a handoff contract between planning and
+execution:
+
+- **Relevant files:** exact paths already discovered during planning
+- **Entrypoints:** behavior boundaries execution should use for orientation
+- **Verification commands:** commands worth running for this change, not a full
+  CI catalog
+- **Acceptance criteria:** externally visible outcomes the reviewer can verify
+- **Constraints:** boundaries that should keep implementation from drifting
+- **Open questions / assumptions:** uncertainties that should trigger a pause if
+  contradicted during execution
 
 ## Task Structure
 

--- a/tests/claude-code/README.md
+++ b/tests/claude-code/README.md
@@ -92,6 +92,17 @@ Tests skill content and requirements (~2 minutes):
 - Review loops documented
 - Task context provision documented
 
+#### test-context-pack-contract.sh
+Tests the planning-to-execution context handoff contract:
+- `writing-plans` requires a concise Context Pack in the plan header
+- Context Pack fields cover relevant files, entrypoints, verification commands,
+  acceptance criteria, constraints, and assumptions
+- `subagent-driven-development` reads the Context Pack once and forwards the
+  relevant fields to subagents
+- Implementer prompts include a Context Pack section
+- The contract does not introduce a feature-doc-pack mode or handoff slash
+  command
+
 ### Integration Tests (use --integration flag)
 
 #### test-subagent-driven-development-integration.sh

--- a/tests/claude-code/run-skill-tests.sh
+++ b/tests/claude-code/run-skill-tests.sh
@@ -74,6 +74,7 @@ done
 # List of skill tests to run (fast unit tests)
 tests=(
     "test-worktree-path-policy.sh"
+    "test-context-pack-contract.sh"
     "test-subagent-driven-development.sh"
 )
 

--- a/tests/claude-code/test-context-pack-contract.sh
+++ b/tests/claude-code/test-context-pack-contract.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Regression check: writing-plans should produce a concise Context Pack and
+# subagent-driven-development should preserve it during dispatch.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+WRITING_PLANS="$REPO_ROOT/skills/writing-plans/SKILL.md"
+SDD_SKILL="$REPO_ROOT/skills/subagent-driven-development/SKILL.md"
+IMPLEMENTER_PROMPT="$REPO_ROOT/skills/subagent-driven-development/implementer-prompt.md"
+
+failures=0
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Fq "$pattern" "$file"; then
+        echo "  [PASS] $label"
+    else
+        echo "  [FAIL] $label"
+        echo "    Expected to find: $pattern"
+        echo "    In file: $file"
+        failures=$((failures + 1))
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Fq "$pattern" "$file"; then
+        echo "  [FAIL] $label"
+        echo "    Did not expect to find: $pattern"
+        echo "    In file: $file"
+        failures=$((failures + 1))
+    else
+        echo "  [PASS] $label"
+    fi
+}
+
+echo "=== Context Pack Contract Test ==="
+echo ""
+
+assert_contains "$WRITING_PLANS" "**Context Pack:**" "writing-plans requires a Context Pack in the plan header"
+assert_contains "$WRITING_PLANS" "Relevant files:" "Context Pack captures relevant files"
+assert_contains "$WRITING_PLANS" "Entrypoints:" "Context Pack captures entrypoints"
+assert_contains "$WRITING_PLANS" "Verification commands:" "Context Pack captures verification commands"
+assert_contains "$WRITING_PLANS" "Acceptance criteria:" "Context Pack captures acceptance criteria"
+assert_contains "$WRITING_PLANS" "Constraints:" "Context Pack captures constraints"
+assert_contains "$WRITING_PLANS" "Open questions / assumptions:" "Context Pack captures open questions and assumptions"
+assert_contains "$WRITING_PLANS" "Do not document the whole repository" "Context Pack stays feature-scoped"
+
+assert_contains "$SDD_SKILL" "Read the Context Pack once" "SDD reads the Context Pack once"
+assert_contains "$SDD_SKILL" "preserve it in controller notes" "SDD preserves Context Pack in controller notes"
+assert_contains "$SDD_SKILL" "include the relevant Context Pack fields" "SDD forwards relevant Context Pack fields to subagents"
+assert_contains "$SDD_SKILL" "Do not make subagents rediscover" "SDD prevents repeated repo rediscovery"
+
+assert_contains "$IMPLEMENTER_PROMPT" "## Context Pack" "implementer prompt has Context Pack section"
+assert_contains "$IMPLEMENTER_PROMPT" "[Relevant Context Pack fields" "implementer prompt provides Context Pack placeholder"
+assert_contains "$IMPLEMENTER_PROMPT" "Treat this as the handoff contract" "implementer prompt explains Context Pack authority"
+
+assert_not_contains "$WRITING_PLANS" "feature-doc-pack mode" "Context Pack does not introduce a feature-doc-pack mode"
+assert_not_contains "$SDD_SKILL" "/create_handoff" "Context Pack does not introduce a handoff slash command"
+
+echo ""
+
+if [ "$failures" -gt 0 ]; then
+    echo "STATUS: FAILED ($failures failures)"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Summary

- Adds a concise `Context Pack` contract to the `writing-plans` plan header
- Updates `subagent-driven-development` to read the Context Pack once, preserve it in controller notes, and forward relevant fields to implementer/reviewer prompts
- Adds a deterministic shell regression test and wires it into the Claude Code fast test list

Refs #1616.
Related: #1238, #931, #1128, #551, #1503, #895.

## Why this shape

This keeps the proposal intentionally small: no new slash command, no persistent memory store, no feature-doc-pack mode, and no repository-wide documentation requirement. It only formalizes the minimum planning-to-execution context that subagents need to avoid rediscovery and drift.

## Test plan

- [x] `bash tests/claude-code/test-context-pack-contract.sh`
- [x] `bash tests/claude-code/test-worktree-path-policy.sh`
- [x] `bash -n tests/claude-code/test-context-pack-contract.sh tests/claude-code/run-skill-tests.sh`
- [x] `git diff --check HEAD~1 HEAD`

## Notes

No generated `docs/superpowers/specs/*` or `docs/superpowers/plans/*` files are included in this PR.
