### PR TITLE
Align execution skills with plan checkbox progress tracking

### DIFF
--- a/docs/superpowers/specs/2026-01-22-document-review-system-design.md
+++ b/docs/superpowers/specs/2026-01-22-document-review-system-design.md
@@ -98,7 +98,7 @@ brainstorming -> spec -> SPEC REVIEW LOOP -> writing-plans -> plan -> PLAN REVIE
 
 ## Markdown Task Syntax
 
-Tasks and steps use checkbox syntax:
+Tasks and steps use checkbox syntax. During execution, agents flip `- [ ]` to `- [x]` in the plan file as steps are verified (durable progress in git).
 
 ```markdown
 - [ ] ### Task 1: Name

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,7 +57,7 @@ The integration test verifies the `subagent-driven-development` skill correctly:
 3. **Verification**: Parses the session transcript (`.jsonl` file) to verify:
    - Skill tool was invoked
    - Subagents were dispatched (Task tool)
-   - TodoWrite was used for tracking
+   - TodoWrite was used for tracking (optional mirror; plan file checkboxes should flip to `- [x]` as steps complete)
    - Implementation files were created
    - Tests pass
    - Git commits show proper workflow

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -19,15 +19,17 @@ Load plan, review critically, execute all tasks, report when complete.
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
 3. If concerns: Raise them with your human partner before starting
-4. If no concerns: Create TodoWrite and proceed
+4. If no concerns: Optionally create TodoWrite to mirror tasks, then proceed
 
 ### Step 2: Execute Tasks
 
+The plan file is the durable progress log. After each step passes verification, edit the plan and flip that step's `- [ ]` to `- [x]`.
+
 For each task:
-1. Mark as in_progress
-2. Follow each step exactly (plan has bite-sized steps)
-3. Run verifications as specified
-4. Mark as completed
+1. Follow each step exactly (plan has bite-sized steps)
+2. Run verifications as specified
+3. Mark the step complete in the plan file (`- [ ]` → `- [x]`)
+4. Optionally mark in_progress / completed in TodoWrite for in-session UI
 
 ### Step 3: Complete Development
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -57,7 +57,7 @@ digraph process {
         "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [shape=box];
         "Code quality reviewer subagent approves?" [shape=diamond];
         "Implementer subagent fixes quality issues" [shape=box];
-        "Mark task complete in TodoWrite" [shape=box];
+        "Mark completed steps in plan file (- [ ] to - [x])" [shape=box];
     }
 
     "Read plan, extract all tasks with full text, note context, create TodoWrite" [shape=box];
@@ -78,8 +78,8 @@ digraph process {
     "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" -> "Code quality reviewer subagent approves?";
     "Code quality reviewer subagent approves?" -> "Implementer subagent fixes quality issues" [label="no"];
     "Implementer subagent fixes quality issues" -> "Dispatch code quality reviewer subagent (./code-quality-reviewer-prompt.md)" [label="re-review"];
-    "Code quality reviewer subagent approves?" -> "Mark task complete in TodoWrite" [label="yes"];
-    "Mark task complete in TodoWrite" -> "More tasks remain?";
+    "Code quality reviewer subagent approves?" -> "Mark completed steps in plan file (- [ ] to - [x])" [label="yes"];
+    "Mark completed steps in plan file (- [ ] to - [x])" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer subagent for entire implementation" [label="no"];
     "Dispatch final code reviewer subagent for entire implementation" -> "Use superpowers:finishing-a-development-branch";
@@ -156,7 +156,7 @@ Spec reviewer: ✅ Spec compliant - all requirements met, nothing extra
 [Get git SHAs, dispatch code quality reviewer]
 Code reviewer: Strengths: Good test coverage, clean. Issues: None. Approved.
 
-[Mark Task 1 complete]
+[Mark Task 1 steps complete in plan file: - [ ] → - [x] for each finished step]
 
 Task 2: Recovery modes
 
@@ -190,7 +190,7 @@ Implementer: Extracted PROGRESS_INTERVAL constant
 [Code reviewer reviews again]
 Code reviewer: ✅ Approved
 
-[Mark Task 2 complete]
+[Mark Task 2 steps complete in plan file]
 
 ...
 
@@ -233,9 +233,20 @@ Done!
 - Review loops add iterations
 - But catches issues early (cheaper than debugging later)
 
+## Plan progress
+
+The plan file is the **durable** progress log. Checkbox syntax (`- [ ]` / `- [x]`) exists for agent tracking, not human-only decoration.
+
+After each step passes its verification, edit the plan file and flip that step's checkbox to `- [x]`. After each task passes both reviews, ensure every step for that task is checked in the plan.
+
+**TodoWrite (optional):** You may mirror tasks in TodoWrite for in-session UI on Cursor/Claude Code. TodoWrite does not replace updating the plan file. On Codex, `update_plan` maps from TodoWrite per `using-superpowers/references/codex-tools.md` — still update plan checkboxes when you have a plan path.
+
+Commit plan updates with your implementation commits when practical so git shows real progress.
+
 ## Red Flags
 
 **Never:**
+- Leave plan checkboxes unchecked after completing and verifying a step
 - Start implementation on main/master branch without explicit user consent
 - Skip reviews (spec compliance OR code quality)
 - Proceed with unfixed issues

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -8,7 +8,7 @@ Skills use Claude Code tool names. When you encounter these in a skill, use your
 | Multiple `Task` calls (parallel) | Multiple `spawn_agent` calls |
 | Task returns result | `wait_agent` |
 | Task completes automatically | `close_agent` to free slot |
-| `TodoWrite` (task tracking) | `update_plan` |
+| `TodoWrite` (task tracking) | `update_plan` (also flip `- [ ]` → `- [x]` in the plan file when executing superpowers plans) |
 | `Skill` tool (invoke a skill) | Skills load natively — just follow the instructions |
 | `Read`, `Write`, `Edit` (files) | Use your native file tools |
 | `Bash` (run commands) | Use your native shell tools |

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -60,6 +60,10 @@ This structure informs the task decomposition. Each task should produce self-con
 ---
 ```
 
+## Progress tracking (agents)
+
+During execution, agents update **this plan file** as they work: flip each verified step from `- [ ]` to `- [x]`. That is the durable progress record in git. Execution skills may also use TodoWrite (or Codex `update_plan`) for in-session tracking, but must not leave plan checkboxes stale.
+
 ## Task Structure
 
 ````markdown


### PR DESCRIPTION
## Summary

Plans and release notes say checkbox syntax is for **agent progress tracking**, but execution skills only documented **TodoWrite** and never instructed flipping `- [ ]` → `- [x]` in the plan file — so every committed plan stayed all-unchecked after shipped work.

This PR aligns execution with authoring intent:

- **`subagent-driven-development`**: Flowchart and "Plan progress" section require marking completed steps in the plan file; TodoWrite is optional mirror only.
- **`executing-plans`**: Each verified step flips its checkbox in the plan file.
- **`writing-plans`**: "Progress tracking (agents)" section documents plan-file updates as the durable log.
- **Document-review spec** + **codex-tools** + **testing.md**: Same clarification.

Replaces the direction of closed PR #1626 (which incorrectly said checkboxes were human-only).

## Test plan

- [ ] Read `subagent-driven-development` — plan file updates required; no "do not flip checkboxes"
- [ ] Read `executing-plans` Step 2 — `- [ ]` → `- [x]` after verification
- [ ] `writing-plans` header still says "syntax for tracking"
- [ ] Run a small plan execution and confirm plan file gains `- [x]` entries
