### PR TITLE
Add explicit handoff skill

### DIFF
--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: handoff
+description: Use when the human asks to pause, stop, resume later, hand off work, preserve context, or leave a continuation note for a future session
+---
+
+# Handoff
+
+Produce a compact continuation note that lets your human partner, or a future
+agent, restart without rediscovering the session.
+
+**Core principle:** capture operational state, not reassurance. The handoff must
+make the next action obvious.
+
+## When Invoked
+
+Stop active work and write the handoff. Do not continue implementation after
+the handoff unless your human partner asks you to. Use already-visible context
+where possible; run only small read-only checks, such as `git status`, when
+needed to avoid guessing.
+
+Do not create persistent handoff files, slash commands, resume systems, or
+memory stores unless explicitly requested. The default output is the message
+itself.
+
+## Handoff Contract
+
+Use this order:
+
+```markdown
+**Goal**
+[One sentence: what we were trying to accomplish.]
+
+**Current State**
+[What is true now. Include branch/PR/status if relevant.]
+
+**Decisions Made**
+[Key choices and why. Omit if none.]
+
+**Files Touched**
+- `path`: what changed or why it matters
+
+**Commands Run**
+- `command`: result or important output
+
+**Risks / Open Questions**
+- [Known risk, blocker, missing verification, or decision still needed]
+
+**Next Action**
+[The single best next step.]
+```
+
+## Rules
+
+- Keep it concise: usually 100-250 words; expand only when the session has
+  multiple branches, PRs, or unresolved risks.
+- Prefer concrete facts over narrative. Include exact file paths, branch names,
+  PR numbers, commands, test results, and blockers.
+- Separate verified facts from guesses. Use "Need to verify:" for uncertain
+  items.
+- Include failed or skipped verification. A future agent needs to know what not
+  to trust.
+- If nothing changed on disk, say so.
+- If the next action requires human review, approval, credentials, or external
+  state, make that the `Next Action`.
+
+## Example
+
+```markdown
+**Goal**
+Add a small `handoff` skill for explicit end-of-session continuation notes.
+
+**Current State**
+Branch `codex/human-handoff-skill` is based on `upstream/dev`. Prior-art search
+found #931, #590, and #1617; this branch is intentionally smaller: no slash
+commands, no persistent resume files.
+
+**Decisions Made**
+Use a single explicit-invocation skill because broad handoff/resume systems have
+been rejected as too speculative.
+
+**Files Touched**
+- `skills/handoff/SKILL.md`: new skill contract
+- `tests/explicit-skill-requests/prompts/handoff-please.txt`: explicit request fixture
+- `tests/explicit-skill-requests/run-all.sh`: includes the fixture
+
+**Commands Run**
+- `gh pr list ... handoff`: found prior art
+- `bash -n tests/explicit-skill-requests/run-all.sh tests/explicit-skill-requests/run-test.sh`: passed
+
+**Risks / Open Questions**
+- Maintainers may ask for stronger behavior evals because this is behavior-shaping skill text.
+
+**Next Action**
+Run the explicit skill request test for `handoff`, then push the branch.
+```

--- a/tests/explicit-skill-requests/prompts/handoff-please.txt
+++ b/tests/explicit-skill-requests/prompts/handoff-please.txt
@@ -1,0 +1,1 @@
+I'm stopping for the day. Please use the handoff skill to leave a clean handoff so I can resume tomorrow.

--- a/tests/explicit-skill-requests/run-all.sh
+++ b/tests/explicit-skill-requests/run-all.sh
@@ -16,7 +16,7 @@ RESULTS=""
 
 # Test: subagent-driven-development, please
 echo ">>> Test 1: subagent-driven-development-please"
-if "$SCRIPT_DIR/run-test.sh" "subagent-driven-development" "$PROMPTS_DIR/subagent-driven-development-please.txt"; then
+if bash "$SCRIPT_DIR/run-test.sh" "subagent-driven-development" "$PROMPTS_DIR/subagent-driven-development-please.txt"; then
     PASSED=$((PASSED + 1))
     RESULTS="$RESULTS\nPASS: subagent-driven-development-please"
 else
@@ -27,7 +27,7 @@ echo ""
 
 # Test: use systematic-debugging
 echo ">>> Test 2: use-systematic-debugging"
-if "$SCRIPT_DIR/run-test.sh" "systematic-debugging" "$PROMPTS_DIR/use-systematic-debugging.txt"; then
+if bash "$SCRIPT_DIR/run-test.sh" "systematic-debugging" "$PROMPTS_DIR/use-systematic-debugging.txt"; then
     PASSED=$((PASSED + 1))
     RESULTS="$RESULTS\nPASS: use-systematic-debugging"
 else
@@ -38,7 +38,7 @@ echo ""
 
 # Test: please use brainstorming
 echo ">>> Test 3: please-use-brainstorming"
-if "$SCRIPT_DIR/run-test.sh" "brainstorming" "$PROMPTS_DIR/please-use-brainstorming.txt"; then
+if bash "$SCRIPT_DIR/run-test.sh" "brainstorming" "$PROMPTS_DIR/please-use-brainstorming.txt"; then
     PASSED=$((PASSED + 1))
     RESULTS="$RESULTS\nPASS: please-use-brainstorming"
 else
@@ -49,12 +49,23 @@ echo ""
 
 # Test: mid-conversation execute plan
 echo ">>> Test 4: mid-conversation-execute-plan"
-if "$SCRIPT_DIR/run-test.sh" "subagent-driven-development" "$PROMPTS_DIR/mid-conversation-execute-plan.txt"; then
+if bash "$SCRIPT_DIR/run-test.sh" "subagent-driven-development" "$PROMPTS_DIR/mid-conversation-execute-plan.txt"; then
     PASSED=$((PASSED + 1))
     RESULTS="$RESULTS\nPASS: mid-conversation-execute-plan"
 else
     FAILED=$((FAILED + 1))
     RESULTS="$RESULTS\nFAIL: mid-conversation-execute-plan"
+fi
+echo ""
+
+# Test: handoff, please
+echo ">>> Test 5: handoff-please"
+if bash "$SCRIPT_DIR/run-test.sh" "handoff" "$PROMPTS_DIR/handoff-please.txt"; then
+    PASSED=$((PASSED + 1))
+    RESULTS="$RESULTS\nPASS: handoff-please"
+else
+    FAILED=$((FAILED + 1))
+    RESULTS="$RESULTS\nFAIL: handoff-please"
 fi
 echo ""
 

--- a/tests/explicit-skill-requests/run-test.sh
+++ b/tests/explicit-skill-requests/run-test.sh
@@ -68,11 +68,21 @@ echo "Running claude -p with explicit skill request..."
 echo "Prompt: $PROMPT"
 echo ""
 
-timeout 300 claude -p "$PROMPT" \
+TIMEOUT_CMD=()
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=(timeout 300)
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_CMD=(gtimeout 300)
+else
+    echo "WARNING: timeout/gtimeout not found; running without a timeout"
+fi
+
+"${TIMEOUT_CMD[@]}" claude -p "$PROMPT" \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns "$MAX_TURNS" \
     --output-format stream-json \
+    --verbose \
     > "$LOG_FILE" 2>&1 || true
 
 echo ""


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 via Codex |
| Harness + version | Codex desktop app / codex-cli 0.140.0-alpha.19 |
| All plugins installed | browser, build-ios-apps, build-web-apps, canva, chrome, documents, figma, github, pdf, presentations, spreadsheets; dynamic tools: codegraph and multi-agent tools |
| Human partner who reviewed this diff | @zaidazmi reviewed the complete diff in Codex before submission |

## What problem are you trying to solve?

When a human partner needs to stop for hours or days, the current workaround is to ask the agent to summarize the session. That can work, but the output varies: some summaries omit commands, some hide skipped verification, some bury the next action, and some drift into reassurance instead of operational state.

The related #931 issue shows real demand for session handoff, but the maintainer explicitly pushed back on adding slash commands and resume machinery: "Just talk to the agent." This PR follows that direction. It gives agents a normal explicit skill to use when the human asks to pause or hand off, without adding slash commands, persistent files, hooks, or a resume system.

## What does this PR change?

Adds `skills/handoff/SKILL.md`, a compact handoff contract with required sections for goal, current state, decisions, files touched, commands run, risks/open questions, and next action. It also adds an explicit-skill request fixture for `handoff` and hardens the explicit-request test runner so it works on macOS/Claude Code 2.1.177 (`gtimeout`/no-timeout fallback and `--verbose` for stream JSON).

## Is this change appropriate for the core library?

Yes. Pausing and resuming agent work is a general AI-native workflow problem across projects and harnesses. The skill is not domain-specific, does not integrate a third-party service, adds no runtime dependency, and avoids the broader plan-aware/resume-command system that maintainers rejected in #931.

## What alternatives did you consider?

- Add `/create_handoff` and `/resume_plan` slash commands like #931. Rejected because the maintainer explicitly said not to add new slash commands and to just talk to the agent.
- Add persistent handoff files, hooks, or memory stores. Rejected because that turns a small pause workflow into a state-management system and overlaps the closed broader attempts in #590 and #1617.
- Modify `writing-plans`, `executing-plans`, or `subagent-driven-development` to support plan-aware resume. Rejected for this PR because that is a larger design change and not necessary for the core pause/handoff request.
- Do nothing and rely on ad hoc summaries. Rejected because a small explicit skill can standardize the output shape and make skipped verification, changed files, and the next action harder to omit.

## Does this PR contain multiple unrelated changes?

No. The skill, prompt fixture, and test-runner compatibility changes all support one behavior: explicit invocation of a handoff skill and verification that the skill loads before action.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs/issues: #931, #590, #1617.

#931 is an open plan-aware handoff command proposal. This PR intentionally does not add slash commands, does not write handoff files, and does not add resume automation. #590 was a closed attempt to add `session-pause` and `session-resume` skills, with the PR body marked `error`; this PR adds one explicit `handoff` skill only. #1617 was a broader context-pack handoff contract touching planning/SDD docs; this PR does not change plan execution or context-pack contracts.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app | codex-cli 0.140.0-alpha.19 | GPT-5 | Codex GPT-5 |
| Claude Code CLI through explicit-request harness | 2.1.177 | Claude Opus | claude-opus-4-8 |
| Local CLI runtime | macOS zsh, Node v23.6.1 | n/a | n/a |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR adds no new harness.

## Evaluation
- Initial prompt: human partner asked for a "Human Handoff" skill for when an agent should pause and produce a clean handoff: current state, decisions made, files touched, risks, commands run, and next action.
- Eval sessions after the change: targeted explicit-invocation harness runs plus a pressure prompt. The external Drill/tmux eval harness is not present in this checkout, so this is targeted pressure testing rather than a full Drill scenario suite.
- Outcome compared to before: three baseline subagent runs without the skill produced generally usable handoffs when given rich facts, so this PR does not claim a dramatic baseline collapse. The improvement is a consistent explicit trigger and output contract: after the change, explicit `handoff` requests load `superpowers:handoff` before other tools, and the pressure prompt produced the ordered handoff sections while stopping implementation.

Verification performed:

```bash
bash -n tests/explicit-skill-requests/run-all.sh tests/explicit-skill-requests/run-test.sh
node /Users/zaidazmi/Github/superpowers-prs/skill-doctor/scripts/lint-skills.js \
  --root /Users/zaidazmi/Github/superpowers-prs/human-handoff \
  --skills-dir skills/handoff
git diff --check upstream/dev...HEAD
bash tests/explicit-skill-requests/run-all.sh
claude -p '<pressure prompt asking to stop and use handoff skill>' \
  --plugin-dir /Users/zaidazmi/Github/superpowers-prs/human-handoff \
  --dangerously-skip-permissions \
  --max-turns 4
```

Results:

```text
Skill Doctor checked 1 skill(s): no issues found.
PASS: subagent-driven-development-please
PASS: use-systematic-debugging
PASS: please-use-brainstorming
PASS: mid-conversation-execute-plan
PASS: handoff-please
Passed: 5
Failed: 0
Total: 5
```

The pressure prompt included an unfinished-work temptation and an explicit instruction to stop for the day. The agent used the handoff skill, produced the ordered handoff sections, and did not continue implementation.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` guidance and completed targeted pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This PR adds a new skill and does not edit existing tuned skill prose. The baseline result was not a dramatic RED failure; the branch is therefore intentionally narrow and the PR body does not overclaim. The explicit-request harness verifies the important runtime property for this MVP: when the human names the skill, Claude Code loads `superpowers:handoff` before taking action.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

@zaidazmi reviewed the complete proposed diff in Codex before submission.
