### PR TITLE
fix(writing-plans): write plan file incrementally to avoid stall watchdog

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -138,6 +138,14 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - Steps that describe what to do without showing how (code blocks required for code steps)
 - References to types, functions, or methods not defined in any task
 
+## Writing Strategy
+
+Write the plan file incrementally — do not generate the full document in a single Write call:
+1. Write the header block (goal, architecture, tech stack, global constraints) first.
+2. Append each task section one at a time with separate Edit calls.
+
+This caps the pre-task thinking time for each generation step. A single large Write triggers an extended-thinking phase whose duration scales with the total document size; on high-effort sessions that phase can exceed the 5-minute stream-stall watchdog, killing the response mid-plan.
+
 ## Self-Review
 
 After writing the complete plan, look at the spec with fresh eyes and check the plan against it. This is a checklist you run yourself — not a subagent dispatch.


### PR DESCRIPTION
## Summary

- `skills/writing-plans/SKILL.md`: adds a **Writing Strategy** section that instructs the agent to write plans incrementally rather than in one large Write call.

## Root cause

On `xhigh`-effort sessions, Opus 4.8 enters an extended-thinking phase before generating a large document (~100KB, 13 tasks). That phase emits no streaming tokens. Claude Code's 5-minute stall watchdog treats 300 s of silence as a stream error and hard-kills the response, discarding the plan.

The thinking duration scales with total output size — so a single large Write can reliably push past the watchdog, while the same content split into bounded chunks never does.

## Fix

Add guidance to write the header block first, then append each task section with a separate Edit call. Each bounded step has its own thinking phase, and none of them approaches the watchdog threshold.

## What the diff does

- Inserts a new `## Writing Strategy` section before `## Self-Review` with a numbered two-step procedure and an explanation of why the chunking is needed.
- No changes to skill logic, prompting, or any other file.

Fixes #1860