### PR TITLE
SDD: cost-tiering stack + plan-mandated-defect escalation + pre-flight plan review (stacked on #1717)

### DIFF
--- a/docs/superpowers/specs/2026-06-10-strict-cost-sdd-design.md
+++ b/docs/superpowers/specs/2026-06-10-strict-cost-sdd-design.md
@@ -133,8 +133,29 @@ opus controller flagged it 5/5. Cheap controllers handle explicit
 escalation; they absorb implicit authority-vs-quality adjudication.
 A possible L2b (discrete rule: "a reviewer finding that conflicts with
 the plan's text is the human's decision — escalate it") would route the
-failing judgment through the escalation behavior that held; untested.
-Original recon notes follow.
+failing judgment through the escalation behavior that held.
+
+**L2b tested 2026-06-11 (E35/E36, evals
+`docs/experiments/2026-06-11-build-loop-autoresearch.md`): improves the
+opus stack, does NOT rescue the sonnet rung.** Two rules: a reviewer
+tripwire (a plan-mandated defect IS a finding — Important, labeled
+plan-mandated; the human decides) and a controller escalation rule
+(plan-mandated findings go to the human like any plan contradiction).
+Micro on frozen sonnet-composed inputs: 0/6 → 6/6 labeled findings.
+Full battery: opus controllers 2/2 internalized the rule, caught their
+reviewer's miss as self-described backstop, and escalated for a
+sanctioned fix (the 4241 ad-hoc behavior made structural); escalation
+sanity 2/2 unbroken. Sonnet controllers: 1/5 full pass — paraphrase
+drops the tripwire from dispatches (2/5 transmitted), transmission
+alone doesn't fire it live (read-once dilution across the reviewer's
+tool reads; placement within the dispatch refuted as the variable),
+and no sonnet controller showed backstop behavior; 1/5 shipped the
+defect. The L2b rules are a candidate commit for the opus stack.
+A future L2c for the sonnet rung would pair the SKILL.md
+constraints-recipe (the one channel sonnet transmits verbatim) with a
+mandatory output-format slot for plan-mandated findings (the skeleton
+survives every observed paraphrase and is consulted at composition
+time); untested. Original recon notes follow.
 
 **Recon (superseded):**
 Sonnet-controller runs (claude-sonnet coding-agent): all gates green at

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -181,6 +181,11 @@ final whole-branch review. When you fill a reviewer template:
   findings in the progress ledger as you go, and point the final
   whole-branch review at that list so it can triage which must be fixed
   before merge. A roll-up nobody reads is a silent discard.
+- A finding labeled plan-mandated — or any finding that conflicts with
+  what the plan's text requires — is the human's decision, like any plan
+  contradiction: present the finding and the plan text, ask which governs.
+  Do not dismiss the finding because the plan mandates it, and do not
+  dispatch a fix that contradicts the plan without asking.
 - The final whole-branch review gets a package too: run
   `scripts/review-package MERGE_BASE HEAD` (MERGE_BASE = the commit the
   branch started from, e.g. `git merge-base main HEAD`) and include the

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -82,6 +82,20 @@ digraph process {
 }
 ```
 
+## Pre-Flight Plan Review
+
+Before dispatching Task 1, scan the plan once for conflicts:
+
+- tasks that contradict each other or the plan's Global Constraints
+- anything the plan explicitly mandates that the review rubric treats as a
+  defect (a test that asserts nothing, verbatim duplication of a logic block)
+
+Present everything you find to your human partner as one batched question —
+each finding beside the plan text that mandates it, asking which governs —
+before execution begins, not one interrupt per discovery mid-plan. If the
+scan is clean, proceed without comment. The review loop remains the net for
+conflicts that only emerge from implementation.
+
 ## Model Selection
 
 Use the least powerful model that can handle each role to conserve cost and increase speed.

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -100,8 +100,10 @@ most expensive — which silently defeats this section.
 **Turn count beats token price.** Wall-clock and context cost scale with how
 many turns a subagent takes, and the cheapest models routinely take 2-3× the
 turns on multi-step work — costing more overall. Use a mid-tier model as the
-floor for implementers and reviewers; reserve the cheapest tier for
-single-file mechanical fixes.
+floor for reviewers and for implementers working from prose descriptions.
+When the task's plan text contains the complete code to write, the
+implementation is transcription plus testing: use the cheapest tier for
+that implementer. Single-file mechanical fixes also take the cheapest tier.
 
 **Task complexity signals (implementation tasks):**
 - Touches 1-2 files with a complete spec → cheap model

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -11,6 +11,9 @@ Execute plan by dispatching a fresh implementer subagent per task, a task review
 
 **Core principle:** Fresh subagent per task + task review (spec + quality) + broad final review = high quality, fast iteration
 
+**Narration:** between tool calls, narrate at most one short line — the
+ledger and the tool results carry the record.
+
 **Continuous execution:** Do not pause to check in with your human partner between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are: BLOCKED status you cannot resolve, ambiguity that genuinely prevents progress, or all tasks complete. "Should I continue?" prompts and progress summaries waste their time — they asked you to execute the plan, so execute it.
 
 ## When to Use
@@ -88,6 +91,8 @@ Use the least powerful model that can handle each role to conserve cost and incr
 **Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
 
 **Architecture and design tasks**: use the most capable available model.
+The final whole-branch review is one of these — dispatch it on the most
+capable available model, not the session default.
 
 **Review tasks**: choose the model with the same judgment, scaled to the
 diff's size, complexity, and risk. A small mechanical diff does not need the

--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -128,6 +128,11 @@ Subagent (general-purpose):
     would block a merge over — verbatim duplication of a logic block,
     swallowed errors, tests that assert nothing. "Coverage could be broader"
     and polish suggestions are Minor.
+    If the plan or brief explicitly mandates something this rubric calls a
+    defect (a test that asserts nothing, verbatim duplication of a logic
+    block), that IS a finding — report it as Important, labeled
+    plan-mandated. The plan's authorship does not grade its own work; the
+    human decides.
     Acknowledge what was done well before listing issues — accurate praise
     helps the implementer trust the rest of the feedback.
 

--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -115,6 +115,11 @@ Subagent (general-purpose):
     "yes." A tight report that cites lines gives the controller everything
     it needs.
 
+    Your final message is the report itself: begin directly with the
+    spec-compliance verdict. Every line is a verdict, a finding with
+    file:line, or a check you ran — no preamble, no process narration,
+    no closing summary.
+
     ## Calibration
 
     Categorize issues by actual severity. Not everything is Critical.


### PR DESCRIPTION
> **Stacked on #1717** (base branch `sdd-review-dispatch`): this PR contains only the optimization/judgment layer on top of the task-scoped review redesign. It retargets `dev` when #1717 lands. Draft until the #1717 eval pass is finished.

**@arittr — sequencing:** please don't stop the eval run you have going on #1717 / `sdd-e27-stack`. Once that one is put to bed, this branch is the next thing to eval — it is `sdd-e27-stack` plus three commits (the two plan-mandated-defect rules, the pre-flight plan review) and the evals/spec bumps.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | claude-fable-5 (Fable 5), session `7c4a7741-5e94-44b9-8c0f-3800d1241f89` |
| Harness + version | Claude Code 2.1.173 |
| All plugins installed | superpowers 5.1.0, episodic-memory, linear, context7, superpowers-chrome, plugin-dev, github-triage, agent-sdk-dev, code-simplifier |
| Human partner who reviewed this diff | @obra — directed each layer; reviewed the L2b rule texts, the pre-flight rule text, and the E27-stack layer verbatim before each push |

## What problem are you trying to solve?

Three measured failure modes in subagent-driven development, each from real eval sessions:

1. **SDD runs cost more than they need to.** Controllers dispatched implementers on the most capable model for transcription-grade tasks, reviewers narrated process instead of reporting findings, and controllers narrated every step. Measured across the 2026-06-10/11 cost campaign (46 runs + 30 micro-experiments).
2. **Reviewers advocate for plan-mandated defects.** When a plan explicitly mandates something the quality rubric calls a defect (our planted fixture: a test named "renders correctly" that asserts nothing), reviewers *praised* it — "no assertion, as required" under Strengths — and the defect shipped. Run `e8e9` showed a controller noticing the defect at plan-read and *deliberately deferring* to the review loop, because nothing told it raising plan conflicts up front was allowed.
3. **Conflicts surface mid-plan instead of up front**, after the defect has been implemented, reviewed, and escalated — paying for a fix dispatch and re-review that an up-front question would have avoided, and interrupting the human at the worst time (hours in) rather than the best (kickoff, when they just issued the command).

## What does this PR change?

Five additions to `skills/subagent-driven-development/` on top of #1717: (1) conditional implementer tiering — cheapest tier when the plan carries complete code; (2) final whole-branch review pinned to the most capable model; (3) a one-line narration recipe and a terse reviewer report contract; (4) two plan-mandated-defect rules — reviewer tripwire ("that IS a finding — Important, labeled plan-mandated; the human decides") and controller escalation rule ("present the finding and the plan text, ask which governs"); (5) a Pre-Flight Plan Review section — scan once before Task 1, batch all plan conflicts into one question. Plus the evals-submodule bump making the planted-defect scenario escalation-aware.

## Is this change appropriate for the core library?

Yes — all changes are to the general-purpose SDD skill and benefit any project type. No third-party dependencies, no domain-specific content.

## What alternatives did you consider?

- **Cheaper controller (sonnet) instead of cheaper subagents:** died at its quality gates — explicit escalation held 5/5 but planted-defect adjudication collapsed into plan-advocacy 4/5 (E34).
- **Haiku task reviewers:** dead — 0/10 planted defects flagged at correct severity; haiku *advocates* for defects (batch D).
- **Reviewer template as a read-once file** (kill paraphrase drift): failed its gate — 0/3 first-pass catches vs 3/5 inline; read-once dilutes (E33).
- **Thinking caps for cost:** backfire — raise the turn floor, output tokens up ~80% (E06).
- **Tripwire placement within the dispatch** (Calibration section vs inside the constraints block): refuted as the variable — the live failure is attention decay across the reviewer's tool reads, which is why the pre-flight rule (controller's own context, no dispatch channel) is the load-bearing fix (E35/E36/E37).

## Does this PR contain multiple unrelated changes?

The commits are one coherent layer: the cost stack and the judgment rules were co-developed against the same eval battery, and the pre-flight rule exists because the L2b battery exposed the dispatch-transmission gap. Splitting them would ship a cost stack whose planted-defect gate we know is weaker without the judgment rules.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1717 (base of this stack), #1715 (compatible — we eval-tested the interaction; see https://github.com/obra/superpowers/pull/1715#issuecomment-4685432362)

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code | 2.1.173 | Opus (controller + subagents) | claude-opus-4-8 |
| Claude Code | 2.1.173 | Sonnet (controller) / mixed subagents | claude-sonnet-4-6 |

## New harness support

N/A — no new harness.

## Evaluation

- **Initial prompt:** quorum-driven eval sessions ("execute docs/superpowers/plans/report-plan.md with subagent-driven-development" and the fractals/svelte build scenarios), run via the superpowers-evals harness.
- **Sessions after the change:** 30+ full quorum runs plus ~90 micro-test samples across the campaign; for the newest layer specifically: 9 full runs (L2b battery) + 5 full runs (E37) + 48 micro samples, every automated score manually verified.
- **Outcomes before → after:**
  - Cost: fractals $16.07 baseline → $6.24–6.60 on this stack; svelte $20.98 → $10.59–11.25.
  - Plan-mandated defect, opus: reviewer praised it before; now 2/2 runs escalate to the human with the rule quoted, sanctioned fix lands.
  - Pre-flight: without the rule, 0/12 micro samples and 0/5 prior full runs asked before dispatching; with it, 12/12 micro and **5/5 full sonnet runs ask before dispatch #0** (zero variance), including one run batching both planted conflicts into a single question.
  - Escalation sanity (plan self-contradiction scenario): 2/2 pass with the new rules — the working behavior is preserved, and the catch moves from mid-plan to time zero.
  - Known limits, stated plainly: sonnet-controller planted-defect remains 1/5 at the *per-task reviewer* gate (the pre-flight rule is what rescues the run outcome); the gauntlet judge is documented unreliable on this scenario (PRI-2160); benign-plan false-positive rate for the pre-flight scan is unmeasured at large-plan scale.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` methodology — micro-tests with no-guidance controls before full runs, pre-registered predictions, negative results logged at equal billing
- [x] This change was tested adversarially, not just on the happy path (planted-defect fixtures, plan self-contradiction fixture, frozen-input replays)
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission — @obra directed and approved each commit in-session; rule texts were reviewed verbatim before pushing
