### PR TITLE
finishing-a-development-branch: don't treat harness worktrees (e.g. .claude/worktrees/) as superpowers-owned

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -180,16 +180,27 @@ WORKTREE_PATH=$(git rev-parse --show-toplevel)
 
 **If `GIT_DIR == GIT_COMMON`:** Normal repo, no worktree to clean up. Done.
 
-**If worktree path is under `.worktrees/`, `worktrees/`, or `~/.config/superpowers/worktrees/`:** Superpowers created this worktree — we own cleanup.
+**Provenance check — who owns this worktree?** Match the path *precisely*: a bare substring like `worktrees/` is NOT enough — it wrongly catches harness dirs such as `.claude/worktrees/`. Anchor to the repo root and the exact directory segment:
 
 ```bash
 MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+case "$WORKTREE_PATH" in
+  "$MAIN_ROOT"/.worktrees/*|"$MAIN_ROOT"/worktrees/*|"$HOME"/.config/superpowers/worktrees/*)
+    OWNER=superpowers ;;   # we created it — we own cleanup
+  *)
+    OWNER=harness ;;       # agent/IDE-managed (e.g. .claude/worktrees/) — leave alone
+esac
+```
+
+**If `OWNER=superpowers`:** Superpowers created this worktree — clean it up.
+
+```bash
 cd "$MAIN_ROOT"
 git worktree remove "$WORKTREE_PATH"
 git worktree prune  # Self-healing: clean up any stale registrations
 ```
 
-**Otherwise:** The host environment (harness) owns this workspace. Do NOT remove it. If your platform provides a workspace-exit tool, use it. Otherwise, leave the workspace in place.
+**If `OWNER=harness`** (anything else — including `.claude/worktrees/…` and other agent/IDE-managed worktree roots): the host environment owns this workspace. Do NOT `git worktree remove` it. If your platform provides a workspace-exit tool, use it. Otherwise, leave the workspace in place.
 
 ## Quick Reference
 
@@ -224,7 +235,7 @@ git worktree prune  # Self-healing: clean up any stale registrations
 
 **Cleaning up harness-owned worktrees**
 - **Problem:** Removing a worktree the harness created causes phantom state
-- **Fix:** Only clean up worktrees under `.worktrees/`, `worktrees/`, or `~/.config/superpowers/worktrees/`
+- **Fix:** Only clean up worktrees matched by the Step 6 provenance check — an exact path prefix under the repo-root `.worktrees/`/`worktrees/` or `~/.config/superpowers/worktrees/`, NOT a bare `worktrees/` substring. Harness dirs like `.claude/worktrees/…` are not superpowers-owned — leave them in place.
 
 **No confirmation for discard**
 - **Problem:** Accidentally delete work


### PR DESCRIPTION
## Problem

Step 6's provenance check decides whether to `git worktree remove` a worktree based on whether its path is "under `.worktrees/`, `worktrees/`, or `~/.config/superpowers/worktrees/`." The bare `worktrees/` substring also matches **harness-managed** worktree roots — notably Claude Code's `.claude/worktrees/<name>/`. A literal reading can therefore classify a harness-owned worktree as superpowers-owned and remove it — the exact phantom-state failure the skill's own Red Flags ("Clean up worktrees you didn't create") warn against.

Hit in practice: a session running inside `.claude/worktrees/<name>` matched the bare `worktrees/` rule.

## Fix

Replace the prose test with a precise `case` match anchored to the repo root and the superpowers home (`$MAIN_ROOT/.worktrees/`, `$MAIN_ROOT/worktrees/`, `$HOME/.config/superpowers/worktrees/`). Anything else → `OWNER=harness` → leave it alone. The matching **Common Mistakes** bullet is updated to stay consistent.

Docs-only change to one skill. No behavior change for genuinely superpowers-created worktrees; it only stops false-positives on harness dirs like `.claude/worktrees/`.