### PR TITLE
feat: handle images on text-only models (GLM, DeepSeek, etc.)

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -98,6 +98,15 @@ These thoughts mean STOP—you're rationalizing:
 | "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
 | "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
 
+## Handling Visual Content on Text-Only Models
+
+Many powerful coding models (GLM, DeepSeek-Coder, etc.) don't accept image input directly. If a user pastes or references an image and the model rejects it, **route around the limitation silently** instead of reporting failure:
+
+1. **If the image arrives as a file path** (common when the CLI or a clipboard watcher offloads pasted images to disk): call the platform's file-reading tool (e.g., `ReadMediaFile`) or a vision MCP tool with that path.
+2. **If a vision MCP server is available** (e.g., `@z_ai/mcp-server`, `@playwright/mcp`): pass the image path or URL to its analysis tool.
+3. **Never tell the user "I can't see images"** when a vision tool exists in the environment. Use the tool, analyze the image, and report results.
+4. **If no vision capability exists at all**: say so once, briefly, and suggest alternatives (describe the screenshot, paste error text, etc.).
+
 ## Skill Priority
 
 When multiple skills could apply, use this order:


### PR DESCRIPTION
## Problem

Many coding agents run text-only models (GLM-5.2, DeepSeek-Coder, etc.) that reject image input with errors like `Error: Current model does not support image input`. When a user pastes or references an image, the agent either fails outright or tells the user it "can't see images" — even when a vision MCP server is available in the environment.

This is common in multi-model setups where:
- The primary coding model is text-only (GLM, DeepSeek, Qwen)
- A vision MCP server is configured alongside it (`@z_ai/mcp-server`, `@playwright/mcp`, etc.)
- The CLI or a clipboard watcher offloads pasted images to disk and provides the file path

## Solution

Add a **"Handling Visual Content on Text-Only Models"** section to `using-superpowers/SKILL.md` with four rules:

1. **File-path images** → use the platform's file-reading tool (`ReadMediaFile`, etc.) or a vision MCP tool with that path
2. **Vision MCP available** → pass the image path/URL to its analysis tool
3. **Never report failure** when a vision tool exists in the environment — use it, analyze, report results
4. **Only say "can't see images"** when no vision capability is present at all

## Context

- Tested on Kimi Code CLI with GLM-5.2 (text-only) + `@z_ai/mcp-server` (vision MCP). Before: hard error on paste. After: agent routes through the vision MCP and analyzes the image.
- The clipboard image watcher pattern (offload pasted images to `/tmp/kilo-shots/`, replace clipboard with file path) is becoming common in agent CLIs that support text-only models.
- This is platform-agnostic guidance — it doesn't name any specific MCP server, just the pattern of routing around the limitation.

## Checklist

- [x] Tested locally on Kimi Code + GLM-5.2 + Z.AI vision MCP
- [x] Guidance is platform-agnostic (no hard-coded tool names)
- [x] Minimal change — one new section, no existing content modified
- [x] Consistent with existing skill tone (direct, actionable rules)