### PR TITLE
fix: Stop in-place mutation of first user message so opencode session titles ignore bootstrap

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -1,7 +1,7 @@
 /**
  * Superpowers plugin for OpenCode.ai
  *
- * Injects superpowers bootstrap context via system prompt transform.
+ * Injects superpowers bootstrap context via message transform.
  * Skills are discovered via OpenCode's native skill tool from symlinked directory.
  */
 
@@ -83,13 +83,49 @@ ${toolMapping}
 </EXTREMELY_IMPORTANT>`;
   };
 
+  const findMessages = (input, output) => {
+    if (Array.isArray(output)) return output;
+    if (Array.isArray(output?.messages)) return output.messages;
+    if (Array.isArray(input)) return input;
+    if (Array.isArray(input?.messages)) return input.messages;
+    return null;
+  };
+
+  const hasBootstrap = (parts) => {
+    return parts.some((part) => {
+      return part?.type === 'text' &&
+        typeof part.text === 'string' &&
+        part.text.includes('<EXTREMELY_IMPORTANT>');
+    });
+  };
+
   return {
-    // Use system prompt transform to inject bootstrap (fixes #226 agent reset bug)
-    'experimental.chat.system.transform': async (_input, output) => {
+    // Use a fresh parts array so shared history references stay unmodified.
+    'experimental.chat.messages.transform': async (input, output) => {
       const bootstrap = getBootstrapContent();
-      if (bootstrap) {
-        (output.system ||= []).push(bootstrap);
-      }
+      if (!bootstrap) return;
+
+      const messages = findMessages(input, output);
+      if (!messages?.length) return;
+
+      const firstUserIndex = messages.findIndex((message) => {
+        return message?.role === 'user' &&
+          Array.isArray(message.parts) &&
+          message.parts.length > 0;
+      });
+      if (firstUserIndex === -1) return;
+
+      const firstUser = messages[firstUserIndex];
+      if (hasBootstrap(firstUser.parts)) return;
+
+      const referencePart = firstUser.parts.find((part) => part?.type === 'text') || {};
+      messages[firstUserIndex] = {
+        ...firstUser,
+        parts: [
+          { ...referencePart, type: 'text', text: bootstrap },
+          ...firstUser.parts
+        ]
+      };
     }
   };
 };

--- a/tests/opencode/test-bootstrap-caching.mjs
+++ b/tests/opencode/test-bootstrap-caching.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const pluginPath = path.join(repoRoot, '.opencode/plugins/superpowers.js');
+
+const loadPlugin = async (filePath, cacheKey = '') => {
+  const moduleUrl = pathToFileURL(filePath).href + cacheKey;
+  const { SuperpowersPlugin } = await import(moduleUrl);
+  const plugin = await SuperpowersPlugin({ client: {}, directory: repoRoot });
+  const transform = plugin['experimental.chat.messages.transform'];
+
+  assert.equal(typeof transform, 'function');
+  return transform;
+};
+
+const countBootstrapParts = (parts) => {
+  return parts.filter((part) => {
+    return part?.type === 'text' &&
+      typeof part.text === 'string' &&
+      part.text.includes('<EXTREMELY_IMPORTANT>');
+  }).length;
+};
+
+const transform = await loadPlugin(pluginPath);
+
+const originalParts = [
+  { type: 'text', text: 'Build a title from this real user prompt.' },
+  { type: 'file', name: 'notes.txt', url: 'file:///tmp/notes.txt' }
+];
+const originalFirstUser = { role: 'user', parts: originalParts };
+const originalPartsSnapshot = structuredClone(originalParts);
+const messages = [
+  { role: 'assistant', parts: [{ type: 'text', text: 'Previous reply' }] },
+  originalFirstUser
+];
+
+await transform({}, messages);
+
+assert.deepEqual(originalParts, originalPartsSnapshot);
+assert.equal(originalFirstUser.parts, originalParts);
+assert.notEqual(messages[1], originalFirstUser);
+assert.notEqual(messages[1].parts, originalParts);
+assert.equal(messages[1].parts.length, originalParts.length + 1);
+assert.equal(messages[1].parts[0].type, 'text');
+assert.match(messages[1].parts[0].text, /<EXTREMELY_IMPORTANT>/);
+assert.deepEqual(messages[1].parts.slice(1), originalPartsSnapshot);
+assert.equal(countBootstrapParts(messages[1].parts), 1);
+
+const transformedParts = messages[1].parts;
+await transform({}, messages);
+
+assert.equal(messages[1].parts, transformedParts);
+assert.equal(messages[1].parts.length, originalParts.length + 1);
+assert.equal(countBootstrapParts(messages[1].parts), 1);
+
+await transform({}, []);
+await transform({}, [{ role: 'assistant', parts: [{ type: 'text', text: 'No user message' }] }]);
+await transform({}, [{ role: 'user', parts: [] }]);
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'superpowers-bootstrap-test-'));
+try {
+  const tempPluginDir = path.join(tempDir, '.opencode/plugins');
+  fs.mkdirSync(tempPluginDir, { recursive: true });
+  const tempPluginPath = path.join(tempPluginDir, 'superpowers.js');
+  fs.copyFileSync(pluginPath, tempPluginPath);
+
+  const missingBootstrapTransform = await loadPlugin(tempPluginPath, `?missing=${Date.now()}`);
+  const missingBootstrapParts = [{ type: 'text', text: 'Hello without bootstrap file' }];
+  const missingBootstrapMessages = [{ role: 'user', parts: missingBootstrapParts }];
+
+  await missingBootstrapTransform({}, missingBootstrapMessages);
+
+  assert.equal(missingBootstrapMessages[0].parts, missingBootstrapParts);
+  assert.deepEqual(missingBootstrapMessages[0].parts, [{ type: 'text', text: 'Hello without bootstrap file' }]);
+} finally {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+console.log('bootstrap caching tests passed');


### PR DESCRIPTION
## Summary
The opencode plugin's 'experimental.chat.messages.transform' hook injects the Superpowers bootstrap blob by calling firstUser.parts.unshift({...ref, text: bootstrap}) (superpowers.js ~line 135-136), mutating the first user message's parts array in place. In opencode that parts array is shared in memory with the session history the built-in title agent reads (ensureTitle -> a.history), so the title model sees the <EXTREMELY_IMPORTANT> bootstrap first and generates titles like 'Superpowers activated' instead of titles derived from the user's real first prompt.

## Changes
In the transform hook in .opencode/plugins/superpowers.js, stop mutating the shared parts array in place. Instead replace firstUser.parts with a new array (e.g.

Fixes #1784
