### PR TITLE
fix(tests): add verbose to explicit skill stream-json evals

### DIFF
--- a/tests/explicit-skill-requests/run-all.sh
+++ b/tests/explicit-skill-requests/run-all.sh
@@ -10,6 +10,9 @@ PROMPTS_DIR="$SCRIPT_DIR/prompts"
 echo "=== Running All Explicit Skill Request Tests ==="
 echo ""
 
+"$SCRIPT_DIR/test-stream-json-verbose.sh"
+echo ""
+
 PASSED=0
 FAILED=0
 RESULTS=""

--- a/tests/explicit-skill-requests/run-extended-multiturn-test.sh
+++ b/tests/explicit-skill-requests/run-extended-multiturn-test.sh
@@ -27,6 +27,7 @@ claude -p "I want to add user authentication to my app. Help me think through th
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 3 \
+    --verbose \
     --output-format stream-json \
     > "$OUTPUT_DIR/turn1.json" 2>&1 || true
 echo "Done."
@@ -38,6 +39,7 @@ claude -p "Let's use JWT tokens with 24-hour expiry. Email/password registration
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 3 \
+    --verbose \
     --output-format stream-json \
     > "$OUTPUT_DIR/turn2.json" 2>&1 || true
 echo "Done."
@@ -49,6 +51,7 @@ claude -p "Great, write this up as an implementation plan." \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 3 \
+    --verbose \
     --output-format stream-json \
     > "$OUTPUT_DIR/turn3.json" 2>&1 || true
 echo "Done."
@@ -60,6 +63,7 @@ claude -p "The plan looks good. What are my options for executing it?" \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 2 \
+    --verbose \
     --output-format stream-json \
     > "$OUTPUT_DIR/turn4.json" 2>&1 || true
 echo "Done."
@@ -72,6 +76,7 @@ claude -p "subagent-driven-development, please" \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 2 \
+    --verbose \
     --output-format stream-json \
     > "$FINAL_LOG" 2>&1 || true
 echo "Done."

--- a/tests/explicit-skill-requests/run-haiku-test.sh
+++ b/tests/explicit-skill-requests/run-haiku-test.sh
@@ -56,6 +56,7 @@ claude -p "I want to add user authentication to my app. Help me think through th
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 3 \
+    --verbose \
     --output-format stream-json \
     > "$OUTPUT_DIR/turn1.json" 2>&1 || true
 echo "Done."
@@ -68,6 +69,7 @@ claude -p "Let's use JWT tokens with 24-hour expiry. Email/password registration
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 3 \
+    --verbose \
     --output-format stream-json \
     > "$OUTPUT_DIR/turn2.json" 2>&1 || true
 echo "Done."
@@ -80,6 +82,7 @@ claude -p "Great, write this up as an implementation plan." \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 3 \
+    --verbose \
     --output-format stream-json \
     > "$OUTPUT_DIR/turn3.json" 2>&1 || true
 echo "Done."
@@ -92,6 +95,7 @@ claude -p "The plan looks good. What are my options for executing it?" \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 2 \
+    --verbose \
     --output-format stream-json \
     > "$OUTPUT_DIR/turn4.json" 2>&1 || true
 echo "Done."
@@ -105,6 +109,7 @@ claude -p "subagent-driven-development, please" \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 2 \
+    --verbose \
     --output-format stream-json \
     > "$FINAL_LOG" 2>&1 || true
 echo "Done."

--- a/tests/explicit-skill-requests/run-multiturn-test.sh
+++ b/tests/explicit-skill-requests/run-multiturn-test.sh
@@ -50,6 +50,7 @@ claude -p "I need to implement an authentication system. Let's plan this out. Th
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 2 \
+    --verbose \
     --output-format stream-json \
     > "$TURN1_LOG" 2>&1 || true
 
@@ -64,6 +65,7 @@ claude -p "Good analysis. I've already written the plan to docs/superpowers/plan
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 2 \
+    --verbose \
     --output-format stream-json \
     > "$TURN2_LOG" 2>&1 || true
 
@@ -78,6 +80,7 @@ claude -p "subagent-driven-development, please" \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns 2 \
+    --verbose \
     --output-format stream-json \
     > "$TURN3_LOG" 2>&1 || true
 

--- a/tests/explicit-skill-requests/run-test.sh
+++ b/tests/explicit-skill-requests/run-test.sh
@@ -72,6 +72,7 @@ timeout 300 claude -p "$PROMPT" \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns "$MAX_TURNS" \
+    --verbose \
     --output-format stream-json \
     > "$LOG_FILE" 2>&1 || true
 

--- a/tests/explicit-skill-requests/test-stream-json-verbose.sh
+++ b/tests/explicit-skill-requests/test-stream-json-verbose.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FAILURES=0
+
+pass() {
+    echo "  PASS: $1"
+}
+
+fail() {
+    echo "  FAIL: $1"
+    echo "    $2"
+    FAILURES=$((FAILURES + 1))
+}
+
+check_file() {
+    local file="$1"
+    local basename
+    local output
+
+    basename="$(basename "$file")"
+
+    if ! grep -q -- "--output-format stream-json" "$file"; then
+        pass "$basename has no stream-json claude calls"
+        return 0
+    fi
+
+    if output="$(awk '
+      function finish_command() {
+        if (in_command && has_stream_json && !has_verbose) {
+          printf "%s:%d: stream-json claude -p command is missing --verbose\n", FILENAME, start_line
+          failed = 1
+        }
+        in_command = 0
+        has_stream_json = 0
+        has_verbose = 0
+      }
+
+      /claude -p / {
+        finish_command()
+        in_command = 1
+        start_line = NR
+        has_verbose = 0
+        has_stream_json = 0
+      }
+
+      in_command && /--verbose/ {
+        has_verbose = 1
+      }
+
+      in_command && /--output-format[[:space:]]+stream-json/ {
+        has_stream_json = 1
+      }
+
+      in_command && /\|\|[[:space:]]+true/ {
+        finish_command()
+      }
+
+      END {
+        finish_command()
+        exit failed
+      }
+    ' "$file" 2>&1)"; then
+        pass "$basename uses --verbose with stream-json"
+    else
+        fail "$basename uses --verbose with stream-json" "$output"
+    fi
+}
+
+echo "Claude stream-json verbose guard"
+
+for file in "$SCRIPT_DIR"/*.sh; do
+    case "$(basename "$file")" in
+        test-stream-json-verbose.sh)
+            continue
+            ;;
+    esac
+    check_file "$file"
+done
+
+if [[ "$FAILURES" -gt 0 ]]; then
+    echo "STATUS: FAILED ($FAILURES failure(s))"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 Codex |
| Harness + version | Codex CLI 0.139.0 |
| All plugins installed | Browser, Documents, frontend-design, Presentations, Spreadsheets, Superpowers |
| Human partner who reviewed this diff | gouzhishuai reviewed the complete proposed diff before submission |

## What problem are you trying to solve?

While looking for a small, real test-infrastructure contribution, I found that the explicit skill request eval runners still call Claude Code as `claude -p ... --output-format stream-json` without `--verbose`.

Claude Code 2.1.179 rejects `--print`/`-p` together with `--output-format stream-json` unless `--verbose` is also present. When that happens, the eval exits before any plugin or skill behavior can be tested, so an explicit skill request can be reported as a skill-triggering failure even though the harness invocation failed first.

This affects the existing shell runners in `tests/explicit-skill-requests`, including the single-turn, multi-turn, extended multi-turn, and Haiku variants.

## What does this PR change?

Adds `--verbose` to every `claude -p` invocation in `tests/explicit-skill-requests` that uses `--output-format stream-json`. It also adds `test-stream-json-verbose.sh`, a small regression guard wired into `run-all.sh`, so future explicit-skill shell runners fail fast if they add a stream-json Claude invocation without `--verbose`.

## Is this change appropriate for the core library?

Yes. This is core test-harness infrastructure for Superpowers' own explicit skill request evals. It does not add dependencies, does not add project-specific configuration, does not modify skill behavior, and does not promote or integrate any third-party service.

## What alternatives did you consider?

I considered removing `--output-format stream-json`, but rejected that because these runners inspect JSON stream events to detect Skill tool invocation and premature tool use.

I considered patching only `run-test.sh`, but rejected that because the same CLI contract appears in the multi-turn, extended multi-turn, and Haiku explicit-skill runners.

I considered reviving the broader approach from #1687, but rejected that because that PR mixed this test-harness fix with unrelated contributor-guidance changes and targeted `main`. This PR keeps the scope to the still-existing explicit-skill request harness and targets `dev`.

## Does this PR contain multiple unrelated changes?

No. The runner changes and the new guard both address one issue: explicit-skill request tests should not invoke `claude -p` with `--output-format stream-json` unless `--verbose` is present.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #452, #1687, #1750

#452 was merged and is useful prior art: it added `--verbose` for the same Claude Code `stream-json` CLI contract in another test runner.

#1687 is closed. It covered the same general class of CLI fix, but also changed contributor guidance and targeted `main`. This PR is intentionally narrower: only the explicit-skill request test harness plus a regression guard, targeting `dev`.

#1750 is currently open and fixes `tests/skill-triggering/run-test.sh`. That file/path is a different runner and is not part of this branch's diff. This PR handles the remaining `tests/explicit-skill-requests` runners that still exist on current `dev`.

I also searched open and closed PRs for `stream-json verbose`, `claude stream-json`, and `explicit-skill-requests` before opening this PR.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI | 0.139.0 | GPT-5 Codex | not exposed by harness |
| Claude Code | 2.1.179 | Claude | claude-opus-4-8[1m] |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add support for a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```text
Not applicable. This PR changes existing explicit-skill request test runners only; it does not add a harness integration.
```

</details>

## Evaluation

- Initial prompt/session issue: my human partner asked for a real, narrow contribution around tests or test infrastructure in this repository. Investigation found existing explicit-skill shell runners with `claude -p` plus `--output-format stream-json` but no `--verbose`, matching the current Claude Code CLI error covered by related PRs.
- Eval sessions after the change: 2 live Claude Code single-turn explicit-skill evals, plus static guard/lint checks.
- Before: `claude -p "Say ok" --max-turns 1 --output-format stream-json` fails on Claude Code 2.1.179 with `Error: When using --print, --output-format=stream-json requires --verbose`.
- After: the patched `run-test.sh` reached Claude Code, loaded the Superpowers plugin, invoked the requested skill, and reported no premature tool invocation for both `systematic-debugging` and `subagent-driven-development` prompts.

Live Claude Code evals run after the change:

```bash
# This macOS environment does not have GNU timeout installed, so I injected a
# temporary PATH-only timeout shim for these live eval commands. The shim only
# strips the leading seconds argument and execs the existing command.

tests/explicit-skill-requests/run-test.sh systematic-debugging tests/explicit-skill-requests/prompts/use-systematic-debugging.txt 3
# PASS: Skill 'systematic-debugging' was triggered
# OK: No premature tool invocations detected

tests/explicit-skill-requests/run-test.sh subagent-driven-development tests/explicit-skill-requests/prompts/subagent-driven-development-please.txt 3
# PASS: Skill 'subagent-driven-development' was triggered
# OK: No premature tool invocations detected
```

Additional verification run after the change:

```bash
tests/explicit-skill-requests/test-stream-json-verbose.sh
bash -n tests/explicit-skill-requests/run-all.sh tests/explicit-skill-requests/run-test.sh tests/explicit-skill-requests/run-multiturn-test.sh tests/explicit-skill-requests/run-extended-multiturn-test.sh tests/explicit-skill-requests/run-haiku-test.sh tests/explicit-skill-requests/test-stream-json-verbose.sh
git diff --check origin/dev..HEAD
bash tests/shell-lint/test-lint-shell.sh
```

I also ran `tests/explicit-skill-requests/run-all.sh` with fake `claude` and `timeout` commands injected via `PATH`. That smoke test verifies the runner passes `--verbose` whenever it requests `stream-json` and that the new guard is wired into `run-all.sh`.

I could not run `scripts/lint-shell.sh` against real ShellCheck because `shellcheck` is not installed in this environment.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is not a skills change and does not modify behavior-shaping skill content. The adversarial check is the regression guard: it scans every shell runner in `tests/explicit-skill-requests` and fails if a `claude -p` command uses `--output-format stream-json` without `--verbose`.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

The human partner reviewed the complete diff before this PR was opened.
