### PR TITLE
fix(writing-skills): make render-graphs ESM-compatible and shell-free

### DIFF
--- a/skills/writing-skills/render-graphs.js
+++ b/skills/writing-skills/render-graphs.js
@@ -15,7 +15,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 function extractDotBlocks(markdown) {
   const blocks = [];
@@ -69,7 +69,7 @@ ${bodies.join('\n\n')}
 
 function renderToSvg(dotContent) {
   try {
-    return execSync('dot -Tsvg', {
+    return execFileSync('dot', ['-Tsvg'], {
       input: dotContent,
       encoding: 'utf-8',
       maxBuffer: 10 * 1024 * 1024
@@ -107,9 +107,10 @@ function main() {
     process.exit(1);
   }
 
-  // Check if dot is available
+  // Check if dot is available. Run the binary directly rather than probing
+  // with `which`, which is not a command on Windows.
   try {
-    execSync('which dot', { encoding: 'utf-8' });
+    execFileSync('dot', ['-V'], { stdio: 'ignore' });
   } catch {
     console.error('Error: graphviz (dot) not found. Install with:');
     console.error('  brew install graphviz    # macOS');

--- a/skills/writing-skills/render-graphs.js
+++ b/skills/writing-skills/render-graphs.js
@@ -13,9 +13,9 @@
  * Requires: graphviz (dot) installed on system
  */
 
-const fs = require('fs');
-const path = require('path');
-const { execFileSync } = require('child_process');
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
 
 function extractDotBlocks(markdown) {
   const blocks = [];

--- a/tests/writing-skills/test-render-graphs.sh
+++ b/tests/writing-skills/test-render-graphs.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/skills/writing-skills/render-graphs.js"
+NODE_BIN="$(command -v node)"
+
+PASSES=0
+FAILURES=0
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+pass() {
+  echo "  [PASS] $1"
+  PASSES=$((PASSES + 1))
+}
+
+fail() {
+  echo "  [FAIL] $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local description="$3"
+
+  if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+    pass "$description"
+  else
+    fail "$description"
+    echo "    expected to find: $needle"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local description="$3"
+
+  if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+    fail "$description"
+    echo "    did not expect to find: $needle"
+  else
+    pass "$description"
+  fi
+}
+
+fixture="$TEST_ROOT/fixture-skill"
+mkdir -p "$fixture" "$TEST_ROOT/empty-path"
+cat >"$fixture/SKILL.md" <<'EOF'
+---
+name: fixture-skill
+---
+
+# Fixture Skill
+
+```dot
+digraph fixture_graph {
+  start -> end;
+}
+```
+EOF
+
+echo "Writing-skills render-graphs tests"
+
+missing_dot_output="$(PATH="$TEST_ROOT/empty-path" "$NODE_BIN" "$SCRIPT_UNDER_TEST" "$fixture" 2>&1)"
+missing_dot_status=$?
+
+if [[ "$missing_dot_status" -ne 0 ]]; then
+  pass "missing Graphviz exits non-zero"
+else
+  fail "missing Graphviz exits non-zero"
+fi
+assert_contains "$missing_dot_output" "Error: graphviz (dot) not found." "missing Graphviz reports install guidance"
+assert_not_contains "$missing_dot_output" "ReferenceError: require is not defined" "script runs as an ES module"
+
+render_output="$("$NODE_BIN" "$SCRIPT_UNDER_TEST" "$fixture" 2>&1)"
+render_status=$?
+
+if [[ "$render_status" -eq 0 ]]; then
+  pass "fixture diagram renders"
+else
+  fail "fixture diagram renders"
+  printf '%s\n' "$render_output"
+fi
+
+assert_contains "$render_output" "Found 1 diagram(s)" "reports discovered diagram"
+assert_contains "$render_output" "Rendered: fixture_graph.svg" "reports rendered SVG"
+
+if [[ -f "$fixture/diagrams/fixture_graph.svg" ]]; then
+  pass "writes SVG output"
+else
+  fail "writes SVG output"
+fi
+
+if [[ -f "$fixture/diagrams/fixture_graph.svg" ]] && grep -Fq "<svg" "$fixture/diagrams/fixture_graph.svg"; then
+  pass "SVG output has SVG markup"
+else
+  fail "SVG output has SVG markup"
+fi
+
+echo
+echo "Results: $PASSES passed, $FAILURES failed"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Original implementation: Claude Opus 4.8 (`claude-opus-4-8[1m]`). Current rebase, regression coverage, and verification: OpenAI GPT-5.6 sol. |
| Harness + version | Original: Claude Code 2.1.181. Current: Codex Desktop 26.730.61639 (app-server 0.147.0-alpha.1.2). |
| All plugins installed | Original: agent-sdk-dev, clangd-lsp, claude-code-setup, claude-opus-4-5-migration, claude-pa, claude-session-driver, code-review, code-simplifier, context7, cxdb-observability, document-skills, double-shot-latte, elements-of-style, episodic-memory, example-skills, feature-dev, frontend-design, github-triage, gopls-lsp, linear, mcp-server-dev, plugin-dev, pr-review-toolkit, primeradiant-ops, release-radar, rust-analyzer-lsp, security-guidance, summarize-meetings, superpowers, superpowers-chrome, superpowers-dev, superpowers-developing-for-claude-code, superpowers-lab, swift-lsp, worldview-synthesis. Current: browser, cloud-build, codex-security, computer-use, documents, github, linear, pdf, presentations, primeradiant-ops, sites, slack, spreadsheets, superpowers, template-creator, visualize. |
| Human partner who reviewed this diff | Jesse Vincent reviewed the original change; Drew Ritter reviewed the complete refreshed diff and authorized the rebase publication. |

## What problem are you trying to solve?

On current `dev`, running `node skills/writing-skills/render-graphs.js skills/writing-skills` fails before doing any work:

```text
ReferenceError: require is not defined in ES module scope
```

The repository declares `"type": "module"`, but `render-graphs.js` still uses CommonJS `require`, so the shipped command cannot run directly as a `.js` file. The same script also probes Graphviz with `execSync('which dot')`; `execSync` invokes the platform shell, and Windows `cmd.exe` has no `which` command. That makes the availability check non-portable even when `dot` is on `PATH`.

The ESM failure was reproduced directly against current `dev` on macOS. The Windows failure follows from the shell command and was not reproduced on a Windows host in this work.

## What does this PR change?

It converts `render-graphs.js` to ESM imports and invokes Graphviz directly with `execFileSync` for both the version probe and SVG render. It also adds a real-process regression test covering direct ESM execution, missing-Graphviz behavior, and generation of an actual SVG fixture.

## Is this change appropriate for the core library?

Yes. `render-graphs.js` is existing core tooling shipped with the general-purpose `writing-skills` skill. This repairs execution and portability of that existing tool; it adds no domain-specific workflow, service integration, or dependency.

## What alternatives did you consider?

- Rename the script to `.cjs`. That would preserve CommonJS but change the documented executable path and leave the repository's ESM convention unresolved.
- Select `which` or `where` based on the operating system. That retains unnecessary shell invocation and duplicates platform logic; executing `dot` directly tests the actual dependency on every platform.
- Add the directory-boundary guard proposed in issue #1794. That is outside this correctness fix and would reject the documented use case of rendering a skill in another repository.
- Keep only the original three-line implementation change. A regression test is warranted because the stale PR had already become incompatible with `dev` while waiting.

## Does this PR contain multiple unrelated changes?

No. The implementation and its regression test are one concern: make the existing render-graphs command executable under the repository's ESM configuration without a platform shell.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #251 (closed), #401 (closed), #1976 (open draft), and issue #1794 (closed invalid).

#251 and #401 proposed broader security remediations in the same file and were closed. This PR makes no command-injection claim: the Graphviz command is constant and diagram input is passed over stdin. #1976 is a later draft that includes the same render-graphs idea among several changes; its own review discussion identifies #1805 as the existing owner of this fix. This PR predates it, is limited to this concern, and now includes the ESM correction and focused regression coverage. Issue #1794's proposed path-boundary change remains intentionally out of scope.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.181 | Claude Opus | `claude-opus-4-8[1m]` |
| Codex Desktop on macOS 26.6 arm64 | 26.730.61639 (app-server 0.147.0-alpha.1.2) | OpenAI GPT | `gpt-5.6-sol` |
| Codex Desktop with Docker/Linux (Debian 12 arm64) | Codex Desktop 26.730.61639; Docker 29.4.0 | OpenAI GPT | `gpt-5.6-sol` |

Current macOS verification used Node v22.23.2 and Graphviz 15.1.0:

- `bash tests/writing-skills/test-render-graphs.sh` — 8 passed, 0 failed
- `scripts/lint-shell.sh tests/writing-skills/test-render-graphs.sh` — passed
- `node --check skills/writing-skills/render-graphs.js` — passed
- `git diff --check origin/dev...HEAD` — passed
- `bash tests/shell-lint/test-lint-shell.sh` — passed

Linux verification used a fresh Debian 12 arm64 container with Node v22.23.2 and Graphviz 2.43.0, with the checkout mounted read-only:

- `bash tests/writing-skills/test-render-graphs.sh` — 8 passed, 0 failed
- `node --check skills/writing-skills/render-graphs.js` — passed

`scripts/lint-shell.sh --all` still reports 11 warnings in three unchanged Claude Code test files. The same 11 warnings reproduce on a clean `dev` worktree, and none of those files are in this PR.

## New harness support (required if this PR adds a new harness)

N/A — this PR does not add a harness.

## Evaluation

- Initial original context: investigation of issue #1794 surfaced the non-portable `which dot` probe.
- Initial refresh prompts from Drew: “can you take a look at how bad the rebase to dev is for this branch its super old but we want it merged?” followed by authorization to fix, rebase, and prepare it for merge.
- Agent-behavior eval sessions after the change: 0. This changes a helper program, not behavior-shaping skill content.
- Direct regression evaluation after the change: the same real-process shell suite passed 8/8 assertions on both macOS and Linux, plus syntax and lint checks.
- Before: the command on current `dev` exits immediately with the ESM `require` error. After: it executes as ESM, reports a clear non-zero error when `dot` is absent, and renders a real fixture to SVG when Graphviz is available.
- Windows was not directly tested in this session; a separate machine/agent is testing it, so no Windows result is claimed here yet.

## Rigor

- [ ] If this is a skills change: N/A — this changes a helper program and test, not skill instructions or agent behavior.
- [x] This change was tested adversarially, not just on the happy path (the suite runs the real command with `dot` deliberately absent as well as a real SVG render).
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, or “human partner” language).

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission