### PR TITLE
Require contributors to disclose authoring environment; document dev-branch target

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,14 +12,17 @@ add a comment or reaction to the existing one instead.
 
 - [ ] I searched existing issues and this is not a duplicate
 
-## Environment
+## Environment (required)
+<!-- Required. We assume an agent filed this report — tell us which one and
+     where it ran. We weigh reports by what produced them. -->
 
 | Field | Value |
 |-------|-------|
 | Superpowers version | |
 | Harness (Claude Code, Cursor, etc.) | |
 | Harness version | |
-| Model | |
+| Your model + version | |
+| All plugins installed | |
 | OS + shell | |
 
 ## Is this a Superpowers issue or a platform issue?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -30,5 +30,18 @@ progress, and some were intentionally declined.
      of project? If this is specific to your domain, workflow, or a
      third-party tool, it may belong as its own plugin instead. -->
 
+## Environment (required)
+<!-- Required. We assume an agent wrote this request — tell us which one and
+     where it ran. We weigh proposals reasoned from documentation differently
+     than ones grounded in a real session where the problem actually came up. -->
+
+| Field | Value |
+|-------|-------|
+| Superpowers version | |
+| Harness (Claude Code, Cursor, etc.) | |
+| Harness version | |
+| Your model + version | |
+| All plugins installed | |
+
 ## Context
-<!-- Optional: version info, harness, model, workflow where you hit this. -->
+<!-- Optional: the workflow where you hit this, links, transcripts. -->

--- a/.github/ISSUE_TEMPLATE/platform_support.md
+++ b/.github/ISSUE_TEMPLATE/platform_support.md
@@ -21,3 +21,14 @@ requested or discussed.
 ## Have you tried manual installation?
 <!-- Many tools work with Superpowers through manual setup even without
      official support. Did you try? What happened? -->
+
+## Environment (required)
+<!-- Required. We assume an agent wrote this request — tell us which one and
+     where it ran. -->
+
+| Field | Value |
+|-------|-------|
+| Harness you currently use (Claude Code, Cursor, etc.) | |
+| Harness version | |
+| Your model + version | |
+| All plugins installed | |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,23 @@ sections blank, contain multiple unrelated changes, or show no evidence
 of human involvement will be closed without review.
 -->
 
+> **This PR MUST target the `dev` branch, not `main`.** `main` is the
+> released branch; active work lands on `dev` first. PRs opened against
+> `main` will be asked to retarget `dev` before review.
+
+## Who is submitting this PR? (required)
+<!-- Required. PRs that omit this will be closed. We assume an agent wrote
+     this PR — tell us which one and where it ran. We weigh contributions by
+     what produced them: content reasoned from documentation is held to a
+     different bar than work grounded in a real session. -->
+
+| Field | Value |
+|-------|-------|
+| Your model + version | |
+| Harness + version | |
+| All plugins installed | |
+| Human partner who reviewed this diff | |
+
 ## What problem are you trying to solve?
 <!-- Describe the specific problem you encountered. If this was a session
      issue, include: what you were doing, what went wrong, the model's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ Before you open a PR against this repo, you MUST:
 2. **Search for existing PRs** — open AND closed — that address the same problem. If duplicates exist, STOP and tell your human partner. Do not open another duplicate.
 3. **Verify this is a real problem.** If your human partner asked you to "fix some issues" or "contribute to this repo" without experiencing a specific problem, push back. Ask them what broke, what failed, what the user experience was.
 4. **Confirm the change belongs in core.** If it's domain-specific, tool-specific, or promotes a third-party project, it belongs in a standalone plugin. Tell your human partner.
-5. **Show your human partner the complete diff** and get their explicit approval before submitting.
+5. **Identify yourself.** Disclose your model, harness, harness version, and every installed plugin in the PR. Hiding that a contribution is agent-generated — or which environment produced it — is grounds for closing it.
+6. **Show your human partner the complete diff** and get their explicit approval before submitting.
 
 If any of these checks fail, do not open the PR. Explain to your human partner why it would be rejected and what would need to change. They will thank you for saving them the embarrassment.
 
@@ -25,6 +26,10 @@ If any of these checks fail, do not open the PR. Explain to your human partner w
 **Before opening a PR, you MUST search for existing PRs** — both open AND closed — that address the same problem or a related area. Reference what you found in the "Existing PRs" section. If a prior PR was closed, explain specifically what is different about your approach and why it should succeed where the previous attempt did not.
 
 **PRs that show no evidence of human involvement will be closed.** A human must review the complete proposed diff before submission.
+
+**Submitters MUST identify themselves.** Every PR and issue must disclose the model, harness, harness version, and all installed plugins used to produce the contribution — or state plainly that it was written by hand with no agent. This is not optional. We need to know what produced a change in order to weigh it: agent-generated content reasoned from documentation is held to a different bar than work grounded in a real session. Contributions that hide their authoring environment will be closed.
+
+**All PRs MUST target the `dev` branch, not `main`.** `main` is the released branch; active work lands on `dev` first. PRs opened against `main` will be asked to retarget `dev` before they are reviewed.
 
 ## What We Will Not Accept
 


### PR DESCRIPTION
Adds a mandatory self-identification disclosure (model, harness, harness version, all installed plugins) to the PR template and all three issue templates, documents the requirement in the contributor guidelines, and states explicitly in both CLAUDE.md and the PR template that all PRs must target `dev`, not `main`.

## What problem are you trying to solve?

While triaging the open backlog, issue #1647 came in as a thorough, well-structured RFC about a conflict between `subagent-driven-development` and Claude Code's `ultracode` — but with no reproduction and strong signals of being agent-authored from reading docs rather than from a real session. There was no field in any template that required the submitter to disclose what produced the contribution, so distinguishing "reasoned from documentation" from "grounded in a real session" took manual investigation every time. The contributor guidelines also never stated, in writing, that PRs should target `dev` — a recurring source of `needs-rebase-to-dev-branch` retargeting.

## What does this PR change?

- **PR template**: adds a required "Who/what authored this PR" table (submitting human, authoring model + version, harness + version, all plugins installed) and a banner stating PRs must target `dev`.
- **Issue templates** (bug_report, feature_request, platform_support): adds a required "Environment" disclosure including model and all installed plugins; feature_request previously made this optional.
- **CLAUDE.md**: adds a self-identification requirement and a dev-branch-target requirement to the contributor guidelines, plus an "Identify yourself" step to the AI-agent checklist.

## Is this change appropriate for the core library?

Yes — this is repository governance for all contributors, not a skill or domain-specific feature.

## What alternatives did you consider?

Folding authoring identity into the existing "Environment tested" table. Rejected: authoring environment (what produced the change) is distinct from tested-on environment (a PR may be tested across several harnesses), so they are kept separate.

## Does this PR contain multiple unrelated changes?

No — every change serves the single goal of knowing what produced a contribution and where it should land.

## Existing PRs
- [x] I have reviewed open and closed PRs; no prior PR adds a submitter-identification requirement or documents the dev-branch target.

## Environment tested

Docs/templates only; no executable code paths changed.

## Who/what authored this PR
- Submitting human: Jesse Vincent
- Authoring model: Claude Opus 4.8 (claude-opus-4-8)
- Harness: Claude Code 2.1.156
- Plugins: superpowers (+ github-triage skill in use during the session that motivated this)

## Human review
- [x] Jesse reviewed the complete diff before submission.

> Note: this PR targets `main` at the maintainer's explicit direction, even though the change it adds asks contributors to target `dev`. The "will be asked to retarget" rule binds contributors, not the maintainer.