### PR TITLE
feat: add Hermes Agent tool mapping

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -37,11 +37,13 @@ If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "alw
 
 **In Gemini CLI:** Skills activate via the `activate_skill` tool. Gemini loads skill metadata at session start and activates the full content on demand.
 
+**In Hermes CLI:** Skills load natively. Type `/<skill-name>` in the TUI/CLI to activate, or use the `skill_view(name)` tool from within a turn.
+
 **In other environments:** Check your platform's documentation for how skills are loaded.
 
 ## Platform Adaptation
 
-Skills speak in actions ("dispatch a subagent", "create a todo", "read a file") rather than naming any one runtime's tools. For per-platform tool equivalents and instructions-file conventions, see [claude-code-tools.md](references/claude-code-tools.md), [codex-tools.md](references/codex-tools.md), [copilot-tools.md](references/copilot-tools.md), [gemini-tools.md](references/gemini-tools.md), [pi-tools.md](references/pi-tools.md), and [antigravity-tools.md](references/antigravity-tools.md). Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
+Skills speak in actions ("dispatch a subagent", "create a todo", "read a file") rather than naming any one runtime's tools. For per-platform tool equivalents and instructions-file conventions, see [claude-code-tools.md](references/claude-code-tools.md), [codex-tools.md](references/codex-tools.md), [copilot-tools.md](references/copilot-tools.md), [gemini-tools.md](references/gemini-tools.md), [hermes-tools.md](references/hermes-tools.md), [pi-tools.md](references/pi-tools.md), and [antigravity-tools.md](references/antigravity-tools.md). Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
 
 # Using Skills
 

--- a/skills/using-superpowers/references/hermes-tools.md
+++ b/skills/using-superpowers/references/hermes-tools.md
@@ -1,0 +1,83 @@
+# Hermes Agent Tool Mapping
+
+Skills speak in actions ("dispatch a subagent", "create a todo", "read a file"). On Hermes these resolve to the tools below.
+
+| Action skills request | Hermes equivalent |
+|----------------------|-------------------|
+| Read a file | `read_file` |
+| Create a new file | `write_file` |
+| Edit a file | `patch` |
+| Run a shell command | `terminal` |
+| Search file contents | `search_files` with `target='content'` |
+| Find files by name | `search_files` with `target='name'` |
+| Fetch a URL | `web_extract` |
+| Search the web | `web_search` |
+| Invoke a skill | `skill_view(name)` — or type `/<skill-name>` in the TUI/CLI |
+| Dispatch a subagent (`Subagent (general-purpose):` template) | `delegate_task` (see [Subagent support](#subagent-support)) |
+| Multiple parallel dispatches | `delegate_task` with an array of task objects — all run concurrently |
+| Task tracking ("create a todo", "mark complete") | `todo` |
+
+## Invoking Skills
+
+In the Hermes TUI or CLI, type `/<skill-name>` to activate a skill. From within a tool call, use `skill_view(name='<skill-name>')` to load a skill's full content, then follow its instructions.
+
+Browse available skills with `skills_list()` or the `/skills` command.
+
+## Subagent Support
+
+`delegate_task` spawns one or more isolated subagents. Each gets its own conversation, terminal session, and toolset. Only the final summary is returned to your context.
+
+```
+# Single subagent
+delegate_task(tasks=[{"prompt": "Research X and summarise findings"}])
+
+# Multiple parallel subagents
+delegate_task(tasks=[
+    {"prompt": "Review the auth module for security issues", "label": "security"},
+    {"prompt": "Profile the database query layer",           "label": "perf"},
+    {"prompt": "Check types across the API surface",         "label": "types"},
+])
+```
+
+Skills that reference `Subagent (general-purpose):` blocks map to a single entry in the tasks array. Skills that fan out multiple subagents in parallel map to multiple entries in one `delegate_task` call.
+
+## Task Tracking
+
+Use the `todo` tool for session-scoped task tracking. Pass a `todos` array to create or update items:
+
+```
+todo(todos=[
+    {"content": "Write failing test", "status": "in_progress"},
+    {"content": "Implement feature",  "status": "pending"},
+    {"content": "Refactor",           "status": "pending"},
+])
+```
+
+Call `todo()` with no arguments to read the current list.
+
+## Long-Running Processes
+
+Hermes supports background processes via `terminal`:
+
+```
+terminal(command="npm run dev", background=True, notify_on_complete=True)
+# Check status later:
+process(action="poll")
+```
+
+## Environment Detection for Git Skills
+
+Skills that create worktrees or finish branches should detect their environment first:
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+BRANCH=$(git branch --show-current)
+```
+
+- `GIT_DIR != GIT_COMMON` → already in a linked worktree (skip creation)
+- `BRANCH` empty → detached HEAD (cannot branch/push/PR)
+
+## Instructions-File Convention
+
+Hermes reads `~/.hermes/SOUL.md` as a personality/persona file and `~/.hermes/config.yaml` for model and agent settings. Skills live at `~/.hermes/skills/`. The equivalent of `CLAUDE.md` / `AGENTS.md` context is set in the Hermes system prompt or via `SOUL.md`.


### PR DESCRIPTION
## Summary

- Adds `skills/using-superpowers/references/hermes-tools.md` — a full tool mapping for [Hermes Agent](https://github.com/NousResearch/hermes-agent) (Nous Research's open-source AI agent)
- Updates `using-superpowers/SKILL.md` to list Hermes CLI as a supported platform and link to the new reference file

## What Hermes is

Hermes is an open-source AI agent from Nous Research — multi-platform (CLI, Telegram, Discord, Slack, 22 total messaging adapters), runs on any model, and ships its own skill system at `~/.hermes/skills/`. It has a large and active community (~300 contributors, 14 releases in 2026 so far).

## Tool mapping highlights

| Action skills request | Hermes equivalent |
|---|---|
| Read a file | `read_file` |
| Create / overwrite a file | `write_file` |
| Edit a file | `patch` |
| Run a shell command | `terminal` |
| Search file contents | `search_files` with `target='content'` |
| Find files by name | `search_files` with `target='name'` |
| Fetch a URL | `web_extract` |
| Search the web | `web_search` |
| Invoke a skill | `skill_view(name)` or `/<skill-name>` in the TUI |
| Dispatch a subagent | `delegate_task` |
| Multiple parallel dispatches | `delegate_task` with an array of task objects |
| Task tracking | `todo` |

## Test plan

- [ ] Verify `hermes-tools.md` renders correctly in GitHub
- [ ] Confirm tool names against Hermes built-in tools reference (all verified against v0.14.0 docs)
- [ ] Confirm `SKILL.md` diff is minimal (one new platform line + one new reference link)