### PR TITLE
Fix 3 critical OpenCode integration bugs

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -48,6 +48,24 @@ use skill tool to list skills
 use skill tool to load brainstorming
 ```
 
+### Enabling todowrite for subagents
+
+Superpowers subagent-driven development requires subagents to use `todowrite` for TDD checklists. OpenCode disables `todowrite` for subagents by default. Enable it in `opencode.json`:
+
+```json
+{
+  "agent": {
+    "build": {
+      "permission": {
+        "todowrite": "allow"
+      }
+    }
+  }
+}
+```
+
+If you create custom agents for Superpowers, enable `todowrite` on each one that acts as an implementer.
+
 ## Updating
 
 OpenCode installs Superpowers through a git-backed package spec. Some OpenCode

--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -76,13 +76,17 @@ export const SuperpowersPlugin = async ({ client, directory }) => {
     const toolMapping = `**Tool Mapping for OpenCode:**
 When skills request actions, substitute OpenCode equivalents:
 - Create or update todos → \`todowrite\`
-- \`Subagent (general-purpose):\` → \`task\` with \`subagent_type: "general"\`
+- \`Subagent (general-purpose):\` → \`task\` with \`subagent_type: "general"\` (or \`"explore"\` for codebase exploration)
 - Invoke a skill → OpenCode's native \`skill\` tool
 - Read files → \`read\`
-- Create, edit, or delete files → \`apply_patch\`
+- Create a file → \`write\`
+- Edit an existing file → \`edit\`
+- Apply a diff/patch → \`patch\`
 - Run shell commands → \`bash\`
 - Search files → \`grep\`, \`glob\`
 - Fetch a URL → \`webfetch\`
+- Search the web → \`websearch\` (requires OPENCODE_ENABLE_EXA=1)
+- Ask user questions → \`question\`
 
 Use OpenCode's native \`skill\` tool to list and load skills.`;
 

--- a/docs/README.opencode.md
+++ b/docs/README.opencode.md
@@ -117,6 +117,24 @@ Skills speak in actions rather than naming any one runtime's tools. On OpenCode 
 
 (Verified against the installed OpenCode CLI's tool inventory.)
 
+### Enabling todowrite for subagents
+
+Superpowers subagent-driven development requires subagents to use `todowrite` for TDD checklists. OpenCode disables `todowrite` for subagents by default. Enable it in `opencode.json`:
+
+```json
+{
+  "agent": {
+    "build": {
+      "permission": {
+        "todowrite": "allow"
+      }
+    }
+  }
+}
+```
+
+If you create custom agents for Superpowers, enable `todowrite` on each one that acts as an implementer.
+
 ## Troubleshooting
 
 ### Plugin not loading

--- a/skills/using-superpowers/references/opencode-tools.md
+++ b/skills/using-superpowers/references/opencode-tools.md
@@ -1,0 +1,106 @@
+# OpenCode Tool Mapping
+
+Skills speak in actions ("dispatch a subagent", "create a todo", "read a file"). On OpenCode these resolve to the tools below.
+
+| Action skills request | OpenCode tool |
+|----------------------|---------------|
+| Read a file | `read` |
+| Create a file | `write` |
+| Edit an existing file | `edit` |
+| Delete a file | `bash` with `rm`/`del` |
+| Apply a diff/patch | `patch` |
+| Run a shell command | `bash` |
+| Search file contents | `grep` |
+| Find files by name | `glob` |
+| Fetch a URL | `webfetch` |
+| Search the web | `websearch` (requires `OPENCODE_ENABLE_EXA=1`) |
+| Invoke a skill | OpenCode's native `skill` tool |
+| Dispatch a subagent (`Subagent (general-purpose):` template) | `task` with `subagent_type: "general"` (or `"explore"` for read-only codebase exploration) |
+| Multiple parallel dispatches | Multiple `task` calls in one response |
+| Task tracking ("create a todo", "mark complete") | `todowrite` |
+| Ask user questions | `question` |
+| LSP code intelligence | `lsp` (experimental, requires `OPENCODE_EXPERIMENTAL_LSP_TOOL=true`) |
+
+## Instructions file
+
+When a skill mentions "your instructions file", on OpenCode this is **`AGENTS.md`** at the project root. OpenCode also reads `~/.config/opencode/AGENTS.md` for global context. As a fallback, `CLAUDE.md` is used if `AGENTS.md` does not exist.
+
+Additional instruction files can be configured via `opencode.json`:
+
+```json
+{
+  "instructions": ["CONTRIBUTING.md", "docs/guidelines.md"]
+}
+```
+
+## Personal skills directory
+
+User-level skills live at **`~/.config/opencode/skills/`**. OpenCode also reads:
+- `~/.claude/skills/` (Claude Code compatibility)
+- `~/.agents/skills/` (cross-runtime, shared with Codex, Copilot CLI, Gemini CLI)
+- `.opencode/skills/` (project-level)
+- `.claude/skills/` (project-level, Claude compatibility)
+- `.agents/skills/` (project-level, cross-runtime)
+
+Each skill is a subdirectory containing a `SKILL.md` with `name` and `description` frontmatter.
+
+## Model selection for subagents
+
+**Important limitation:** OpenCode's `task` tool does NOT accept a `model` parameter. Subagents inherit the model of the parent agent. To use different models for different task types, create separate OpenCode agents with different models configured:
+
+```json
+{
+  "agent": {
+    "superpowers-implementer": {
+      "mode": "subagent",
+      "model": "anthropic/claude-haiku-4-5"
+    },
+    "superpowers-reviewer": {
+      "mode": "subagent",
+      "model": "anthropic/claude-sonnet-4-5"
+    }
+  }
+}
+```
+
+Then dispatch with the appropriate `subagent_type`.
+
+**Alternative:** Use OpenCode's variant system (`Ctrl+T` in TUI) to switch reasoning levels before dispatching tasks:
+- Mechanical tasks → `low`/`minimal` variant
+- Integration tasks → default variant
+- Review/architecture tasks → `high`/`max` variant
+
+## Environment Detection
+
+Skills that create worktrees or finish branches should detect their environment with read-only git commands before proceeding:
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+BRANCH=$(git branch --show-current)
+```
+
+- `GIT_DIR != GIT_COMMON` → already in a linked worktree (skip creation)
+- `BRANCH` empty → detached HEAD (cannot branch/push/PR)
+
+## Compaction
+
+OpenCode supports auto-compaction. The SDD progress ledger (`.superpowers/sdd/progress.md`) is git-ignored scratch. After compaction, trust the ledger file and `git log` over conversation memory.
+
+## Permissions
+
+Recommend configuring these in `opencode.json` for Superpowers workflows:
+
+```json
+{
+  "permission": {
+    "external_directory": {
+      ".worktrees/**": "allow",
+      "worktrees/**": "allow"
+    },
+    "doom_loop": "allow"
+  }
+}
+```
+
+`external_directory` is needed because worktrees live outside the main repo. `doom_loop` is set to `allow` because the SDD review→fix→re-review cycle can trigger false-positive loop detection.


### PR DESCRIPTION
1. `apply_patch` is not an OpenCode tool - it was copy-pasted from the Codex tool mapping where it is correct. Agents trying to create or edit files would call a nonexistent tool and fail. Replaced with the three real OpenCode file tools: `write` (create), `edit` (modify), `patch` (apply diffs). Also added `websearch` and `question` which were missing entirely.

2. `todowrite` is disabled for subagents by default in OpenCode. This breaks subagent-driven development - implementer subagents cannot follow TDD checklists. Added config instructions to both INSTALL.md and README.opencode.md.

3. No `opencode-tools.md` existed - all 6 other supported platforms have one in `skills/using-superpowers/references/`, but OpenCode was missing. Skills rely on this file to know which tools to use on each platform. Created it (tool mapping, instructions file conventions, personal skills directory, model selection for subagents, permissions, compaction notes).
