### PR TITLE
fix: writing-plans generates bare git commits; subagents drift to main branch

### DIFF
--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -38,6 +38,11 @@ Task tool (general-purpose):
 
     Work from: [directory]
 
+    **Git:** ALL git commands must use `git -C [worktree path]`. The `.worktrees/`
+    directory is gitignored in the main repo — running `git status` from the main
+    repo path will show nothing. If you see an empty `git status`, you are using
+    the wrong path. Always use the worktree path from the plan's Git Target section.
+
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -13,7 +13,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
 
-**Context:** If working in an isolated worktree, it should have been created via the `superpowers:using-git-worktrees` skill at execution time.
+**Context:** If working in an isolated worktree, it should have been created via the `superpowers:using-git-worktrees` skill at execution time. Before writing the plan, run `git worktree list` to find the worktree path. Every commit step must use `git -C <worktree-path>` — never bare `git` commands. See the Git Target section below.
 
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)
@@ -58,7 +58,23 @@ This structure informs the task decomposition. Each task should produce self-con
 **Tech Stack:** [Key technologies/libraries]
 
 ---
+
+## Git Target
+
+**ALL git commands in this plan must use the worktree path below. Never use the main repo path for commits.**
+
 ```
+WORKTREE=<absolute path from `git worktree list`>
+```
+
+Every commit step is written as `git -C $WORKTREE ...`. If you are running steps manually, substitute the full path.
+
+The `.worktrees/` directory is gitignored in the main repo — `git status` from the main repo path will show nothing. All reads, writes, and commits must target the worktree path.
+
+---
+```
+
+**How to fill in the Git Target:** Before writing tasks, run `git worktree list`. Use the path of the feature worktree (not the main repo). If no worktree exists yet, note that one must be created before execution begins.
 
 ## Task Structure
 
@@ -98,8 +114,8 @@ Expected: PASS
 - [ ] **Step 5: Commit**
 
 ```bash
-git add tests/path/test.py src/path/file.py
-git commit -m "feat: add specific feature"
+git -C /absolute/path/to/worktree add tests/path/test.py src/path/file.py
+git -C /absolute/path/to/worktree commit -m "feat: add specific feature"
 ```
 ````
 


### PR DESCRIPTION
## Problem

When a worktree is created at `.worktrees/<branch>/`, the `.worktrees/` directory is typically gitignored in the main repo. The `writing-plans` skill generates commit steps with bare `git add / git commit` (no `-C` path flag).

Subagents dispatched by `subagent-driven-development` inherit the main repo as their git context. When they run `git status` from the main path they see **nothing** (gitignored), which causes them to either fail silently or drift back to committing on the main branch — defeating worktree isolation entirely.

Relates to #1040 (file-write drift to main repo); this is the git-commit equivalent.

## Root cause

Two gaps:

1. `writing-plans/SKILL.md` — the Plan Document Header template has no Git Target section, and the Task Structure commit example uses bare `git add/commit` with no path. Subagents copy this pattern literally.

2. `subagent-driven-development/implementer-prompt.md` — the `Work from: [directory]` line is interpreted as the reading/editing root, not as the git target. There is no explanation that `.worktrees/` is gitignored and that an empty `git status` means the wrong path is being used.

## Fix

**`writing-plans/SKILL.md`**
- Add pre-writing instruction to run `git worktree list` and capture the worktree path before writing tasks
- Add a mandatory **Git Target** section to the Plan Document Header template with the worktree path and an explanation of the gitignore behaviour
- Change the Task Structure commit example from bare `git add/commit` to `git -C /absolute/path/to/worktree add/commit`

**`subagent-driven-development/implementer-prompt.md`**
- Add an explicit git warning block under `Work from:` explaining that `.worktrees/` is gitignored and an empty `git status` means the wrong path is being used

## Observed in

Confirmed on Claude Code with a Python project where `.worktrees/` is gitignored. Subagents repeatedly committed to `master` despite the worktree being on a feature branch.