### PR TITLE
docs: warn about docs-build publication hazard at docs/superpowers/ save location

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -110,6 +110,7 @@ digraph brainstorming {
 
 - Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
+  - **Documentation build warning:** If this project publishes docs from `docs/` (Sphinx, MkDocs, Docusaurus, Read the Docs), `docs/superpowers/specs/` may be rendered publicly. After committing, check for a docs build config (`docs/conf.py`, `mkdocs.yml`, `.readthedocs.yaml`, `docusaurus.config.*`) and add an exclusion if needed. Sphinx: add `"superpowers"` to `exclude_patterns`; MkDocs: add `superpowers/` under `exclude_docs:`.
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -18,6 +18,11 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)
 
+> **Documentation build warning:** If this project publishes docs generated from `docs/` (Sphinx, MkDocs, Docusaurus, Read the Docs, etc.), `docs/superpowers/plans/` may be rendered and published publicly. After saving the plan, check for a docs build config (`docs/conf.py`, `mkdocs.yml`, `.readthedocs.yaml`, `docusaurus.config.*`). If found, add an exclusion so plans stay in git but never reach the published output:
+>
+> **Sphinx** (`docs/conf.py`): `exclude_patterns = ["_build", "Thumbs.db", "superpowers"]`
+> **MkDocs** (`mkdocs.yml`): add `superpowers/` under `exclude_docs:`
+
 ## Scope Check
 
 If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.


### PR DESCRIPTION
## Summary

Fixes #1690

The default save locations for `writing-plans` (`docs/superpowers/plans/`) and `brainstorming` (`docs/superpowers/specs/`) sit inside the directory that most documentation generators treat as their source root. Sphinx, MkDocs, Docusaurus, and Read the Docs will silently render and publish every `.md` file they find there — including internal implementation plans and design specs — even without an explicit `toctree` or `nav` entry.

This has already caused a real data leak in at least one open-source project (reported in the issue).

## Fix

Add a one-sentence callout at the save-location line in both skills:

- **`skills/writing-plans/SKILL.md`** — callout below the `Save plans to:` line
- **`skills/brainstorming/SKILL.md`** — callout below the `docs/superpowers/specs/` save instruction

The callout names the affected generators, says what to check for (docs build config files), and shows the one-line fix for Sphinx and MkDocs. No behavior change — just surfacing the hazard at the exact moment the skill is about to create the file.

## Why this approach

The issue author considered alternatives (moving plans outside `docs/`, gitignoring) and explains why the committed-in-`docs/` default is correct to keep. The simplest fix is teaching users about the `exclude_patterns` / `exclude_docs` pattern right when they'd need it.