### PR TITLE
fix: stop brainstorming from routing conversational asks to AskUserQuestion on Claude Code

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -59,13 +59,13 @@ digraph brainstorming {
 **Understanding the idea:**
 - Check out the current project state first (files, docs, recent commits)
 - Ask questions one at a time to refine the idea
-- Prefer multiple choice questions when possible, but open-ended is fine too
+- Prefer multiple choice questions when possible, but render choices as plain A/B/C/D terminal text, not a native picker widget. Open-ended is fine too
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
 - Focus on understanding: purpose, constraints, success criteria
 
 **Exploring approaches:**
 - Propose 2-3 different approaches with trade-offs
-- Present options conversationally with your recommendation and reasoning
+- Present options conversationally in terminal text with your recommendation and reasoning
 - Lead with your recommended option and explain why
 
 **Presenting the design:**
@@ -89,7 +89,7 @@ digraph brainstorming {
 ## Key Principles
 
 - **One question at a time** - Don't overwhelm with multiple questions
-- **Multiple choice preferred** - Easier to answer than open-ended when possible
+- **Multiple choice preferred** - Easier to answer than open-ended when possible; write the choices as A/B/C/D text in the terminal
 - **YAGNI ruthlessly** - Remove unnecessary features from all designs
 - **Explore alternatives** - Always propose 2-3 approaches before settling
 - **Incremental validation** - Present design, get approval before moving on

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -17,6 +17,12 @@ This is not negotiable. This is not optional. You cannot rationalize your way ou
 
 **In other environments:** Check your platform's documentation for how skills are loaded.
 
+## Platform Adaptation
+
+Skills speak in actions rather than naming any one runtime's tools. Map mechanism verbs to the local tool that performs them, such as dispatching a subagent, creating a todo, or reading a file.
+
+Interaction modality is part of the instruction. When a skill explicitly says to ask conversationally, present multiple-choice or other text options, or use the terminal, do that directly in the conversation. Do not remap those instructions to a native interactive-prompt or picker tool such as Claude Code's `AskUserQuestion`.
+
 # Using Skills
 
 ## The Rule

--- a/skills/using-superpowers/references/claude-code-tools.md
+++ b/skills/using-superpowers/references/claude-code-tools.md
@@ -1,0 +1,13 @@
+# Claude Code Tool Mapping
+
+Use this reference when translating skill instructions into Claude Code behavior.
+
+| Skill instruction | Claude Code behavior |
+|-------------------|----------------------|
+| Invoke or load a skill | Use the `Skill` tool. |
+| Dispatch a subagent or task | Use the local subagent/task mechanism. |
+| Create or update a todo | Use the local todo mechanism. |
+| Read, edit, or search files | Use the appropriate file and shell tools. |
+| Ask the user, present multiple-choice options, ask conversationally, present text options, or use the terminal | Render the question and any A/B/C/D choices as plain conversational terminal text. Do not use `AskUserQuestion`. |
+
+`AskUserQuestion` is not the default mapping for user questions. Only use a native interactive prompt or picker when a skill explicitly asks for that modality.


### PR DESCRIPTION
## Summary
The brainstorming skill instructed agents to "present options" and "ask conversationally", which on Claude Code was being remapped to the native `AskUserQuestion` picker. This clarifies that choices should render as plain A/B/C/D terminal text, and adds a platform-adaptation note plus a Claude Code tool-mapping reference so the conversational instruction is not rerouted to a native picker widget.

Fixes #1773

AI was used for assistance.
