### PR TITLE
Add Factory Droid plugin config for marketplace install

### DIFF
--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "superpowers",
+  "description": "Superpowers core skills library: TDD, debugging, collaboration patterns",
+  "owner": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "plugins": [
+    {
+      "name": "superpowers",
+      "description": "Core skills library for Factory Droid: TDD, debugging, collaboration patterns, and proven techniques",
+      "version": "6.0.3",
+      "source": "./",
+      "author": {
+        "name": "Jesse Vincent",
+        "email": "jesse@fsck.com"
+      }
+    }
+  ]
+}

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "superpowers",
+  "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
+  "version": "6.0.3",
+  "author": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "homepage": "https://github.com/obra/superpowers",
+  "repository": "https://github.com/obra/superpowers",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "tdd",
+    "debugging",
+    "collaboration",
+    "best-practices",
+    "workflows"
+  ]
+}


### PR DESCRIPTION
## Summary

Droid (Factory AI CLI) requires `.factory-plugin/plugin.json` and `.factory-plugin/marketplace.json` to install a plugin from a marketplace — it does not read `.claude-plugin/` config.

Without these files, `droid plugin install superpowers@superpowers` fails with:

```
Error: Could not install plugin. Please try again.
```

Root cause from droid logs:
```
ENOENT: no such file or directory, stat '.../.factory-plugin/marketplace.json'
```

## What this adds

- `.factory-plugin/plugin.json` — plugin metadata (name, description, version, author)
- `.factory-plugin/marketplace.json` — marketplace descriptor pointing to the plugin

## Testing

Successfully installed and verified with droid v0.157.1:

```
$ droid plugin install superpowers@superpowers
Successfully installed superpowers@superpowers (896224c)

$ droid plugin list
  superpowers@superpowers  [user]  896224c
```
