### PR TITLE
fix(sdd): add -C DIR flag to review-package for harness allowlisting

### DIFF
--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -4,13 +4,23 @@
 # call. Using the recorded per-task BASE (not HEAD~1) keeps multi-commit
 # tasks intact.
 #
-# Usage: review-package PLAN_FILE BASE HEAD [OUTFILE]
+# Usage: review-package [-C DIR] PLAN_FILE BASE HEAD [OUTFILE]
 # Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-basename>/review-<base7>..<head7>.diff
 # (named per range, so a re-review after fixes gets a distinct fresh file).
 set -euo pipefail
 
+# Optional leading "-C DIR": run as if invoked from DIR, so callers whose
+# cwd isn't the repo don't need a `cd DIR ; review-package ...` compound.
+# (That compound can't be allowlisted by harnesses because BASE and the
+#  worktree path vary on every run.)
+if [ "${1:-}" = "-C" ]; then
+  [ -d "${2:-}" ] || { echo "bad -C dir: ${2:-}" >&2; exit 2; }
+  cd "$2"
+  shift 2
+fi
+
 if [ $# -lt 3 ] || [ $# -gt 4 ]; then
-  echo "usage: review-package PLAN_FILE BASE HEAD [OUTFILE]" >&2
+  echo "usage: review-package [-C DIR] PLAN_FILE BASE HEAD [OUTFILE]" >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary

Fixes #1799.

`review-package` runs all git commands against `$PWD`, so any caller whose cwd isn't the target repo must use:

```bash
cd /path/to/worktree ; review-package BASE HEAD
```

That compound can't be statically allowlisted by harnesses like Claude Code — the `cd` target and `BASE` SHA vary on every run, so no literal rule generalizes across tasks.

This PR adds an optional leading `-C DIR` argument (modelled on `git -C`), letting callers pass a single stable command:

```bash
scripts/review-package -C /path/to/worktree BASE HEAD
```

A harness can pre-approve this with one prefix rule (e.g. `Bash(.../scripts/review-package*)`) regardless of the varying worktree path or SHA.

## Changes

- `skills/subagent-driven-development/scripts/review-package`: parse optional `-C DIR` before the existing argument check; `cd` into it and `shift 2` so the rest of the script is unchanged.

## Backward compatibility

Fully backward-compatible — omitting `-C` preserves existing behavior exactly.

## Testing

- `review-package BASE HEAD` (no `-C`): unchanged behavior
- `review-package -C /some/repo BASE HEAD`: equivalent to running from `/some/repo`
- `review-package -C /nonexistent BASE HEAD`: exits with `bad -C dir: /nonexistent`