### PR TITLE
feat(writing-plans): add Evaluator section + self-review check

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -119,6 +119,38 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - Exact commands with expected output
 - DRY, YAGNI, TDD, frequent commits
 
+## Evaluator
+
+Every plan declares an **Evaluator** — the deterministic check that gates moving the plan from in-progress to complete. Without one, "done" defaults to vibes: a maintainer reads the implementation, decides it looks right, and moves the plan to its completed location. Weeks later a regression surfaces and there's no record of what "passing" was supposed to mean.
+
+This is the **Planner → Generator → Evaluator** topology: the **Planner** (this skill) writes the spec, the **Generator** (`superpowers:executing-plans` / `superpowers:subagent-driven-development`) executes one task at a time, and the **Evaluator** returns pass/fail before lifecycle transition.
+
+**Acceptable Evaluator forms** (pick one or combine):
+
+- **Test command** — `pytest path::test_function`, `npx playwright test specs/<feature>.spec.ts`, `cargo test <name>`, `go test ./pkg/...` — that exits 0
+- **HTTP assertion** — `curl -fsS <url>` with expected status + body shape against a deployed endpoint
+- **Database query** — a SELECT (or equivalent) asserting expected state after the plan runs
+- **Skill invocation** — a project-local `verify-*` skill that returns success
+- **Rubric pass-list** — N/N criteria met by manual inspection, for AI-system or design plans where a deterministic check isn't possible
+
+**Placement:** add a top-level `## Evaluator` section AFTER the implementation/task breakdown and BEFORE any terminal `## Rollback` or sign-off block. Title MUST be exactly `## Evaluator` (or `## Evaluator spec`) so the gate is grep-discoverable across the plan corpus.
+
+**Example:**
+
+````markdown
+## Evaluator
+
+```bash
+pytest tests/auth/test_session_refresh.py::test_token_rotation -v
+```
+
+Expected: PASS. Verifies the refresh-token rotation flow returns a new access
+token, invalidates the old refresh token, and writes the rotation event to
+the audit log.
+````
+
+**Gate:** the executing session may NOT move a plan to its completed location until the Evaluator runs green. Paste the passing evidence into the commit message, CHANGELOG entry, or PR body that closes the plan — that's the durable record of what "done" meant for this plan.
+
 ## Self-Review
 
 After writing the complete plan, look at the spec with fresh eyes and check the plan against it. This is a checklist you run yourself — not a subagent dispatch.
@@ -128,6 +160,8 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 **2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+**4. Evaluator declared:** Does the plan include a top-level `## Evaluator` section with a concrete check (test command, curl assertion, database query, skill invocation, or rubric)? If not, add one — without it, the `partial` → `completed` transition defaults to vibes.
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (1M context), `claude-opus-4-8` |
| Harness + version | Claude Code (CLI) |
| All plugins installed | superpowers; plan-evaluator-gate (a downstream companion that enforces this same gate while this PR is pending) |
| Human partner who reviewed this diff | Suresh (@suresh2824) — directed the work and reviewed the diff + eval |

## What problem are you trying to solve?

`writing-plans` produces plans with **task-level** verification (`Step: Run test to verify it fails/passes`), a pre-implementation `plan-document-reviewer` (checks the plan is *well-written*), and a subjective `## Self-Review`. What it does **not** produce is a single **deterministic, plan-level completion gate** — one runnable check that answers "is the whole plan actually done?" Today that question is answered only by fresh-eyes review.

Concrete failure (a real `writing-plans`-driven session): a plan was moved to `completed/` and its PR declared the ticket "done", but a staging slip meant the change never reached `main` — the PR merged with only a doc rename. Every per-task test was green; "done" rode on merge-state + the subjective review, and the miss survived until a manual re-verify (costing a follow-up PR). A goal-level Evaluator gate would have failed and caught it immediately.

## What does this PR change?

Adds an `## Evaluator` section to the plan template requiring exactly one deterministic, goal-level completion check (a test/curl/query/`verify-*` run) that gates the plan's completion. It does not touch the existing per-task tests or Self-Review.

## Is this change appropriate for the core library?

Yes — it's general-purpose: any plan in any project benefits from a deterministic "definition of done." The PR keeps the `## Evaluator` *section* as the core ask; the `partial/→completed/` lifecycle phrasing is advisory wording, not a directory convention imported into core.

## What alternatives did you consider?

- **Rely on the existing per-task tests** — they prove each *step* works in isolation; they do not prove the *aggregate goal* was achieved or that the change reached the merged surface (see the incident).
- **Rely on `plan-document-reviewer`** — it runs *before* implementation and checks the plan is well-written, not that the result is done.
- **Rely on `Self-Review`** — subjective, not deterministic; the failure above passed it.

## Does this PR contain multiple unrelated changes?

No — a single new section in one file (`skills/writing-plans/SKILL.md`).

## Existing PRs

None that add a plan-level completion gate. This does not duplicate an open PR.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code | current | Claude Opus | `claude-opus-4-8` (1M) |

Eval generations were produced with `claude --safe-mode` (CLAUDE.md/plugins/hooks/skills disabled) so only the bare skill drove behavior.

## Evaluation

RED/GREEN behavioral eval posted as a PR comment — summary: **RED 0/3** plans contain a plan-level gate; **GREEN 3/3** do, all deterministic and goal-level, with **no bloat** (every GREEN plan ≤ +1% / shorter than RED). 3 diverse prompts (auth / streamed-CSV / irreversible tz-migration), one being this repo's own `tests/skill-triggering/prompts/writing-plans.txt`. Falsifiable: RED>0 would withdraw the PR; it scored 0/3.

## Rigor

Clean-room method (see the comment's caveat): a first run inside a configured repo gave a false RED 3/3 because a downstream CLAUDE.md already mandated the gate — so the eval was re-run under `--safe-mode` with only the bare `SKILL.md`. Recommend running it that way in CI.

## Human review

Reviewed by Suresh (@suresh2824), who directed the work, reviewed the diff, and reviewed the eval results before submission.
