### PR TITLE
docs: add SessionStart prompt budget guard

### DIFF
--- a/hooks/session-start
+++ b/hooks/session-start
@@ -7,6 +7,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# Prompt Budget Guard:
+# Only inject `skills/using-superpowers/SKILL.md` from this hook. Do not read or
+# inject CLAUDE.md, AGENTS.md, GEMINI.md, or other repository instruction files
+# here; host harnesses own their own repo-instruction loading behavior.
+
 # Read using-superpowers content
 using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
 

--- a/hooks/session-start-codex
+++ b/hooks/session-start-codex
@@ -6,6 +6,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# Prompt Budget Guard:
+# Only inject `skills/using-superpowers/SKILL.md` from this hook. Do not read or
+# inject CLAUDE.md, AGENTS.md, GEMINI.md, or other repository instruction files
+# here; host harnesses own their own repo-instruction loading behavior.
+
 using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
 
 escape_for_json() {

--- a/tests/hooks/test-session-start-prompt-budget-guard.sh
+++ b/tests/hooks/test-session-start-prompt-budget-guard.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression check: Superpowers SessionStart hooks should not inject repository
+# instruction files such as CLAUDE.md or AGENTS.md. Host harnesses may inject
+# those separately; this hook owns only the Superpowers bootstrap.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SESSION_START="$REPO_ROOT/hooks/session-start"
+CODEX_SESSION_START="$REPO_ROOT/hooks/session-start-codex"
+
+failures=0
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Fq "$pattern" "$file"; then
+        echo "  [PASS] $label"
+    else
+        echo "  [FAIL] $label"
+        echo "    Expected to find: $pattern"
+        echo "    In file: $file"
+        failures=$((failures + 1))
+    fi
+}
+
+assert_not_contains() {
+    local text="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if printf '%s' "$text" | grep -Fq "$pattern"; then
+        echo "  [FAIL] $label"
+        echo "    Did not expect to find: $pattern"
+        failures=$((failures + 1))
+    else
+        echo "  [PASS] $label"
+    fi
+}
+
+run_hook() {
+    local hook="$1"
+
+    env -i \
+        PATH="${PATH:-}" \
+        HOME="$(mktemp -d)" \
+        CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
+        bash "$hook"
+}
+
+echo "=== SessionStart Prompt Budget Guard Test ==="
+echo ""
+
+assert_contains "$SESSION_START" "Prompt Budget Guard" "Claude hook documents prompt budget boundary"
+assert_contains "$CODEX_SESSION_START" "Prompt Budget Guard" "Codex hook documents prompt budget boundary"
+assert_contains "$SESSION_START" 'Only inject `skills/using-superpowers/SKILL.md`' "Claude hook names the only injected file"
+assert_contains "$CODEX_SESSION_START" 'Only inject `skills/using-superpowers/SKILL.md`' "Codex hook names the only injected file"
+
+claude_output="$(run_hook "$SESSION_START")"
+codex_output="$(run_hook "$CODEX_SESSION_START")"
+
+for output in "$claude_output" "$codex_output"; do
+    assert_not_contains "$output" "Superpowers — Contributor Guidelines" "SessionStart output omits CLAUDE.md content"
+    assert_not_contains "$output" "94% PR rejection rate" "SessionStart output omits contributor warning content"
+    assert_not_contains "$output" "Pull Request Requirements" "SessionStart output omits PR guideline content"
+done
+
+echo ""
+
+if [ "$failures" -gt 0 ]; then
+    echo "STATUS: FAILED ($failures failures)"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Summary

- Documents a SessionStart prompt budget boundary in both Claude and Codex hooks
- Locks the hook contract to only inject `skills/using-superpowers/SKILL.md`
- Adds a regression test proving SessionStart output does not include repository contributor files such as `CLAUDE.md` / `AGENTS.md`

Refs #1600.

## Why this shape

This is a narrow first slice for prompt-budget work. It does not introduce a slim bootstrap, config flag, or harness-specific behavior. It only prevents Superpowers' own hooks from becoming responsible for repo-instruction injection, which host harnesses may handle separately.

## Test plan

- [x] `bash tests/hooks/test-session-start-prompt-budget-guard.sh`
- [x] `bash tests/hooks/test-session-start.sh`
- [x] `bash -n hooks/session-start hooks/session-start-codex tests/hooks/test-session-start-prompt-budget-guard.sh`
- [x] `git diff --check HEAD~1 HEAD`

## Notes

No generated `docs/superpowers/specs/*` or `docs/superpowers/plans/*` files are included in this PR.
