### PR TITLE
docs: add task triage contract

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -49,6 +49,23 @@ Skills speak in actions ("dispatch a subagent", "create a todo", "read a file") 
 
 **Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
 
+## Task Triage Before Heavy Workflows
+
+Before launching heavyweight document workflows such as brainstorming/spec/plan
+artifacts, classify the user's task size. This determines workflow weight, not
+whether requested skills must be checked.
+
+- **Direct answer / command-only:** answer the question or run the requested
+  command after checking applicable skills.
+- **Small edit:** clear, localized work that appears to touch 1-3 files and has
+  no new architecture or product ambiguity. Use the relevant implementation,
+  debugging, or verification skills. Do not launch brainstorming/spec/plan artifacts for small edits unless the user asks for them.
+- **Debugging:** use systematic debugging before proposing or implementing a fix.
+- **Multi-step or ambiguous feature:** use brainstorming first, then planning
+  and execution skills when the design is approved.
+
+Do not use triage to skip a requested or clearly applicable skill. If the user explicitly asks for the full workflow, honor that.
+
 ```dot
 digraph skill_flow {
     "User message received" [shape=doublecircle];

--- a/tests/claude-code/test-task-triage-contract.sh
+++ b/tests/claude-code/test-task-triage-contract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression check: using-superpowers should triage task scope before launching
+# heavyweight document workflows.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+USING_SUPERPOWERS="$REPO_ROOT/skills/using-superpowers/SKILL.md"
+
+failures=0
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Fq "$pattern" "$file"; then
+        echo "  [PASS] $label"
+    else
+        echo "  [FAIL] $label"
+        echo "    Expected to find: $pattern"
+        echo "    In file: $file"
+        failures=$((failures + 1))
+    fi
+}
+
+echo "=== Task Triage Contract Test ==="
+echo ""
+
+assert_contains "$USING_SUPERPOWERS" "## Task Triage Before Heavy Workflows" "using-superpowers documents task triage"
+assert_contains "$USING_SUPERPOWERS" "Direct answer / command-only" "triage supports direct-answer tasks"
+assert_contains "$USING_SUPERPOWERS" "Small edit" "triage supports small edits"
+assert_contains "$USING_SUPERPOWERS" "Debugging" "triage supports debugging tasks"
+assert_contains "$USING_SUPERPOWERS" "Multi-step or ambiguous feature" "triage supports full workflow candidates"
+assert_contains "$USING_SUPERPOWERS" "Do not use triage to skip a requested or clearly applicable skill" "triage cannot bypass explicit skills"
+assert_contains "$USING_SUPERPOWERS" "Do not launch brainstorming/spec/plan artifacts for small edits unless the user asks for them" "small edits avoid heavyweight artifacts"
+assert_contains "$USING_SUPERPOWERS" "If the user explicitly asks for the full workflow, honor that" "user can still request full workflow"
+
+echo ""
+
+if [ "$failures" -gt 0 ]; then
+    echo "STATUS: FAILED ($failures failures)"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Summary

- Adds a lightweight task triage contract to `using-superpowers`
- Classifies work into direct answer, small edit, debugging, and multi-step/ambiguous feature before launching heavyweight document workflows
- Preserves existing skill rules: triage cannot skip requested or clearly applicable skills, and users can still request the full workflow
- Adds a deterministic shell regression test

Refs #1061.
Related: #1600, #1098, #1096.

## Why this shape

This solves the common "minor task triggers full workflow" cost problem without adding a new slash command or broad new skill. It only clarifies workflow weight selection before producing brainstorming/spec/plan artifacts.

## Test plan

- [x] `bash tests/claude-code/test-task-triage-contract.sh`
- [x] `bash -n tests/claude-code/test-task-triage-contract.sh`
- [x] `git diff --check HEAD~1 HEAD`

## Notes

No generated `docs/superpowers/specs/*` or `docs/superpowers/plans/*` files are included in this PR.
