### PR TITLE
[codex] Fix packaged Codex plugin version display

### DIFF
--- a/skills/brainstorming/scripts/server.cjs
+++ b/skills/brainstorming/scripts/server.cjs
@@ -206,14 +206,22 @@ const helperInjection = '<script>\n' + helperScript + '\n</script>';
 // ========== Helper Functions ==========
 
 function readSuperpowersVersion() {
-  try {
-    const packageJson = JSON.parse(
-      fs.readFileSync(path.join(__dirname, '../../..', 'package.json'), 'utf-8')
-    );
-    return String(packageJson.version || 'unknown');
-  } catch (e) {
-    return 'unknown';
+  const root = path.join(__dirname, '../../..');
+  const manifests = [
+    path.join(root, 'package.json'),
+    path.join(root, '.codex-plugin/plugin.json')
+  ];
+
+  for (const manifest of manifests) {
+    try {
+      const data = JSON.parse(fs.readFileSync(manifest, 'utf-8'));
+      if (data.version) return String(data.version);
+    } catch (e) {
+      // Packaged Codex plugins omit package.json; try the next manifest.
+    }
   }
+
+  return 'unknown';
 }
 
 function isTruthyEnv(value) {

--- a/tests/brainstorm-server/branding.test.js
+++ b/tests/brainstorm-server/branding.test.js
@@ -26,9 +26,9 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function startServer({ port, dir, env = {} }) {
+function startServer({ port, dir, env = {}, serverPath = SERVER_PATH }) {
   cleanup(dir);
-  return spawn('node', [SERVER_PATH], {
+  return spawn('node', [serverPath], {
     env: {
       ...process.env,
       BRAINSTORM_PORT: String(port),
@@ -74,6 +74,21 @@ function writeFragment(dir) {
   fs.writeFileSync(path.join(contentDir, 'screen.html'), '<h2>Pick a layout</h2>');
 }
 
+function createPackagedServerFixture(version) {
+  const root = fs.mkdtempSync(path.join('/tmp', 'superpowers-packaged-server-'));
+  const scriptDir = path.join(root, 'skills/brainstorming/scripts');
+  fs.cpSync(path.join(REPO_ROOT, 'skills/brainstorming/scripts'), scriptDir, { recursive: true });
+  fs.mkdirSync(path.join(root, '.codex-plugin'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.codex-plugin/plugin.json'),
+    JSON.stringify({ name: 'superpowers', version }, null, 2)
+  );
+  return {
+    root,
+    serverPath: path.join(scriptDir, 'server.cjs')
+  };
+}
+
 async function withServer(options, fn) {
   const server = startServer(options);
   try {
@@ -104,13 +119,13 @@ async function test(name, fn) {
   }
 }
 
-function assertBrandedWithLogo(html) {
+function assertBrandedWithLogo(html, version = PACKAGE_VERSION) {
   assert(
-    html.includes(`Superpowers v${PACKAGE_VERSION}`),
+    html.includes(`Superpowers v${version}`),
     'branding text should include dynamic package version'
   );
   assert(
-    !html.includes(`Superpowers v${PACKAGE_VERSION} by`),
+    !html.includes(`Superpowers v${version} by`),
     'branding text should not include "by" when the logo is visible'
   );
   assert(
@@ -139,15 +154,15 @@ function assertBrandedWithLogo(html) {
   );
 }
 
-function assertBrandedFallbackText(html) {
+function assertBrandedFallbackText(html, version = PACKAGE_VERSION) {
   assert(
-    html.includes(`Prime Radiant Superpowers v${PACKAGE_VERSION}`),
+    html.includes(`Prime Radiant Superpowers v${version}`),
     'disabled telemetry should keep plain text Prime Radiant/Superpowers branding'
   );
 }
 
-function assertTelemetryImage(html) {
-  const expectedUrl = `${ASSET_URL}?v=${encodeURIComponent(PACKAGE_VERSION)}`;
+function assertTelemetryImage(html, version = PACKAGE_VERSION) {
+  const expectedUrl = `${ASSET_URL}?v=${encodeURIComponent(version)}`;
   assert(html.includes(`src="${expectedUrl}"`), 'remote image should use the dedicated main-domain asset with only v=');
   assert(!html.includes('event='), 'remote image URL must not include event=');
   assert(!html.includes('surface='), 'remote image URL must not include surface=');
@@ -253,6 +268,26 @@ async function main() {
       assertTelemetryImage(html);
       assertLogoKeepsTransparentBackground(html);
     });
+  });
+
+  await test('packaged Codex plugin reads version from .codex-plugin manifest', async () => {
+    const port = 3457;
+    const dir = '/tmp/brainstorm-branding-packaged-codex';
+    const packagedVersion = '7.8.9';
+    const fixture = createPackagedServerFixture(packagedVersion);
+
+    try {
+      await withServer({ port, dir, serverPath: fixture.serverPath }, async () => {
+        writeFragment(dir);
+        await sleep(300);
+        const html = await fetchHtml(port);
+        assertBrandedWithLogo(html, packagedVersion);
+        assertTelemetryImage(html, packagedVersion);
+        assert(!html.includes('Superpowers vunknown'), 'packaged plugin should not fall back to unknown version');
+      });
+    } finally {
+      cleanup(fixture.root);
+    }
   });
 
   await test('SUPERPOWERS_DISABLE_TELEMETRY=true omits remote image but keeps local branding', async () => {


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5-based Codex coding agent |
| Harness + version | Codex desktop app; exact app version not exposed in this session |
| All plugins installed | Browser, Codex Security, Documents, GitHub, Linear, PDF, Presentations, Prime Radiant Ops, Slack, Spreadsheets |
| Human partner who reviewed this diff | Drew Ritter requested this split after reviewing the combined Codex session work and Jesse's request to separate the changes |

## What problem are you trying to solve?

A sync PR to the OpenAI plugins marketplace, openai/plugins#332, was closed after automated Codex review surfaced a real upstream Superpowers defect: the visual companion reads version metadata only from `package.json`, but the packaged Codex plugin intentionally does not include `package.json`.

In that installed shape, companion pages render `Superpowers vunknown` and the remote branding URL cannot report the actual plugin version.

## What does this PR change?

The visual companion version lookup now tries the source-tree `package.json` first, then falls back to `.codex-plugin/plugin.json`. The fallback matches the packaged Codex plugin artifact, where the plugin manifest is present and root package metadata is not.

The regression test builds a temporary packaged-plugin fixture with no `package.json`, writes `.codex-plugin/plugin.json`, starts the copied visual companion server, and asserts the rendered branding and telemetry image URL use the manifest version instead of `unknown`.

## Is this change appropriate for the core library?

Yes. This is a general Superpowers distribution/runtime fix for the Codex plugin package. It is not project-specific behavior, and it affects any user running the visual companion from the packaged Codex plugin.

## What alternatives did you consider?

Adding `package.json` to the embedded Codex plugin was rejected because the sync helper intentionally excludes source-repo package metadata from the marketplace payload. Reading the committed Codex plugin manifest is narrower and matches the installed artifact.

Leaving the visual companion to report `unknown` in packaged installs was rejected because the manifest already contains the version and the rendered branding should reflect the actual installed plugin.

## Does this PR contain multiple unrelated changes?

No. This PR is intentionally split down to only the packaged Codex plugin version fallback. The Codex sync exclude cleanup and the SDD task-brief path change are being handled in separate PRs.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: openai/plugins#332, #1720, #1763. No duplicate Superpowers PR found.

openai/plugins#332 is the closed marketplace sync PR that surfaced this packaged-plugin version defect. #1720 and #1763 are related visual companion and branding work, but they do not cover packaged Codex plugin version fallback.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app + local shell | exact app version not exposed | GPT-5-based Codex coding agent | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```text
Not applicable: no new harness support is added in this PR.
```

</details>

## Evaluation

- Initial prompt: Drew asked to inspect the closed OpenAI plugins sync PR because it flagged real issues: `i closed that PR bc it also flagged two real issues we should address, pls take a look openai/plugins#332`.
- Eval sessions after making the change: 0 multi-session behavioral evals. This PR changes visual companion runtime behavior and tests, not behavior-shaping skill prose.
- Outcome change: Before the fix, a packaged Codex plugin fixture without `package.json` rendered `Superpowers vunknown`. After the fix, the packaged fixture reads the version from `.codex-plugin/plugin.json` and renders the manifest version.

Verification commands run:

```bash
node --check skills/brainstorming/scripts/server.cjs
npm test --prefix tests/brainstorm-server
git diff --check --cached
```

All commands exited 0 before commit.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

`superpowers:writing-skills` is not applicable here: this PR does not change behavior-shaping skill prose. It changes a bundled Node runtime script and its tests. Adversarial coverage includes the installed Codex plugin shape with no root `package.json`.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew Ritter requested this split after the complete combined diff had been reviewed in the Codex session and after Jesse asked that the obvious version fix be separated from the SDD change. This PR now contains only the version fallback diff.
