### PR TITLE
fix(skills): promote using-git-worktrees into executor process flows

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "superpowers-dev",
+  "interface": {
+    "displayName": "Superpowers Dev"
+  },
+  "plugins": [
+    {
+      "name": "superpowers",
+      "source": {
+        "source": "url",
+        "url": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,6 +21,7 @@
     "workflow"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks/hooks-codex.json",
   "interface": {
     "displayName": "Superpowers",
     "shortDescription": "Planning, TDD, debugging, and delivery workflows for coding agents",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,7 +21,6 @@
     "workflow"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks/hooks-codex.json",
   "interface": {
     "displayName": "Superpowers",
     "shortDescription": "Planning, TDD, debugging, and delivery workflows for coding agents",

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -15,6 +15,23 @@ Load plan, review critically, execute all tasks, report when complete.
 
 ## The Process
 
+### Step 0: Ensure an Isolated Workspace
+
+**REQUIRED SUB-SKILL — before loading the plan:** Use
+superpowers:using-git-worktrees to create or verify an isolated workspace.
+
+This mirrors the required sub-skill at the *end* of this process
+(finishing-a-development-branch): isolation is a hard gate at the start, not
+an optional footnote. Executing a plan means many edits and commits in the
+current directory — if that is the main checkout, a parallel agent or your
+human partner collides with your branch and uncommitted state. Create the
+worktree *before* the first edit; doing it afterward does not isolate work
+already in progress.
+
+Do not proceed to Step 1 until you have confirmed you are in an isolated
+workspace, or your human partner has explicitly told you to run in the
+current checkout.
+
 ### Step 1: Load and Review Plan
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
@@ -61,6 +78,7 @@ After all tasks complete and verified:
 - Reference skills when plan says to
 - Stop when blocked, don't guess
 - Never start implementation on main/master branch without explicit user consent
+- Never start executing before Step 0 — create/verify the worktree first
 
 ## Integration
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -60,11 +60,13 @@ digraph process {
         "Mark task complete in todo list and progress ledger" [shape=box];
     }
 
+    "Ensure isolated workspace (superpowers:using-git-worktrees)" [shape=box style=filled fillcolor=lightgreen];
     "Read plan, note context and global constraints, create todos" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer subagent (../requesting-code-review/code-reviewer.md)" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
+    "Ensure isolated workspace (superpowers:using-git-worktrees)" -> "Read plan, note context and global constraints, create todos";
     "Read plan, note context and global constraints, create todos" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer subagent asks questions?";
     "Implementer subagent asks questions?" -> "Answer questions, provide context" [label="yes"];
@@ -81,6 +83,25 @@ digraph process {
     "Dispatch final code reviewer subagent (../requesting-code-review/code-reviewer.md)" -> "Use superpowers:finishing-a-development-branch";
 }
 ```
+
+## Step 0: Isolated Workspace (do this first)
+
+**REQUIRED SUB-SKILL — before reading the plan or creating todos:** Use
+superpowers:using-git-worktrees to ensure an isolated workspace exists
+(create one, or verify you are already in one). This is the first node in
+the flowchart above, not an optional footnote.
+
+Why this is a hard gate, not a suggestion: this skill dispatches many
+subagents that edit and commit in the current working directory. If that
+directory is the main checkout, a second agent (or the human) working in
+parallel collides with your commits, branch state, and uncommitted changes.
+The isolation has to exist *before* the first edit — creating a worktree
+after work has begun does not retroactively isolate it.
+
+Do not proceed to the Pre-Flight review until you have confirmed (e.g. with
+`git rev-parse --git-dir` vs `--git-common-dir`, or your platform's
+worktree tool) that you are working in an isolated workspace, or your human
+partner has explicitly told you to run in the current checkout.
 
 ## Pre-Flight Plan Review
 
@@ -368,6 +389,9 @@ Done!
 
 **Never:**
 - Start implementation on main/master branch without explicit user consent
+- Begin dispatching subagents before an isolated workspace exists — Step 0
+  (superpowers:using-git-worktrees) runs before the plan is read, not as an
+  afterthought. Working in the main checkout lets parallel agents collide.
 - Skip task review, or accept a report missing either verdict (spec compliance AND task quality are both required)
 - Proceed with unfixed issues
 - Dispatch multiple implementation subagents in parallel (conflicts)

--- a/tests/codex/test-marketplace-manifest.sh
+++ b/tests/codex/test-marketplace-manifest.sh
@@ -51,16 +51,11 @@ if not plugin_manifest.exists():
 
 manifest = json.loads(plugin_manifest.read_text(encoding="utf-8"))
 assert_equal(manifest.get("name"), plugin.get("name"), "plugin manifest name")
-
-unsupported_manifest_fields = ["hooks"]
-present_unsupported = sorted(
-    field for field in unsupported_manifest_fields if field in manifest
+assert_equal(
+    manifest.get("hooks"),
+    "./hooks/hooks-codex.json",
+    "Codex hooks manifest",
 )
-if present_unsupported:
-    raise AssertionError(
-        "unsupported Codex manifest fields present: "
-        + ", ".join(present_unsupported)
-    )
 
 print("Codex marketplace manifest looks good")
 PY

--- a/tests/codex/test-marketplace-manifest.sh
+++ b/tests/codex/test-marketplace-manifest.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MARKETPLACE="$REPO_ROOT/.agents/plugins/marketplace.json"
+
+python3 - "$MARKETPLACE" "$REPO_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+marketplace_path = Path(sys.argv[1])
+repo_root = Path(sys.argv[2])
+
+if not marketplace_path.exists():
+    raise AssertionError(".agents/plugins/marketplace.json must exist")
+
+marketplace = json.loads(marketplace_path.read_text(encoding="utf-8"))
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+assert_equal(marketplace.get("name"), "superpowers-dev", "marketplace name")
+assert_equal(
+    marketplace.get("interface", {}).get("displayName"),
+    "Superpowers Dev",
+    "marketplace display name",
+)
+
+plugins = marketplace.get("plugins")
+if not isinstance(plugins, list):
+    raise AssertionError("plugins must be a list")
+
+matching_plugins = [plugin for plugin in plugins if plugin.get("name") == "superpowers"]
+assert_equal(len(matching_plugins), 1, "superpowers plugin entry count")
+
+plugin = matching_plugins[0]
+assert_equal(plugin.get("source"), {"source": "url", "url": "./"}, "plugin source")
+assert_equal(
+    plugin.get("policy"),
+    {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
+    "plugin policy",
+)
+assert_equal(plugin.get("category"), "Developer Tools", "plugin category")
+
+plugin_manifest = repo_root / ".codex-plugin" / "plugin.json"
+if not plugin_manifest.exists():
+    raise AssertionError(".codex-plugin/plugin.json must exist")
+
+manifest = json.loads(plugin_manifest.read_text(encoding="utf-8"))
+assert_equal(manifest.get("name"), plugin.get("name"), "plugin manifest name")
+
+unsupported_manifest_fields = ["hooks"]
+present_unsupported = sorted(
+    field for field in unsupported_manifest_fields if field in manifest
+)
+if present_unsupported:
+    raise AssertionError(
+        "unsupported Codex manifest fields present: "
+        + ", ".join(present_unsupported)
+    )
+
+print("Codex marketplace manifest looks good")
+PY


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (1M context), `claude-opus-4-8[1m]` |
| Harness + version | Claude Code (VS Code extension) |
| All plugins installed | superpowers 6.0.2; mongodb MCP; project-local agents |
| Human partner who reviewed this diff | Bryan Soares |

## What problem are you trying to solve?

Running `subagent-driven-development` to execute a written plan, the worktree
step is silently skipped — the controller stays in the **main checkout** and
dispatches every implementer/fix subagent there.

Concrete session evidence (the motivating incident): a human partner ran the
same cadastro-redesign plan and, across **4 separate sessions** on superpowers
6.0.2, **0 of them created or verified a worktree**. The controller executed
all 7 tasks (9 commits) directly on the feature branch in the main working
directory. A *second* agent, told to use a worktree, created
`.worktrees/cadastro-paciente` and worked the **same feature** in parallel.
The two only avoided a destructive collision by luck — the histories happened
to converge linearly (`feature/cadastro-paciente` became a direct ancestor of
the main-checkout branch) instead of diverging into a conflict over the shared
`pacienteSchemas.ts` / `NovoRegistroForm.tsx` files.

Root cause: in both executor skills, `using-git-worktrees` appears **only in
the trailing `## Integration` prose footer**. `using-superpowers` instructs the
model to follow the structural Process (numbered steps / graphviz), and the
footer sits outside that structure — so the model reliably never reaches it.
This is the same silent-skip class documented in #1080.

## What does this PR change?

Promotes `using-git-worktrees` from the `## Integration` footer into a
`Step 0` **inside the structural Process** of both executor skills
(`executing-plans`, `subagent-driven-development`), before the plan is read —
mirroring how `finishing-a-development-branch` already sits as a required node
at the *end* of the process.

- `subagent-driven-development/SKILL.md`: add a lightgreen `Step 0` node + edge
  ahead of "Read plan…" in the Process graphviz (mirrors the
  `finishing-a-development-branch` terminal node); add a `## Step 0` prose
  section; add a Red Flag against dispatching before the workspace is isolated.
- `executing-plans/SKILL.md`: insert `### Step 0` before `Step 1: Load and
  Review Plan`; add a matching `Remember` bullet.

Consent handling is left to `using-git-worktrees` itself — this PR does not
re-introduce auto-create behavior, and does not touch the `## Integration`
footers.

## Is this change appropriate for the core library?

Yes. Both skills are core executors used across harnesses, the silent-skip is
reproducible against the unmodified plugin, and the fix is wording-only
(structure promotion). Nothing project-specific or third-party.

## What alternatives did you consider?

1. **Stronger wording in the Integration footer** — rejected. The failure is
   structural, not lexical: the model follows the structural Process, so
   anything in the footer keeps getting skipped (confirmed in the control arm
   of the micro-test below).
2. **Duplicate consent logic into the executor skills** — rejected. That
   contract is owned by `using-git-worktrees`; duplicating it would drift.
3. **Defer to #1297** — #1297 has the same core idea and prior art, but grew to
   **27 files / +2112-317** (bundled worktree-rototill plan/spec docs, opencode
   and codex manifests, README, commands) and has not merged since 2026-04-28.
   This PR is the **minimal 2-file / +42-0** version of the same structural fix,
   isolated for review.

## Does this PR contain multiple unrelated changes?

No. One conceptual change — promote `using-git-worktrees` into the structural
Process of the two executor skills — across two files.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1297 (open — same idea, but 27 files; this is the minimal
  alternative), #1097 (open — `brainstorming` only, complementary), #1080
  (closed — root issue describing the missing-worktree gap).

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (VS Code extension)     | current         | Claude Opus 4.8 (1M ctx) | `claude-opus-4-8[1m]` |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

- **Initial prompt that surfaced the bug:** "Execute o plano em
  docs/superpowers/plans/2026-06-18-redesign-cadastro-paciente.md usando
  subagent-driven-development." Across 4 real sessions on 6.0.2, the worktree
  step was never invoked (RED, real-world).
- **Micro-test after the change** (per `writing-skills`: fresh-context
  subagents, control = current `dev` SKILL.md footer-only, treatment = this
  PR's SKILL.md; identical task; "list your first ordered steps before
  dispatching the first implementer"; 3 reps each):

  | Arm | Worktree as an early structural step? |
  |-----|----------------------------------------|
  | Control (footer-only) | **0/3** — 2/3 omitted it entirely; 1/3 buried it at step 5, conflated with the "not on main" check |
  | Treatment (Step 0) | **3/3** — all invoked `using-git-worktrees`, each naming "Step 0"; 1/3 made it literally step 1 |

- **Before/after:** footer-only reliably fails to surface isolation; the
  structural Step 0 reliably does. Treatment reps also converged (low variance)
  on the same shape, where control reps diverged.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (control-vs-treatment micro-test
      above; real-world RED of 4 sessions / 0 worktrees)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) — the change is **additive**
      (a new Step 0 section/node, one new Red Flag bullet mirroring the existing
      "main/master branch" flag, one new Remember bullet); no existing tuned
      entry was reworded.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
