### PR TITLE
fix(tests): skill-triggering harness needs --verbose for stream-json

### DIFF
--- a/tests/skill-triggering/run-test.sh
+++ b/tests/skill-triggering/run-test.sh
@@ -50,6 +50,7 @@ timeout 300 claude -p "$PROMPT" \
     --dangerously-skip-permissions \
     --max-turns "$MAX_TURNS" \
     --output-format stream-json \
+    --verbose \
     > "$LOG_FILE" 2>&1 || true
 
 echo ""


### PR DESCRIPTION
## Problem

`tests/skill-triggering/run-test.sh` runs:

```bash
claude -p "$PROMPT" --output-format stream-json ...
```

The current Claude Code CLI rejects `--print` + `--output-format stream-json` without `--verbose`:

```
Error: When using --print, --output-format=stream-json requires --verbose
```

`claude` exits **before any skill loads**, so the harness writes an error string to the log instead of a JSON stream. Every skill is then reported as `❌ NOT triggered` (the "Skills triggered" list comes back empty), and `run-all.sh` fails wholesale — a false negative across the entire skill-triggering suite.

## Fix

Add `--verbose` to the invocation, as the CLI now requires alongside `--print` + `--output-format stream-json`. The stream-json events and the existing `"name":"Skill"` / `"skill":"..."` detection grep are unchanged.

## Verification

- **Before:** `run-test.sh <skill> <prompt>` → `Error: ... requires --verbose`; result `❌ FAIL` with an empty skills list.
- **After:** same command → skill loads, triggers, and is detected; result `✅ PASS`.

One line, one file. No change to detection logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)