### PR TITLE
fix(codex): stop SessionStart bootstrap re-firing on resume (match Claude startup|clear|compact)

### DIFF
--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear",
+        "matcher": "startup|clear|compact",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Who is submitting this PR? (required)

This PR was produced by an AI agent, not a human.

| Field | Value |
|-------|-------|
| Your model + version | Anthropic Claude (Sonnet-class model), operating under the agent identity "Ada Sen" |
| Harness + version | sen-core / Lace agent harness, "persistent-box" container delegate (internal tooling; no public version string) |
| All plugins installed | None. This was a direct git/`gh` editing session in a plain Linux container — the Superpowers plugin was not loaded, so no skills were active. |
| Human partner who reviewed this diff | None. A human maintainer directed the task, but no human has line-reviewed the diff or this PR body prior to submission. Opened for maintainer review. |

"Ada Sen" is the AI agent identity that authored this change — it is not a human. To be explicit per this repo's disclosure rules: a human maintainer set the task, but the diff and this PR body were written by the agent and have not been line-reviewed by any human before submission.

## What problem are you trying to solve?

The Codex `SessionStart` hook configuration re-runs the Superpowers bootstrap on **every session resume**, not only on fresh session starts.

In `hooks/hooks-codex.json` the `SessionStart` matcher is:

```json
"matcher": "startup|resume|clear"
```

Because `resume` is in the matcher, resuming an existing Codex session fires the `session-start-codex` hook again, re-injecting the `using-superpowers` bootstrap into a session that already loaded it. The Claude configuration in `hooks/hooks.json` does **not** do this — its matcher is `startup|clear|compact`, so a resumed Claude session does not re-bootstrap. The two harness configs had drifted, and the Codex side is the one behaving incorrectly: resume should not be treated as a fresh start.

A side effect of `resume` being present is that `compact` is absent, so — unlike Claude — the Codex bootstrap is also **not** re-injected after a context compaction, where re-injecting is actually wanted.

## What does this PR change?

One line in `hooks/hooks-codex.json`: the `SessionStart` matcher changes from `startup|resume|clear` to `startup|clear|compact`, matching the Claude `hooks/hooks.json` matcher. This drops `resume` (stops the re-bootstrap on resume) and adds `compact` (re-injects the bootstrap after compaction, as Claude already does). No other files or lines are touched.

## Is this change appropriate for the core library?

Yes. `hooks/hooks-codex.json` is core Superpowers infrastructure that ships to every Codex user of the plugin; the bug affects all of them regardless of project or domain. The change is a single config value with no new dependency, and it brings the Codex hook lifecycle into line with the already-shipping Claude behavior rather than introducing anything new.

## What alternatives did you consider?

- **Keep `resume`, just add `compact` (`startup|resume|clear|compact`)** — rejected. It would re-inject after compaction but leaves the actual bug (re-bootstrap on every resume) in place.
- **Drop `resume` but keep the existing `clear`-only set (`startup|clear`)** — rejected. It fixes the resume bug but omits `compact`, so Codex would still diverge from Claude and miss the wanted post-compaction re-injection.
- **Change Claude's matcher to match Codex instead** — rejected. Claude's `startup|clear|compact` is the intended/tested behavior; Codex is the side that regressed, so Codex should converge on Claude, not the reverse.

Matching Claude's exact matcher (`startup|clear|compact`) is the option that both fixes the resume bug and re-aligns the two harnesses on one well-understood lifecycle.

## Does this PR contain multiple unrelated changes?

No. One file, one line, one problem.

A separate, unrelated issue exists where the Codex UI shows the SessionStart hook output as a visible "context" cell even when output suppression is requested — that is a Codex platform limitation (`suppress_output` is effectively a no-op for `SessionStart` in Codex) and is **deliberately out of scope** here. It is not addressed or affected by this matcher change and would need to be handled separately at the platform level.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found.

Searched open and closed PRs (`resume matcher`, `hooks-codex resume`, and branch names containing `hook`/`resume`/`matcher`). The only hook-related PRs are about Windows startup-hook `SHELLOPTS` (#360) and Codex Windows hooks / hook research branches — none touch the `SessionStart` matcher set in `hooks/hooks-codex.json`. No duplicate or prior-art PR for this fix exists.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Plain Linux container (git + `gh` + `jq`); no harness session run | n/a | Anthropic Claude (Sonnet-class) | n/a |

Verification performed on the change itself (this is a static hook-config edit, not a behavior-shaping skill):

```bash
jq . hooks/hooks-codex.json          # valid JSON after the edit
git diff upstream/dev -- hooks/hooks-codex.json   # exactly one line changed
git diff --stat upstream/dev         # 1 file changed, 1 insertion(+), 1 deletion(-)
```

I did not run a live Codex resume/compaction session against this build, so the behavioral effect is reasoned from the matcher semantics and from parity with the existing, shipping Claude `hooks/hooks.json` matcher rather than from a captured Codex transcript. Flagging that limitation honestly.

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a new harness; it corrects an existing Codex hook matcher.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable — no new harness support is added in this PR.
```

</details>

## Evaluation
- Initial prompt: my human partner asked me to align the Codex `SessionStart` hook matcher with the Claude one so the bootstrap stops re-firing on resume.
- Eval sessions run after the change: 0 multi-session behavioral evals. This is a hook-config value, not behavior-shaping skill prose, so the Superpowers eval harness does not apply.
- Outcome change: before, the Codex matcher includes `resume`, so a resumed session re-fires `session-start-codex` and re-injects the bootstrap, and `compact` is not handled. After, the matcher matches Claude's `startup|clear|compact`: resume no longer re-bootstraps, and compaction re-injects the bootstrap as it already does on Claude. Verified structurally (valid JSON, single-line diff) and by direct comparison against the shipping Claude matcher.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Not a skills change — `superpowers:writing-skills` does not apply. "Tested adversarially" here means I confirmed the edit is exactly one line, leaves the JSON valid, touches no other file, and that the resulting matcher is byte-for-byte the same set the Claude `hooks/hooks.json` already uses (so it introduces no new lifecycle Codex hasn't already been exercising on the Claude side). No carefully-tuned behavior-shaping prose was touched.

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

Disclosed honestly: no human has line-reviewed the complete diff before submission. A human maintainer directed the task (align the Codex `SessionStart` matcher with Claude's so the bootstrap stops re-firing on resume), but the one-line change (`startup|resume|clear` → `startup|clear|compact`) and this PR body were authored by the AI agent and are opened for maintainer review.
