### PR TITLE
docs: show output path override example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,29 @@ The Pi package loads the Superpowers skills and a small extension that injects t
 
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
 
+## Customizing Output Paths
+
+By default, brainstorming writes design specs to `docs/superpowers/specs/`
+and writing-plans writes implementation plans to `docs/superpowers/plans/`.
+
+If your project wants those artifacts somewhere else, add both a table and a
+direct instruction to the project instruction file your harness reads at
+session start, such as `CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`:
+
+```markdown
+## Output Paths
+
+| Artifact | Location |
+|---|---|
+| Design specs | `docs/design-docs/` |
+| Implementation plans | `docs/exec-plans/` |
+
+**Design specs MUST be saved to `docs/design-docs/`, NOT `docs/superpowers/specs/`. Implementation plans MUST be saved to `docs/exec-plans/`, NOT `docs/superpowers/plans/`.**
+```
+
+The direct instruction matters: agents are more likely to follow the override
+when it appears next to the table instead of only as a table row.
+
 ## What's Inside
 
 ### Skills Library


### PR DESCRIPTION
## What problem are you trying to solve?

Issue #939 reports that project-level output path preferences can be missed when an agent follows the concrete Superpowers defaults for design specs and implementation plans.

The issue's working workaround is to put an explicit imperative instruction next to the `Output Paths` table. The maintainer direction on #939 was that the right fix is a README example showing how to override the default.

## What does this PR change?

Adds a README-only `Customizing Output Paths` section that shows users how to configure alternate spec and plan locations in their project instruction file.

The example includes both the table and the direct MUST/NOT instruction from the working workaround, without changing any skill behavior.

## Is this change appropriate for the core library?

Yes. This is general Superpowers user documentation for where core workflow artifacts are written. It is not project-specific, does not add a service or dependency, and does not change behavior-shaping skill content.

## What alternatives did you consider?

I considered editing `skills/brainstorming/SKILL.md` and `skills/writing-plans/SKILL.md`, but that repeats the risky part of #1020: behavior-shaping skill edits without multi-session eval evidence.

I also considered adding a README regression test, but #1593 was closed partly because that test only grepped for strings the PR itself added. This PR intentionally keeps the change README-only, with no decorative test.

## Does this PR contain multiple unrelated changes?

No. It changes one README section for one documentation gap: how to override the default output paths.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1020, #1593

#1020 bundled skill edits with README documentation and did not follow the PR template. #1593 was closer, but it was part of a batch and added a tautological grep test. This PR is the narrower shape requested in the #1593 closure comment: README-only, no decorative regression test.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Local shell/docs verification | zsh on macOS | n/a | n/a |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add support for a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable: no new harness support is added by this PR.
```

</details>

## Evaluation

- Initial problem source: #939, including the reported workaround and the maintainer comment recommending a README example.
- This is documentation-only. I did not run agent behavior eval sessions because this PR does not change skill behavior.
- The README example documents the already-reported working form: an `Output Paths` table plus a direct MUST/NOT instruction next to it.

Verification run locally:

```bash
git diff --check
# no output

git diff --name-only | rg '^docs/superpowers/(specs|plans)/' || echo 'no generated spec/plan changes'
# no generated spec/plan changes

bash tests/opencode/run-tests.sh
# STATUS: PASSED, 2 passed, 0 failed

rg -n "Customizing Output Paths|Design specs MUST|Implementation plans MUST" README.md
# finds the new section and imperative instruction
```

Not run as a PR signal: `node --test tests/pi/test-pi-extension.mjs`. In this shell it cannot import `.pi/extensions/superpowers.ts` directly and failed the same way before the README edit.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is not a skills change. It deliberately avoids behavior-shaping skill edits and does not add a tautological docs test.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Fixes #939.
