### PR TITLE
Clarify SDD dispatch model intent

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -106,15 +106,22 @@ Use the least powerful model that can handle each role to conserve cost and incr
 
 **Architecture and design tasks**: use the most capable available model.
 The final whole-branch review is one of these — dispatch it on the most
-capable available model, not the session default.
+capable available model; if the parent session is already on that exact
+model/version, intentional inheritance is acceptable.
 
 **Review tasks**: choose the model with the same judgment, scaled to the
 diff's size, complexity, and risk. A small mechanical diff does not need the
 most capable model; a subtle concurrency change does.
 
-**Always specify the model explicitly when dispatching a subagent.** An
-omitted model inherits your session's model — often the most capable and
-most expensive — which silently defeats this section.
+**Make the model decision explicit at the dispatch site.** When your
+harness exposes a per-dispatch model parameter, pass a harness-supported
+model name to route a subagent to a cheaper or different tier. On harnesses
+where omission inherits the parent model/version, omit the model only when
+that inheritance is the intended choice; record that intention in the
+dispatch description or a nearby note. If your harness has no per-dispatch
+model field, choose the configured worker/profile whose model matches the
+intended tier, or set the session/worker default before dispatch; don't invent
+unsupported payload fields.
 
 **Turn count beats token price.** Wall-clock and context cost scale with how
 many turns a subagent takes, and the cheapest models routinely take 2-3× the

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -5,8 +5,9 @@ Use this template when dispatching an implementer subagent.
 ```
 Subagent (general-purpose):
   description: "Implement Task N: [task name]"
-  model: [MODEL — REQUIRED: choose per SKILL.md Model Selection; an omitted
-         model silently inherits the session's most expensive one]
+  model: [MODEL — choose per SKILL.md Model Selection. If unsupported by
+         the harness, omit this line and choose a worker/profile/default
+         that encodes the intended model tier.]
   prompt: |
     You are implementing Task N: [task name]
 

--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -10,8 +10,9 @@ more, nothing less) and is well-built (clean, tested, maintainable)
 ```
 Subagent (general-purpose):
   description: "Review Task N (spec + quality)"
-  model: [MODEL — REQUIRED: choose per SKILL.md Model Selection; an omitted
-         model silently inherits the session's most expensive one]
+  model: [MODEL — choose per SKILL.md Model Selection. If unsupported by
+         the harness, omit this line and choose a worker/profile/default
+         that encodes the intended model tier.]
   prompt: |
     You are reviewing one task's implementation: first whether it matches its
     requirements, then whether it is well-built. This is a task-scoped gate,
@@ -166,7 +167,9 @@ Subagent (general-purpose):
 ```
 
 **Placeholders:**
-- `[MODEL]` — REQUIRED: reviewer model per SKILL.md Model Selection
+- `[MODEL]` — reviewer model per SKILL.md Model Selection. If the harness has
+  no per-dispatch model field, choose the configured worker/profile/default
+  that encodes the intended model tier and omit the field.
 - `[BRIEF_FILE]` — REQUIRED: the task brief file (`scripts/task-brief PLAN N`
   prints the path; same file the implementer worked from)
 - `[GLOBAL_CONSTRAINTS]` — the binding requirements copied verbatim from


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 via Codex |
| Harness + version | Codex desktop app / codex-cli 0.140.0-alpha.19 |
| All plugins installed | browser, build-ios-apps, build-web-apps, canva, chrome, documents, figma, github, pdf, presentations, spreadsheets; dynamic tools: codegraph and multi-agent tools |
| Human partner who reviewed this diff | @zaidazmi reviewed the complete diff in Codex before submission |

## What problem are you trying to solve?

Issue #1631 reports that `subagent-driven-development` tells controllers to use the least powerful model that can handle each role, but the dispatch templates do not carry that decision at the point where workers are launched. The issue author measured 78 of 150 `general-purpose` dispatches inheriting the parent model, 77 of those from Opus parent sessions, while 72 dispatches in the same dataset already passed an explicit model.

The issue discussion also identified an important constraint: always forcing a model field can be wrong when the human partner intentionally chose a newer or exact parent model/version and the harness supports omission-as-inheritance. Issue #1776 adds the cross-harness version of the same problem: OpenCode-family harnesses may not expose a per-dispatch model field at all, so telling agents to pass a `model` payload field can increase confusion rather than reduce cost.

This PR solves the action-point gap without making the model rule too rigid: dispatches must make the model decision intentional, but the exact mechanism depends on what the harness supports.

## What does this PR change?

Updates SDD Model Selection and the implementer/reviewer dispatch templates so controllers either pass a harness-supported per-dispatch model or intentionally omit the field and choose the right inherited/default worker/profile path. The templates now point readers to the Model Selection section instead of asserting that omission always means accidental expensive inheritance.

## Is this change appropriate for the core library?

Yes. This is general SDD workflow guidance that applies across projects and harnesses. It does not add a third-party integration, a project-specific workflow, or a new dependency. It also preserves the current SDD philosophy that the controller should use judgment about model tier instead of always using the most capable model.

## What alternatives did you consider?

- Always require a `model:` field in every dispatch template. Rejected because #1631's own discussion notes exact parent model/version inheritance as a legitimate use case, and #1776 reports harnesses where no per-dispatch field exists.
- Tell controllers to inherit the parent model for all high-risk dispatches. Rejected because #1738 was closed after the maintainer said evals show SDD should not always dispatch to the most capable frontier model; the controller should choose the tier.
- Name specific current model IDs. Rejected because the repo is trying to avoid stale model-lineup recall; model names rot quickly and vary by harness.
- Do nothing because current `SKILL.md` already has Model Selection prose. Rejected because #1631's evidence is exactly that prose away from the dispatch site gets missed at runtime.

## Does this PR contain multiple unrelated changes?

No. All changes are in the SDD model-dispatch guidance and templates, addressing #1631 and the harness fallback raised in #1776.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1719, #1738, #1786.

#1719 is an open broad model-lineup/Fable PR with many unrelated file changes; this PR does not name Fable or change model-lineup docs. #1738 was closed because it pushed too far toward inheriting the most capable model; this PR preserves controller judgment and only clarifies how to express the decision. #1786 was closed by its author because it was built on an older base and duplicated current guidance; this PR edits the current `dev` branch's existing section and templates directly.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app | codex-cli 0.140.0-alpha.19 | GPT-5 | Codex GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR adds no new harness.

## Evaluation
- Initial prompt: human partner asked for four contribution candidates to be prepared properly, including "Make worker model explicit in SDD dispatch templates (issue #1631)" and a fallback note for Codex/OpenCode-style harnesses (#1776).
- Eval sessions after the change: 16 fresh subagent micro-test samples following `superpowers:writing-skills` guidance for single-shot wording probes. The external Drill/tmux eval harness is not present in this checkout, so this is targeted pressure testing, not a full Drill scenario suite.
- Outcome compared to before:
  - Exact parent model/version inheritance case: baseline wording failed 5/5 by forcing an explicit model field such as `model: "most_capable"` or `model: "exact-newest-frontier"` even though omission was the only way to preserve the parent session's exact model/version. Candidate wording passed 5/5 by intentionally omitting the model field and recording that inheritance intent.
  - OpenCode-family no-per-dispatch-model case: candidate wording passed 5/5 by choosing the configured `fast-worker` and not inventing an unsupported `model` field. A single baseline/control sample also chose `fast-worker`, so this PR does not claim a measured before/after win for that harness; it claims the candidate text preserves the intended fallback path explicitly.

Representative baseline failures:

```text
DISPATCH: {"task":"final whole-branch review","model":"most_capable"}
PASS_OR_FAIL_FOR_EXACT_INHERITANCE: fail

DISPATCH: {"task":"final whole-branch review","model":"exact-newest-frontier"}
PASS_OR_FAIL_FOR_EXACT_INHERITANCE: fail
```

Representative candidate passes:

```text
DISPATCH: {"task":"final whole-branch review","intentional_model_inheritance":true,"inheritance_note":"Omit model so worker inherits parent session's exact newest frontier model/version selected by human."}
PASS_OR_FAIL_FOR_EXACT_INHERITANCE: pass

DISPATCH: {"agent":"fast-worker","prompt":"Perform the small one-file config parser cleanup according to the complete spec, then add and run the obvious tests."}
PASS_OR_FAIL_FOR_NO_UNSUPPORTED_MODEL_FIELD: pass
```

Verification performed:

```bash
git diff --check upstream/dev...HEAD
bash -n skills/subagent-driven-development/scripts/review-package skills/subagent-driven-development/scripts/task-brief
node /Users/zaidazmi/Github/superpowers-prs/skill-doctor/scripts/lint-skills.js \
  --root /Users/zaidazmi/Github/superpowers-prs/issue-1631-models \
  --skills-dir skills/subagent-driven-development
```

`Skill Doctor checked 1 skill(s): no issues found.`

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed targeted subagent pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

The pressure case combines the exact-version inheritance concern from #1631's comments with the final whole-branch review's strong incentive to use the most capable model. The no-per-dispatch-model case covers #1776's OpenCode-family API shape. This PR does not touch Red Flags tables, rationalization lists, or "human partner" language.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

@zaidazmi reviewed the complete proposed diff in Codex before submission.
