### PR TITLE
fix(brainstorming): suppress AskUserQuestion; add explicit conversational-text rule

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -70,6 +70,7 @@ digraph brainstorming {
 - For appropriately-scoped projects, ask questions one at a time to refine the idea
 - Prefer multiple choice questions when possible, but open-ended is fine too
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
+- **Present questions as plain conversational text — do not use structured-choice tools (e.g. `AskUserQuestion`).** Ask in the chat/terminal interface directly.
 - Focus on understanding: purpose, constraints, success criteria
 
 **Exploring approaches:**

--- a/skills/using-superpowers/references/claude-code-tools.md
+++ b/skills/using-superpowers/references/claude-code-tools.md
@@ -19,6 +19,7 @@ Skills speak in actions ("dispatch a subagent", "create a todo", "read a file").
 | Multiple parallel dispatches | Multiple `Agent` calls in one response |
 | Task tracking ("create a todo", "mark complete") | `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`; `TodoWrite` in `claude -p` / Agent SDK unless `CLAUDE_CODE_ENABLE_TASKS=1` is set |
 | Background-process / subagent lifecycle (read output, cancel) | `TaskOutput`, `TaskStop` — these are distinct from the todo tools above and apply to running shells, agents, and remote sessions |
+| **Ask the user a question / present multiple-choice options** | **Plain conversational text in the terminal — do NOT use `AskUserQuestion`.** Skills that say "ask one question at a time" or "prefer multiple choice" mean to type the question/options directly into the chat, not invoke a structured-choice tool. |
 
 ## Instructions file
 


### PR DESCRIPTION
## Summary

On v6.0.0 the platform-neutral bootstrap reframe caused Claude Code to route "ask clarifying questions / present multiple-choice options" to the native `AskUserQuestion` structured-choice tool, overriding the skill's explicit "present options conversationally / use the terminal" intent (see #1773 root-cause analysis).

Fixes #1773

## Changes

- `skills/brainstorming/SKILL.md`: Add an explicit rule near "Prefer multiple choice questions" that brainstorming questions must be presented as plain conversational text — `AskUserQuestion` is not used here.
- `skills/using-superpowers/references/claude-code-tools.md`: Add a row to the tool mapping table clarifying that "ask the user a question" is **not** a mapped tool action on Claude Code; skills that say "ask one question at a time" or "prefer multiple choice" mean to type into the chat directly.

The fix is scoped to Claude Code (in `claude-code-tools.md`) so harnesses like Kimi that explicitly opt in to `AskUserQuestion` are unaffected.