### PR TITLE
feat: add context checkpoint pattern to executing-plans

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -28,6 +28,23 @@ For each task:
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
 4. Mark as completed
+5. **Tick `[x]` in the plan file** — write this immediately after each task completes. This is the cross-session progress record; it is what allows a fresh context to resume without re-reading history.
+6. **Offer a context checkpoint** if the plan has more tasks remaining (see below)
+
+### Context Checkpoints
+
+Long plans accumulate tool output, file reads, and test results that consume context without helping future steps. After each task, offer a checkpoint when:
+
+- 5 or more tasks have completed, **or**
+- The session has produced heavy output (many file reads, large test runs, repeated diffs)
+
+**Checkpoint offer (copy verbatim):**
+
+> "Task N complete — `[x]` marked in the plan. Context is growing after N tasks. To keep subsequent tasks sharp: type `/clear`, then `execute <plan-file>` — the `[x]` marks track progress and the next session will skip completed tasks automatically."
+
+**Never offer a checkpoint** after the final task — proceed directly to Step 3.
+
+**If the user clears context and restarts:** Read the plan file, skip all `[x]`-marked tasks, announce which task you are resuming from, and continue.
 
 ### Step 3: Complete Development
 
@@ -61,6 +78,8 @@ After all tasks complete and verified:
 - Reference skills when plan says to
 - Stop when blocked, don't guess
 - Never start implementation on main/master branch without explicit user consent
+- Tick `[x]` in the plan file immediately after each task — it is the only progress record that survives a context clear
+- Offer a context checkpoint after every 5 tasks or any heavy-output session; never after the last task
 
 ## Integration
 


### PR DESCRIPTION
## Problem

On long plans (5+ tasks), `executing-plans` accumulates tool output, file reads, and test results that consume context without benefiting future steps. The skill offered no mechanism to shed that weight mid-execution, and no durable progress record that would survive a `/clear`.

## RED Baseline

Observed during a real 9-task plan execution (V5 security/code-quality hardening pass):

- 9 sequential tasks, each with file edits + a full test run (~57 s output per run)
- 23 files modified across `app/`, `lib/`, `Test/`, `scripts/`
- Skill never offered a checkpoint; no `[x]` ticks written to the plan file
- Context grew continuously from task 1 through task 9 with no release valve
- User noted the gap directly: *"Claude can often run out of context doing multiple steps — given that everything is documented in the plan, why doesn't this superpower clear context every now and again?"*

The plan file already documents every step with complete before/after code, making it the natural resumption point — the skill just wasn't using it that way.

## GREEN Fix

Two minimal additions to `executing-plans/SKILL.md`:

**1. Checkbox ticking (Step 2, items 5–6)**
After each task completes, tick `[x]` in the plan file immediately. This is the only progress record that survives a context clear and enables clean resumption.

**2. Context Checkpoints section**
Defines when to offer a checkpoint (5+ tasks completed, or heavy-output session), prescribes verbatim wording so the offer is consistent across instances, and specifies resume behaviour (read plan, skip `[x]`-marked tasks, announce resumption point).

The verbatim offer is intentional — prescribing the exact message prevents vague improvisation and gives users a reliable, actionable prompt every time.

**Never offer after the final task** — proceed directly to `finishing-a-development-branch` as before.

## Scope

- `skills/executing-plans/SKILL.md` only
- No new files, no changes to other skills, no changes to hooks or config
- Fully backwards-compatible: plans without `[x]` syntax execute identically; the checkpoint offer is additive

## Testing Notes

The V5 session serves as the documented RED baseline. A formal subagent pressure test per `writing-skills` conventions would strengthen this further — happy to run one if that's preferred before merge.