### PR TITLE
fix(hooks): discover per-user Git Bash and skip WSL stub on Windows

### DIFF
--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -27,11 +27,19 @@ if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
     exit /b %ERRORLEVEL%
 )
 
-REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
-where bash >nul 2>nul
-if %ERRORLEVEL% equ 0 (
-    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+REM Try per-user Git for Windows install (%LOCALAPPDATA%\Programs\Git)
+if exist "%LOCALAPPDATA%\Programs\Git\bin\bash.exe" (
+    "%LOCALAPPDATA%\Programs\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
     exit /b %ERRORLEVEL%
+)
+
+REM Try bash on PATH, skipping WindowsApps\bash.exe (the WSL stub)
+for /f "usebackq delims=" %%B in (`where bash 2^>nul`) do (
+    echo(%%B | findstr /i "WindowsApps" >nul 2>nul
+    if errorlevel 1 (
+        "%%B" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+        exit /b %ERRORLEVEL%
+    )
 )
 
 REM No bash found - exit silently rather than error


### PR DESCRIPTION
## Summary

- `hooks/run-hook.cmd`: adds `%LOCALAPPDATA%\Programs\Git\bin\bash.exe` to the bash discovery probe list, covering per-user Git for Windows installs that are invisible to the existing system-path checks.
- Replaces the plain `where bash | bash` fallback with a `for /f` loop that iterates every candidate returned by `where bash` and skips any path under `WindowsApps\` — the WSL launcher stub that errors with "No such file or directory" when no WSL distro is installed.

The two changes together ensure a user with a per-user Git install and no WSL distro gets a working `SessionStart` hook instead of a silent failure or a confusing relay error.

Fixes #1863

## Changes

- `hooks/run-hook.cmd`: add per-user Git path probe; filter WSL stub in PATH fallback