### PR TITLE
Clarify plan checkboxes vs TodoWrite progress tracking

### DIFF
--- a/docs/superpowers/plans/2026-01-22-document-review-system.md
+++ b/docs/superpowers/plans/2026-01-22-document-review-system.md
@@ -285,7 +285,7 @@ Run: `grep -A 20 "Plan Document Header" skills/writing-plans/SKILL.md`
 The plan header should note that tasks and steps use checkbox syntax. Update the header comment:
 
 ```markdown
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Tasks and steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Checkboxes (`- [ ]`) are for human scanability only — track progress in TodoWrite (Cursor/Claude Code) or `update_plan` (Codex); do not flip checkboxes in this file during execution.
 ```
 
 - [ ] **Step 3:** Verify the change

--- a/docs/superpowers/plans/2026-02-19-visual-brainstorming-refactor.md
+++ b/docs/superpowers/plans/2026-02-19-visual-brainstorming-refactor.md
@@ -1,6 +1,6 @@
 # Visual Brainstorming Refactor Implementation Plan
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Checkboxes (`- [ ]`) are for human scanability only — track progress in TodoWrite (Cursor/Claude Code) or `update_plan` (Codex); do not flip checkboxes in this file during execution.
 
 **Goal:** Refactor visual brainstorming from blocking TUI feedback model to non-blocking "Browser Displays, Terminal Commands" architecture.
 

--- a/docs/superpowers/plans/2026-03-11-zero-dep-brainstorm-server.md
+++ b/docs/superpowers/plans/2026-03-11-zero-dep-brainstorm-server.md
@@ -1,6 +1,6 @@
 # Zero-Dependency Brainstorm Server Implementation Plan
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Checkboxes (`- [ ]`) are for human scanability only — track progress in TodoWrite (Cursor/Claude Code) or `update_plan` (Codex); do not flip checkboxes in this file during execution.
 
 **Goal:** Replace the brainstorm server's vendored node_modules with a single zero-dependency `server.js` using Node built-ins.
 

--- a/docs/superpowers/plans/2026-03-23-codex-app-compatibility.md
+++ b/docs/superpowers/plans/2026-03-23-codex-app-compatibility.md
@@ -1,6 +1,6 @@
 # Codex App Compatibility Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Checkboxes (`- [ ]`) are for human scanability only — track progress in TodoWrite (Cursor/Claude Code) or `update_plan` (Codex); do not flip checkboxes in this file during execution.
 
 **Goal:** Make `using-git-worktrees`, `finishing-a-development-branch`, and related skills work in the Codex App's sandboxed worktree environment without breaking existing behavior.
 

--- a/docs/superpowers/plans/2026-04-06-worktree-rototill.md
+++ b/docs/superpowers/plans/2026-04-06-worktree-rototill.md
@@ -1,6 +1,6 @@
 # Worktree Rototill Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Checkboxes (`- [ ]`) are for human scanability only — track progress in TodoWrite (Cursor/Claude Code) or `update_plan` (Codex); do not flip checkboxes in this file during execution.
 
 **Goal:** Make superpowers defer to native harness worktree systems when available, fall back to manual git worktrees when not, and fix three known finishing bugs.
 

--- a/docs/superpowers/specs/2026-01-22-document-review-system-design.md
+++ b/docs/superpowers/specs/2026-01-22-document-review-system-design.md
@@ -98,7 +98,7 @@ brainstorming -> spec -> SPEC REVIEW LOOP -> writing-plans -> plan -> PLAN REVIE
 
 ## Markdown Task Syntax
 
-Tasks and steps use checkbox syntax:
+Tasks and steps use `- [ ]` checkbox syntax for structure and human scanability (not live agent tracking). During execution, agents track progress in TodoWrite or Codex `update_plan`; they do not edit checkboxes in the plan file.
 
 ```markdown
 - [ ] ### Task 1: Name

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -23,11 +23,13 @@ Load plan, review critically, execute all tasks, report when complete.
 
 ### Step 2: Execute Tasks
 
+Track progress in **TodoWrite** (or Codex `update_plan` — see `using-superpowers/references/codex-tools.md`). Do **not** flip `- [ ]` → `- [x]` in the plan file; checkboxes are for human scanability only.
+
 For each task:
-1. Mark as in_progress
+1. Mark as in_progress in TodoWrite
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
-4. Mark as completed
+4. Mark as completed in TodoWrite
 
 ### Step 3: Complete Development
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -233,9 +233,16 @@ Done!
 - Review loops add iterations
 - But catches issues early (cheaper than debugging later)
 
+## Plan progress
+
+- After reading the plan once, create TodoWrite entries for all tasks (full text + context).
+- Mark each task complete in **TodoWrite** after spec and code-quality review pass.
+- **Do not** edit plan checkboxes (`- [ ]` → `- [x]`) — they stay unchecked in git; session todos are ephemeral on Cursor/Claude Code. On Codex, use `update_plan` per `using-superpowers/references/codex-tools.md`.
+
 ## Red Flags
 
 **Never:**
+- Edit plan file checkboxes to record progress (use TodoWrite / `update_plan`)
 - Start implementation on main/master branch without explicit user consent
 - Skip reviews (spec compliance OR code quality)
 - Proceed with unfixed issues

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -49,7 +49,7 @@ This structure informs the task decomposition. Each task should produce self-con
 ```markdown
 # [Feature Name] Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Checkboxes (`- [ ]`) are for human scanability only — track progress in TodoWrite (Cursor/Claude Code) or `update_plan` (Codex); do not flip checkboxes in this file during execution.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -59,6 +59,10 @@ This structure informs the task decomposition. Each task should produce self-con
 
 ---
 ```
+
+## Progress tracking (agents)
+
+Checkboxes in the plan are **not** a live progress log. Execution skills (`subagent-driven-development`, `executing-plans`) require TodoWrite (or Codex `update_plan`) and explicitly do not edit plan checkboxes. Humans may check boxes manually when reviewing a plan in git.
 
 ## Task Structure
 


### PR DESCRIPTION
## Summary

Plans generated by `writing-plans` told agents that `- [ ]` checkbox syntax was **for tracking**, but `subagent-driven-development` and `executing-plans` require **TodoWrite** (or Codex `update_plan`) and never instruct flipping plan checkboxes. Every checked-in plan stays all-unchecked even after shipped work.

This PR aligns the docs so agents and humans are not misled:

- **writing-plans**: Header template + new "Progress tracking (agents)" section — checkboxes are human scanability; TodoWrite/`update_plan` is the live tracker.
- **subagent-driven-development**: New "Plan progress" section + red flag against editing plan checkboxes.
- **executing-plans**: Step 2 explicitly tracks in TodoWrite, not plan file.
- **Document-review spec** + sample plan headers in `docs/superpowers/plans/`: same wording as the template.

Historical `RELEASE-NOTES.md` left unchanged (describes what shipped at the time).

## Test plan

- [ ] Read `writing-plans` header template — no "syntax for tracking" claim
- [ ] Read `subagent-driven-development` — TodoWrite path matches flowchart; explicit do-not-flip-checkboxes guidance
- [ ] Grep repo for `syntax for tracking` — zero matches outside RELEASE-NOTES history
