### PR TITLE
fix(executing-plans): scope STOP triggers to real blockers to prevent…

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -38,13 +38,21 @@ After all tasks complete and verified:
 
 ## When to Stop and Ask for Help
 
-**STOP executing immediately when:**
-- Hit a blocker (missing dependency, test fails, instruction unclear)
-- Plan has critical gaps preventing starting
-- You don't understand an instruction
-- Verification fails repeatedly
+**STOP executing only when:**
+- A real blocker exists: missing credential/file/permission, OR ambiguity where the
+  wrong choice would cause real harm (data loss, breaking production, etc.)
+- ALL plan tasks are complete
 
-**Ask for clarification rather than guessing.**
+**NOT a real blocker — keep going, surface in text:**
+- A single failed test: investigate or re-run
+- A subagent returning DONE_WITH_CONCERNS: read the concerns and proceed
+- A minor interpretation ambiguity: pick the most reasonable interpretation,
+  note the assumption in your output, continue
+- Hedging language in your own output: state the uncertainty in prose; keep working
+
+**When you do stop:**
+- Your last line of output MUST be a one-sentence question
+- A bullet inside a summary is not a question
 
 ## When to Revisit Earlier Steps
 


### PR DESCRIPTION
… silent stalls

The STOP triggers in executing-plans fire on minor ambiguities — a single failed test, any unclear instruction, self-hedging language — and halt mid-task. This contradicts subagent-driven-development's "Continuous execution: do not pause" rule, and the conservative skill wins by default when both apply. The clarifying question is often buried in a recap rather than surfaced as a clear last-line prompt, so the session sits silently idle with no visible question to answer.

Reclassify single test failures, DONE_WITH_CONCERNS, minor interpretation ambiguity, and self-hedging as "keep going, surface in text". Reserve STOP for real blockers (missing credential/file/permission, or harmful ambiguity) or all-tasks-complete. When a genuine stop occurs, require the last line of output to be a one-sentence question.

Implements Option 1 from #1545.

## Who is submitting this PR? (required)
I explicitly asked claude to do implement what was proposed in #1545

| Field | Value |
|-------|-------|
| opus | 4.8 |
| claude-code-cli | 2.1.185 |
| superpowers, gsd, custom | |
| Daniel Böckenhoff | |

## What problem are you trying to solve?
I want to combine superpowers and gsd properly and this is a stopper :)

## What does this PR change?
Allow seamless combination of superpowers + gsd workflow (and other subagents)

## Is this change appropriate for the core library?
yes

## What alternatives did you consider?
none

## Does this PR contain multiple unrelated changes?
no

## Existing PRs
none was listed in #1545

## Environment tested
claude-cli see above

## New harness support (required if this PR adds a new harness)

no new harness

## Evaluation
- What was the initial prompt you (or your human partner) used to start
  the session that led to this change?
"Evaluate the superpowers:fix-1545-executing-plans-stalls branch by fixing issue <my private issue on a different project I disclose here>. I want to see it seemlessly transition."
- How many eval sessions did you run AFTER making the change?
1
- How did outcomes change compared to before the change?

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

