### PR TITLE
Add impact & regression checks to code reviewer template

### DIFF
--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -56,6 +56,12 @@ Task tool (general-purpose):
     - Integration tests where they matter?
     - All tests passing?
 
+    **Impact & Regression:**
+    - What existing flows/consumers does this change touch? (impact analysis)
+    - Are those impacted flows still working correctly? (regression check)
+    - Are there callers that assume the old behavior or interface?
+    - Do adjacent features have sufficient test coverage to catch regressions?
+
     **Production readiness:**
     - Migration strategy if schema changed?
     - Backward compatibility considered?


### PR DESCRIPTION
## Summary
- Adds an **Impact & Regression** section to the code reviewer prompt template (after Testing, before Production readiness)
- Prompts reviewers to analyze affected flows/consumers, verify regressions, check caller assumptions, and assess adjacent test coverage

## Test plan
- [x] Verified template structure and placement of new checklist section
- [ ] Dispatch a code reviewer subagent on a real change and confirm it evaluates impact/regression


Made with [Cursor](https://cursor.com)