### PR TITLE
writing-plans: optional Invariants block for spec→test traceability

### DIFF
--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -188,6 +188,7 @@ You MUST complete each phase before proceeding to the next.
    - Test passes now?
    - No other tests broken?
    - Issue actually resolved?
+   - **If yes — name the class:** Ask "what *category* of bug was this?" Write the smallest named test that would catch a recurrence of that category — not just this instance. Name the test after the root cause (`test_null_session_crashes_auth`, not `test_bug_from_today`). This converts the one-shot fix into a permanent regression net.
 
 4. **If Fix Doesn't Work**
    - STOP

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -188,7 +188,6 @@ You MUST complete each phase before proceeding to the next.
    - Test passes now?
    - No other tests broken?
    - Issue actually resolved?
-   - **If yes — name the class:** Ask "what *category* of bug was this?" Write the smallest named test that would catch a recurrence of that category — not just this instance. Name the test after the root cause (`test_null_session_crashes_auth`, not `test_bug_from_today`). This converts the one-shot fix into a permanent regression net.
 
 4. **If Fix Doesn't Work**
    - STOP

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -92,6 +92,10 @@ include this section.]
   and return types. A task's implementer sees only their own task; this
   block is how they learn the names and types neighboring tasks use.]
 
+**Invariants:** (1-3 conditions this task must guarantee, each bound to a named test)
+- `condition the task must hold` → `test_function_name` in the test file
+- (omit this block when no non-obvious invariants exist)
+
 - [ ] **Step 1: Write the failing test**
 
 ```python


### PR DESCRIPTION
## What and why

A small A/B benchmark (cavekit v4 vs the superpowers loop on a real Node CLI ticket; n=1) suggested two possible loop improvements. I then ran a controlled stock-vs-patched eval to check whether either actually changes agent output — full data and methodology are in the comment thread.

**Finding 1 (systematic-debugging) has been withdrawn.** The eval showed stock Sonnet-4.6 already resolves the out-of-scope scope conflict it targeted — 0 genuine rescues across 8 stock runs — so the original n=1 "0 vs 1 rescue" signal did not replicate. That change has been removed from this PR.

**This PR now contains only Finding 2.**

## Change

- `skills/writing-plans/SKILL.md` — optional `Invariants:` block in the Task Structure template, each invariant bound to a named test, with an explicit "omit when no non-obvious invariants exist" escape hatch. Purely additive; no existing step is altered.

## Eval result for this change

Judged on the actual generated plan files (Sonnet-4.6 agent + blind Sonnet-4.6 judge, N=5/arm, isolated config, one-block independent variable):

| arm | mean score | invariant surfaced | bound to test |
|---|---|---|---|
| stock | 1.40 | 2/5 | 5/5 |
| invariants | 2.00 | 5/5 | 5/5 |

Both arms reliably write a guarding test (5/5 each), so this is **not** a correctness change — stock already writes a test that fails if the invariant is violated. The measurable effect is explicit articulation: the patched arm states the non-obvious invariant in a dedicated `**Invariants:**` block 5/5 of the time vs 2/5 for stock. A documentation/clarity improvement; whether it's worth the template addition is a maintainer call.

## Caveats

N=5, single model (Sonnet-4.6 for both agent and judge), judge non-determinism observed. Directional, not statistically powered. Raw transcripts, fixtures, runner/judge, and scorecard are on branch `evals/pr-1831` in the memory-bus repo.
