### PR TITLE
Release v6.0.2: remove evals submodule that breaks plugin installs (#1778, #1774)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "superpowers",
       "description": "Core skills library for Claude Code: TDD, debugging, collaboration patterns, and proven techniques",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "source": "./",
       "author": {
         "name": "Jesse Vincent",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers",
   "description": "Core skills library for Claude Code: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.",
   "author": {
     "name": "Jesse Vincent",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "superpowers",
   "displayName": "Superpowers",
   "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ node_modules/
 inspo
 triage/
 
-# Eval harness — drill ships its own gitignore at evals/.gitignore;
-# these are belt-and-suspenders entries for tools that don't recurse.
-evals/results/
-evals/.venv/
-evals/.env
+# Eval harness lives in its own repository, cloned into evals/ for local
+# development (see CLAUDE.md / README.md). It is not part of the published
+# plugin, so the whole directory is ignored here.
+evals/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "evals"]
-	path = evals
-	url = git@github.com:prime-radiant-inc/superpowers-evals.git

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "An agentic skills framework and software development methodology.",
   "author": {
     "name": "Jesse Vincent",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Skills are not prose — they are code that shapes agent behavior. If you modify
 
 ## Eval harness
 
-Skill-behavior evals live in the `evals/` submodule — after cloning, run `git submodule update --init evals`, then see `evals/README.md`. Drill (the harness) drives real tmux sessions of Claude Code / Codex / Gemini CLI and judges skill compliance with an LLM verifier. Plugin-infrastructure tests still live at `tests/`.
+Skill-behavior evals live in [superpowers-evals](https://github.com/prime-radiant-inc/superpowers-evals/), cloned into `evals/` — see `evals/README.md` for setup. Drill (the harness) drives real tmux sessions of Claude Code / Codex / Gemini CLI and judges skill compliance with an LLM verifier. Plugin-infrastructure tests still live at `tests/`.
 
 ## Understand the Project Before Contributing
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The general contribution process for Superpowers is below. Keep in mind that we 
 4. Follow the `writing-skills` skill for creating and testing new and modified skills
 5. Submit a PR, being sure to fill in the pull request template.
 
-Skill-behavior tests use the eval harness submodule at `evals/`. After cloning this repo, run `git submodule update --init evals`, then see `evals/README.md` for setup. Plugin-infrastructure tests live at `tests/` and run via the relevant `run-*.sh` or `npm test`.
+Skill-behavior tests use the drill eval harness from [superpowers-evals](https://github.com/prime-radiant-inc/superpowers-evals/), cloned into `evals/` — see `evals/README.md` for setup. Plugin-infrastructure tests live at `tests/` and run via the relevant `run-*.sh` or `npm test`.
 
 See `skills/writing-skills/SKILL.md` for the complete guide.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Superpowers Release Notes
 
+## v6.0.2 (2026-06-16)
+
+### Install Fixes
+
+- **We no longer ship the `evals` submodule.** It broke plugin installs for some users, so the eval harness now lives in its own repo, separate from the published plugin. (#1778, #1774)
+
 ## v6.0.1 (2026-06-16)
 
 ### Codex Fixes

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
   "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Superpowers skills and runtime bootstrap for coding agents",
   "type": "module",
   "main": ".opencode/plugins/superpowers.js",


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (`claude-opus-4-8[1m]`) |
| Harness + version | Claude Code 2.1.179 |
| All plugins installed | `superpowers` (under test) plus ~30 others on a maintainer dev box: `superpowers-chrome`, `superpowers-lab`, `superpowers-developing-for-claude-code`, `claude-session-driver`, `episodic-memory`, `plugin-dev`, `github-triage`, `primeradiant-ops`, `context7`, `code-simplifier`, … |
| Human partner who reviewed this diff | Jesse Vincent (@obra) |

## What problem are you trying to solve?

`claude plugin install` fails on the `evals` submodule. Its URL is the SSH form (`git@github.com:…`), and cloning over GitHub SSH needs a key plus a `github.com` `known_hosts` entry that the install environment often lacks, so recursive submodule init aborts with `Host key verification failed` (#1778). On Windows it fails differently: the eval `results/` tree has paths over `MAX_PATH` (#1774). The repo is public and clones fine anonymously over HTTPS — the SSH URL, not the repo's visibility, is the cause.

## What does this PR change?

Removes the `evals` submodule from the plugin (deletes the gitlink and `.gitmodules`), gitignores the local `evals/` directory, updates the eval-harness note in `CLAUDE.md`/`README.md`, and releases v6.0.2.

## Is this change appropriate for the core library?

Yes — it fixes the core plugin's install path for all users on all platforms, and removes a dependency rather than adding one.

## What alternatives did you consider?

Switching the submodule URL to HTTPS would fix #1778 (the repo is public) but not #1774. Removing the submodule fixes both, and the eval harness isn't needed by consumers of the plugin.

## Does this PR contain multiple unrelated changes?

No. The new change is the submodule removal. As the `dev` → `main` release PR it also carries the v6.0.1 Codex fixes already on `dev` (`e6cc1de`, `7968079`, `5c6151d`).

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related: **#1541** introduced the submodule; this reverses that packaging choice because it broke installs. Submodule-bump PRs (#1733, #1752, …) become moot. No prior PR addresses the install failure.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.179 | Claude Opus 4.8 | `claude-opus-4-8[1m]` |

Reproduced in a clean Alpine container with no SSH keys: the current `main` commit fails submodule init with `Host key verification failed`; the fixed commit has no submodule and the install simulation completes. The same repo clones fine over HTTPS in that container. The Windows `MAX_PATH` failure (#1774) wasn't reproduced on Linux, but the long paths exist only in the removed submodule (core's longest tracked path is 82 chars).

## New harness support

N/A — no new harness.

## Evaluation

N/A — this is a packaging fix, not a behavior-shaping skills change. Verified by the before/after container reproduction above rather than eval sessions. The session began by investigating #1778.

## Rigor

- [ ] If this is a skills change: N/A — no skill content changed.
- [x] This change was tested adversarially — reproduced the real install failure in a clean, no-SSH-keys container before and after the fix.
- [x] I did not modify carefully-tuned content.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission.
