### PR TITLE
Feat/riso tech human docs roadmap

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,125 @@
+name: Sync upstream
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: sync-upstream-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Merge upstream main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add upstream https://github.com/obra/superpowers.git
+          git fetch --prune origin main
+          git fetch --prune upstream main
+
+          origin_sha="$(git rev-parse origin/main)"
+          upstream_sha="$(git rev-parse upstream/main)"
+
+          {
+            echo "### Upstream sync"
+            echo "- Fork before sync: \`$origin_sha\`"
+            echo "- Upstream: \`$upstream_sha\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if git merge-base --is-ancestor "$upstream_sha" "$origin_sha"; then
+            echo "- Result: already up to date" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git checkout -B upstream-sync origin/main
+
+          if git merge --no-edit upstream/main; then
+            if git push origin HEAD:main; then
+              result_sha="$(git rev-parse HEAD)"
+              echo "- Result: pushed \`$result_sha\` to \`origin/main\`" >> "$GITHUB_STEP_SUMMARY"
+
+              issue_number="$(
+                gh issue list \
+                  --repo "$REPOSITORY" \
+                  --state open \
+                  --search '"Upstream sync requires attention" in:title' \
+                  --json number \
+                  --jq '.[0].number // empty'
+              )"
+              if [[ -n "$issue_number" ]]; then
+                gh issue comment "$issue_number" \
+                  --repo "$REPOSITORY" \
+                  --body "Upstream sync succeeded at commit \`$result_sha\`. Closing this alert."
+                gh issue close "$issue_number" --repo "$REPOSITORY"
+              fi
+              exit 0
+            fi
+
+            issue_body="$(
+              printf '%s\n' \
+                "The scheduled upstream sync merged cleanly but GitHub rejected the push to \`main\`." \
+                "" \
+                "- Fork commit checked: \`$origin_sha\`" \
+                "- Upstream commit checked: \`$upstream_sha\`" \
+                "" \
+                "This usually means \`main\` changed while the workflow was running. Re-run the workflow; do not force-push."
+            )"
+          else
+            conflicts="$(git diff --name-only --diff-filter=U)"
+            git merge --abort
+
+            issue_body="$(
+              printf '%s\n' \
+                "The scheduled sync could not merge \`obra/superpowers:main\` into this fork's \`main\`." \
+                "" \
+                "- Fork commit: \`$origin_sha\`" \
+                "- Upstream commit: \`$upstream_sha\`" \
+                "" \
+                "Conflicting files:" \
+                "\`\`\`" \
+                "$conflicts" \
+                "\`\`\`" \
+                "" \
+                "No changes were pushed. Resolve the merge manually, then re-run this workflow."
+            )"
+          fi
+
+          issue_number="$(
+            gh issue list \
+              --repo "$REPOSITORY" \
+              --state open \
+              --search '"Upstream sync requires attention" in:title' \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          if [[ -n "$issue_number" ]]; then
+            gh issue comment "$issue_number" --repo "$REPOSITORY" --body "$issue_body"
+          else
+            gh issue create \
+              --repo "$REPOSITORY" \
+              --title "Upstream sync requires attention" \
+              --body "$issue_body"
+          fi
+
+          echo "- Result: action required; no changes pushed" >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/docs/superpowers/specs/2026-06-26-product-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-26-product-roadmap-design.md
@@ -1,0 +1,79 @@
+# Product Roadmap — Design
+
+**Date:** 2026-06-26
+**Status:** approved
+
+## Problem
+
+When working feature-by-feature ("vibe coding"), there is no comprehensive,
+human-readable view of the whole product or of what progress has been made. The
+existing superpowers artifacts (per-feature specs and plans, the SDD progress
+ledger) are for LLM consumption and are scoped to a single feature each — nothing
+aggregates them into a product-level picture for stakeholders.
+
+## Solution
+
+A per-project **roadmap** that aggregates features and their status, maintained
+automatically at two existing workflow hooks:
+
+- **`brainstorming`** — when a feature's spec is written, add the feature to the
+  roadmap with status `planned`.
+- **`finishing-a-development-branch`** — when the work is integrated (merge or
+  PR), set that feature's status to `done`.
+
+## Files (per working project)
+
+```
+docs/superpowers/
+  roadmap.json    # source of truth (LLM reads/writes)
+  ROADMAP.html    # rendered view for humans, regenerated from roadmap.json
+```
+
+## Data model
+
+`roadmap.json` is an array of entries keyed by `slug`:
+
+| Field | Meaning |
+|-------|---------|
+| `slug` | stable key = `<topic>` from `YYYY-MM-DD-<topic>-design.md` |
+| `title` | human-readable feature name |
+| `status` | `planned` or `done` |
+| `spec` / `plan` | paths relative to `docs/superpowers/` (or `null`) |
+| `created` / `completed` | `YYYY-MM-DD` (`completed` null until done) |
+
+## Behavior
+
+- **Idempotent by `slug`:** find-and-update if the slug exists, append otherwise.
+  Re-running brainstorming on the same feature never duplicates a row.
+- **Status lifecycle:** `planned` (after brainstorm) → `done` (after integrate).
+  Two states only.
+- **Finish step scope:** updates to `done` only for merge (Option 1) and PR
+  (Option 2); not for keep-as-is or discard. If the slug is ambiguous, ask the
+  user.
+- **ROADMAP.html:** self-contained (inline CSS, embedded data) so it opens by
+  double-click; planned rows first, then done; status shown as a colored badge.
+
+## Constraints
+
+- **Zero dependency, runtime-agnostic:** no render script; the agent edits the
+  JSON and regenerates the HTML from a fixed template stored in the skill
+  reference. Works regardless of the target project's language/runtime.
+- **Marked sections:** every addition to the skills is wrapped in
+  `<!-- created by riso-tech -->` … `<!-- end created by riso-tech -->`.
+
+## Implementation
+
+- `skills/brainstorming/roadmap.md` — shared reference: schema, idempotent update
+  rules, and the `ROADMAP.html` template.
+- `skills/brainstorming/SKILL.md` — Documentation step + checklist updated to add
+  the feature to the roadmap.
+- `skills/finishing-a-development-branch/SKILL.md` — new Step 5b updates the
+  matching entry to `done`.
+
+## Out of scope
+
+- `in-progress` status (rejected: only two hooks, two states).
+- HTML companions / roadmap entries for SDD scratch files (`progress.md`,
+  `task-N-report.md`) — those are machine recovery/handoff scratch, not reader
+  deliverables.
+- A render script or any new runtime dependency.

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -26,7 +26,7 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`, generate the HTML companion, add the feature to the product roadmap (see Documentation), and commit all
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
@@ -107,6 +107,20 @@ digraph brainstorming {
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
+
+<!-- created by riso-tech -->
+**Human-readable HTML companion:**
+
+- After writing and committing the markdown spec, also generate a standalone HTML version for human readers at the same path with a `.html` extension (e.g. `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.html`).
+- The markdown is the source of truth (for LLMs); the HTML is a rendered view for people — self-contained (inline CSS, no external assets) so it opens directly in a browser.
+- Regenerate the HTML whenever the spec changes, and commit it alongside the `.md`.
+
+**Add the feature to the product roadmap:**
+
+- After writing the spec, add (or update) this feature's entry in the project roadmap so stakeholders get a comprehensive view of the product.
+- `slug` = `<topic>` from the spec filename; status = `planned`; `spec` = the spec path; `created` = today.
+- Follow [roadmap.md](roadmap.md) for the schema, idempotent update rules, and the `ROADMAP.html` template. Commit `roadmap.json` and `ROADMAP.html` with the spec.
+<!-- end created by riso-tech -->
 
 **Spec Self-Review:**
 After writing the spec document, look at it with fresh eyes:

--- a/skills/brainstorming/roadmap.md
+++ b/skills/brainstorming/roadmap.md
@@ -1,0 +1,105 @@
+<!-- created by riso-tech -->
+# Product Roadmap (shared reference)
+
+A per-project roadmap that gives humans a comprehensive view of the product and
+its progress. `brainstorming` adds a feature when its spec is written;
+`finishing-a-development-branch` marks it done when the work is integrated.
+
+Both skills read/write the same two files in the working project:
+
+```
+docs/superpowers/
+  roadmap.json    # source of truth (LLM reads/writes — precise edits)
+  ROADMAP.html    # rendered view for humans (regenerated from roadmap.json)
+```
+
+## roadmap.json schema
+
+An array of entries, keyed by `slug`:
+
+```json
+[
+  {
+    "slug": "user-auth",
+    "title": "User authentication",
+    "status": "planned",
+    "spec": "specs/2026-06-26-user-auth-design.md",
+    "plan": null,
+    "created": "2026-06-26",
+    "completed": null
+  }
+]
+```
+
+- `slug` — stable key. Use `<topic>` from the spec filename
+  `YYYY-MM-DD-<topic>-design.md` (strip the date prefix and the `-design` suffix).
+- `status` — `"planned"` or `"done"`.
+- `spec` / `plan` — paths relative to `docs/superpowers/` (or `null` if none yet).
+- `created` / `completed` — `YYYY-MM-DD` (use today's date). `completed` is `null`
+  until done.
+
+## Update rules (idempotent by slug)
+
+1. Read `roadmap.json` if it exists, else start from `[]`.
+2. Find the entry whose `slug` matches. If found, **update** it; never append a
+   duplicate. If not found, **append** a new entry.
+3. Write `roadmap.json` back (2-space indent, entries in file order — newest
+   appended last).
+4. Regenerate `ROADMAP.html` from the full `roadmap.json` using the template below.
+5. Commit both files alongside the spec/plan or the integration commit.
+
+When you can't determine the slug (e.g. at finish time with no spec in context),
+ask the user which feature this work corresponds to rather than guessing.
+
+## ROADMAP.html template
+
+Self-contained — inline CSS, data embedded directly so it opens by double-click
+(no server, no external assets). Render one `<tr>` per entry, **planned rows
+first, then done**. Make `spec`/`plan` cells links to the relative path (show "—"
+when `null`). Status cell is a badge: `planned` → amber, `done` → green.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Product Roadmap</title>
+<style>
+  body { font: 15px/1.5 system-ui, sans-serif; margin: 2rem auto; max-width: 960px; color: #1a1a1a; }
+  h1 { margin: 0 0 .25rem; }
+  .meta { color: #666; margin-bottom: 1.5rem; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { text-align: left; padding: .5rem .75rem; border-bottom: 1px solid #eee; }
+  th { font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; color: #888; }
+  .badge { display: inline-block; padding: .1rem .55rem; border-radius: 999px; font-size: .8rem; font-weight: 600; }
+  .planned { background: #fef3c7; color: #92400e; }
+  .done { background: #d1fae5; color: #065f46; }
+  a { color: #2563eb; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  footer { margin-top: 2rem; color: #aaa; font-size: .8rem; }
+</style>
+</head>
+<body>
+  <h1>Product Roadmap</h1>
+  <div class="meta">Generated from <code>roadmap.json</code></div>
+  <table>
+    <thead>
+      <tr><th>Feature</th><th>Status</th><th>Spec</th><th>Plan</th><th>Created</th><th>Completed</th></tr>
+    </thead>
+    <tbody>
+      <!-- one row per entry, planned first then done -->
+      <tr>
+        <td>User authentication</td>
+        <td><span class="badge planned">planned</span></td>
+        <td><a href="specs/2026-06-26-user-auth-design.md">spec</a></td>
+        <td>—</td>
+        <td>2026-06-26</td>
+        <td>—</td>
+      </tr>
+    </tbody>
+  </table>
+  <footer>created by riso-tech</footer>
+</body>
+</html>
+```
+<!-- end created by riso-tech -->

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -158,6 +158,24 @@ Then: Cleanup worktree (Step 6), then force-delete branch:
 git branch -D <feature-branch>
 ```
 
+<!-- created by riso-tech -->
+### Step 5b: Update Product Roadmap
+
+**Runs for Options 1 (merge) and 2 (PR) only** — the work is being integrated, so
+the feature is done. Skip for Option 3 (keep as-is) and Option 4 (discard).
+
+- Identify the feature's `slug` from the spec/plan filename used for this work
+  (`YYYY-MM-DD-<slug>-design.md`). If no spec/plan is in context and the slug is
+  ambiguous, ask the user which feature this work corresponds to.
+- Set that entry's `status` to `done` and `completed` to today's date in
+  `docs/superpowers/roadmap.json`, then regenerate `ROADMAP.html`. If the entry
+  doesn't exist yet, create it as done.
+- See [../brainstorming/roadmap.md](../brainstorming/roadmap.md) for the schema,
+  idempotent update rules, and the `ROADMAP.html` template.
+- For Option 1, commit the roadmap update with (or right after) the merge. For
+  Option 2, commit it on the branch before pushing.
+<!-- end created by riso-tech -->
+
 ### Step 6: Cleanup Workspace
 
 **Only runs for Options 1 and 4.** Options 2 and 3 always preserve the worktree.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -18,6 +18,14 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 **Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)
 
+<!-- created by riso-tech -->
+**Human-readable HTML companion:**
+
+- After saving the markdown plan, also generate a standalone HTML version for human readers at the same path with a `.html` extension (e.g. `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.html`).
+- The markdown is the source of truth (for LLMs); the HTML is a rendered view for people — self-contained (inline CSS, no external assets) so it opens directly in a browser. Render task checkboxes as a readable checklist.
+- Regenerate the HTML whenever the plan changes, and save it alongside the `.md`.
+<!-- end created by riso-tech -->
+
 ## Scope Check
 
 If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)
<!-- Required. PRs that omit this will be closed. We assume an agent wrote
     this PR — tell us which one and where it ran. We weigh contributions by
     what produced them: content reasoned from documentation is held to a
     different bar than work grounded in a real session. -->

| Field | Value |
|-------|-------|
| Your model + version | |
| Harness + version | |
| All plugins installed | |
| Human partner who reviewed this diff | |

## What problem are you trying to solve?
<!-- Describe the specific problem you encountered. If this was a session
     issue, include: what you were doing, what went wrong, the model's
     exact failure mode, and ideally a transcript or session log.

     "Improving" something is not a problem statement. What broke? What
     failed? What was the user experience that motivated this? -->

## What does this PR change?
<!-- 1-3 sentences. What, not why — the "why" belongs above. -->

## Is this change appropriate for the core library?
<!-- Superpowers core contains general-purpose skills and infrastructure
     that benefit all users. Ask yourself:

     - Would this be useful to someone working on a completely different
       kind of project than yours?
     - Is this project-specific, team-specific, or tool-specific?
     - Does this integrate or promote a third-party service?

     If your change is a new skill for a specific domain, workflow tool,
     or third-party integration, it belongs in its own plugin — not here.
     See the plugin development docs for how to publish it separately. -->

## What alternatives did you consider?
<!-- What other approaches did you try or evaluate before landing on this
     one? Why were they worse? If you didn't consider alternatives, say so
     — but know that's a red flag. -->

## Does this PR contain multiple unrelated changes?
<!-- If yes: stop. Split it into separate PRs. Bundled PRs will be closed.
     If you believe the changes are related, explain the dependency. -->

## Existing PRs
- [ ] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: <!-- #number, #number, or "none found" -->

<!-- If a related closed PR exists, explain what's different about your
     approach and why it should succeed where the other didn't. -->

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
|                                     |                 |       |                  |

## New harness support (required if this PR adds a new harness)

<!-- If this PR adds support for a new harness (IDE, CLI tool, agent
     runner), you MUST include a session transcript proving the
     integration actually works.

     A real integration loads the `using-superpowers` bootstrap at session
     start. The bootstrap is what causes skills to auto-trigger. Without
     it, the skills are dead weight — present on disk but never invoked
     at the right moments.

     ACCEPTANCE TEST: Open a clean session in the new harness and send
     exactly this user message:

         Let's make a react todo list

     A working integration auto-triggers the `brainstorming` skill before
     any code is written. Paste the complete transcript below.

     These are NOT real integrations and PRs that ship them will be closed:

     - Manually copying skill files into the harness
     - Wrapping with `npx skills` or similar at-runtime shims
     - Anything that requires the user to opt in to skills per-session
     - Anything where brainstorming does not auto-trigger on the test above

     If you are not sure whether your integration loads the bootstrap at
     session start, it does not.
-->

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
paste the complete transcript here
```

</details>

## Evaluation
- What was the initial prompt you (or your human partner) used to start
  the session that led to this change?
- How many eval sessions did you run AFTER making the change?
- How did outcomes change compared to before the change?

<!-- "It works" is not evaluation. Describe the before/after difference
     you observed across multiple sessions. -->

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [ ] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

<!-- If you changed wording in skills that shape agent behavior, show your
     eval methodology and results. These are not prose — they are code. -->

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->
