### PR TITLE
[codex] Make SDD task brief paths unique

### DIFF
--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -4,8 +4,7 @@
 # through the controller's context.
 #
 # Usage: task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
-# Default OUTFILE: <git-dir>/sdd/task-<N>-brief.md — unique per repo
-# instance, so concurrent sessions cannot collide.
+# Default OUTFILE: <git-dir>/sdd/task-<N>.<unique>/task-<N>-brief.md.
 set -euo pipefail
 
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then
@@ -23,7 +22,8 @@ else
   dir=$(git rev-parse --git-path sdd)
   mkdir -p "$dir"
   dir=$(cd "$dir" && pwd)
-  out="$dir/task-${n}-brief.md"
+  brief_dir=$(mktemp -d "$dir/task-${n}.XXXXXX")
+  out="$brief_dir/task-${n}-brief.md"
 fi
 
 awk -v n="$n" '

--- a/tests/claude-code/test-task-brief.sh
+++ b/tests/claude-code/test-task-brief.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TASK_BRIEF="$REPO_ROOT/skills/subagent-driven-development/scripts/task-brief"
+
+FAILURES=0
+TEST_ROOT=""
+
+pass() {
+    echo "  [PASS] $1"
+}
+
+fail() {
+    echo "  [FAIL] $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+cleanup() {
+    if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+        rm -rf "$TEST_ROOT"
+    fi
+}
+
+extract_written_path() {
+    local output="$1"
+    printf '%s\n' "$output" | sed -n 's/^wrote \(.*\): [0-9][0-9]* lines$/\1/p'
+}
+
+assert_not_equals() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+
+    if [[ "$actual" != "$expected" ]]; then
+        pass "$description"
+    else
+        fail "$description"
+        echo "    both were: $actual"
+    fi
+}
+
+assert_file_contains() {
+    local path="$1"
+    local needle="$2"
+    local description="$3"
+
+    if grep -Fq -- "$needle" "$path"; then
+        pass "$description"
+    else
+        fail "$description"
+        echo "    expected $path to contain: $needle"
+    fi
+}
+
+main() {
+    echo "=== Test: task-brief output paths ==="
+
+    TEST_ROOT="$(mktemp -d)"
+    trap cleanup EXIT
+
+    local repo="$TEST_ROOT/repo"
+    local plan="$repo/plan.md"
+    local output_one
+    local output_two
+    local path_one
+    local path_two
+
+    git init -q -b main "$repo"
+
+    cat > "$plan" <<'EOF'
+# Implementation Plan
+
+## Task 1: First thing
+
+Do the first thing.
+
+## Task 2: Second thing
+
+Do the second thing.
+EOF
+
+    output_one="$(cd "$repo" && "$TASK_BRIEF" "$plan" 1)"
+    output_two="$(cd "$repo" && "$TASK_BRIEF" "$plan" 1)"
+    path_one="$(extract_written_path "$output_one")"
+    path_two="$(extract_written_path "$output_two")"
+
+    assert_not_equals "$path_one" "$path_two" "Default task brief paths are unique per invocation"
+    assert_file_contains "$path_one" "## Task 1: First thing" "First default brief contains the requested task"
+    assert_file_contains "$path_two" "## Task 1: First thing" "Second default brief contains the requested task"
+
+    if [[ "$path_one" == "$repo/.git/sdd/"* ]]; then
+        pass "First default brief stays under the repo git metadata directory"
+    else
+        fail "First default brief stays under the repo git metadata directory"
+        echo "    actual: $path_one"
+    fi
+
+    if [[ "$path_two" == "$repo/.git/sdd/"* ]]; then
+        pass "Second default brief stays under the repo git metadata directory"
+    else
+        fail "Second default brief stays under the repo git metadata directory"
+        echo "    actual: $path_two"
+    fi
+
+    if [[ $FAILURES -ne 0 ]]; then
+        echo ""
+        echo "FAILED: $FAILURES assertion(s) failed."
+        exit 1
+    fi
+
+    echo ""
+    echo "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5-based Codex coding agent |
| Harness + version | Codex desktop app; exact app version not exposed in this session |
| All plugins installed | Browser, Codex Security, Documents, GitHub, Linear, PDF, Presentations, Prime Radiant Ops, Slack, Spreadsheets |
| Human partner who reviewed this diff | Drew Ritter requested this split after reviewing the combined Codex session work and Jesse's request to separate the SDD change for focused review |

## What problem are you trying to solve?

A sync PR to the OpenAI plugins marketplace, openai/plugins#332, was closed after automated Codex review surfaced a real upstream SDD defect: `skills/subagent-driven-development/scripts/task-brief` writes its default output to `.git/sdd/task-<N>-brief.md`.

That path is stable for a task number inside a repo. Two SDD runs in the same repo, or a resumed run switching plans, can overwrite an existing task brief while implementer/reviewer prompts still point at the old path. The script comment claimed the default path was collision-safe for concurrent sessions, but the filename was only unique per task number.

This PR is a draft because Jesse explicitly asked to split this from the obvious Codex plugin fixes and said the SDD change made him uncomfortable for reasons he could not quite place.

## What does this PR change?

When no explicit `OUTFILE` is provided, `task-brief` now creates a unique per-invocation directory under `.git/sdd/` and writes the brief inside it:

```text
<git-dir>/sdd/task-<N>.<unique>/task-<N>-brief.md
```

Explicit `OUTFILE` behavior is unchanged.

The new shell regression test initializes a temporary git repo, runs `task-brief` twice for the same task number and plan, and asserts the two generated paths are distinct, still under `.git/sdd/`, and contain the requested task text.

## Is this change appropriate for the core library?

Probably, but this is the part intentionally separated for maintainer judgment. The problem is in a core SDD utility script used by any SDD controller that relies on the default brief path, and the fix is dependency-free shell code. The remaining design question is whether unique-by-default brief paths are the right SDD contract, or whether the controller should instead own session/run identity explicitly and pass `OUTFILE` itself.

## What alternatives did you consider?

Requiring every controller call to pass an explicit `OUTFILE` was rejected for this patch because the script already provides a default and the current default advertises collision safety. That may still be the better larger design if maintainers want run/session identity to be explicit in SDD orchestration.

Adding a timestamp or random suffix directly to `task-<N>-brief.md` was rejected because the stable basename is useful for humans and report-file derivation. A unique parent directory keeps the final filename predictable while avoiding overwrites.

Using a plan hash in the path was considered but not used here. It would avoid collisions across different plans, but it would still collide for repeated runs of the same plan/task unless paired with another unique component.

## Does this PR contain multiple unrelated changes?

No. This PR is intentionally split down to only the SDD `task-brief` default path collision fix. The packaged-plugin version fallback is in #1770, and the Codex sync exclusion cleanup is in #1771.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: openai/plugins#332, #1717, #578, #1770, #1771. No duplicate Superpowers PR found for unique default `task-brief` paths.

Searches run before opening this PR:

```text
task-brief sdd unique path collision
subagent-driven-development task brief
```

openai/plugins#332 is the closed marketplace sync PR that surfaced the issue. #1717 added the current SDD task-brief/review-package workflow and is the main prior art. #578 is an open SDD-adjacent PR, but it does not touch `scripts/task-brief` or this test path. #1770 and #1771 are sibling split PRs for the obvious Codex plugin fixes.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app + local shell | exact app version not exposed | GPT-5-based Codex coding agent | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```text
Not applicable: no new harness support is added in this PR.
```

</details>

## Evaluation

- Initial prompt: Drew asked to inspect openai/plugins#332 because it flagged real issues, then asked to split this SDD change out after Jesse requested separation.
- Eval sessions after making the change: 0 multi-session behavioral SDD evals. This draft changes a skill-bundled utility script and adds a direct shell regression test; it does not change behavior-shaping SDD prose.
- Outcome change: Before the fix, two default `task-brief PLAN 1` calls in the same repo wrote the same `.git/sdd/task-1-brief.md` path. After the fix, repeated calls produce distinct paths under `.git/sdd/`.

Verification commands run:

```bash
bash tests/claude-code/test-task-brief.sh
scripts/lint-shell.sh skills/subagent-driven-development/scripts/task-brief tests/claude-code/test-task-brief.sh
git diff --check --cached
git diff --check origin/dev..HEAD
```

All commands exited 0.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This PR does not change SDD prompt prose or SKILL.md behavior-shaping guidance. It changes a small utility script under the SDD skill and includes a shell regression for the collision it fixes. I did read `superpowers:writing-skills` before opening this draft; broader SDD behavioral pressure testing has not been run, which is why this PR is draft and scoped for explicit maintainer discussion.

Adversarial coverage here is limited to the script-level failure mode: repeated same-task extraction in the same repository, which previously collided.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew Ritter requested this three-way split after the complete combined diff had been reviewed in the Codex session and after Jesse asked that the SDD change be separated from the obvious fixes. This PR now contains only the SDD `task-brief` path diff and is intentionally draft for further maintainer review.
