### PR TITLE
docs(using-git-worktrees): add variable assignments before Create the Worktree block

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -90,6 +90,11 @@ git check-ignore -q .worktrees 2>/dev/null || git check-ignore -q worktrees 2>/d
 #### Create the Worktree
 
 ```bash
+# Set from the directory you selected above (e.g. ".worktrees" or "worktrees")
+LOCATION="<chosen-location>"
+# Set to the branch name for this task (e.g. "feat-add-login")
+BRANCH_NAME="<chosen-branch-name>"
+
 # Determine path based on chosen location
 path="$LOCATION/$BRANCH_NAME"
 


### PR DESCRIPTION
> **This PR targets the `dev` branch.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Sonnet 4.6 |
| Harness + version | Claude Code (CLI) |
| All plugins installed | superpowers@claude-plugins-official |
| Human partner who reviewed this diff | creazyfrog |

## What problem are you trying to solve?

In `skills/using-git-worktrees/SKILL.md`, the "Create the Worktree" code block (Step 1b) uses `$LOCATION` and `$BRANCH_NAME` without assigning them first. An agent reading and executing the block verbatim runs `git worktree add "/" -b ""`, which fails with an empty-branch-name error. The prose above the block explains *how to choose* a location, but never assigns the shell variable the code block depends on.

See #1797 for the full report including the exact failure mode.

## What does this PR change?

Prepends two explicit placeholder-assignment lines to the "Create the Worktree" bash block:

```bash
# Set from the directory you selected above (e.g. ".worktrees" or "worktrees")
LOCATION="<chosen-location>"
# Set to the branch name for this task (e.g. "feat-add-login")
BRANCH_NAME="<chosen-branch-name>"
```

The block is now self-contained: an agent sees exactly which values it must supply and where they come from, with examples.

## Is this change appropriate for the core library?

Yes. This is a documentation fix in a core skill that affects every agent using the git worktree fallback path.

## What alternatives did you consider?

The alternative (suggested in the issue) is to add a prose note above the block saying "Agent fills: `LOCATION` = …, `BRANCH_NAME` = …". Inline assignment lines were chosen instead because they keep the information at the point of use and match the convention of other executable code blocks in the skill.

## Does this PR contain multiple unrelated changes?

No. Five lines added to one file.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code CLI | latest | Claude Sonnet | claude-sonnet-4-6 |

## Evaluation

- Initial prompt: "Fix the undefined $LOCATION and $BRANCH_NAME variables in the using-git-worktrees Create the Worktree block."
- This is a docs-only change; no logic was altered. Verified by reading the before/after diff.

## Rigor

- [x] This change was tested adversarially — confirmed the variable names match exactly what the surrounding prose discusses
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language)

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Closes #1797

🤖 Generated with [Claude Code](https://claude.ai/code)