### PR TITLE
docs: add animated hero gif to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Superpowers is a complete software development methodology for your coding agents, built on top of a set of composable skills and some initial instructions that make sure your agent uses them.
 
+![Demo: a coding agent with Superpowers steps back to tease out a spec, writes a junior-proof plan, then runs subagent-driven development with red/green TDD and code review — 14 composable skills that trigger automatically, across Claude Code, Codex, Gemini CLI, Cursor and more.](assets/hero.gif)
+
 ## Quickstart
 
 Give your agent Superpowers: [Claude Code](#claude-code), [Codex CLI](#codex-cli), [Codex App](#codex-app), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [OpenCode](#opencode), [Cursor](#cursor), [GitHub Copilot CLI](#github-copilot-cli).


### PR DESCRIPTION
The README describes the methodology really well in words — this shows it in 20 seconds: step back and tease out the spec, write a junior-proof plan, run subagent-driven development with red/green TDD and review, all 14 skills triggering on their own.

![preview](https://raw.githubusercontent.com/livlign/superpowers/docs/add-hero-gif/assets/hero.gif)

The copy is lifted from the README's own phrasing, the skill list matches the 14 in `skills/`, and the harness row matches the Quickstart. Uses your existing cape mark from `assets/`. No stars or version numbers baked in, so it won't go stale. 1200×675, ~5.3 MB, loops cleanly.

Happy to tweak pacing, copy, or drop it entirely if it's not your taste.

---
*Generated with [repo-visuals](https://github.com/livlign/claude-skills)*