### PR TITLE
fix: make finishing PR creation remote-aware

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -124,7 +124,10 @@ git branch -d <feature-branch>
 # Push branch
 git push -u origin <feature-branch>
 
-# Create PR
+# Create PR/MR with the tool that matches the remote host.
+REMOTE_URL=$(git remote get-url origin)
+# `gh pr create` below is the GitHub example. For non-GitHub remotes, do not
+# run it; use the matching PR/MR CLI or print the branch URL instead.
 gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Summary
 <2-3 bullets of what changed>


### PR DESCRIPTION
## Summary

- Updates the `finishing-a-development-branch` Option 2 PR/MR example to check the remote host before choosing a PR/MR tool.
- Keeps the existing GitHub `gh pr create` example, but explicitly marks it as GitHub-only and tells agents not to run it for non-GitHub remotes.
- Directs non-GitHub remotes to use the matching PR/MR CLI or print the pushed branch URL for manual creation.

Fixes #1609.

## Why this shape

This is the narrow version requested after #1613 was closed: a 5-line edit around the single GitHub-specific `gh pr create` example, not a platform reference manual and not a new test harness. The bug is real; the previous PR was too large.

## Verification

- [x] `git diff --check HEAD~1 HEAD`
- [x] `git diff --name-only HEAD~1 HEAD | rg '^docs/superpowers/(specs|plans)/' || echo 'no generated spec/plan changes'`

No shell regression test is included because a grep test for this prose would be tautological; #1613 was closed partly for that reason.

## Notes

No generated `docs/superpowers/specs/*` or `docs/superpowers/plans/*` files are included.
