### PR TITLE
docs: add context-frugal resume contract

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -21,6 +21,14 @@ Load plan, review critically, execute all tasks, report when complete.
 3. If concerns: Raise them with your human partner before starting
 4. If no concerns: Create todos for the plan items and proceed
 
+## Context-Frugal Resume
+
+When resuming an existing plan, keep the initial reload small. Read the plan header first, then load the next pending task and only the surrounding context
+needed to execute it.
+
+Do not reload the entire plan just to find status or locate the next unchecked
+task. Expand to the full plan only when dependencies, unclear context, or cross-task coupling require it.
+
 ### Step 2: Execute Tasks
 
 For each task:

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -119,6 +119,14 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 
 **Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
 
+## Context-Frugal Resume
+
+When resuming an existing plan, keep the controller's reload small. Read the plan header first, then load the next pending task and only the surrounding
+context needed for dispatch.
+
+Do not make subagents reload the whole plan. The controller provides task text
+and curated context. Expand to the full plan only when dependencies, unclear context, or cross-task coupling require it.
+
 ## Prompt Templates
 
 - [implementer-prompt.md](implementer-prompt.md) - Dispatch implementer subagent

--- a/tests/claude-code/test-context-frugal-resume-contract.sh
+++ b/tests/claude-code/test-context-frugal-resume-contract.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression check: plan execution skills should support context-frugal resume
+# without reloading an entire long plan just to find the next task.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+EXECUTING_PLANS="$REPO_ROOT/skills/executing-plans/SKILL.md"
+SDD_SKILL="$REPO_ROOT/skills/subagent-driven-development/SKILL.md"
+
+failures=0
+
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    if grep -Fq "$pattern" "$file"; then
+        echo "  [PASS] $label"
+    else
+        echo "  [FAIL] $label"
+        echo "    Expected to find: $pattern"
+        echo "    In file: $file"
+        failures=$((failures + 1))
+    fi
+}
+
+echo "=== Context-Frugal Resume Contract Test ==="
+echo ""
+
+assert_contains "$EXECUTING_PLANS" "## Context-Frugal Resume" "executing-plans documents context-frugal resume"
+assert_contains "$EXECUTING_PLANS" "Read the plan header first" "executing-plans reads header first"
+assert_contains "$EXECUTING_PLANS" "then load the next pending task" "executing-plans loads next pending task"
+assert_contains "$EXECUTING_PLANS" "Do not reload the entire plan just to find status" "executing-plans avoids full-plan status reload"
+assert_contains "$EXECUTING_PLANS" "Expand to the full plan only when dependencies, unclear context, or cross-task coupling require it" "executing-plans has expansion rule"
+
+assert_contains "$SDD_SKILL" "## Context-Frugal Resume" "SDD documents context-frugal resume"
+assert_contains "$SDD_SKILL" "Read the plan header first" "SDD reads header first"
+assert_contains "$SDD_SKILL" "then load the next pending task" "SDD loads next pending task"
+assert_contains "$SDD_SKILL" "Do not make subagents reload the whole plan" "SDD protects subagent context"
+assert_contains "$SDD_SKILL" "Expand to the full plan only when dependencies, unclear context, or cross-task coupling require it" "SDD has expansion rule"
+
+echo ""
+
+if [ "$failures" -gt 0 ]; then
+    echo "STATUS: FAILED ($failures failures)"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Summary

- Adds a context-frugal resume contract to `executing-plans`
- Adds the same resume contract to `subagent-driven-development`
- Defines a lightweight resume path: read the plan header first, then load the next pending task and only expand to the full plan when needed
- Adds a deterministic shell contract test

Related: #931, #1075, #1599, #1602, #1616, #1617.

## Why this shape

This is a small first slice for large-plan resume efficiency. It does not add slash commands, persistent state, or a new memory store. It just teaches the execution skills to avoid reloading an entire long plan merely to find status or the next unchecked task.

## Test plan

- [x] `bash tests/claude-code/test-context-frugal-resume-contract.sh`
- [x] `bash -n tests/claude-code/test-context-frugal-resume-contract.sh`
- [x] `git diff --check HEAD~1 HEAD`

## Notes

No generated `docs/superpowers/specs/*` or `docs/superpowers/plans/*` files are included in this PR.
