### PR TITLE
fix: namespace SDD task reports per-plan so multiple plans don't overwrite task-N-report.md

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -88,6 +88,39 @@ digraph process {
 - `./spec-reviewer-prompt.md` - Dispatch spec compliance reviewer subagent
 - `./code-quality-reviewer-prompt.md` - Dispatch code quality reviewer subagent
 
+## File Handoffs
+
+Use the scripts in `./scripts/` for short-lived task artifacts. `./scripts/sdd-workspace` is the single source of truth for where SDD artifacts live.
+
+When a plan file is available, resolve paths through the plan-scoped workspace:
+
+```
+workspace=$(./scripts/sdd-workspace "$PLAN_FILE")
+```
+
+This writes artifacts under `.superpowers/sdd/<plan-slug>/`, where `<plan-slug>` is a safe single path segment derived from the plan identity. If no plan identity is supplied, `sdd-workspace` intentionally falls back to the legacy `.superpowers/sdd/` directory.
+
+For each task, create the brief with:
+
+```
+./scripts/task-brief "$PLAN_FILE" "$TASK_NUMBER"
+```
+
+The default task brief path is `.superpowers/sdd/<plan-slug>/task-N-brief.md`. The implementer report for the same task must replace `-brief.md` with `-report.md`, for example `.superpowers/sdd/<plan-slug>/task-N-report.md`.
+
+For review packages, pass the same plan identity through the environment so reviewers read from the same plan-scoped workspace instead of the legacy flat directory:
+
+```
+SDD_PLAN_ID="$PLAN_FILE" ./scripts/review-package "$BASE_REF" "$HEAD_REF"
+```
+
+For the progress ledger, read from the resolved workspace rather than hard-coding the flat path:
+
+```
+workspace=$(./scripts/sdd-workspace "$PLAN_FILE")
+cat "$workspace/progress.md" 2>/dev/null || true
+```
+
 ## Example Workflow
 
 ```

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Build a compact review package for the current SDD task.
+#
+# Usage:
+#   review-package BASE_REF HEAD_REF [OUTFILE]
+#
+# If OUTFILE is omitted, the package is written into the SDD workspace. Set
+# SDD_PLAN_ID to the same plan identity used for task-brief to keep review
+# artifacts next to the implementer's report.
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 BASE_REF HEAD_REF [OUTFILE]" >&2
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
+    exit 2
+fi
+
+base_ref=$1
+head_ref=$2
+
+git rev-parse --verify "$base_ref^{commit}" >/dev/null
+git rev-parse --verify "$head_ref^{commit}" >/dev/null
+
+if [ "$#" -eq 3 ]; then
+    outfile=$3
+else
+    script_dir=$(cd "$(dirname "$0")" && pwd)
+    workspace=$("$script_dir/sdd-workspace")
+    safe_base=$(printf '%s' "$base_ref" | sed 's/[^A-Za-z0-9._-]/-/g')
+    safe_head=$(printf '%s' "$head_ref" | sed 's/[^A-Za-z0-9._-]/-/g')
+    outfile="$workspace/review-$safe_base..$safe_head.md"
+fi
+
+mkdir -p "$(dirname "$outfile")"
+
+{
+    echo "# Review Package: $base_ref..$head_ref"
+    echo
+    echo "## Commit Summary"
+    echo
+    git log --oneline "$base_ref..$head_ref" || true
+    echo
+    echo "## Changed Files"
+    echo
+    git diff --name-status "$base_ref..$head_ref"
+    echo
+    echo "## Diff"
+    echo
+    echo '```diff'
+    git diff -U10 "$base_ref..$head_ref"
+    echo '```'
+} > "$outfile"
+
+line_count=$(wc -l < "$outfile" | tr -d ' ')
+echo "wrote $outfile: $line_count lines"

--- a/skills/subagent-driven-development/scripts/sdd-workspace
+++ b/skills/subagent-driven-development/scripts/sdd-workspace
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Resolve and ensure the short-lived workspace for subagent-driven-development.
+#
+# This is the single source of truth for SDD artifact paths. Keep task-brief and
+# review-package pointed here so brief, report, review, and progress files stay
+# in the same directory.
+#
+# Usage:
+#   sdd-workspace [PLAN_ID]
+#
+# With no PLAN_ID, this preserves the legacy workspace:
+#   <repo-root>/.superpowers/sdd
+#
+# With PLAN_ID (or SDD_PLAN_ID / SDD_PLAN_SLUG), artifacts are namespaced:
+#   <repo-root>/.superpowers/sdd/<safe-plan-slug>-<checksum>
+set -euo pipefail
+
+if [ "$#" -gt 1 ]; then
+    echo "usage: $0 [PLAN_ID]" >&2
+    exit 2
+fi
+
+root=$(git rev-parse --show-toplevel)
+plan_id="${1:-${SDD_PLAN_ID:-${SDD_PLAN_SLUG:-}}}"
+dir="$root/.superpowers/sdd"
+
+if [ -n "$plan_id" ]; then
+    base=$(basename "$plan_id")
+
+    case "$base" in
+        .* | *.*.*)
+            stem="${base%.*}"
+            ;;
+        *.*)
+            stem="${base%.*}"
+            ;;
+        *)
+            stem="$base"
+            ;;
+    esac
+
+    slug=$(
+        printf '%s' "$stem" |
+            LC_ALL=C tr '[:upper:]' '[:lower:]' |
+            sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//' |
+            cut -c 1-80
+    )
+    if [ -z "$slug" ]; then
+        slug="plan"
+    fi
+
+    checksum=$(printf '%s' "$plan_id" | cksum | awk '{print $1}')
+    dir="$dir/$slug-$checksum"
+fi
+
+mkdir -p "$dir"
+printf '*\n' > "$dir/.gitignore"
+cd "$dir"
+pwd

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Extract the brief for a single task from an implementation plan.
+#
+# Usage:
+#   task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
+#
+# If OUTFILE is omitted, the brief is written into the plan-scoped SDD workspace:
+#   <repo-root>/.superpowers/sdd/<plan-slug>/task-N-brief.md
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 PLAN_FILE TASK_NUMBER [OUTFILE]" >&2
+}
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    usage
+    exit 2
+fi
+
+plan_file=$1
+task_number=$2
+
+if [ ! -f "$plan_file" ]; then
+    echo "task-brief: plan file not found: $plan_file" >&2
+    exit 1
+fi
+
+case "$task_number" in
+    '' | *[!0-9]*)
+        echo "task-brief: task number must be numeric: $task_number" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$#" -eq 3 ]; then
+    outfile=$3
+else
+    script_dir=$(cd "$(dirname "$0")" && pwd)
+    plan_dir=$(cd "$(dirname "$plan_file")" && pwd)
+    plan_id="$plan_dir/$(basename "$plan_file")"
+    workspace=$("$script_dir/sdd-workspace" "$plan_id")
+    outfile="$workspace/task-$task_number-brief.md"
+fi
+
+mkdir -p "$(dirname "$outfile")"
+
+awk -v n="$task_number" '
+    BEGIN {
+        in_task = 0
+        in_fence = 0
+        lines = 0
+    }
+
+    /^```/ {
+        if (in_task) {
+            print
+            lines++
+        }
+        in_fence = !in_fence
+        next
+    }
+
+    !in_fence && $0 ~ "Task " n "([^0-9]|$)" {
+        in_task = 1
+    }
+
+    !in_fence && in_task && $0 ~ /^#{1,6}[[:space:]]+Task [0-9]+/ && $0 !~ "Task " n "([^0-9]|$)" {
+        exit
+    }
+
+    in_task {
+        print
+        lines++
+    }
+
+    END {
+        if (lines == 0) {
+            exit 1
+        }
+    }
+' "$plan_file" > "$outfile" || {
+    rm -f "$outfile"
+    echo "task-brief: task $task_number not found in $plan_file" >&2
+    exit 1
+}
+
+line_count=$(wc -l < "$outfile" | tr -d ' ')
+echo "wrote $outfile: $line_count lines"

--- a/tests/subagent-driven-dev/test-sdd-artifact-workspace.sh
+++ b/tests/subagent-driven-dev/test-sdd-artifact-workspace.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tests for subagent-driven-development artifact workspace scripts.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT_DIR="$REPO_ROOT/skills/subagent-driven-development/scripts"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local expected=$1
+    local actual=$2
+    local message=$3
+
+    if [ "$expected" != "$actual" ]; then
+        fail "$message: expected '$expected', got '$actual'"
+    fi
+}
+
+assert_file() {
+    local file=$1
+    [ -f "$file" ] || fail "expected file to exist: $file"
+}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+worktree="$tmpdir/repo"
+mkdir -p "$worktree"
+cd "$worktree"
+worktree=$(pwd -P)
+
+git init --quiet
+git config user.email "test@example.com"
+git config user.name "Test User"
+
+echo "initial" > file.txt
+git add file.txt
+git commit -m "initial" --quiet
+
+legacy_workspace=$("$SCRIPT_DIR/sdd-workspace")
+assert_eq "$worktree/.superpowers/sdd" "$legacy_workspace" "legacy workspace path"
+assert_file "$legacy_workspace/.gitignore"
+assert_eq "*" "$(cat "$legacy_workspace/.gitignore")" "legacy workspace gitignore"
+
+mkdir -p "plans/a" "plans/b"
+plan_a="$worktree/plans/a/Same Plan.md"
+plan_b="$worktree/plans/b/Same_Plan.md"
+
+cat > "$plan_a" <<'PLAN'
+# Plan A
+
+## Task 1: Alpha
+
+Implement alpha.
+
+## Task 2: Beta
+
+Implement beta.
+PLAN
+
+cat > "$plan_b" <<'PLAN'
+# Plan B
+
+## Task 1: Gamma
+
+Implement gamma.
+PLAN
+
+brief_a_output=$("$SCRIPT_DIR/task-brief" "$plan_a" 1)
+brief_b_output=$("$SCRIPT_DIR/task-brief" "$plan_b" 1)
+
+brief_a=${brief_a_output#wrote }
+brief_a=${brief_a%%:*}
+brief_b=${brief_b_output#wrote }
+brief_b=${brief_b%%:*}
+
+assert_file "$brief_a"
+assert_file "$brief_b"
+
+dir_a=$(dirname "$brief_a")
+dir_b=$(dirname "$brief_b")
+
+[ "$dir_a" != "$legacy_workspace" ] || fail "plan A brief used legacy workspace"
+[ "$dir_b" != "$legacy_workspace" ] || fail "plan B brief used legacy workspace"
+[ "$dir_a" != "$dir_b" ] || fail "plans with colliding sanitized names used the same workspace"
+
+case "$(basename "$dir_a")" in
+    *[!a-z0-9-]*)
+        fail "plan A workspace is not a safe single path segment: $(basename "$dir_a")"
+        ;;
+esac
+
+case "$(basename "$dir_b")" in
+    *[!a-z0-9-]*)
+        fail "plan B workspace is not a safe single path segment: $(basename "$dir_b")"
+        ;;
+esac
+
+grep -q "Implement alpha" "$brief_a" || fail "plan A brief missing task 1 content"
+if grep -q "Implement beta" "$brief_a"; then
+    fail "plan A brief leaked task 2 content"
+fi
+
+report_a="${brief_a%-brief.md}-report.md"
+report_b="${brief_b%-brief.md}-report.md"
+printf 'report A\n' > "$report_a"
+printf 'report B\n' > "$report_b"
+
+assert_file "$report_a"
+assert_file "$report_b"
+assert_eq "report A" "$(cat "$report_a")" "plan A report content"
+assert_eq "report B" "$(cat "$report_b")" "plan B report content"
+
+echo "changed" > file.txt
+git add file.txt
+git commit -m "change file" --quiet
+base_ref=HEAD~1
+
+mkdir -p "$legacy_workspace"
+printf 'stale review package\n' > "$legacy_workspace/review-$base_ref..HEAD.md"
+
+plan_a_id="$(cd "$(dirname "$plan_a")" && pwd)/$(basename "$plan_a")"
+review_output=$(SDD_PLAN_ID="$plan_a_id" "$SCRIPT_DIR/review-package" "$base_ref" HEAD)
+review_path=${review_output#wrote }
+review_path=${review_path%%:*}
+
+assert_file "$review_path"
+assert_eq "$dir_a" "$(dirname "$review_path")" "review package workspace matches task brief workspace"
+assert_eq "stale review package" "$(cat "$legacy_workspace/review-$base_ref..HEAD.md")" "stale flat review package was untouched"
+grep -q "changed" "$review_path" || fail "review package missing diff content"
+
+echo "All SDD artifact workspace tests passed"


### PR DESCRIPTION
## Summary
When multiple plans run subagent-driven development in the same repo, their task reports collided on a shared `task-N-report.md` path, so a later plan overwrote an earlier plan's reports. This namespaces SDD artifacts per-plan under `.superpowers/sdd/<plan-slug>/`, with `./scripts/sdd-workspace` as the single source of truth for artifact paths. With no plan identity supplied it falls back to the legacy `.superpowers/sdd/` directory, so existing flows are unchanged.

Adds `task-brief`, `review-package`, and `sdd-workspace` helper scripts plus an artifact-workspace test.

Fixes #1816

AI was used for assistance.
