### PR TITLE
fix: use blocked todo status at brainstorming approval gates

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -11,6 +11,8 @@ Start by understanding the current project context, then ask questions one at a 
 
 <HARD-GATE>
 Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
+
+**Todo status at approval gates:** When you are waiting for user approval (design review, spec review, or any user decision), mark the corresponding todo as `blocked` — not `in_progress`. This prevents automated todo-continuation systems from injecting messages that bypass the user approval gate. Switch back to `in_progress` only after the user responds.
 </HARD-GATE>
 
 ## Anti-Pattern: "This Is Too Simple To Need A Design"
@@ -124,11 +126,11 @@ After writing the spec document, look at it with fresh eyes:
 Fix any issues inline. No need to re-review — just fix and move on.
 
 **User Review Gate:**
-After the spec review loop passes, ask the user to review the written spec before proceeding:
+After the spec review loop passes, ask the user to review the written spec before proceeding. Mark the "User reviews written spec" todo as `blocked` while waiting:
 
 > "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
 
-Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves. Switch the todo back to `in_progress` upon user response.
 
 **Implementation:**
 


### PR DESCRIPTION
## Problem

Automated todo-continuation systems (e.g. OMO's `todo-continuation-enforcer`) inject continuation nudges when they detect incomplete todos (`status: in_progress`). When the brainstorming skill reaches an approval gate and waits for user confirmation, the todo remains `in_progress` — triggering a nudge that the agent interprets as user approval, bypassing the gate.

## Root Cause

Two systems with conflicting assumptions:
- **brainstorming skill**: pauses at approval gates, waiting for user input
- **OMO enforcer**: detects `in_progress` todos and injects system messages to continue work

The injected message is indistinguishable from real user input at the agent level.

## Fix

Add a rule to the brainstorming skill's HARD-GATE and User Review Gate sections: when waiting for user approval, mark the corresponding todo as `blocked` instead of `in_progress`.

OMO's `getIncompleteCount()` already filters out `blocked` status, so no code changes are needed on the OMO side. The `todowrite` tool accepts `blocked` as a valid string status value.

## Changes

- **HARD-GATE section** (L12-16): Added blocked-status rule that applies to ALL approval gates
- **User Review Gate section** (L128-133): Added explicit `blocked` → `in_progress` transition instruction

## Testing

Verified that `todowrite` accepts `status: \"blocked\"` and that OMO's `getIncompleteCount()` in `src/hooks/todo-continuation-enforcer/todo.ts` already excludes `blocked` todos from the incomplete count.