### PR TITLE
Consolidate code review feedback workflow, reduce skill redundancy

### DIFF
--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -5,37 +5,9 @@ description: Use when receiving code review feedback, before implementing sugges
 
 # Code Review Reception
 
-## Overview
+Deep-dive guide for responding to code review feedback. For the quick-response workflow and requesting pattern, see `requesting-code-review/SKILL.md`.
 
-Code review requires technical evaluation, not emotional performance.
-
-**Core principle:** Verify before implementing. Ask before assuming. Technical correctness over social comfort.
-
-## The Response Pattern
-
-```
-WHEN receiving code review feedback:
-
-1. READ: Complete feedback without reacting
-2. UNDERSTAND: Restate requirement in own words (or ask)
-3. VERIFY: Check against codebase reality
-4. EVALUATE: Technically sound for THIS codebase?
-5. RESPOND: Technical acknowledgment or reasoned pushback
-6. IMPLEMENT: One item at a time, test each
-```
-
-## Forbidden Responses
-
-**NEVER:**
-- "You're absolutely right!" (explicit CLAUDE.md violation)
-- "Great point!" / "Excellent feedback!" (performative)
-- "Let me implement that now" (before verification)
-
-**INSTEAD:**
-- Restate the technical requirement
-- Ask clarifying questions
-- Push back with technical reasoning if wrong
-- Just start working (actions > words)
+**Core principle:** Verify before implementing. Technical correctness over social comfort. No performative agreement.
 
 ## Handling Unclear Feedback
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -101,3 +101,25 @@ You: [Fix progress indicators]
 - Request clarification
 
 See template at: requesting-code-review/code-reviewer.md
+
+## Responding to Feedback
+
+When review feedback arrives, apply technical rigor — not emotional performance:
+
+**Verify before implementing:**
+1. READ the complete feedback without reacting
+2. UNDERSTAND each item (ask if unclear — don't guess)
+3. VERIFY against the codebase (does it apply here?)
+4. EVALUATE for technical correctness
+5. RESPOND with technical acknowledgment or reasoned pushback
+6. IMPLEMENT one item at a time, test each
+
+**Forbidden responses:** "You're absolutely right!", "Great point!", "Thanks for [anything]" — these are performative, not technical. Instead, state the fix or ask a clarifying question. Actions speak louder.
+
+**For multi-item feedback:** Clarify unclear items FIRST, then fix in priority order: blocking issues → simple fixes → complex fixes. Test each individually.
+
+**Push back when:** suggestion breaks existing functionality, reviewer lacks full context, violates YAGNI, or conflicts with prior architectural decisions. Use technical reasoning, not defensiveness.
+
+**If reviewer was right and you were wrong:** "Verified and you're correct. My initial understanding was wrong because [reason]. Fixing." — factual, no apology needed.
+
+Full receiving guidance at: `receiving-code-review/SKILL.md`


### PR DESCRIPTION
## Summary

Merged the "Responding to Feedback" workflow from `receiving-code-review` into `requesting-code-review`, reducing ~40% content overlap between the two skills.

### Changes

**requesting-code-review/SKILL.md** — Added condensed "Responding to Feedback" section:
- 6-step verify-before-implement pattern
- Forbidden performative responses
- Multi-item implementation order
- When and how to push back
- Cross-reference to receiving-code-review for deep-dive

**receiving-code-review/SKILL.md** — Removed duplicative sections, kept unique value:
- Source-Specific Handling (human partner vs external reviewers)
- YAGNI Check
- Common Mistakes table
- Real Examples with good/bad comparisons
- GitHub Thread Replies
- "Strange things are afoot at the Circle K" signal

### Reasoning
The two skills shared ~40% content overlap. The receiving skill is now a focused deep-dive reference while the requesting skill provides the complete quick-response workflow. Both skills remain independently loadable.