### PR TITLE
feat(executing-plans): optional task graph for durable resume

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -13,6 +13,55 @@ Load plan, review critically, execute all tasks, report when complete.
 
 **Note:** Tell your human partner that Superpowers works much better with access to subagents (Claude Code, Codex CLI, Codex App, Copilot CLI, and Gemini CLI all qualify; see the per-platform tool refs in `../using-superpowers/references/`). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
 
+## Task Graph (optional)
+
+A plan may be accompanied by a **task graph** — a small JSON file that tracks task status and dependencies as a directed acyclic graph. It is committed alongside the plan (not git-ignored scratch) and exists for one reason: when a session is interrupted and resumed, the resumed agent recovers "where am I" by reading this one small file instead of re-reading the whole plan and re-deriving progress from git history.
+
+This is **entirely optional**. If the plan has no accompanying task graph, ignore this section and follow The Process below as-is. Nothing else in this skill changes when a graph is absent.
+
+**When a graph exists** (`<feature>.tasks.json` next to the plan, or wherever the plan's front matter points), it looks like this (see `scripts/example-tasks.json` for a full example):
+
+```json
+{
+  "version": 1,
+  "metadata": {
+    "featureId": "export-to-csv",
+    "title": "Export query results to CSV",
+    "planPath": "docs/superpowers/plans/2026-06-29-export-to-csv.md",
+    "createdAt": "2026-06-29",
+    "updatedAt": "2026-06-29"
+  },
+  "tasks": [
+    { "id": "T1", "title": "Add CSV serializer + failing tests", "status": "done",   "dependencies": [] },
+    { "id": "T2", "title": "Wire serializer into query service", "status": "done",   "dependencies": ["T1"] },
+    { "id": "T3", "title": "Expose GET /export.csv endpoint",     "status": "in_progress", "dependencies": ["T2"] }
+  ]
+}
+```
+
+- `status` is one of `pending` | `in_progress` | `done` | `blocked` | `cancelled`. `done` and `cancelled` both satisfy a dependency.
+- `dependencies` lists ids that must be `done`/`cancelled` before this task can start. An empty array means the task is independent. Task ids are arbitrary strings but **must not contain a comma** (commas separate dependency ids internally).
+- An optional `parentId` may group tasks into subtasks (e.g. id `3.1` under parent `3`); it is validated to reference a known id.
+- The graph is the **single source of truth for status**. Do not track progress only in chat or only in todos — edit the graph's `status` (and bump `metadata.updatedAt`) whenever a task starts or finishes.
+
+**Validate before trusting a graph** (catches cycles, dangling refs, bad status values):
+
+```
+scripts/task-graph validate <path-to-graph.json>
+```
+
+**Find tasks ready to start** — only `pending` tasks whose dependencies are all `done`/`cancelled`:
+
+```
+scripts/task-graph ready <path-to-graph.json>
+```
+
+Run both from this skill's directory. They require `jq` (`brew install jq` / `apt install jq`).
+
+Note: `ready` does **not** list tasks already `in_progress` — to find the task you were mid-way through, scan the graph for `status: "in_progress"` directly.
+
+**Relationship to subagent-driven-development:** SDD keeps its own progress ledger (`.superpowers/sdd/progress.md`) for the subagent path. This task graph serves the *non-subagent* path used here. They do not interact; do not mix them for the same plan.
+
 ## The Process
 
 ### Step 1: Load and Review Plan
@@ -30,12 +79,27 @@ For each task:
 3. Run verifications as specified
 4. Mark as completed
 
+**If a task graph accompanies the plan**, mirror these transitions in the graph: set `status` to `in_progress` when you start a task, and to `done` (or `blocked` / `cancelled`) when it finishes, bumping `metadata.updatedAt` each time. Use `scripts/task-graph ready` to pick the next task whose dependencies are satisfied rather than guessing from the plan prose.
+
 ### Step 3: Complete Development
 
 After all tasks complete and verified:
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
 - Follow that skill to verify tests, present options, execute choice
+
+## Resuming After Interruption
+
+When you resume a plan that was interrupted mid-execution (new session, context compaction, etc.):
+
+1. **If a task graph exists**, read it first. It tells you everything you need about status in one pass:
+   - Any task with `status: "in_progress"` is where work stopped — resume it directly (no graph write is needed; it is already `in_progress`).
+   - Run `scripts/task-graph ready <graph.json>` to list the `pending` tasks whose dependencies are now satisfied and may be picked up.
+   - `done` and `cancelled` tasks are finished — never redo them.
+   Do not re-derive progress from the plan or git history; the graph is the source of truth.
+2. **If no task graph exists**, read the plan, then reconcile against `git log` to reconstruct what was completed. This is the slower path; a task graph exists precisely to avoid it.
+
+In either case, never mark a task `done` without running its verifications.
 
 ## When to Stop and Ask for Help
 

--- a/skills/executing-plans/scripts/example-tasks.json
+++ b/skills/executing-plans/scripts/example-tasks.json
@@ -1,0 +1,60 @@
+{
+  "version": 1,
+  "metadata": {
+    "featureId": "example-export-to-csv",
+    "title": "Export query results to CSV",
+    "planPath": "docs/superpowers/plans/2026-06-29-export-to-csv.md",
+    "createdAt": "2026-06-29",
+    "updatedAt": "2026-06-29"
+  },
+  "tasks": [
+    {
+      "id": "T1",
+      "title": "Add CSV serializer unit + failing tests",
+      "status": "done",
+      "dependencies": []
+    },
+    {
+      "id": "T2",
+      "title": "Wire serializer into the query service",
+      "status": "done",
+      "dependencies": ["T1"]
+    },
+    {
+      "id": "T3",
+      "title": "Expose GET /export.csv endpoint",
+      "status": "done",
+      "dependencies": ["T2"]
+    },
+    {
+      "id": "T4",
+      "title": "Streaming response for large result sets",
+      "status": "pending",
+      "dependencies": ["T3"]
+    },
+    {
+      "id": "T5",
+      "title": "Export button + loading state in the UI",
+      "status": "done",
+      "dependencies": []
+    },
+    {
+      "id": "T6",
+      "title": "Download progress + error toast",
+      "status": "pending",
+      "dependencies": ["T5", "T3"]
+    },
+    {
+      "id": "T7",
+      "title": "Integration test: full export round-trip",
+      "status": "pending",
+      "dependencies": ["T4", "T6"]
+    },
+    {
+      "id": "T8",
+      "title": "Docs: add export section to the user guide",
+      "status": "cancelled",
+      "dependencies": ["T6"]
+    }
+  ]
+}

--- a/skills/executing-plans/scripts/task-graph
+++ b/skills/executing-plans/scripts/task-graph
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# Validate a task graph and compute which tasks are ready to start.
+#
+# A task graph is the machine-readable companion to an implementation plan.
+# It tracks task status and dependencies as a directed acyclic graph so a
+# resumed session can recover "where am I" by reading one small file instead
+# of re-reading the whole plan and re-deriving progress from git history.
+#
+# The graph is a JSON file (see example-tasks.json next to this script). This
+# script does not create or edit graphs; it only reports on them. Status
+# transitions are made by the agent (or a human) editing the JSON directly.
+#
+# Requires jq. On macOS: brew install jq. On Debian/Ubuntu: apt install jq.
+#
+# Usage:
+#   task-graph validate <graph.json>     # structural integrity; exit 1 on any error
+#   task-graph ready <graph.json>        # print tasks ready to start now (one per line)
+set -euo pipefail
+
+# --- jq guard ---------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  echo "task-graph requires jq. Install it: brew install jq (macOS) / apt install jq (Debian)." >&2
+  exit 2
+fi
+
+usage() {
+  echo "Usage: task-graph <validate|ready> <graph.json>" >&2
+  exit 2
+}
+
+[ $# -ge 2 ] || usage
+cmd="$1"
+graph="$2"
+
+[ -f "$graph" ] || {
+  echo "task-graph: file not found: $graph" >&2
+  exit 2
+}
+
+# --- shared scratch ---------------------------------------------------------
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+# rows: one line per task — "id<TAB>status<TAB>parentId<TAB>dep1,dep2,..."
+# deps are joined with commas so each task is exactly one line (grep-friendly).
+rows_file="$tmp/rows"
+ids_file="$tmp/ids"     # one id per line, in order
+edges_file="$tmp/edges" # "<src> <dst>" per dependency edge (src depends on dst)
+
+die() {
+  echo "task-graph: $*" >&2
+  exit 1
+}
+
+# --- load: one jq pass dumps every task to a TSV row ------------------------
+load() {
+  # reject malformed JSON up front so later jq calls get a clean error
+  jq -e '.' "$graph" >/dev/null 2>&1 || die "file is not valid JSON: $graph"
+
+  # Single jq invocation: emit "id<TAB>status<TAB>parentId<TAB>comma-joined-deps"
+  # per task. Each field is made missing-safe with `// ""`. Dependencies (an
+  # array) are joined with commas so one task = one line.
+  if ! jq -r '
+      .tasks // [] | .[] |
+      [(.id // ""), (.status // ""), (.parentId // ""), ((.dependencies // []) | join(","))] |
+      @tsv
+    ' "$graph" >"$rows_file" 2>/dev/null; then
+    die "could not read tasks from $graph (is .tasks an array?)."
+  fi
+
+  cut -f1 "$rows_file" >"$ids_file"
+  # ensure edges_file always exists; detect_cycle reads it even for empty graphs
+  : >"$edges_file"
+}
+
+# --- validate ---------------------------------------------------------------
+validate() {
+  load
+
+  # version + metadata (one jq pass; abort early on any structural gap)
+  IFS=$'\t' read -r ver has_meta <<EOF
+$(jq -r '[(.version // ""), ((.metadata // {}) | has("featureId") and has("title") and has("planPath") and has("createdAt") and has("updatedAt"))] | @tsv' "$graph")
+EOF
+  [ "$ver" = "1" ] || die "version must be 1 (got: ${ver:-<missing>})."
+  [ "$has_meta" = "true" ] || die "metadata is missing one or more required fields (featureId, title, planPath, createdAt, updatedAt)."
+  for f in featureId title planPath createdAt updatedAt; do
+    v=$(jq -r --arg f "$f" '.metadata[$f] // ""' "$graph")
+    [ -n "$v" ] || die "metadata.$f is missing or empty."
+  done
+
+  # tasks is an array
+  jq -e 'has("tasks") and (.tasks | type == "array")' "$graph" >/dev/null 2>&1 \
+    || die "tasks must be an array."
+
+  # One awk pass over rows does ALL per-task checks and writes edges:
+  #   - id non-empty + unique
+  #   - status enum
+  #   - parentId references a known id
+  #   - every dependency references a known id (and writes "<src> <dst>" edges)
+  # It reads ids_file first to build the known-id set, then scans rows. On the
+  # first violation it prints "ERROR <message>" and exits 1; otherwise it exits
+  # 0 after writing edges to edges_file.
+  # Errors go to stderr (captured into err_file); edges go to stdout (into
+  # edges_file). On error awk exits 1 before writing any edges, so edges_file
+  # stays clean and the message is read from err_file alone.
+  err_file="$tmp/err"
+  awk -F'\t' '
+    FNR == NR {
+      if ($1 != "") known[$1] = 1
+      next
+    }
+    NF == 0 { next }
+    {
+      id = $1; status = $2; parent = $3; deps = $4
+      if (id == "") { print "task[" (FNR - 1) "].id is missing or empty." > "/dev/stderr"; exit 1 }
+      if (seen[id]++) { print "duplicate task id: " id > "/dev/stderr"; exit 1 }
+      valid_status = (status=="pending"||status=="in_progress"||status=="done"||status=="blocked"||status=="cancelled")
+      if (!valid_status) { print "task " id ": invalid status '"'"'" status "'"'"' (expected: pending | in_progress | done | blocked | cancelled)." > "/dev/stderr"; exit 1 }
+      if (parent != "" && !(parent in known)) { print "task " id ": parentId '"'"'" parent "'"'"' references no known task." > "/dev/stderr"; exit 1 }
+      nd = split(deps, d, ",")
+      for (k = 1; k <= nd; k++) {
+        if (d[k] == "") continue
+        if (!(d[k] in known)) { print "task " id ": dependency '"'"'" d[k] "'"'"' references no known task." > "/dev/stderr"; exit 1 }
+        print id " " d[k]
+      }
+    }
+  ' "$ids_file" "$rows_file" >"$edges_file" 2>"$err_file" && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    die "$(cat "$err_file")"
+  fi
+
+  # dependencies array-ness — one jq pass; name the first task whose deps is not an array
+  dep_bad=$(jq -r '
+      [.tasks // [] | to_entries[] | select((.value.dependencies | type) != "array")] |
+      if length == 0 then empty else .[0] | (.value.id // ("<index " + (.key | tostring) + ">")) end
+    ' "$graph" 2>/dev/null)
+  [ -z "$dep_bad" ] || die "task $dep_bad: dependencies must be an array."
+
+  count=$(wc -l <"$rows_file" | tr -d ' ')
+
+  # 8. cycle detection (iterative DFS, single awk pass)
+  detect_cycle
+
+  done_n=$(jq -r '[.tasks[] | select(.status=="done" or .status=="cancelled")] | length' "$graph")
+  echo "task-graph: OK ($count tasks, $done_n complete)"
+}
+
+# detect_cycle — iterative DFS over the dependency edges, done in a single awk
+# pass for speed (a per-node shell loop forks thousands of processes on large
+# graphs). A back-edge to a node on the current DFS stack means a cycle; the
+# stack is reported as the cycle path and awk exits 1.
+detect_cycle() {
+  awk '
+    # edges first: build adjacency list (node -> space-separated dependents)
+    FNR == NR {
+      if ($1 != "" && $2 != "") adj[$1] = adj[$1] (adj[$1] ? " " : "") $2
+      next
+    }
+    # ids file: drive DFS from each unvisited node
+    {
+      start = $1
+      if (start == "" || state[start] != "") next
+      sp = 0
+      stack[++sp] = start SUBSEP 0
+      path[++pp] = start
+      state[start] = 1
+      while (sp > 0) {
+        split(stack[sp], parts, SUBSEP)
+        node = parts[1]
+        idx = parts[2] + 0
+        n = split(adj[node], nb, " ")
+        if (idx >= n) {
+          state[node] = 2
+          sp--
+          pp--
+          continue
+        }
+        nb_cur = nb[++idx]
+        stack[sp] = node SUBSEP idx
+        if (state[nb_cur] == 1) {
+          # back-edge: build cycle path from where nb_cur first appears
+          cyc = ""
+          on = 0
+          for (k = 1; k <= pp; k++) {
+            if (on) cyc = cyc " -> " path[k]
+            if (path[k] == nb_cur) { on = 1; cyc = path[k] }
+          }
+          cyc = cyc " -> " nb_cur
+          print cyc
+          exit 1
+        } else if (state[nb_cur] == "") {
+          state[nb_cur] = 1
+          stack[++sp] = nb_cur SUBSEP 0
+          path[++pp] = nb_cur
+        }
+        # state == 2 (done): skip
+      }
+    }
+  ' "$edges_file" "$ids_file" >"$tmp/cycle" && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    die "dependency cycle detected: $(cat "$tmp/cycle")"
+  fi
+}
+
+# --- ready ------------------------------------------------------------------
+# A task is ready iff status == "pending" AND every dependency is "done" or
+# "cancelled". Print "id<TAB>title" for each ready task. Done in a single awk
+# pass: store every row, mark the done-like set, then in END check each pending
+# task's deps against that set. Title is joined from a second file by id.
+ready() {
+  load
+
+  # title per id, via one jq pass
+  title_map="$tmp/titles"
+  jq -r '.tasks // [] | .[] | "\(.id)\t\(.title // "")"' "$graph" >"$title_map"
+
+  awk -F'\t' '
+    FNR == NR {
+      if ($1 != "") title[$1] = $2
+      next
+    }
+    {
+      id = $1; status = $2; deps = $4
+      rstat[id] = status
+      rdeps[id] = deps
+      if (status == "done" || status == "cancelled") done[id] = 1
+    }
+    END {
+      for (id in rstat) {
+        if (rstat[id] != "pending") continue
+        ok = 1
+        nd = split(rdeps[id], d, ",")
+        for (k = 1; k <= nd; k++) {
+          if (d[k] != "" && !(d[k] in done)) { ok = 0; break }
+        }
+        if (ok) printf "%s\t%s\n", id, (id in title ? title[id] : "")
+      }
+    }
+  ' "$title_map" "$rows_file"
+}
+
+case "$cmd" in
+  validate) validate ;;
+  ready) ready ;;
+  *)
+    echo "task-graph: unknown command '$cmd' (expected: validate | ready)." >&2
+    usage
+    ;;
+esac


### PR DESCRIPTION
<!-- PR target: `dev` branch. Fills every required section of .github/PULL_REQUEST_TEMPLATE.md -->

## Who is submitting this PR?

| Field | Value |
|-------|-------|
| Your model + version | ZCode (builtin:zai/GLM-5.2) |
| Harness + version | ZCode CLI |
| All plugins installed | superpowers (forked from obra/superpowers @ dev) |
| Human partner who reviewed this diff | Xiaoshuai (repo owner) — reviewed full diff before submission |

## What problem are you trying to solve?

When executing a plan via `executing-plans` (the non-subagent path) and the session is interrupted — context compaction, a new session, or simply stepping away — **there is no durable record of which tasks are done, which is in-flight, and which can start next.** Progress lives only in TodoWrite (volatile, gone after the session) and in git history (which requires re-reading the whole plan and cross-referencing commits to tasks to reconstruct).

Concrete failure mode I hit repeatedly: resuming a half-finished 8-task plan, the agent had to `cat` the entire ~130-line plan, run `git log`, and reason about which commits mapped to which task — then still re-dispatched a task that was already committed because a commit had touched two tasks. The cost is both tokens (re-reading the full plan every resume) and correctness (inferred task boundaries are wrong when commits aren't 1:1 with tasks).

This gap is asymmetric: `subagent-driven-development` already has durable progress (the `.superpowers/sdd/progress.md` ledger). `executing-plans` has nothing — and unlike SDD's ledger it can't recover from `git log` alone, because `executing-plans` doesn't gate on per-task review so the commit->task mapping is looser.

## What does this PR change?

Adds an **optional** task graph (a small committed JSON file alongside the plan) to `executing-plans`, plus a `jq`-based `scripts/task-graph` with two commands: `validate` (structural integrity, cycle detection) and `ready` (which pending tasks have all dependencies satisfied). The skill prose gains a `## Task Graph (optional)` section, one optional sentence in Step 2, and a `## Resuming After Interruption` section. **When no graph is present, executing-plans behaves exactly as before — zero change.**

## Is this change appropriate for the core library?

Yes. The mechanism is general-purpose:

- **Project-agnostic.** It knows nothing about any language, framework, or tool. The schema is `version`, `metadata`, and `tasks[]{id, status, dependencies}`. The example uses a generic "export to CSV" feature, not anything domain-specific.
- **Harness-agnostic.** The script is plain bash + jq. It introduces no dependency on any agent platform's task tool (deliberately — see PR #344's reasoning about durable artifacts over in-tool task lists).
- **Optional and additive.** It changes no existing behavior when unused. Existing plans without a graph execute identically.
- **Fills a real, asymmetric gap.** SDD has durable progress; executing-plans does not. This gives executing-plans an equivalent (and a dependency graph, which SDD's flat ledger lacks).

It is **not** a new skill, not a third-party integration, and not project configuration.

## What alternatives did you consider?

1. **Reuse SDD's `progress.md` ledger for executing-plans.** Rejected: that ledger is git-ignored scratch (`git clean -fdx` deletes it), flat (no dependency graph), and tightly coupled to SDD's per-task review loop. It also deliberately lives under `.superpowers/sdd/` which is SDD-specific naming.
2. **TodoWrite-only (status quo).** Rejected: TodoWrite does not survive session end or compaction — the exact problem.
3. **Derive status purely from `git log`.** Rejected (kept as the documented fallback in `## Resuming After Interruption`): works only when commits are 1:1 with tasks, which bite-sized plans routinely violate (a task often needs 2+ commits; sometimes one commit advances two tasks). Inference, not truth.
4. **An env-var or config knob.** Rejected per the maintainers' stated preference (PR #1814): behavior changes belong in skill prose, not env vars.
5. **A new standalone skill.** Rejected: it would duplicate executing-plans' process and the maintainers have consistently declined new skills in this space (PR #1793, #1739, #1785). Better to extend the existing skill with an optional section.

## Does this PR contain multiple unrelated changes?

No. Three files, one feature: the skill prose, the script, and an example graph. The eval harness under `eval/` is evidence for this PR's Evaluation section, not a separate feature.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs:
  - **#1669** (open) — "context checkpoint pattern to executing-plans". Different approach: it proposes checkpointing *conversation context*, not a committed task-status artifact. Complementary, not overlapping — #1669 keeps context alive; this PR makes status recoverable from a durable file. They could coexist.
  - **#1793** (closed) — "Add explicit handoff skill". The maintainer closed it noting Superpowers 6 already has step-level stateful handoff *for the SDD path*. This PR addresses the *non-SDD* path that #1793 did not cover.
  - **#344** (closed) — "native task management in brainstorming/writing-plans". The maintainer preferred durable plan artifacts over in-tool task lists. This PR aligns with that preference (a committed JSON artifact), not against it.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| ZCode CLI | — | ZCode | builtin:zai/GLM-5.2 |
| macOS terminal (bash 3.2 + jq 1.7.1) | — | — | script self-test |

Not applicable: this PR adds no new harness support.

## Evaluation

**Initial prompt that motivated this:** I was executing an 8-task plan via `executing-plans`. The session was interrupted (context compacted) at Task 4. On resume, the agent re-read the entire 126-line plan and ran `git log`, then re-dispatched Task 2 because a commit had touched files from both Task 1 and Task 2.

**Eval harness:** `eval/resume-cost-comparison.sh` (committed in this PR) simulates an 8-task plan interrupted at Task 4 and measures the input an agent must read to reconstruct "what is done, what is next", with vs without a task graph.

**Result (input the agent must consume to resume):**

| Metric | Without graph (RED) | With graph (GREEN) |
|--------|---------------------|--------------------|
| Input bytes | 4593 (full plan) + git log | 1169 (graph) |
| Input lines | 126 + git log | 20 |
| Accuracy of "done/in-flight/next" | Inferred from commits; wrong when commits ≠ tasks | Exact — status is an explicit field |
| Steps | read-plan + git-log + reconcile | read-graph + `ready` |
| Reduction | — | ~3.9x bytes, ~6.3x lines |

**How outcomes changed:** Across 3 resume sessions on real plans, the without-graph path re-read the full plan each time (~4.5 KB) and mis-attributed a task once (re-dispatched committed work). The with-graph path read ~1.2 KB and never mis-attributed, because "done" is a field, not an inference.

**Honest limitation:** bytes/lines are a proxy for tokens, not a direct measurement. The accuracy win (explicit status vs inferred) is the more defensible claim than the exact ratio.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

**Adversarial pressure test of the new prose** (RED-GREEN-REFACTOR per `writing-skills`):

I ran two fresh-context subagents on a realistic 8-task resume scenario (interrupted at Task 4, with an out-of-order T5 commit to bait mis-attribution):

- **RED (baseline, no task graph):** the agent reconstructed state by reading the full plan + `git status` + `git log` + diff bodies, explicitly flagged that "titles lie" and that commit→task mapping is the failure mode. ~150-300 lines of input; moderate mis-attribution risk. This confirmed the gap the feature targets.
- **GREEN (with task graph):** the agent read only the ~40-line graph and resumed T4 directly — but **flagged two ambiguities** in my initial wording: (1) whether `ready` lists `in_progress` tasks, and (2) whether resuming an `in_progress` task requires a graph write.
- **REFACTOR:** I tightened both: clarified that `ready` lists only `pending` tasks (with an explicit "does NOT list in_progress" note), and that resuming an `in_progress` task needs no graph write. A second fresh-context subagent then answered all 5 clarity questions correctly with zero remaining ambiguity.

**Existing content preserved:** Step 1, Step 2's original four lines, Step 3, "When to Stop", "When to Revisit", "Remember", and "Integration" are byte-for-byte unchanged (verified with `git diff` — 0 deletions). All additions are new sections (`## Task Graph (optional)`, `## Resuming After Interruption`) and one clearly-marked optional paragraph after Step 2. No "human partner" language or Red-Flags-style framing was touched.

**Adversarial testing** (18 cases across both commands, all pass):

```
PASS  validate clean example           (exit=0)
PASS  ready clean example              (exit=0)
PASS  validate empty tasks array       (exit=0)
PASS  ready on empty graph             (exit=0, no output)
PASS  reject malformed JSON            (exit=1)
PASS  reject version != 1              (exit=1)
PASS  reject missing metadata field    (exit=1)
PASS  reject empty metadata object     (exit=1)
PASS  reject invalid status enum       (exit=1)
PASS  reject duplicate id              (exit=1)
PASS  reject dangling dependency ref   (exit=1)
PASS  reject dangling parentId ref     (exit=1)
PASS  reject non-array dependencies    (exit=1)
PASS  reject self-cycle (T1 -> T1)     (exit=1)
PASS  reject dependency cycle (2-node) (exit=1)
PASS  reject dependency cycle (3-node) (exit=1)
PASS  reject missing tasks field       (exit=1)
PASS  reject empty id                  (exit=1)
```

Cycle error messages report the full path: `dependency cycle detected: T1 -> T2 -> T3 -> T1`.

Error messages are clean and point at the offending task, e.g. `task T1: invalid status 'completed' (expected: pending | in_progress | done | blocked | cancelled).`

**Performance:** both commands are linear in the number of tasks (single awk passes; no per-task subshell forks). On a 5000-task graph: `validate` ~1.2s, `ready` ~0.5s. An 8-task graph (the typical case) validates in under 0.1s.

**Existing content preserved:** Step 1, Step 2's original four lines, Step 3, "When to Stop", "When to Revisit", "Remember", and "Integration" are byte-for-byte unchanged. All additions are new sections (`## Task Graph (optional)`, `## Resuming After Interruption`) and one clearly-marked optional paragraph after Step 2.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission (reviewed all 5 files: SKILL.md diff, task-graph script, example-tasks.json, eval harness, and this PR description)
