### PR TITLE
docs: add target-system responsibility boundary

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -60,6 +60,7 @@ After all tasks complete and verified:
 - Don't skip verifications
 - Reference skills when plan says to
 - Stop when blocked, don't guess
+- Before adding inference, derivation, or helper logic, ask: am I implementing the target system, or compensating for missing target-system structure?
 - Never start implementation on main/master branch without explicit user consent
 
 ## Integration

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -49,6 +49,7 @@ Subagent (general-purpose):
     - Reasonable scalability and performance?
     - Security concerns?
     - Integrates cleanly with surrounding code?
+    - Target-system responsibility boundary: Does this change make target-system responsibilities explicit, or hide them inside hidden development-time inference or helper logic?
 
     **Testing:**
     - Tests verify real behavior, not mocks?

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -54,6 +54,13 @@ Subagent (general-purpose):
     - In existing codebases, follow established patterns. Improve code you're touching
       the way a good developer would, but don't restructure things outside your task.
 
+    ## Target-System Responsibility Boundary
+
+    Do not silently substitute for capabilities that should be explicitly modeled
+    in the target product, subsystem, or agent. If behavior belongs in schema, state, policy, interface contracts, or the target agent's own responsibilities,
+    report NEEDS_CONTEXT or DONE_WITH_CONCERNS instead of hiding it inside
+    development-time inference or convenience helpers.
+
     ## When You're in Over Your Head
 
     It is always OK to stop and say "this is too hard for me." Bad work is worse than

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -33,6 +33,18 @@ Before defining tasks, map out which files will be created or modified and what 
 
 This structure informs the task decomposition. Each task should produce self-contained changes that make sense independently.
 
+## Target-System Responsibility Boundary
+
+You are the development agent, not the target product/system. During planning,
+check whether the plan explicitly models behavior that belongs in the target
+system instead of relying on the implementing agent to infer it at development
+time.
+
+If behavior belongs in schema, state, policy, interface contracts, or the target
+agent's own responsibilities, prefer explicit modeling over implementation-time inference.
+Do not hide target-system responsibilities inside convenience helpers that only
+make the current implementation pass.
+
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**

--- a/tests/claude-code/test-target-system-boundary-contract.sh
+++ b/tests/claude-code/test-target-system-boundary-contract.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Regression check: planning, execution, and review should guard against the
+# development agent silently swallowing responsibilities that belong in the
+# target system.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+WRITING_PLANS="$REPO_ROOT/skills/writing-plans/SKILL.md"
+EXECUTING_PLANS="$REPO_ROOT/skills/executing-plans/SKILL.md"
+IMPLEMENTER_PROMPT="$REPO_ROOT/skills/subagent-driven-development/implementer-prompt.md"
+CODE_REVIEWER="$REPO_ROOT/skills/requesting-code-review/code-reviewer.md"
+
+failures=0
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Fq "$pattern" "$file"; then
+        echo "  [PASS] $label"
+    else
+        echo "  [FAIL] $label"
+        echo "    Expected to find: $pattern"
+        echo "    In file: $file"
+        failures=$((failures + 1))
+    fi
+}
+
+echo "=== Target-System Boundary Contract Test ==="
+echo ""
+
+assert_contains "$WRITING_PLANS" "## Target-System Responsibility Boundary" "writing-plans documents the boundary"
+assert_contains "$WRITING_PLANS" "You are the development agent, not the target product/system" "planning names the development-agent boundary"
+assert_contains "$WRITING_PLANS" "schema, state, policy, interface contracts" "planning calls out explicit modeling surfaces"
+assert_contains "$WRITING_PLANS" "prefer explicit modeling over implementation-time inference" "planning prefers explicit system modeling"
+
+assert_contains "$EXECUTING_PLANS" "Before adding inference, derivation, or helper logic" "executing-plans checks helper/inference additions"
+assert_contains "$EXECUTING_PLANS" "am I implementing the target system, or compensating for missing target-system structure?" "executing-plans asks the boundary question"
+
+assert_contains "$IMPLEMENTER_PROMPT" "## Target-System Responsibility Boundary" "implementer prompt documents the boundary"
+assert_contains "$IMPLEMENTER_PROMPT" "Do not silently substitute for capabilities that should be explicitly modeled" "implementer prompt prevents capability substitution"
+assert_contains "$IMPLEMENTER_PROMPT" "If behavior belongs in schema, state, policy, interface contracts, or the target agent's own responsibilities" "implementer prompt names escalation surfaces"
+
+assert_contains "$CODE_REVIEWER" "Target-system responsibility boundary" "code reviewer checks target-system boundary"
+assert_contains "$CODE_REVIEWER" "Does this change make target-system responsibilities explicit" "code reviewer asks explicitness question"
+assert_contains "$CODE_REVIEWER" "hidden development-time inference or helper logic" "code reviewer catches hidden helper substitution"
+
+echo ""
+
+if [ "$failures" -gt 0 ]; then
+    echo "STATUS: FAILED ($failures failures)"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Summary

- Adds a target-system responsibility boundary check to `writing-plans`
- Adds execution guidance for inference/derivation/helper logic in `executing-plans`
- Adds implementer prompt guidance to avoid silently substituting for target-system capabilities
- Adds a reviewer checklist item for hidden development-time inference/helper logic
- Adds a deterministic shell contract test

Refs #1096.
Related: #895, #1098.

## Why this shape

This is a small guardrail against a common agentic-development failure: the development agent makes a patch pass by carrying responsibilities that should have been explicitly modeled in the target system. The PR does not introduce a new skill or workflow; it adds the boundary at planning, execution, and review points where the mistake can happen.

## Test plan

- [x] `bash tests/claude-code/test-target-system-boundary-contract.sh`
- [x] `bash -n tests/claude-code/test-target-system-boundary-contract.sh`
- [x] `git diff --check HEAD~1 HEAD`

## Notes

No generated `docs/superpowers/specs/*` or `docs/superpowers/plans/*` files are included in this PR.
