### PR TITLE
Add Codex marketplace manifest

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "superpowers-dev",
+  "interface": {
+    "displayName": "Superpowers Dev"
+  },
+  "plugins": [
+    {
+      "name": "superpowers",
+      "source": {
+        "source": "url",
+        "url": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,6 +21,7 @@
     "workflow"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks/hooks-codex.json",
   "interface": {
     "displayName": "Superpowers",
     "shortDescription": "Planning, TDD, debugging, and delivery workflows for coding agents",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,7 +21,6 @@
     "workflow"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks/hooks-codex.json",
   "interface": {
     "displayName": "Superpowers",
     "shortDescription": "Planning, TDD, debugging, and delivery workflows for coding agents",

--- a/tests/codex/test-marketplace-manifest.sh
+++ b/tests/codex/test-marketplace-manifest.sh
@@ -51,16 +51,11 @@ if not plugin_manifest.exists():
 
 manifest = json.loads(plugin_manifest.read_text(encoding="utf-8"))
 assert_equal(manifest.get("name"), plugin.get("name"), "plugin manifest name")
-
-unsupported_manifest_fields = ["hooks"]
-present_unsupported = sorted(
-    field for field in unsupported_manifest_fields if field in manifest
+assert_equal(
+    manifest.get("hooks"),
+    "./hooks/hooks-codex.json",
+    "Codex hooks manifest",
 )
-if present_unsupported:
-    raise AssertionError(
-        "unsupported Codex manifest fields present: "
-        + ", ".join(present_unsupported)
-    )
 
 print("Codex marketplace manifest looks good")
 PY

--- a/tests/codex/test-marketplace-manifest.sh
+++ b/tests/codex/test-marketplace-manifest.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MARKETPLACE="$REPO_ROOT/.agents/plugins/marketplace.json"
+
+python3 - "$MARKETPLACE" "$REPO_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+marketplace_path = Path(sys.argv[1])
+repo_root = Path(sys.argv[2])
+
+if not marketplace_path.exists():
+    raise AssertionError(".agents/plugins/marketplace.json must exist")
+
+marketplace = json.loads(marketplace_path.read_text(encoding="utf-8"))
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+assert_equal(marketplace.get("name"), "superpowers-dev", "marketplace name")
+assert_equal(
+    marketplace.get("interface", {}).get("displayName"),
+    "Superpowers Dev",
+    "marketplace display name",
+)
+
+plugins = marketplace.get("plugins")
+if not isinstance(plugins, list):
+    raise AssertionError("plugins must be a list")
+
+matching_plugins = [plugin for plugin in plugins if plugin.get("name") == "superpowers"]
+assert_equal(len(matching_plugins), 1, "superpowers plugin entry count")
+
+plugin = matching_plugins[0]
+assert_equal(plugin.get("source"), {"source": "url", "url": "./"}, "plugin source")
+assert_equal(
+    plugin.get("policy"),
+    {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
+    "plugin policy",
+)
+assert_equal(plugin.get("category"), "Developer Tools", "plugin category")
+
+plugin_manifest = repo_root / ".codex-plugin" / "plugin.json"
+if not plugin_manifest.exists():
+    raise AssertionError(".codex-plugin/plugin.json must exist")
+
+manifest = json.loads(plugin_manifest.read_text(encoding="utf-8"))
+assert_equal(manifest.get("name"), plugin.get("name"), "plugin manifest name")
+
+unsupported_manifest_fields = ["hooks"]
+present_unsupported = sorted(
+    field for field in unsupported_manifest_fields if field in manifest
+)
+if present_unsupported:
+    raise AssertionError(
+        "unsupported Codex manifest fields present: "
+        + ", ".join(present_unsupported)
+    )
+
+print("Codex marketplace manifest looks good")
+PY


### PR DESCRIPTION
## Summary
- Add a repo-local Codex marketplace manifest so the superpowers repository exposes an installable `superpowers@superpowers-dev` plugin entry.
- Point the marketplace entry at the repository root with the same-root `url: "./"` source pattern Codex accepts for local marketplaces.
- Keep `.codex-plugin/plugin.json` pointed at the Codex-specific hook config and add a focused Codex marketplace manifest test that locks that in.

## Test Plan
- [x] `bash tests/codex/test-marketplace-manifest.sh`
- [x] throwaway `HOME` with `codex plugin marketplace add ...` and `codex plugin add superpowers@superpowers-dev --json`, verifying installed `.codex-plugin/plugin.json` keeps `hooks: "./hooks/hooks-codex.json"`
- [x] `bash tests/codex-plugin-sync/test-sync-to-codex-plugin.sh`
- [x] `bash tests/kimi/test-plugin-manifest.sh`
- [x] `bash tests/shell-lint/test-lint-shell.sh`
- [x] `scripts/lint-shell.sh tests/codex/test-marketplace-manifest.sh`
