### PR TITLE
docs: clarify session terminology in SDD and writing-plans

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -19,23 +19,22 @@ Execute plan by dispatching fresh subagent per task, with two-stage review after
 digraph when_to_use {
     "Have implementation plan?" [shape=diamond];
     "Tasks mostly independent?" [shape=diamond];
-    "Stay in this session?" [shape=diamond];
+    "Coordinate from this session?" [shape=diamond];
     "subagent-driven-development" [shape=box];
     "executing-plans" [shape=box];
     "Manual execution or brainstorm first" [shape=box];
 
     "Have implementation plan?" -> "Tasks mostly independent?" [label="yes"];
     "Have implementation plan?" -> "Manual execution or brainstorm first" [label="no"];
-    "Tasks mostly independent?" -> "Stay in this session?" [label="yes"];
+    "Tasks mostly independent?" -> "Coordinate from this session?" [label="yes"];
     "Tasks mostly independent?" -> "Manual execution or brainstorm first" [label="no - tightly coupled"];
-    "Stay in this session?" -> "subagent-driven-development" [label="yes"];
-    "Stay in this session?" -> "executing-plans" [label="no - parallel session"];
+    "Coordinate from this session?" -> "subagent-driven-development" [label="yes"];
+    "Coordinate from this session?" -> "executing-plans" [label="no - single-agent execution"];
 }
 ```
 
-**vs. Executing Plans (parallel session):**
-- Same session (no context switch)
-- Fresh subagent per task (no context pollution)
+**vs. Executing Plans (single-agent execution):**
+- This session coordinates; fresh subagent per task (no context pollution)
 - Two-stage review after each task: spec compliance first, then code quality
 - Faster iteration (no human-in-loop between tasks)
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -137,16 +137,16 @@ After saving the plan, offer execution choice:
 
 **"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
 
-**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+**1. Subagent-Driven (recommended)** - I coordinate from this session, dispatch a fresh subagent per task, review between tasks, fast iteration
 
-**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+**2. Single-Agent Execution** - Execute tasks directly using executing-plans, batch execution with checkpoints
 
 **Which approach?"**
 
 **If Subagent-Driven chosen:**
 - **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
-- Fresh subagent per task + two-stage review
+- Fresh subagent per task + two-stage review; this session acts as coordinator
 
-**If Inline Execution chosen:**
+**If Single-Agent Execution chosen:**
 - **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
-- Batch execution with checkpoints for review
+- Batch execution with checkpoints for review; no subagent dispatch


### PR DESCRIPTION
## Summary

- Renames "Stay in this session?" to "Coordinate from this session?" in the `subagent-driven-development` decision graph — the old label was ambiguous because SDD *does* stay in the session (as coordinator) while subagents run outside it
- Changes the graph edge label from "no - parallel session" to "no - single-agent execution"
- Updates `vs. Executing Plans` heading from "(parallel session)" to "(single-agent execution)"
- Renames "Inline Execution" to "Single-Agent Execution" in `writing-plans` handoff options to match the updated terminology
- Adds brief clarifying notes: SDD = "this session acts as coordinator"; executing-plans = "no subagent dispatch"

Fixes #1478

## Changes

- `skills/subagent-driven-development/SKILL.md`: rename decision node and edge label; update comparison heading and bullet
- `skills/writing-plans/SKILL.md`: rename option 2 label and update conditional blocks to "Single-Agent Execution"