### PR TITLE
fix: foreground mode saves node PID and clears OWNER_PID on Windows/MSYS2

### DIFF
--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -107,10 +107,23 @@ if [[ -z "$OWNER_PID" || "$OWNER_PID" == "1" ]]; then
   OWNER_PID="$PPID"
 fi
 
+# Windows/MSYS2: Node.js cannot see POSIX PIDs from the MSYS2 namespace.
+# Passing a PID node cannot verify causes server to log owner-pid-invalid
+# and self-terminate at the 60-second lifecycle check. Clear it so the
+# watchdog is disabled and the idle timeout becomes the only shutdown trigger.
+case "${OSTYPE:-}" in
+  msys*|cygwin*|mingw*) OWNER_PID="" ;;
+esac
+if [[ -n "${MSYSTEM:-}" ]]; then
+  OWNER_PID=""
+fi
+
 # Foreground mode for environments that reap detached/background processes.
 if [[ "$FOREGROUND" == "true" ]]; then
-  echo "$$" > "$PID_FILE"
-  env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs
+  env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs &
+  SERVER_PID=$!
+  echo "$SERVER_PID" > "$PID_FILE"
+  wait "$SERVER_PID"
   exit $?
 fi
 


### PR DESCRIPTION
## What problem are you trying to solve?

On Windows with Git Bash (MSYS2/Cygwin), running the brainstorm server leaves orphaned `node server.cjs` processes after `stop-server.sh` is called. Each orphaned process holds a port and accumulates across sessions. This is issue #1652.

Two root causes:

**1. Wrong PID saved in foreground mode.**
`start-server.sh` wrote `echo "$$"` — the bash wrapper shell's PID — to the PID file. `stop-server.sh` killed the shell wrapper, but `node` is a child of that shell and kept running. The port was never released.

**2. OWNER_PID invisible to Node.js on Windows.**
MSYS2 POSIX PIDs are not visible in the Windows PID namespace that Node.js uses. The server received a non-zero `BRAINSTORM_OWNER_PID` it could not verify, logged `owner-pid-invalid`, and disabled its watchdog — but only by accident of the new `owner-pid-invalid` behaviour. On builds where the watchdog fires on an unverifiable PID, the server would self-terminate within 60 seconds.

## What does this PR change?

In `skills/brainstorming/scripts/start-server.sh`:

1. Foreground mode now backgrounds `node` with `&`, captures its PID via `$!`, writes that to the PID file, then `wait`s — keeping the blocking behaviour while saving the correct PID.
2. `OWNER_PID` is cleared to empty on `msys*`, `cygwin*`, `mingw*`, and when `MSYSTEM` is set, so Node.js receives an empty owner PID and disables the watchdog cleanly.

## Is this change appropriate for the core library?

Yes. The brainstorm server ships as part of core and Windows/Git Bash is a supported platform. The bug affects any Windows user of the brainstorming skill.

## What alternatives did you consider?

- **`exec node`**: replaces the shell with node directly — but `exec` prevents writing the PID file before node starts, creating a race condition.
- **`pkill -f server.cjs`**: kills unrelated node processes.
- **Only fix the OWNER_PID**: leaves the wrong-PID-in-file bug, so `stop-server.sh` still cannot kill the process.

The `& / $! / wait` pattern is the minimal correct fix with no race condition and preserved blocking behaviour.

## Does this PR contain multiple unrelated changes?

No. Both changes are in the same file and fix the same bug (#1652): orphaned node processes on Windows. They are causally linked — fixing only one leaves the other failure mode active.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #936 (OWNER_PID fix, closed draft), #879 (WSL owner PID, closed), #751 (stop-server verification, merged), #1592 (test alignment, closed — maintainer landed a targeted repair as eef50b9)

#936 and #879 addressed OWNER_PID only and did not fix the foreground shell-PID bug. #1592 fixed the test file but not the script itself. This PR fixes both root causes.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.156 | Claude Sonnet | claude-sonnet-4-6 |

Platform: Windows 11 Home 10.0.26200, Git Bash (OSTYPE=cygwin, MSYSTEM=MINGW64), Node v24.16.0

Full test suite run:

```
=== Brainstorm Server Windows Lifecycle Tests ===
Platform: cygwin
MSYSTEM: MINGW64
Node: v24.16.0

=== Results: 12 passed, 0 failed, 0 skipped ===
```

## New harness support

N/A

## Evaluation

- Initial prompt: brainstorm server left orphaned node processes on Windows after stop-server.sh (issue #1652)
- Before: `stop-server.sh` returned `{"status":"stopped"}` but node kept running — confirmed via `ps -W` and `tasklist`
- After: `stop-server.sh` kills node cleanly; `ps -W` confirms the process is gone and the port is released. Verified manually across multiple start/stop cycles.

## Rigor

- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content without evals

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

---
*Authored with Claude Sonnet 4.6 (claude-sonnet-4-6) via Claude Code 2.1.156 with superpowers installed. Human partner reviewed and approved the diff before submission.*