### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "superpowers",
       "description": "Core skills library for Claude Code: TDD, debugging, collaboration patterns, and proven techniques",
-      "version": "5.1.0",
+      "version": "6.0.0",
       "source": "./",
       "author": {
         "name": "Jesse Vincent",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers",
   "description": "Core skills library for Claude Code: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.",
   "author": {
     "name": "Jesse Vincent",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "superpowers",
   "displayName": "Superpowers",
   "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "An agentic skills framework and software development methodology.",
   "author": {
     "name": "Jesse Vincent",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
   "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Superpowers skills and runtime bootstrap for coding agents",
   "type": "module",
   "main": ".opencode/plugins/superpowers.js",


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (`claude-opus-4-8[1m]`) |
| Harness + version | Claude Code 2.1.178 |
| All plugins installed | superpowers, superpowers-dev, superpowers-lab, superpowers-chrome, superpowers-developing-for-claude-code, primeradiant-ops, episodic-memory, claude-session-driver, elements-of-style, double-shot-latte, release-radar, github-triage, claude-code-setup, code-review, code-simplifier, context7, linear, plugin-dev, mcp-server-dev, feature-dev, frontend-design, pr-review-toolkit, agent-sdk-dev, security-guidance, document-skills, example-skills, summarize-meetings, worldview-synthesis, claude-pa, cxdb-observability, claude-opus-4-5-migration, clangd-lsp, gopls-lsp, rust-analyzer-lsp, swift-lsp |
| Human partner who reviewed this diff | Jesse Vincent (maintainer) |

## What problem are you trying to solve?

This is the version-bump step of the Superpowers 6.0.0 release. Every plugin manifest still read `5.1.0`; they need to read `6.0.0` for the 6.0 release. This is maintainer release engineering, not a fix for a session failure.

## What does this PR change?

Bumps the `version` field from `5.1.0` to `6.0.0` in all seven declared version files via `scripts/bump-version.sh`: `package.json`, the four harness plugin manifests (`.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.kimi-plugin/plugin.json`), the in-repo `.claude-plugin/marketplace.json`, and `gemini-extension.json`. No code or skill content changes.

## Is this change appropriate for the core library?

Yes — it is the repo's own release version bump, not a feature.

## What alternatives did you consider?

None meaningful — version bumping is mechanical. Used the repo's existing `scripts/bump-version.sh` + `.version-bump.json` tooling instead of hand-editing, specifically to avoid version drift between the seven manifests.

## Does this PR contain multiple unrelated changes?

No. Single concern: the version bump. 7 files, each a one-line `5.1.0` → `6.0.0` change.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found — no open version-bump PR in this repo.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.178 | Claude Opus 4.8 | `claude-opus-4-8[1m]` |

`scripts/bump-version.sh --check` reports all 7 declared files in sync at `6.0.0`. Separately confirmed the brainstorming visual companion reads the version dynamically from `package.json` (`server.cjs` `readSuperpowersVersion()`), so its telemetry logo URL now serves `?v=6.0.0` automatically — no code change needed there.

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

N/A — mechanical version bump with no behavior change, so there is nothing to eval.
- Initial prompt: "We're doing PART of the superpowers 6.0 release engineering ... do all the version bumping inside the repo, but NOT tagging or merging to main and NOT updating the marketplace."
- Eval sessions run after the change: 0 — no behavior to evaluate.

## Rigor

- [ ] Skills change — N/A, no skill content modified.
- [x] Verified mechanically: ran `scripts/bump-version.sh --check` and confirmed all 7 files in sync at 6.0.0.
- [x] Did not modify any behavior-shaping content (Red Flags tables, rationalizations, "human partner" language).

## Human review
- [x] A human (Jesse) has reviewed the complete diff before submission.

---

> **Scope note:** This is intentionally *only* the in-repo version bump. Tagging `v6.0.0`, merging to `main`, and updating the external `superpowers-marketplace` registry are deliberately **not** part of this PR.
