### PR TITLE
docs: warn when docs/ is a doc-build source root

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -111,6 +111,10 @@ digraph brainstorming {
 - Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
+- Before committing, check if the project publishes docs built from `docs/` (look for `docs/conf.py`, `mkdocs.yml`, `.readthedocs.yaml`, `docusaurus.config.*`). If found, generators like Sphinx and MkDocs will publish these spec files as public web pages. Add an exclusion first:
+  - **Sphinx** (`docs/conf.py`): add `"superpowers"` to `exclude_patterns`
+  - **MkDocs** (`mkdocs.yml`): add `- superpowers/` under `not_in_nav:` or use `exclude_docs`
+  - **Docusaurus** (`docusaurus.config.*`): add `superpowers/**` to `exclude` in the docs plugin config
 - Commit the design document to git
 
 **Spec Self-Review:**

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -18,6 +18,11 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)
 
+> **Documentation build warning:** If the project publishes documentation built from `docs/` (check for `docs/conf.py`, `mkdocs.yml`, `.readthedocs.yaml`, `docusaurus.config.*`), generators like Sphinx and MkDocs may publish these plan files as public web pages. Before committing the plan, check for these files and add an exclusion if needed:
+> - **Sphinx** (`docs/conf.py`): add `"superpowers"` to the `exclude_patterns` list
+> - **MkDocs** (`mkdocs.yml`): add `- superpowers/` under `not_in_nav:` or use `exclude_docs`
+> - **Docusaurus** (`docusaurus.config.*`): add `superpowers/**` to `exclude` in the docs plugin config
+
 ## Scope Check
 
 If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.


### PR DESCRIPTION
## Summary

- Adds a documentation build warning to both `writing-plans` and `brainstorming` skills
- When a project has `docs/conf.py`, `mkdocs.yml`, `.readthedocs.yaml`, or `docusaurus.config.*`, the default `docs/superpowers/` save location puts internal plans/specs inside the directory that Sphinx, MkDocs, and Docusaurus treat as their source root
- Provides per-generator exclusion instructions so agents can prevent accidental publication before committing

Fixes #1690

## Changes

- `skills/brainstorming/SKILL.md`: add pre-commit check step with exclusion instructions for Sphinx / MkDocs / Docusaurus
- `skills/writing-plans/SKILL.md`: add blockquote warning with the same exclusion instructions