### PR TITLE
Add dependency-safety skill and tighten planning/review guidance

### DIFF
--- a/CODEOWNER
+++ b/CODEOWNER
@@ -1,0 +1,2 @@
+# Repo owner
+*       @magicfish23

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -94,6 +94,7 @@ digraph brainstorming {
 **Design for isolation and clarity:**
 
 - Break the system into smaller units that each have one clear purpose, communicate through well-defined interfaces, and can be understood and tested independently
+- When operations recur across multiple flows, separate the domain rules (the *why/when*) from the reusable mechanics (the *how*) so a fix in one place holds everywhere. Apply this only to genuinely shared operations — logic used by a single flow stays put (no premature shared layer).
 - For each unit, you should be able to answer: what does it do, how do you use it, and what does it depend on?
 - Can someone understand what a unit does without reading its internals? Can you change the internals without breaking consumers? If not, the boundaries need work.
 - Smaller, well-bounded units are also easier for you to work with - you reason better about code you can hold in context at once, and your edits are more reliable when files are focused. When a file grows large, that's often a signal that it's doing too much.

--- a/skills/dependency-and-security-guardrails/SKILL.md
+++ b/skills/dependency-and-security-guardrails/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: dependency-and-security-guardrails
+description: Use when adding or upgrading a dependency, editing lockfiles, handling secrets / API keys / .env files, or when a supply-chain breach or malicious-package advisory is trending — before the install, commit, or paste happens.
+---
+
+# Dependency and Security Guardrails
+
+## Overview
+
+The agent vets what enters the codebase and never leaks secrets. Your human partner owns account-level security (2FA, password manager) — remind, don't attempt.
+
+**Core principle:** A new dependency and a leaked secret are both one-way doors. Check before, not after.
+
+## When to Use
+
+- Before any package install or lockfile change (`npm`/`pnpm`/`yarn`/`pip`/`uv`/`cargo`/`go get` ...)
+- Before committing files that could contain secrets
+- When a supply-chain breach or malicious package version is reported
+
+**Not for:** reading code, or edits that touch no dependencies and no secrets.
+
+## Dependency Gate
+
+Before adding or upgrading a dependency:
+
+1. Check **age, adoption, and provenance** — publish date, download counts, source repo, maintainers.
+2. **STOP and flag to your human partner** (get explicit approval before installing) if the package is:
+   - less than 14 days old (tunable default),
+   - near-zero usage or a single unknown maintainer,
+   - typo-squat-shaped (name is a near-miss of a popular package),
+   - pulling in surprising transitive dependencies.
+3. Don't add a dependency for something you can write inline in a few lines (YAGNI).
+
+Report what you found — don't just install and move on.
+
+## Secrets Hygiene
+
+- Never echo, log, paste, or commit secret **values**. Reference env var **names** instead.
+- Before committing: scan the diff for keys/tokens, and confirm `.env` (and similar) are gitignored.
+- If you discover a secret already committed, stop and tell your human partner — rotation is their call.
+
+## Breach-Exposure Check
+
+When a supply-chain breach or malicious version is reported:
+
+1. Identify the package name and affected version range.
+2. Grep lockfiles for it: `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `requirements.txt`, `uv.lock`, `Cargo.lock`, `go.sum`.
+3. Report matches (file + version) and the remediation (pin, upgrade, remove). Don't auto-upgrade across majors without approval.
+
+## Quick Reference
+
+| Trigger | Do | Don't |
+|---|---|---|
+| Adding a dependency | Check age/adoption/provenance; flag if risky | Install silently to save time |
+| New tiny dependency | Write it inline if trivial (YAGNI) | Pull a package for 3 lines |
+| Handling a secret | Reference the env var name | Echo/log/commit the value |
+| Breach reported | Grep lockfiles, report exposure | Assume "probably not affected" |
+
+## Red Flags — STOP
+
+These thoughts mean you're rationalizing past the gate:
+
+| Rationalization | Reality |
+|---|---|
+| "This package is probably fine" | You didn't check age, adoption, or provenance. |
+| "I'll just install it to save time" | The check takes seconds; a supply-chain compromise costs days. |
+| "The secret is only for testing" | Test secrets leak too. Reference the env var name. |
+| "I'll clean up the committed .env later" | A committed secret is already exposed. Rotation is your partner's call — now. |
+| "It's one tiny package, not worth flagging" | Tiny packages are the classic supply-chain vector. Flag it. |
+| "I'll just bump it to the patched version" | Don't auto-upgrade/remove a flagged package without approval. |
+
+## Your Human Partner's Job
+
+2FA via an authenticator app (not SMS), and a password manager. These are theirs — remind when relevant, don't attempt them.

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -21,6 +21,12 @@ Dispatch a code reviewer subagent to catch issues before they cascade. The revie
 - Before refactoring (baseline check)
 - After fixing complex bug
 
+## Keep the Review Unit Small
+
+Review reliability drops as the diff grows — AI reviewers and humans both lose accuracy on large, multi-concern changes. Before requesting:
+- If the diff is large or spans several unrelated concerns, split it (or review in focused chunks) so each review has a clear, checkable scope.
+- A clean review means the diff looks correct — not that the change was the right thing to build. Keep that product judgment separate.
+
 ## How to Request
 
 **1. Get git SHAs:**

--- a/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -21,5 +21,7 @@ Task tool (general-purpose):
 - Are units decomposed so they can be understood and tested independently?
 - Is the implementation following the file structure from the plan?
 - Did this implementation create new files that are already large, or significantly grow existing files? (Don't flag pre-existing file sizes — focus on what this change contributed.)
+- Are the same runtime mechanics (API calls, parsing, validation, payload transforms) duplicated across multiple files? If so, flag extracting them into one reusable service-layer module, keeping domain policy (auth, business rules, error classification) in the calling route/action.
+- If you recommend an extraction, is it behavior-preserving and a small, focused diff? (No whole-app refactor, no naming churn — cleanup is scoped to what this change touched.)
 
 **Code reviewer returns:** Strengths, Issues (Critical/Important/Minor), Assessment

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -56,6 +56,8 @@ Task tool (general-purpose):
       and note it as a concern in your report
     - In existing codebases, follow established patterns. Improve code you're touching
       the way a good developer would, but don't restructure things outside your task.
+    - When coding against an external library/SDK/API, search its real source or current
+      docs for the actual signatures before writing — don't guess API names from memory.
 
     ## When You're in Over Your Head
 

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -38,6 +38,9 @@ Task tool (general-purpose):
 
     Work from: [directory]
 
+    **If your work adds/upgrades a dependency or touches secrets/`.env` files:** invoke the
+    `dependency-and-security-guardrails` skill before installing or committing.
+
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -114,6 +114,7 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - "Similar to Task N" (repeat the code — the engineer may be reading tasks out of order)
 - Steps that describe what to do without showing how (code blocks required for code steps)
 - References to types, functions, or methods not defined in any task
+- Calls to external libraries/SDKs/APIs written from memory instead of verified against the real source or current docs (a hallucinated API name poisons every task built on it)
 
 ## Remember
 - Exact file paths always

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -29,6 +29,8 @@ Before defining tasks, map out which files will be created or modified and what 
 - Design units with clear boundaries and well-defined interfaces. Each file should have one clear responsibility.
 - You reason best about code you can hold in context at once, and your edits are more reliable when files are focused. Prefer smaller, focused files over large ones that do too much.
 - Files that change together should live together. Split by responsibility, not by technical layer.
+- Separate orchestration (domain rules — the *why/when*: auth, state transitions, error classification) from reusable mechanics (the *how*: provider calls, command execution). Keep domain policy in the orchestration layer; shared mechanics take explicit inputs and return structured results rather than reaching into shared state.
+- Extract a shared unit only when an operation is needed by 2+ callers (DRY); logic used once stays inline (YAGNI). When pulling shared logic out of existing code, migrate one caller at a time and verify before the next.
 - In existing codebases, follow established patterns. If the codebase uses large files, don't unilaterally restructure - but if a file you're modifying has grown unwieldy, including a split in the plan is reasonable.
 
 This structure informs the task decomposition. Each task should produce self-contained changes that make sense independently.


### PR DESCRIPTION
## What this PR changes
Folds principles from two external skill collections into superpowers' planning,
review, and implementation skills, and adds one new dependency/secret-safety skill.
(See the four bullets below.)

- New `dependency-and-security-guardrails` skill — dependency-vetting gate, secrets
  hygiene, breach-exposure lockfile grep; wired into the implementer prompt so
  subagents (which skip the auto-trigger bootstrap) get it at install/commit time.
- External-API grounding — verify library/SDK/API calls against real source/docs
  instead of writing them from memory (writing-plans + implementer prompt).
- Orchestration vs. mechanics — separate domain rules from reusable mechanics, with
  an extraction trigger (2+ callers / DRY) and incremental migration (brainstorming,
  writing-plans, code-quality reviewer).
- Review-unit scope — "Keep the Review Unit Small" in requesting-code-review.

## Appropriate for core (of this fork)
Yes — general-purpose skill refinements + a general safety skill. Nothing
project/tool/third-party-specific. (The source material's `reference/repos/` folder
convention was deliberately dropped as project setup.)

## Alternatives considered
Applied each principle only where it genuinely fit rather than force-injecting —
left systematic-debugging / executing-plans untouched, dropped the folder convention.
For the safety skill, chose an implementer-prompt cross-ref over editing
using-superpowers (which loads every session — too costly).

## Multiple changes?
Yes, four — intentionally batched as one coordinated "align the fork with studied
principles" effort. (For upstream these would be split into separate PRs.)

## Status
- Behavior-shaping edits made without writing-skills pressure-testing (intentional
  this iteration; recommended before any upstream use).
- Reviewed by the fork maintainer.