### PR TITLE
fix(tests): resolve shellcheck warnings in Claude Code test helpers

### DIFF
--- a/tests/claude-code/test-helpers.sh
+++ b/tests/claude-code/test-helpers.sh
@@ -7,7 +7,8 @@ run_claude() {
     local prompt="$1"
     local timeout="${2:-60}"
     local allowed_tools="${3:-}"
-    local output_file=$(mktemp)
+    local output_file
+    output_file=$(mktemp)
 
     # Build command as an argv array so timeout wraps claude directly.
     local cmd=(claude -p "$prompt")
@@ -74,7 +75,8 @@ assert_count() {
     local expected="$3"
     local test_name="${4:-test}"
 
-    local actual=$(echo "$output" | grep -c "$pattern" || echo "0")
+    local actual
+    actual=$(echo "$output" | grep -c "$pattern" || echo "0")
 
     if [ "$actual" -eq "$expected" ]; then
         echo "  [PASS] $test_name (found $actual instances)"
@@ -98,8 +100,9 @@ assert_order() {
     local test_name="${4:-test}"
 
     # Get line numbers where patterns appear
-    local line_a=$(echo "$output" | grep -n "$pattern_a" | head -1 | cut -d: -f1)
-    local line_b=$(echo "$output" | grep -n "$pattern_b" | head -1 | cut -d: -f1)
+    local line_a line_b
+    line_a=$(echo "$output" | grep -n "$pattern_a" | head -1 | cut -d: -f1)
+    line_b=$(echo "$output" | grep -n "$pattern_b" | head -1 | cut -d: -f1)
 
     if [ -z "$line_a" ]; then
         echo "  [FAIL] $test_name: pattern A not found: $pattern_a"
@@ -125,7 +128,8 @@ assert_order() {
 # Create a temporary test project directory
 # Usage: test_project=$(create_test_project)
 create_test_project() {
-    local test_dir=$(mktemp -d)
+    local test_dir
+    test_dir=$(mktemp -d)
     echo "$test_dir"
 }
 

--- a/tests/claude-code/test-subagent-driven-development-integration.sh
+++ b/tests/claude-code/test-subagent-driven-development-integration.sh
@@ -37,7 +37,8 @@ TEST_PROJECT=$(create_test_project)
 echo "Test project: $TEST_PROJECT"
 
 # Trap to cleanup
-trap "cleanup_test_project $TEST_PROJECT" EXIT
+_cleanup() { cleanup_test_project "$TEST_PROJECT"; }
+trap _cleanup EXIT
 
 # Set up minimal Node.js project
 cd "$TEST_PROJECT"
@@ -165,9 +166,10 @@ PLUGIN_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
 echo "Running Claude (plugin-dir: $PLUGIN_DIR, cwd: $TEST_PROJECT)..."
 echo "================================================================================"
 cd "$TEST_PROJECT" && timeout 1800 claude -p "$PROMPT" --plugin-dir "$PLUGIN_DIR" --allowed-tools=all --permission-mode bypassPermissions 2>&1 | tee "$OUTPUT_FILE" || {
+    exit_code=$?
     echo ""
     echo "================================================================================"
-    echo "EXECUTION FAILED (exit code: $?)"
+    echo "EXECUTION FAILED (exit code: $exit_code)"
     exit 1
 }
 echo "================================================================================"

--- a/tests/claude-code/test-worktree-path-policy.sh
+++ b/tests/claude-code/test-worktree-path-policy.sh
@@ -47,15 +47,19 @@ assert_not_contains() {
 echo "=== Worktree Path Policy Test ==="
 echo ""
 
+# shellcheck disable=SC2088 # Tilde is intentional: checking for the literal string "~/.config/..." in skill file text
 assert_not_contains "$USING_SKILL" "~/.config/superpowers/worktrees" "using-git-worktrees does not mention old global path"
 assert_not_contains "$USING_SKILL" "global legacy" "using-git-worktrees does not use unclear global legacy shorthand"
 assert_not_contains "$USING_SKILL" "Global path" "using-git-worktrees has no global path quick-reference row"
 assert_contains "$USING_SKILL" 'default to `.worktrees/` at the project root' "using-git-worktrees defaults new manual worktrees to .worktrees/"
 
+# shellcheck disable=SC2088 # Tilde is intentional: checking for the literal string "~/.config/..." in skill file text
 assert_not_contains "$FINISHING_SKILL" "~/.config/superpowers/worktrees" "finishing-a-development-branch does not treat old global path as owned"
 assert_contains "$FINISHING_SKILL" '`.worktrees/` or `worktrees/`' "finishing-a-development-branch keeps project-local cleanup ownership"
 
+# shellcheck disable=SC2088 # Tilde is intentional: checking for the literal string "~/.config/..." in skill file text
 assert_not_contains "$ROTOTILL_SPEC" "~/.config/superpowers/worktrees" "rototill spec does not preserve old global path policy"
+# shellcheck disable=SC2088 # Tilde is intentional: checking for the literal string "~/.config/..." in skill file text
 assert_not_contains "$ROTOTILL_PLAN" "~/.config/superpowers/worktrees" "rototill plan does not preserve old global path policy"
 assert_not_contains "$ROTOTILL_PLAN" "legacy path compat" "rototill plan does not advertise legacy path compatibility"
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Sonnet 4.6 |
| Harness + version | Claude Code CLI |
| All plugins installed | superpowers |
| Human partner who reviewed this diff | rohitcse.gec@gmail.com |

## What problem are you trying to solve?

Running `scripts/lint-shell.sh --all` (the project's own linter) exits with code 1 due to shellcheck warnings in three test files. Two of these warnings reflect real bugs:

- **SC2320** in `test-subagent-driven-development-integration.sh` line 170: `$?` in the failure handler referred to the preceding `echo ""` (exit 0), not to the failed `claude` command. The error message always printed `exit code: 0`, making test failures hard to diagnose.
- **SC2155** in `test-helpers.sh`: five `local var=$(cmd)` patterns where the `local` builtin's exit code (always 0) masks a failure from `mktemp` or `grep`. Under `set -e` this silently continues with an empty variable instead of halting.
- **SC2064** in `test-subagent-driven-development-integration.sh` line 40: `trap "..." EXIT` with double-quotes expands `$TEST_PROJECT` immediately. A wrapper function makes the intent explicit.
- **SC2088** in `test-worktree-path-policy.sh`: four grep patterns intentionally check for the literal tilde string `~/.config/...` in Markdown skill files — not the expanded `$HOME` path. Added `# shellcheck disable` comments to document this.

## What does this PR change?

- `tests/claude-code/test-helpers.sh`: declare five `local` variables on their own line, then assign separately
- `tests/claude-code/test-subagent-driven-development-integration.sh`: capture `$?` into `exit_code` before `echo`, replace inline trap with `_cleanup()` wrapper
- `tests/claude-code/test-worktree-path-policy.sh`: add `# shellcheck disable=SC2088` with explanation on four lines where `~` must remain unexpanded

After this PR, `scripts/lint-shell.sh --all` exits 0 with no warnings.

## What alternatives did you consider?

Adding `# shellcheck disable=SC2155` comments inline. Chose separate-declaration instead because it is the idiomatic fix, makes the code correct under `set -e`, and produces no extra noise.

## Does this PR contain multiple unrelated changes?

No — all three files are test helpers in the same `tests/claude-code/` directory, all changes are shellcheck correctness fixes, and the goal is a single clean `lint-shell.sh --all` run.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code CLI | latest | Claude | Sonnet 4.6 |

## Evaluation

`scripts/lint-shell.sh --all` before: exits 1 with 11 warnings across 3 files.
`scripts/lint-shell.sh --all` after: exits 0, `Linting 39 shell files`, no output.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

🤖 Generated with [Claude Code](https://claude.ai/code)