### PR TITLE
fix: remove config.skills.paths injection causing duplicate skill entries

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -2,7 +2,8 @@
  * Superpowers plugin for OpenCode.ai
  *
  * Injects superpowers bootstrap context via system prompt transform.
- * Auto-registers skills directory via config hook (no symlinks needed).
+ * Skills are auto-discovered by OpenCode's plugin mechanism with the
+ * `superpowers:` prefix — no config.skills.paths injection needed.
  */
 
 import path from 'path';
@@ -96,18 +97,6 @@ ${toolMapping}
   };
 
   return {
-    // Inject skills path into live config so OpenCode discovers superpowers skills
-    // without requiring manual symlinks or config file edits.
-    // This works because Config.get() returns a cached singleton — modifications
-    // here are visible when skills are lazily discovered later.
-    config: async (config) => {
-      config.skills = config.skills || {};
-      config.skills.paths = config.skills.paths || [];
-      if (!config.skills.paths.includes(superpowersSkillsDir)) {
-        config.skills.paths.push(superpowersSkillsDir);
-      }
-    },
-
     // Inject bootstrap into the first user message of each session.
     // Using a user message instead of a system message avoids:
     //   1. Token bloat from system messages repeated every turn (#750)


### PR DESCRIPTION
## Problem

When using the superpowers plugin with OpenCode, every skill appears twice in the skill list:
- `superpowers:brainstorming` (discovered via plugin mechanism)
- `brainstorming` (discovered via config.skills.paths)

This happens because the plugin's `config` hook injects the superpowers skills directory into `config.skills.paths`, but OpenCode's plugin mechanism already auto-discovers skills from the plugin's `skills/` directory with the `superpowers:` prefix.

OpenCode does not deduplicate skills by underlying file path, so the same SKILL.md file gets registered twice under different names.

## Solution

Remove the `config` hook that injects into `config.skills.paths`. The plugin mechanism already handles skill discovery correctly.

## Testing

1. Install superpowers plugin in OpenCode
2. Before fix: `/` shows both `brainstorming` and `superpowers:brainstorming`
3. After fix: `/` shows only `superpowers:brainstorming`

## Impact

- No functionality lost — skills are still fully discoverable via plugin mechanism
- Cleaner skill list without confusing duplicates
- Users can still add custom skills via `config.skills.paths` in their own config

## Checklist

- [x] Tested the fix locally
- [x] No breaking changes
- [x] Updated documentation (docstring)