### PR TITLE
Model selection hard gate

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -26,7 +26,7 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Write design doc** — save to `docs/specs/YYYY-MM-DD-HHMMSS-<topic>-design.md` (get the timestamp via `date +%Y-%m-%d-%H%M%S`) and commit
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
@@ -108,7 +108,7 @@ digraph brainstorming {
 
 **Documentation:**
 
-- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+- Write the validated design (spec) to `docs/specs/YYYY-MM-DD-HHMMSS-<topic>-design.md` (get the timestamp via `date +%Y-%m-%d-%H%M%S`)
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git

--- a/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -4,7 +4,7 @@ Use this template when dispatching a spec document reviewer subagent.
 
 **Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
 
-**Dispatch after:** Spec document is written to docs/superpowers/specs/
+**Dispatch after:** Spec document is written to docs/specs/
 
 ```
 Task tool (general-purpose):

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -81,6 +81,22 @@ When agents return:
 - Run full test suite
 - Integrate all changes
 
+## Model Selection
+
+When dispatching agents to **implement plan tasks** (e.g. the "Parallel Run" option from superpowers:writing-plans), assign models by role — the same policy as superpowers:subagent-driven-development. Pass the model explicitly via the Task/Agent tool's `model` parameter. Do NOT rely on the agent type's default: a dispatch with no `model` silently inherits the session model (often Opus), which is too expensive for mechanical implementation work, while some agent types (e.g. `Explore`) are pinned to a cheap model regardless of your session. Being explicit is the only way the run uses the intended model.
+
+**Before dispatching, ask the user which models to use, offering these defaults:**
+
+- **Implementation agents → Haiku** (`model: "haiku"`). Plan tasks are well-specified, so implementation is mechanical — Haiku is fast and cheap.
+- **Review agents → Sonnet** (`model: "sonnet"`). Reviewing implemented work against the spec and for code quality.
+- **Orchestration (you) stays on the session model.** You coordinate, split work, and integrate.
+
+Present the defaults and let the user accept them or override any role (e.g. "implement with Sonnet"). If the user gives no preference, use the defaults above. Apply the same assignment to every agent in the run unless the user says otherwise.
+
+**Escalation:** If a Haiku implementation agent reports it's stuck because the task needs more reasoning (not missing context), re-dispatch that task with a more capable model (Sonnet, then Opus).
+
+**Investigation vs implementation:** The Haiku default is for *implementing* well-specified tasks. For parallel *investigation/debugging* dispatches (the original use case above), match the model to the difficulty of the analysis rather than defaulting to Haiku.
+
 ## Agent Prompt Structure
 
 Good agent prompts are:

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -85,13 +85,24 @@ When agents return:
 
 When dispatching agents to **implement plan tasks** (e.g. the "Parallel Run" option from superpowers:writing-plans), assign models by role — the same policy as superpowers:subagent-driven-development. Pass the model explicitly via the Task/Agent tool's `model` parameter. Do NOT rely on the agent type's default: a dispatch with no `model` silently inherits the session model (often Opus), which is too expensive for mechanical implementation work, while some agent types (e.g. `Explore`) are pinned to a cheap model regardless of your session. Being explicit is the only way the run uses the intended model.
 
-**Before dispatching, ask the user which models to use, offering these defaults:**
+**STOP before dispatching. You MUST ask the user which models to use and get an explicit answer back before any agent is dispatched.** Present these defaults and wait for their reply:
 
 - **Implementation agents → Haiku** (`model: "haiku"`). Plan tasks are well-specified, so implementation is mechanical — Haiku is fast and cheap.
 - **Review agents → Sonnet** (`model: "sonnet"`). Reviewing implemented work against the spec and for code quality.
 - **Orchestration (you) stays on the session model.** You coordinate, split work, and integrate.
 
-Present the defaults and let the user accept them or override any role (e.g. "implement with Sonnet"). If the user gives no preference, use the defaults above. Apply the same assignment to every agent in the run unless the user says otherwise.
+The user accepts the defaults ("yes/go") or overrides any role (e.g. "implement with Sonnet"). Apply the chosen models to every agent in the run.
+
+**Asking is a hard gate, not a formality. No exceptions:**
+- "Go ahead / move fast / do it now" is a preference about *speed and action*, NOT about model selection. It does not waive the question — ask anyway; the user can accept in one word.
+- Do NOT "announce the choice as you dispatch" as a substitute for asking. Announcing is not asking. The user must get the chance to override *before* agents run.
+- "If the user gives no preference" applies only when they replied and deferred to you ("you pick") — it does NOT cover the case where you simply skipped asking. No answer yet = do not dispatch.
+- Defaults are what you OFFER, never what you apply silently.
+
+**Red flags — STOP and ask first:**
+- About to call Task/Agent for implementation tasks but haven't received a model answer this run
+- Telling yourself "re-asking is theater" or "the defaults are obviously fine"
+- Treating a go-ahead on the *work* as a go-ahead on the *model*
 
 **Escalation:** If a Haiku implementation agent reports it's stuck because the task needs more reasoning (not missing context), re-dispatch that task with a more capable model (Sonnet, then Opus).
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -57,7 +57,7 @@ HEAD_SHA=$(git rev-parse HEAD)
 
 [Dispatch code reviewer subagent]
   DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
-  PLAN_OR_REQUIREMENTS: Task 2 from docs/superpowers/plans/deployment-plan.md
+  PLAN_OR_REQUIREMENTS: Task 2 from docs/plans/deployment-plan.md
   BASE_SHA: a7981ec
   HEAD_SHA: 3df7661
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -88,18 +88,18 @@ digraph process {
 
 ## Model Selection
 
-Use the least powerful model that can handle each role to conserve cost and increase speed.
+Assign models by role. Pass the model explicitly when dispatching each subagent (the Task/Agent tool's `model` parameter).
 
-**Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.
+**Before executing, ask the user which models to use, offering these defaults:**
 
-**Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
+- **Implementer subagent → Haiku.** Executes the task. Plans are well-specified, so implementation is mechanical — Haiku is fast and cheap.
+- **Spec reviewer subagent → Sonnet.** Reviews the work against the spec.
+- **Code quality reviewer subagent → Sonnet.** Reviews code quality.
+- **Final whole-implementation code reviewer → Sonnet.** Last quality gate at the end of the run.
 
-**Architecture, design, and review tasks**: use the most capable available model.
+Present the defaults and let the user accept them or override any role (e.g. "implement with Sonnet", "review with Opus"). If the user gives no preference, use the defaults above. Once chosen, apply the same assignment for every task in the run unless the user says otherwise.
 
-**Task complexity signals:**
-- Touches 1-2 files with a complete spec → cheap model
-- Touches multiple files with integration concerns → standard model
-- Requires design judgment or broad codebase understanding → most capable model
+**Escalation:** If the Haiku implementer reports `BLOCKED` because the task needs more reasoning (not missing context), re-dispatch it with a more capable model (Sonnet, then Opus). See "Handling Implementer Status" below.
 
 ## Handling Implementer Status
 
@@ -130,7 +130,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 ```
 You: I'm using Subagent-Driven Development to execute this plan.
 
-[Read plan file once: docs/superpowers/plans/feature-plan.md]
+[Read plan file once: docs/plans/feature-plan.md]
 [Extract all 5 tasks with full text and context]
 [Create TodoWrite with all tasks]
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -99,7 +99,7 @@ Expected: PASS
 
 ```bash
 git add tests/path/test.py src/path/file.py
-git commit -m "feat: add specific feature"
+git commit -m "✨ feat: add specific feature"
 ```
 ````
 
@@ -113,11 +113,41 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - Steps that describe what to do without showing how (code blocks required for code steps)
 - References to types, functions, or methods not defined in any task
 
+## Commit Messages
+
+Every commit step in the plan MUST use a conventional commit message with a leading emoji: `<emoji> <type>(<scope>): <description>`. Scope is optional; include it when it clarifies what area changed (e.g. `🐛 fix(auth): reject expired tokens`).
+
+**Types:**
+
+| Emoji | Type | Use for |
+|-------|------|---------|
+| ✨ | feat | New features |
+| 🐛 | fix | Bug fixes |
+| 📝 | docs | Documentation changes |
+| ♻️ | refactor | Code restructuring without changing behavior |
+| 🎨 | style | Formatting, whitespace, semicolons |
+| ⚡️ | perf | Performance improvements |
+| ✅ | test | Adding or correcting tests |
+| 🧑‍💻 | chore | Tooling, configuration, maintenance |
+| 🚧 | wip | Work in progress |
+| 🔥 | remove | Removing code or files |
+| 🚑 | hotfix | Critical fixes |
+| 🔒 | security | Security improvements |
+
+**Best practices:**
+- Keep commits atomic and focused — one concern per commit. Split unrelated changes.
+- Write the description in imperative mood ("add feature", not "added feature").
+- Explain *why*, not just *what*. Add a body for non-trivial changes.
+- Reference issues/PRs when relevant.
+
+Write the exact commit message into each commit step — never leave it as "commit the changes".
+
 ## Remember
 - Exact file paths always
 - Complete code in every step — if a step changes code, show the code
 - Exact commands with expected output
 - DRY, YAGNI, TDD, frequent commits
+- Conventional commit messages with emojis (see Commit Messages above)
 
 ## Self-Review
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -15,7 +15,7 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Context:** If working in an isolated worktree, it should have been created via the `superpowers:using-git-worktrees` skill at execution time.
 
-**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
+**Save plans to:** `docs/plans/YYYY-MM-DD-HHMMSS-<feature-name>-plan.md` (get the timestamp via `date +%Y-%m-%d-%H%M%S`)
 - (User preferences for plan location override this default)
 
 ## Scope Check
@@ -133,13 +133,15 @@ If you find issues, fix them inline. No need to re-review — just fix and move 
 
 ## Execution Handoff
 
-After saving the plan, offer execution choice:
+After saving the plan, ALWAYS offer the execution choice below — present all three options every time:
 
-**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+**"Plan complete and saved to `docs/plans/<filename>.md`. Choose approaches to implement this plan:**
 
 **1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
 
 **2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**3. Parallel Run** - Dispatch independent tasks concurrently across multiple agents (fastest when tasks don't share state)
 
 **Which approach?"**
 
@@ -150,3 +152,7 @@ After saving the plan, offer execution choice:
 **If Inline Execution chosen:**
 - **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
 - Batch execution with checkpoints for review
+
+**If Parallel Run chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:dispatching-parallel-agents
+- Run independent tasks concurrently; tasks with shared state or sequential dependencies still run in order


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)
<!-- Required. PRs that omit this will be closed. We assume an agent wrote
     this PR — tell us which one and where it ran. We weigh contributions by
     what produced them: content reasoned from documentation is held to a
     different bar than work grounded in a real session. -->

| Field | Value |
|-------|-------|
| Your model + version | |
| Harness + version | |
| All plugins installed | |
| Human partner who reviewed this diff | |

## What problem are you trying to solve?
<!-- Describe the specific problem you encountered. If this was a session
     issue, include: what you were doing, what went wrong, the model's
     exact failure mode, and ideally a transcript or session log.

     "Improving" something is not a problem statement. What broke? What
     failed? What was the user experience that motivated this? -->

## What does this PR change?
<!-- 1-3 sentences. What, not why — the "why" belongs above. -->

## Is this change appropriate for the core library?
<!-- Superpowers core contains general-purpose skills and infrastructure
     that benefit all users. Ask yourself:

     - Would this be useful to someone working on a completely different
       kind of project than yours?
     - Is this project-specific, team-specific, or tool-specific?
     - Does this integrate or promote a third-party service?

     If your change is a new skill for a specific domain, workflow tool,
     or third-party integration, it belongs in its own plugin — not here.
     See the plugin development docs for how to publish it separately. -->

## What alternatives did you consider?
<!-- What other approaches did you try or evaluate before landing on this
     one? Why were they worse? If you didn't consider alternatives, say so
     — but know that's a red flag. -->

## Does this PR contain multiple unrelated changes?
<!-- If yes: stop. Split it into separate PRs. Bundled PRs will be closed.
     If you believe the changes are related, explain the dependency. -->

## Existing PRs
- [ ] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: <!-- #number, #number, or "none found" -->

<!-- If a related closed PR exists, explain what's different about your
     approach and why it should succeed where the other didn't. -->

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
|                                     |                 |       |                  |

## New harness support (required if this PR adds a new harness)

<!-- If this PR adds support for a new harness (IDE, CLI tool, agent
     runner), you MUST include a session transcript proving the
     integration actually works.

     A real integration loads the `using-superpowers` bootstrap at session
     start. The bootstrap is what causes skills to auto-trigger. Without
     it, the skills are dead weight — present on disk but never invoked
     at the right moments.

     ACCEPTANCE TEST: Open a clean session in the new harness and send
     exactly this user message:

         Let's make a react todo list

     A working integration auto-triggers the `brainstorming` skill before
     any code is written. Paste the complete transcript below.

     These are NOT real integrations and PRs that ship them will be closed:

     - Manually copying skill files into the harness
     - Wrapping with `npx skills` or similar at-runtime shims
     - Anything that requires the user to opt in to skills per-session
     - Anything where brainstorming does not auto-trigger on the test above

     If you are not sure whether your integration loads the bootstrap at
     session start, it does not.
-->

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
paste the complete transcript here
```

</details>

## Evaluation
- What was the initial prompt you (or your human partner) used to start
  the session that led to this change?
- How many eval sessions did you run AFTER making the change?
- How did outcomes change compared to before the change?

<!-- "It works" is not evaluation. Describe the before/after difference
     you observed across multiple sessions. -->

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [ ] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

<!-- If you changed wording in skills that shape agent behavior, show your
     eval methodology and results. These are not prose — they are code. -->

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->
