### PR TITLE
[codex] fix Windows SessionStart hook invocation

### DIFF
--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -7,6 +7,7 @@
           {
             "type": "command",
             "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start-codex",
+            "commandWindows": "& \"${PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start-codex",
             "async": false
           }
         ]


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Codex (GPT-5) |
| Harness + version | Codex desktop app; `gh` 2.92.0 used for local publish checks |
| All plugins installed | GitHub plugin 0.1.5 available in Codex; no repo plugin changes installed for this PR |
| Human partner who reviewed this diff | Drew |

## What problem are you trying to solve?

On Windows, the Codex SessionStart hook command in `hooks/hooks-codex.json` invokes a quoted `.cmd` path followed by an argument. PowerShell treats a bare quoted path as a string expression, so the following `session-start-codex` token fails to parse as an executable argument. That prevents the Codex SessionStart hook from emitting the Superpowers bootstrap context for Windows Codex app users.

This implements the Windows fix proposed in #1827 without changing the default command used on macOS/Linux.

## What does this PR change?

Adds a Codex `commandWindows` override that invokes the quoted `run-hook.cmd` path with PowerShell's call operator (`&`). The existing cross-platform `command` remains unchanged for macOS/Linux.

`commandWindows` is documented in the official Codex hooks docs as an optional Windows-only command override: https://developers.openai.com/codex/hooks

## Is this change appropriate for the core library?

Yes. This changes the existing core Codex hook manifest so the existing Codex integration works on Windows. It is not project-specific and does not add or promote a third-party service.

## What alternatives did you consider?

I first considered adding `&` to the default `command`, but that would be PowerShell-specific and would break POSIX shells on macOS/Linux. Codex hook metadata supports `commandWindows`, so the narrowest safe fix is to keep the default command as-is and add a Windows-only override.

I also considered changing the batch wrapper, but the failure happens before the wrapper executes: PowerShell needs `&` to invoke a quoted command path with arguments.

## Does this PR contain multiple unrelated changes?

No. It contains one related change to the Codex hook command metadata.

## Existing PRs

- [x] I reviewed relevant open and closed PR search results for duplicates or prior art
- Related PRs/issues: #1827, #1540, #1829, #1680, #1661, #1678

I searched for `1827`, `hooks-codex`, `session-start-codex`, and `Windows PowerShell Codex hook`. I found prior Codex hook and Windows hook work, but no open PR applying this exact manifest fix.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app / Codex plugin hook eval | App version not exposed in shell; `gh` 2.92.0 for publish flow | Codex | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. This fixes the existing Codex harness hook manifest; it does not add a new harness.

## Evaluation

- Initial prompt: apply the fix from #1827, rerun the newly added `superpowers-evals` check, and confirm the eval changes from red to green.
- Eval sessions run after making the change: 1 targeted check run after updating the eval to require a Windows-only override and reject a PowerShell-only default command.
- Outcome change: before the fix, `codex-session-start-hook-executes` exited `1` with `Codex SessionStart hook missing commandWindows override`. After this fix, the same eval exited `0` with `Codex SessionStart hook executes through PowerShell`.

Validation commands/results:

```text
git diff --check
# passed

bun test test/fs-verbs-bootstrap.test.ts test/scenario-pinning.test.ts
# 35 pass

bunx biome check src/check/fs-verbs.ts test/fs-verbs-bootstrap.test.ts
# passed

bun run typecheck
# passed

bun run src/cli/check-tool.ts codex-session-start-hook-executes
CHECK_EXIT=0
passed=true
detail="Codex SessionStart hook executes through PowerShell"
```

## Rigor

- [x] Not a skills content change; `superpowers:writing-skills` is not applicable
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

The adversarial check first used the old manifest and confirmed it failed because the Windows override was absent. The eval also has a guard that fails if the default command starts with PowerShell's `&`, which protects macOS/Linux from this regression.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew caught that putting `&` in the default command would break macOS/Linux; the PR was amended to use Codex's documented Windows-only hook command override.