### PR TITLE
fix(sdd): write artifacts to a working-tree dir, not .git/ (#1780)

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -251,7 +251,7 @@ sequences — the single most expensive failure observed. Track progress in
 a ledger file, not only in todos.
 
 - At skill start, check for a ledger:
-  `cat "$(git rev-parse --git-path sdd)/progress.md"`. Tasks listed there
+  `cat "$(git rev-parse --show-toplevel)/.superpowers/sdd/progress.md"`. Tasks listed there
   as complete are DONE — do not re-dispatch them; resume at the first task
   not marked complete.
 - When a task's review comes back clean, append one line to the ledger in

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -5,9 +5,8 @@
 # tasks intact.
 #
 # Usage: review-package BASE HEAD [OUTFILE]
-# Default OUTFILE: <git-dir>/sdd/review-<base7>..<head7>.diff — unique per
-# repo instance and per range, so concurrent sessions cannot collide and a
-# re-review after fixes always gets a distinctly named fresh file.
+# Default OUTFILE: <repo-root>/.superpowers/sdd/review-<base7>..<head7>.diff
+# (named per range, so a re-review after fixes gets a distinct fresh file).
 set -euo pipefail
 
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then
@@ -24,9 +23,7 @@ git rev-parse --verify --quiet "$head" >/dev/null || { echo "bad HEAD: $head" >&
 if [ $# -eq 3 ]; then
   out=$3
 else
-  dir=$(git rev-parse --git-path sdd)
-  mkdir -p "$dir"
-  dir=$(cd "$dir" && pwd)
+  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace")
   out="$dir/review-$(git rev-parse --short "$base")..$(git rev-parse --short "$head").diff"
 fi
 

--- a/skills/subagent-driven-development/scripts/sdd-workspace
+++ b/skills/subagent-driven-development/scripts/sdd-workspace
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Resolve and ensure the working-tree directory SDD uses for its short-lived
+# artifacts: task briefs, implementer reports, review packages, and the
+# progress ledger. Print the directory's absolute path.
+#
+# The workspace lives in the working tree (not under .git/) because Claude Code
+# treats .git/ as a protected path and denies agent writes there — which blocks
+# an implementer subagent from writing its report file. A self-ignoring
+# .gitignore keeps the workspace out of `git status` and out of accidental
+# commits without modifying any tracked file.
+#
+# Single source of truth for the workspace location, so task-brief and
+# review-package cannot drift to different directories.
+#
+# Usage: sdd-workspace
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+dir="$root/.superpowers/sdd"
+mkdir -p "$dir"
+printf '*\n' > "$dir/.gitignore"
+cd "$dir" && pwd

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -4,8 +4,8 @@
 # through the controller's context.
 #
 # Usage: task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
-# Default OUTFILE: <git-dir>/sdd/task-<N>-brief.md — unique per repo
-# instance, so concurrent sessions cannot collide.
+# Default OUTFILE: <repo-root>/.superpowers/sdd/task-<N>-brief.md
+# (per worktree; concurrent runs in the same working tree share it).
 set -euo pipefail
 
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then
@@ -20,9 +20,7 @@ n=$2
 if [ $# -eq 3 ]; then
   out=$3
 else
-  dir=$(git rev-parse --git-path sdd)
-  mkdir -p "$dir"
-  dir=$(cd "$dir" && pwd)
+  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace")
   out="$dir/task-${n}-brief.md"
 fi
 

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Tests for the SDD workspace: scripts/sdd-workspace resolves a self-ignoring
+# working-tree directory for SDD artifacts, and the SDD scripts write into it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SDD_SCRIPTS="$REPO_ROOT/skills/subagent-driven-development/scripts"
+
+FAILURES=0
+TEST_ROOT=""
+
+pass() { echo "  [PASS] $1"; }
+fail() {
+    echo "  [FAIL] $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+cleanup() {
+    if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+        rm -rf "$TEST_ROOT"
+    fi
+}
+
+main() {
+    echo "=== Test: sdd-workspace ==="
+
+    TEST_ROOT="$(mktemp -d)"
+    trap cleanup EXIT
+
+    # Resolve repo to its physical path so string comparisons match the
+    # helper's output (git rev-parse --show-toplevel resolves symlinks; on
+    # macOS mktemp lives under /var -> /private/var).
+    git init -q -b main "$TEST_ROOT/repo"
+    local repo
+    repo="$(cd "$TEST_ROOT/repo" && git rev-parse --show-toplevel)"
+
+    local dir
+    dir="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace")"
+
+    if [[ "$dir" == "$repo/.superpowers/sdd" ]]; then
+        pass "prints <repo-root>/.superpowers/sdd"
+    else
+        fail "prints <repo-root>/.superpowers/sdd"
+        echo "    got: $dir"
+    fi
+
+    if [[ -f "$repo/.superpowers/sdd/.gitignore" && "$(cat "$repo/.superpowers/sdd/.gitignore")" == "*" ]]; then
+        pass "self-ignoring .gitignore created with '*'"
+    else
+        fail "self-ignoring .gitignore created with '*'"
+    fi
+
+    printf 'x\n' > "$repo/.superpowers/sdd/artifact.md"
+    local status
+    status="$(cd "$repo" && git status --porcelain)"
+    if [[ -z "$status" ]]; then
+        pass "workspace invisible to git status"
+    else
+        fail "workspace invisible to git status"
+        echo "    status: $status"
+    fi
+
+    ( cd "$repo" && git add -A )
+    local staged
+    staged="$(cd "$repo" && git diff --cached --name-only)"
+    if [[ -z "$staged" ]]; then
+        pass "git add -A does not stage the workspace"
+    else
+        fail "git add -A does not stage the workspace"
+        echo "    staged: $staged"
+    fi
+
+    echo ""
+    if [[ "$FAILURES" -ne 0 ]]; then
+        echo "FAILED: $FAILURES assertion(s)."
+        exit 1
+    fi
+    echo "PASS"
+}
+
+main "$@"

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -71,6 +71,42 @@ main() {
         echo "    staged: $staged"
     fi
 
+    cat > "$repo/plan.md" <<'PLAN'
+# Plan
+
+## Task 1: First thing
+
+Do the first thing.
+PLAN
+
+    local brief_out brief_path
+    brief_out="$(cd "$repo" && "$SDD_SCRIPTS/task-brief" plan.md 1)"
+    brief_path="$(printf '%s\n' "$brief_out" | sed -n 's/^wrote \(.*\): [0-9][0-9]* lines$/\1/p')"
+    case "$brief_path" in
+        "$repo/.superpowers/sdd/"*) pass "task-brief writes its brief under the workspace" ;;
+        *)
+            fail "task-brief writes its brief under the workspace"
+            echo "    got: $brief_path"
+            ;;
+    esac
+
+    local git_id=(-c user.email=t@example.com -c user.name=t -c commit.gpgsign=false)
+    ( cd "$repo" \
+        && git add plan.md \
+        && git "${git_id[@]}" commit -qm c1 \
+        && printf 'y\n' > f && git add f \
+        && git "${git_id[@]}" commit -qm c2 )
+    local rp_out rp_path
+    rp_out="$(cd "$repo" && "$SDD_SCRIPTS/review-package" HEAD~1 HEAD)"
+    rp_path="$(printf '%s\n' "$rp_out" | sed -n 's/^wrote \(.*\): [0-9].*$/\1/p')"
+    case "$rp_path" in
+        "$repo/.superpowers/sdd/"*) pass "review-package writes its diff under the workspace" ;;
+        *)
+            fail "review-package writes its diff under the workspace"
+            echo "    got: $rp_path"
+            ;;
+    esac
+
     echo ""
     if [[ "$FAILURES" -ne 0 ]]; then
         echo "FAILED: $FAILURES assertion(s)."

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -107,6 +107,30 @@ PLAN
             ;;
     esac
 
+    # --- Worktree isolation: a linked worktree resolves its own workspace ---
+    local wt="$TEST_ROOT/wt"
+    ( cd "$repo" && git worktree add -q "$wt" -b wt-feature )
+    local wt_root wt_dir
+    wt_root="$(cd "$wt" && git rev-parse --show-toplevel)"
+    wt_dir="$(cd "$wt" && "$SDD_SCRIPTS/sdd-workspace")"
+    if [[ "$wt_dir" == "$wt_root/.superpowers/sdd" && "$wt_dir" != "$dir" ]]; then
+        pass "linked worktree resolves its own distinct workspace"
+    else
+        fail "linked worktree resolves its own distinct workspace"
+        echo "    main: $dir"
+        echo "    wt:   $wt_dir"
+    fi
+
+    printf 'y\n' > "$wt/.superpowers/sdd/artifact.md"
+    local wt_status
+    wt_status="$(cd "$wt" && git status --porcelain)"
+    if [[ -z "$wt_status" ]]; then
+        pass "worktree workspace invisible to git status"
+    else
+        fail "worktree workspace invisible to git status"
+        echo "    status: $wt_status"
+    fi
+
     echo ""
     if [[ "$FAILURES" -ne 0 ]]; then
         echo "FAILED: $FAILURES assertion(s)."


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (`claude-opus-4-8[1m]`) |
| Harness + version | Claude Code 2.1.179 |
| All plugins installed (enabled) | agent-sdk-dev, claude-code-setup, claude-session-driver, code-simplifier, context7, elements-of-style, episodic-memory, frontend-design, github-triage, gopls-lsp, linear, mcp-server-dev, plugin-dev, primeradiant-ops, release-radar, summarize-meetings, superpowers, superpowers-chrome, superpowers-developing-for-claude-code, superpowers-lab, worldview-synthesis |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — maintainer; reviewed the complete diff in-session before submission |

## What problem are you trying to solve?

SDD writes its short-lived artifacts (task briefs, implementer reports, review packages, the progress ledger) under `.git/sdd/` (via `git rev-parse --git-path sdd`). Claude Code treats `.git/` as a protected ("sensitive") path and **denies any write an agent issues there.** When an implementer subagent follows `implementer-prompt.md`'s instruction — *"Write your full report to [REPORT_FILE]"* — and `[REPORT_FILE]` is `.git/sdd/task-N-report.md`, the Write-tool call is denied. The reviewer that reads the report then has nothing to read, and the workflow stalls.

This was reported in #1780 (a user hit it with sandbox mode on, showing a subagent issuing `Write(.git/sdd/task-4-report.md)`). An earlier triage reply called it a non-problem because the scripts use bash — but that analysis was incomplete: it checked the *scripts*, and missed that the *report* is the subagent's own Write-tool call against a literal `.git/` path.

Reproduced deterministically on Claude Code 2.1.179 with headless `claude -p --output-format json`, holding the tool and permission mode constant and varying only the path:

| Tool | working-tree path | `.git/sdd/` path |
|------|-------------------|------------------|
| Write (acceptEdits) | created | **denied** — *"…which is a sensitive file"* (`permission_denials` names Write + the `.git/sdd/...` path) |
| Bash `>` (Bash allowed) | created | **denied** — same "sensitive file" message |

Sandbox mode is not the cause — the gate fires in plain `acceptEdits` with no sandbox. The SDD scripts (`task-brief`, `review-package`) escape it only because they write through a `"$out"` variable the command analyzer cannot resolve to a literal `.git/` path; the report write has no such cover.

## What does this PR change?

Relocates the SDD workspace from `.git/sdd` to a working-tree directory `.superpowers/sdd`, resolved by a new single-source-of-truth helper `scripts/sdd-workspace`, and routes `task-brief`, `review-package`, and the SKILL.md ledger path through it. The directory is kept invisible to git by a self-ignoring `.superpowers/sdd/.gitignore` (`*`) — no tracked file is modified and no `.git/` write occurs.

## Is this change appropriate for the core library?

Yes. SDD is a core, general-purpose workflow; this fixes a write that any SDD controller on Claude Code hits, regardless of project, domain, or third-party tooling. The change is dependency-free shell + a path string in SKILL.md.

## What alternatives did you consider?

- **Add `.superpowers/` to the user's tracked `.gitignore`** (the form #1780 proposed): simplest, but it mutates a tracked file in the user's repo — a committable diff they have to notice on the first SDD run. Rejected for breaking the "SDD never touches your tracked files" property that `.git/sdd` has today.
- **`.git/info/exclude`**: no tracked change, but per-clone and itself a `.git/` write (needs a path-hidden helper). Rejected as more plumbing for no gain over the self-ignoring dir.
- **Self-ignoring `.superpowers/sdd/.gitignore` (`*`)** — chosen. Verified: invisible to `git status`, ignored, unstageable by `git add -A`, ignores itself, zero tracked-file mutation, zero `.git/` write.
- **Keep `.git/sdd`, route the report write through a path-hiding wrapper script**: preserves the location but adds a fragile two-step dance (the subagent may still reach for the Write tool on the real `.git/` path).
- **A temp dir outside the repo**: worse discoverability and a real sandbox `$TMPDIR` split-brain (sandboxed bash and the unsandboxed Read tool resolve `$TMPDIR` differently), which can break the brief handoff.

## Does this PR contain multiple unrelated changes?

No — one problem: the SDD artifact write location. The adjacent task-brief path-collision bug (#1772 / PRI-2240) is **deliberately out of scope**: it is orthogonal (`.superpowers/sdd/task-1-brief.md` collides exactly as `.git/sdd/task-1-brief.md` did), it has its own unresolved design question, and it has its own PR. This change leaves that fix easier — `sdd-workspace` becomes the single seam a unique-leaf/run-id scheme slots into.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1772 (open), #1588 (closed), #1717 (merged), openai/plugins#332 (closed). No PR addresses the `.git/` protected-path gate / SDD artifact relocation.

- **#1717 (merged)** added the `task-brief`/`review-package` scripts and the `.git/sdd` convention this PR modifies — the prior art this builds on.
- **#1772 (open, draft)** fixes the task-brief *collision* by minting unique paths under `.git/sdd`; it does not address the `.git/` gate (its briefs stay under `.git/`). Orthogonal; see scope note above.
- **#1588 (closed)** also concerned worktrees and SDD, but a *different* problem: it threaded a "worktree root" contract through five SDD prompt templates so implementers write their *code* in the active worktree. It was closed for modifying carefully-tuned behavior-shaping prose without eval evidence, and for being part of a large batch. This PR is the opposite shape: a mechanical path/script change, **zero** prompt-prose changes, one focused problem, not part of a batch — it specifically avoids both reasons #1588 was closed.
- **openai/plugins#332 (closed)** is the marketplace sync PR whose automated Codex review surfaced the collision bug (#1772); referenced for context.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code CLI | 2.1.179 | Claude Opus | `claude-opus-4-8[1m]` |
| Shell/static test + headless `claude -p` repro | macOS (darwin 25.2) zsh | — | — |

## New harness support (required if this PR adds a new harness)

Not applicable — this PR does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable: no new harness support is added in this PR.
```

</details>

## Evaluation

This is a mechanical change — file paths and a utility script — **not** a change to behavior-shaping skill prose, so the verification is deterministic rather than session-eval-based.

- **Initial prompt:** "https://github.com/obra/superpowers/issues/1780 suggests that some of the changes in superpowers 6.0 break claude code when running in sandbox mode. Let's root cause this, repro it, and then brainstorm potential ways to fix it."
- **Before/after (the gate):** headless `claude -p --output-format json`, same tool and permission mode, only the path varied. Before — Write/Edit and literal bash redirection to `.git/sdd/...` are denied ("sensitive file"; `permission_denials` names the tool). After — the same writes to `.superpowers/sdd/...` return zero denials and create the file. (Table above.)
- **Regression test:** `tests/claude-code/test-sdd-workspace.sh`, 8 assertions — path resolution, self-ignore content, `git status` invisibility, `git add -A` safety, `task-brief`/`review-package` routing, and **per-worktree isolation**. The worktree assertion is not a tautology: a documented mutation (`git rev-parse --show-toplevel` → `pwd` in the helper) flips it to FAIL. All 8 pass; `scripts/lint-shell.sh` is clean.
- **Real-world dogfood:** this plan was executed end-to-end via SDD itself, with artifacts routed through the new working-tree `.superpowers/sdd` — three implementer subagents wrote their reports with no permission prompt, which is exactly the failure the change removes.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing — **N/A here: this PR changes no behavior-shaping skill prose.** The only skill-dir edits are two utility scripts, a new utility script, and one SKILL.md path string. `implementer-prompt.md` and `task-reviewer-prompt.md` are untouched.
- [x] This change was tested adversarially, not just on the happy path (path×tool reproduction matrix; worktree mutation check proving the regression test has teeth; edge cases probed: empty repo, paths with spaces, subdir invocation, symlinked temp dirs, outside-a-repo failure under `set -e`).
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language, prompt templates) — confirmed untouched.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
