### PR TITLE
fix(using-git-worktrees): verify the chosen worktree directory is ignored

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -62,30 +62,44 @@ Only proceed to Step 1b if you have no native worktree tool available.
 
 #### Directory Selection
 
-Follow this priority order. Explicit user preference always beats observed filesystem state.
+Follow this priority order. Explicit user preference always beats observed filesystem state. Bind the chosen directory to `LOCATION` so later steps verify and create against the same path.
 
-1. **Check your instructions for a declared worktree directory preference.** If the user has already specified one, use it without asking.
-
-2. **Check for an existing project-local worktree directory:**
+1. **Check your instructions for a declared worktree directory preference.** If the user has already specified one, use it without asking:
    ```bash
-   ls -d .worktrees 2>/dev/null     # Preferred (hidden)
-   ls -d worktrees 2>/dev/null      # Alternative
+   LOCATION="<user-specified-directory>"
    ```
-   If found, use it. If both exist, `.worktrees` wins.
 
-3. **If there is no other guidance available**, default to `.worktrees/` at the project root.
+2. **Otherwise, check for an existing project-local worktree directory:**
+   ```bash
+   if [ -d .worktrees ]; then       # Preferred (hidden)
+     LOCATION=".worktrees"
+   elif [ -d worktrees ]; then      # Alternative
+     LOCATION="worktrees"
+   fi
+   ```
+   If both exist, `.worktrees` wins.
+
+3. **If there is no other guidance available**, default to `.worktrees/` at the project root:
+   ```bash
+   LOCATION=".worktrees"
+   ```
 
 #### Safety Verification (project-local directories only)
 
-**MUST verify directory is ignored before creating worktree:**
+**MUST verify the chosen directory is ignored before creating worktree:**
 
 ```bash
-git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/dev/null
+git check-ignore -q "$LOCATION"
 ```
 
-**If NOT ignored:** Add to .gitignore, commit the change, then proceed.
+**If NOT ignored:** Add `$LOCATION/` to .gitignore, commit the change, then proceed:
 
-**Why critical:** Prevents accidentally committing worktree contents to repository.
+```bash
+echo "$LOCATION/" >> .gitignore
+git add .gitignore && git commit -m "chore: ignore worktree directory"
+```
+
+**Why critical:** Prevents accidentally committing worktree contents to repository. Verifying the specific chosen location matters: a repo may ignore `.worktrees/` but not `worktrees/` (or vice versa). An `||` across both candidates can pass on the unchosen one and silently skip adding the ignore rule for the directory actually about to be created.
 
 #### Create the Worktree
 


### PR DESCRIPTION
> Targeting `dev` per the PR template.

## Who is submitting this PR?

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.7 (1M context) |
| Harness + version | Claude Code |
| All plugins installed | superpowers (vendored as v5.1.0 in a downstream repo) |
| Human partner who reviewed this diff | J Chris Anderson (jchris@gmail.com) |

## What problem are you trying to solve?

`skills/using-git-worktrees/SKILL.md` contains a safety verification step whose stated purpose is to prevent committing worktree contents to the repo. The current check is:

```bash
git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/dev/null
```

This passes if *either* candidate is ignored. But the directory-selection steps above may choose `worktrees/` for this run (because that's the existing project-local directory) while only `.worktrees/` appears in `.gitignore` — a common setup, especially in repos that picked the hidden default before they had a `worktrees/` directory, or vice versa.

When that happens, the guard succeeds on the unchosen candidate, the "If NOT ignored" branch is skipped, no `.gitignore` rule is added, and `git worktree add "$LOCATION/$BRANCH_NAME"` then creates untracked, non-ignored worktree contents inside the chosen directory. That is exactly the "don't commit worktree contents to repository" hazard this step is documented as preventing.

I noticed this while vendoring superpowers v5.1.0 into another repo. The same code is present on current `dev`, and the bug is independent of vendoring.

There's a related, already-merged PR (#160) that switched this verification from `grep` to `git check-ignore`. This PR builds on top of that — same step, different remaining bug.

## What does this PR change?

In `skills/using-git-worktrees/SKILL.md`, binds the chosen worktree directory to a `LOCATION` shell variable in the three directory-selection sub-steps, then has the Safety Verification check only `"\$LOCATION"`. The `\$LOCATION` variable was already referenced downstream in the "Create the Worktree" snippet (`path=\"\$LOCATION/\$BRANCH_NAME\"`) but was never explicitly assigned anywhere; this change makes the contract explicit and reuses it for the ignore check.

## Is this change appropriate for the core library?

Yes. `using-git-worktrees` is a general-purpose skill in core; the fix is to that skill's safety logic and applies to anyone whose `.gitignore` ignores one worktree directory name but not the other.

## What alternatives did you consider?

- **Check both candidates with AND instead of OR** (`check-ignore .worktrees && check-ignore worktrees`). Rejected — it would over-correct: a repo that only intends to use `.worktrees/` would be forced to also ignore `worktrees/`.
- **Always verify the literal chosen path inline without a variable.** Rejected — the "Create the Worktree" step already references `\$LOCATION`. Introducing it earlier (where it's chosen) is the minimal change that matches the existing downstream usage.
- **Leave the OR and just document the hazard.** Rejected — the whole point of the step is to prevent the hazard, not warn about it.

## Does this PR contain multiple unrelated changes?

No. Single focused change to one file (`skills/using-git-worktrees/SKILL.md`) addressing one bug.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #160 (merged) — switched the same step from `grep` to `git check-ignore`; addresses a different bug in the same step. No PR found that addresses the OR-bypass.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | current | Claude Opus 4.7 (1M context) | claude-opus-4-7 |

## Evaluation

This change is to documentation/instruction prose (a `.md` skill), and the substantive change is to the embedded bash. I verified the fix by:

1. Reproducing the failure mode on a scratch repo with `.gitignore` containing only `.worktrees/` and an existing `worktrees/` directory: the old check returns success (exit 0) and would skip adding the ignore rule, while the new `git check-ignore -q \"\$LOCATION\"` (with `LOCATION=worktrees`) correctly returns non-zero and triggers the "add to .gitignore" branch.
2. Verifying the inverse case (`.gitignore` contains only `worktrees/`, `LOCATION=.worktrees`) — same correct behavior.
3. Verifying the happy path (`LOCATION` is already ignored): `git check-ignore -q \"\$LOCATION\"` returns 0, skill proceeds, matching prior behavior.

I did not run a full skill-eval pass across multiple agent sessions because the change is to a code snippet in a SKILL.md and the agent-behavioral content (Quick Reference, Common Mistakes, Red Flags, "Always") is unchanged — those sections all still say "verify directory is ignored", which is exactly what the new snippet does, just against the correct directory.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Adversarial cases I checked against the new snippet:
- Only `.worktrees/` ignored, repo has `worktrees/` directory → selection picks `worktrees`, check fails, ignore rule added. ✓
- Only `worktrees/` ignored, repo has `.worktrees/` directory → selection picks `.worktrees`, check fails, ignore rule added. ✓
- Both ignored → either selection passes the check. ✓
- Neither ignored, neither directory exists → selection defaults to `.worktrees`, check fails, ignore rule added. ✓
- User-specified directory not matching either default → check verifies that exact path. ✓

The Red Flags / Always tables and Common Mistakes prose are unchanged.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission