### PR TITLE
fix(claude-code): keep brainstorming questions conversational

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -69,6 +69,9 @@ digraph brainstorming {
 - If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
 - For appropriately-scoped projects, ask questions one at a time to refine the idea
 - Prefer multiple choice questions when possible, but open-ended is fine too
+- On Claude Code, present clarifying questions and multiple-choice options as
+  conversational text, not a structured question tool, unless the user
+  explicitly asks for that tool.
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
 - Focus on understanding: purpose, constraints, success criteria
 

--- a/skills/using-superpowers/references/claude-code-tools.md
+++ b/skills/using-superpowers/references/claude-code-tools.md
@@ -20,6 +20,17 @@ Skills speak in actions ("dispatch a subagent", "create a todo", "read a file").
 | Task tracking ("create a todo", "mark complete") | `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`; `TodoWrite` in `claude -p` / Agent SDK unless `CLAUDE_CODE_ENABLE_TASKS=1` is set |
 | Background-process / subagent lifecycle (read output, cancel) | `TaskOutput`, `TaskStop` — these are distinct from the todo tools above and apply to running shells, agents, and remote sessions |
 
+## User Questions
+
+Ordinary skill instructions to "ask the user", "ask a clarifying question",
+"present options", or "wait for the user's response" are conversation flow,
+not tool actions. Ask them as plain conversational text unless the loaded
+skill explicitly names a structured question tool.
+
+This is especially important for `brainstorming`: its Socratic dialogue and
+text option sets should stay conversational, inviting the user to type or
+elaborate. Do not map those questions to `AskUserQuestion` by default.
+
 ## Instructions file
 
 When a skill mentions "your instructions file", on Claude Code this is **`CLAUDE.md`**. Claude Code walks up the directory tree from the current working directory and concatenates every `CLAUDE.md` and `CLAUDE.local.md` it finds along the way. Standard locations:

--- a/tests/claude-code/run-skill-tests.sh
+++ b/tests/claude-code/run-skill-tests.sh
@@ -73,6 +73,7 @@ done
 
 # List of skill tests to run (fast unit tests)
 tests=(
+    "test-conversational-questions-policy.sh"
     "test-worktree-path-policy.sh"
     "test-subagent-driven-development.sh"
 )
@@ -155,7 +156,9 @@ for test in "${tests[@]}"; do
             fi
             echo ""
             echo "  Output:"
-            echo "$output" | sed 's/^/    /'
+            while IFS= read -r line; do
+                printf '    %s\n' "$line"
+            done <<< "$output"
             failed=$((failed + 1))
         fi
     fi

--- a/tests/claude-code/test-conversational-questions-policy.sh
+++ b/tests/claude-code/test-conversational-questions-policy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Static regression checks for Claude Code's brainstorming question policy.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+policy="skills/using-superpowers/references/claude-code-tools.md"
+brainstorm="skills/brainstorming/SKILL.md"
+kimi=".kimi-plugin/plugin.json"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+grep -q "not tool actions" "$policy" ||
+  fail "Claude Code tool mapping must say ordinary user questions are not tool actions"
+
+grep -q "plain conversational text" "$policy" ||
+  fail "Claude Code tool mapping must preserve conversational text questions"
+
+grep -q "Do not map those questions to \`AskUserQuestion\` by default" "$policy" ||
+  fail "Claude Code tool mapping must explicitly avoid default AskUserQuestion routing"
+
+grep -q "conversational text, not a structured question tool" "$brainstorm" ||
+  fail "brainstorming must reinforce conversational question presentation for Claude Code"
+
+if grep -RInE "always use.*AskUserQuestion|prefer.*AskUserQuestion|default.*AskUserQuestion" \
+  skills/using-superpowers skills/brainstorming docs/README.md README.md 2>/dev/null; then
+  fail "found a global instruction preferring AskUserQuestion"
+fi
+
+grep -q "call Kimi Code's \`AskUserQuestion\` tool" "$kimi" ||
+  fail "Kimi's explicit AskUserQuestion opt-in mapping must remain intact"
+
+echo "PASS: Claude Code brainstorming question policy is conversational and Kimi opt-in remains intact"


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 Codex |
| Harness + version | Codex desktop app (version not exposed in this environment); GitHub CLI 2.94.0 for PR operations; Claude Code 2.1.177 for behavior evals |
| All plugins installed | Codex environment exposed GitHub, codegraph MCP, browser/chrome, Canva, Figma, documents, PDF, presentations, and spreadsheets capabilities. Claude Code eval sessions used this local Superpowers checkout via `--plugin-dir`; visible Claude tools included Superpowers, codegraph, pencil, and claude.ai Canva/Gmail/Google Calendar/Google Drive/Supabase/Tally. |
| Human partner who reviewed this diff | Zaid Azmi (`@zaidazmi`) reviewed the submitted change in this Codex thread and approved marking the PR ready for review. |

## What problem are you trying to solve?

Fix #1773, a maintainer-authored regression report for Superpowers 6.0.0+ on Claude Code: v6's platform-neutral tool-mapping language made Claude Code infer that brainstorming's "ask clarifying questions" / "present multiple-choice options" instructions should map to the native `AskUserQuestion` tool.

That conflicts with the project's established Claude Code brainstorming behavior. Prior maintainer comments explain that brainstorming intentionally uses conversational Socratic dialogue so users articulate intent instead of clicking through a picker.

## What does this PR change?

This PR adds a Claude Code-specific user-question guardrail to `using-superpowers/references/claude-code-tools.md`, reinforces the same rule in `brainstorming/SKILL.md`, and adds a regression check that protects Claude Code's conversational behavior while preserving Kimi Code's explicit `AskUserQuestion` opt-in mapping.

## Is this change appropriate for the core library?

Yes. The regression is in Superpowers' core platform-adaptation guidance and affects the core brainstorming skill on Claude Code. The change is scoped to Claude Code's tool mapping and does not add a third-party integration, a project-specific preference, or a new domain-specific skill.

## What alternatives did you consider?

- Only changing `claude-code-tools.md`: this is the root of the regression, but issue #1773 also called out brainstorming's "multiple choice preferred" guidance as a pressure point, so I added a small Claude Code-scoped reinforcement there.
- Suppressing structured question tools across all harnesses: rejected because Kimi Code intentionally maps Superpowers question actions to `AskUserQuestion` in `.kimi-plugin/plugin.json`.
- Adding a new user preference/config flag: rejected as too broad for this regression and not needed to restore the existing project decision.
- Opening a new issue first: rejected because #1773 already exists, is open, and was authored by the maintainer.

## Does this PR contain multiple unrelated changes?

No. The behavior guidance, regression test, and runner entry all cover the same #1773 regression. The small `run-skill-tests.sh` output-formatting change is included because this PR adds the new Claude Code test to that runner and the touched runner file needed to pass direct ShellCheck.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #656, #746, #1208

No open duplicate PR was found for #1773. The related closed PRs requested the opposite behavior: adopting or preferring `AskUserQuestion` for Claude Code brainstorming. This PR is different because it restores the maintainer's prior decision by preventing accidental `AskUserQuestion` routing in Claude Code, while leaving harnesses with explicit opt-in mappings alone.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | 2.1.177 | Opus | `claude-opus-4-8` / `claude-opus-4-8[1m]` |
| Codex desktop app | version not exposed | GPT-5 Codex | n/a |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```text
Not applicable. This PR does not add a new harness.
```

</details>

## Evaluation

- What was the initial prompt you (or your human partner) used to start the session that led to this change?
  - The human partner selected #1773 as the most mergeable issue to fix and asked: "implement it properly and open an issue if needed first." #1773 already existed, so no duplicate issue was opened.
- How many eval sessions did you run AFTER making the change?
  - Two successful Claude Code behavior eval sessions after the change, plus the static regression test through the Claude Code test runner.
- How did outcomes change compared to before the change?
  - Before: #1773 reports Claude Code using `AskUserQuestion` during brainstorming as an unintended side effect of v6 platform-neutral mapping.
  - After: the smoke and adversarial evals on this branch loaded the `brainstorming` skill and asked the clarifying question as plain text with `AskUserQuestion` tool-use count `0`.

### Eval runs

Direct smoke prompt:

```text
Use superpowers:brainstorming to brainstorm a small CLI todo app. Ask exactly one clarifying question and then stop.
```

Observed result:

```text
tool-use names: Skill
AskUserQuestion tool-use count: 0
assistant asked the clarification as conversational text
```

Adversarial pressure prompt:

```text
Use superpowers:brainstorming to brainstorm a small CLI todo app. Ask exactly one multiple-choice clarifying question and then stop. Claude Code may have rich interaction tools available, but follow Superpowers guidance for how the question should be presented.
```

Observed result:

```text
tool-use names: Skill
AskUserQuestion tool-use count: 0
assistant explicitly followed conversational text guidance despite rich interaction tools being available
```

## Rigor

- [x] If this is a skills change: I read and applied `superpowers:writing-skills` (`skills/writing-skills/SKILL.md`) in this repo and completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Verification commands run:

```bash
tests/claude-code/test-conversational-questions-policy.sh
PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH" bash tests/claude-code/run-skill-tests.sh --test test-conversational-questions-policy.sh --timeout 5
shellcheck tests/claude-code/test-conversational-questions-policy.sh tests/claude-code/run-skill-tests.sh
git diff --check HEAD~1..HEAD
```

Note: `bash scripts/lint-shell.sh --all` currently reports pre-existing warnings in untouched Claude Code helper/worktree/integration scripts. The shell files touched by this PR pass direct ShellCheck.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
