### PR TITLE
fix(using-git-worktrees): assign $LOCATION and $BRANCH_NAME in Step 1 before use

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -90,6 +90,11 @@ git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/d
 #### Create the Worktree
 
 ```bash
+# Use the LOCATION you chose above (e.g. ".worktrees" or a project-specific path)
+LOCATION="<chosen-location>"
+# Use BRANCH_NAME based on the task (e.g. "feat-add-login")
+BRANCH_NAME="<chosen-branch-name>"
+
 # Determine path based on chosen location
 path="$LOCATION/$BRANCH_NAME"
 


### PR DESCRIPTION
Fixes #1797.

`skills/using-git-worktrees/SKILL.md` Step 1 uses `$LOCATION` and `$BRANCH_NAME` in a Bash code block without assigning them, so an agent that executes the block verbatim ends up running `git worktree add "/" -b ""`.

This PR prepends two explicit assignment lines with descriptive placeholder values so the block is runnable and the agent has a clear cue about what to fill in.
