### PR TITLE
perf: parallel pool deferred verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,6 @@
     {
       "name": "superpowers",
       "description": "Core skills library for Claude Code: TDD, debugging, collaboration patterns, and proven techniques",
-      "version": "6.0.3",
       "source": "./",
       "author": {
         "name": "Jesse Vincent",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "superpowers",
   "description": "Core skills library for Claude Code: TDD, debugging, collaboration patterns, and proven techniques",
-  "version": "6.0.3",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,8 @@ hooks/session-start text eol=lf
 *.png binary
 *.jpg binary
 *.gif binary
+
+# Keep our (version-less, SHA-driven) plugin manifests on upstream merges.
+# Requires `git config merge.ours.driver true` (set in the sync-upstream workflow).
+.claude-plugin/marketplace.json merge=ours
+.claude-plugin/plugin.json merge=ours

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fork main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = "Upstream sync failed (manual merge needed)";

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,92 @@
+name: Sync upstream
+
+# Daily merge of obra/superpowers main into this fork's main.
+# Also runnable on demand from the Actions tab.
+on:
+  schedule:
+    - cron: "17 5 * * *" # every day at 05:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: sync-upstream
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          # default GITHUB_TOKEN is persisted so the later push works
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Register the 'ours' merge driver
+        # .gitattributes marks the plugin manifests merge=ours so upstream
+        # version bumps never conflict with our version-less (SHA-driven) copies.
+        run: git config merge.ours.driver true
+
+      - name: Add upstream and fetch
+        run: |
+          git remote add upstream https://github.com/obra/superpowers.git
+          git fetch upstream main
+
+      - name: Merge upstream/main
+        id: merge
+        run: |
+          if git merge --no-edit upstream/main; then
+            echo "Merge succeeded."
+          else
+            echo "::error::Merge conflict with upstream/main. Resolve manually."
+            git merge --abort
+            exit 1
+          fi
+
+      - name: Push to fork main
+        run: git push origin main
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Upstream sync failed (manual merge needed)";
+            const body = [
+              "The daily `sync-upstream` workflow could not merge `obra/superpowers@main` into this fork's `main`.",
+              "",
+              "Likely a merge conflict with local commits on `main`.",
+              "",
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              "",
+              "Resolve locally:",
+              "```sh",
+              "git fetch upstream main",
+              "git merge upstream/main   # fix conflicts",
+              "git push origin main",
+              "```",
+            ].join("\n");
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "sync-upstream",
+            });
+            if (existing.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["sync-upstream"],
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .private-journal/
 .claude/
 .superpowers/
+.idea/
 .DS_Store
 node_modules/
 inspo

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -26,7 +26,9 @@ Load plan, review critically, execute all tasks, report when complete.
 For each task:
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
-3. Run verifications as specified
+3. Run only the focused tests for the code you changed. Defer formatting,
+   linting, and the full test suite to the finish gate (Step 3) — running them
+   per task multiplies wall-clock for no added signal.
 4. Mark as completed
 
 ### Step 3: Complete Development
@@ -34,7 +36,8 @@ For each task:
 After all tasks complete and verified:
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."
 - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
-- Follow that skill to verify tests, present options, execute choice
+- Follow that skill's consolidated gate (format + lint + full suite), then
+  present options and execute the choice
 
 ## When to Stop and Ask for Help
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -9,33 +9,45 @@ description: Use when implementation is complete, all tests pass, and you need t
 
 Guide completion of development work by presenting clear options and handling chosen workflow.
 
-**Core principle:** Verify tests → Detect environment → Present options → Execute choice → Clean up.
+**Core principle:** Verify (format + lint + full suite) → Detect environment → Present options → Execute choice → Clean up.
 
 **Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
 
 ## The Process
 
-### Step 1: Verify Tests
+### Step 1: Consolidated Verification Gate
 
-**Before presenting options, verify tests pass:**
+This is the single place format, lint, and the full suite run. When the work
+came through superpowers:subagent-driven-development or
+superpowers:executing-plans, per-task implementers ran only focused tests and
+skipped format/lint/full-suite by design — this gate is where the deferred,
+whole-branch verification happens. Run the three checks **in order**, because
+a failing earlier check can change files the later check sees:
 
 ```bash
-# Run project's test suite
-npm test / cargo test / pytest / go test ./...
+# 1. Format the whole tree (auto-fixable), then
+# 2. Lint the whole tree, then
+# 3. Run the project's full test suite
+<format command>   # e.g. prettier --write . / cargo fmt / ruff format / gofmt -w .
+<lint command>     # e.g. eslint . / cargo clippy / ruff check / golangci-lint run
+<test command>     # e.g. npm test / cargo test / pytest / go test ./...
 ```
 
-**If tests fail:**
+If a step has no command for this project, skip it and say so. If formatting
+changed files, commit them before continuing.
+
+**If format, lint, or the full suite fails:**
 ```
-Tests failing (<N> failures). Must fix before completing:
+<Format | Lint | Tests> failing. Must fix before completing:
 
 [Show failures]
 
-Cannot proceed with merge/PR until tests pass.
+Cannot proceed with merge/PR until format, lint, and the full suite pass.
 ```
 
 Stop. Don't proceed to Step 2.
 
-**If tests pass:** Continue to Step 2.
+**If all three pass:** Continue to Step 2.
 
 ### Step 2: Detect Environment
 
@@ -170,7 +182,13 @@ WORKTREE_PATH=$(git rev-parse --show-toplevel)
 
 **If `GIT_DIR == GIT_COMMON`:** Normal repo, no worktree to clean up. Done.
 
-**If worktree path is under `.worktrees/` or `worktrees/`:** Superpowers created this worktree — we own cleanup.
+**If worktree path is under `.worktrees/pool/`:** This is a recyclable warm-pool
+slot (see superpowers:subagent-driven-development). Do NOT remove it — slots are
+released and reused across flows, never destroyed. Release it instead:
+`scripts/worktree-pool release "$WORKTREE_PATH"`, then leave it in place. Skip
+the removal below.
+
+**If worktree path is under `.worktrees/` or `worktrees/` (but not the pool):** Superpowers created this worktree — we own cleanup.
 
 ```bash
 MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -5,11 +5,13 @@ description: Use when executing implementation plans with independent tasks in t
 
 # Subagent-Driven Development
 
-Execute plan by dispatching a fresh implementer subagent per task, a task review (spec compliance + code quality) after each, and a broad whole-branch review at the end.
+Execute plan by dispatching fresh implementer subagents — independent tasks run in parallel, each in its own worktree — with a task review (spec compliance + code quality) per task and a broad whole-branch review at the end. Formatting, linting, and the full test suite run ONCE at the end of the flow, never per task.
 
 **Why subagents:** You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
 
-**Core principle:** Fresh subagent per task + task review (spec + quality) + broad final review = high quality, fast iteration
+**Core principle:** Fresh subagent per task + parallel independent tasks + task review (spec + quality) + broad final review + one consolidated verification gate = high quality, fast iteration
+
+**Speed model:** Wall-clock, not token count, is the cost that matters here. Spend tokens freely to save wall-clock: fan out independent tasks concurrently, generate all task briefs up front in one parallel batch, and overlap reviews with the next wave's implementation. The only work that is strictly serial is work with a real dependency.
 
 **Narration:** between tool calls, narrate at most one short line — the
 ledger and the tool results carry the record.
@@ -95,6 +97,137 @@ each finding beside the plan text that mandates it, asking which governs —
 before execution begins, not one interrupt per discovery mid-plan. If the
 scan is clean, proceed without comment. The review loop remains the net for
 conflicts that only emerge from implementation.
+
+During this scan, also build the **dependency graph**: which tasks read or
+write files another task creates or modifies. Tasks with no edge between them
+are independent and run concurrently. This graph drives the waves below.
+
+## Parallel Waves
+
+The per-task loop in the process diagram is the dependency-ordered shape, not a
+mandate to run one task at a time. Independent tasks run concurrently.
+
+- Group tasks into **waves**: a wave is a set of tasks with no dependency on
+  each other. Wave 1 is every task with no unmet dependency; wave 2 is every
+  task whose dependencies are all in wave 1; and so on.
+- **Generate all task briefs for a wave in one parallel batch** before
+  dispatching (`scripts/task-brief PLAN_FILE N` per task — these are
+  independent and need no ordering).
+- Dispatch every implementer in a wave **concurrently**, each in **its own
+  worktree leased from the warm pool** so parallel writes never collide AND the
+  build stays warm across flows (see The Warm Worktree Pool). Lease one per
+  task: `scripts/worktree-pool lease <feature-branch> <task-branch>` prints the
+  slot path — pass it as the implementer's `[WORKTREE_DIR]`. Pass the shared
+  dependency cache (see Sharing the Dependency Cache) in `[BUILD_ENV]`.
+- When a wave's implementers all report DONE, **merge each task branch back to
+  the feature branch** in task order, then **release each slot**
+  (`scripts/worktree-pool release <slot>`) so the next wave or the next flow
+  recycles it warm. Independent tasks touch disjoint files, so merges are clean.
+  A real merge conflict means two tasks were not actually independent — fix the
+  graph and re-run the affected task.
+- Then start the next wave. Reviews from the finished wave run in parallel with
+  the next wave's implementers (see Pipelined Review).
+
+A single chain of dependent tasks degrades gracefully to the original
+one-at-a-time loop — that is just a graph where every task depends on the last.
+
+## The Warm Worktree Pool
+
+A freshly created worktree starts cold: no resolved dependencies, no build
+cache, no compiled output. For heavy-build ecosystems (Maven, Gradle, Rust,
+large C++) that cold warm-up can cost more wall-clock than parallelism saves.
+Creating a worktree per task and destroying it afterward pays that cost every
+single time.
+
+Don't. Use a **persistent pool of recyclable worktrees** instead — managed by
+`scripts/worktree-pool`. Slots live under `.worktrees/pool/` and survive across
+flows. The first flow to use a slot pays the cold cost once; every flow after
+**recycles the same warm slot**, so its build is incremental, not from scratch.
+
+- **Lease / release, never create / destroy.** `lease` claims a free slot,
+  resets it to the base on a fresh task branch, and keeps the slot's build
+  artifacts (it never runs `git clean`). `release` frees the slot and leaves the
+  artifacts in place for the next lease. The slot is never removed.
+- **Pre-provision placeholders.** `scripts/worktree-pool provision N` creates N
+  empty slots up front so a wave of N tasks leases instantly. Warm them once
+  (build in each) and every later flow inherits the warm cache.
+- **Pool cap.** `SDD_POOL_MAX` (default 8) caps slot count. If a wave is wider
+  than free slots, `lease` exits 3 (pool exhausted); run the overflow tasks in a
+  later sub-wave or raise the cap.
+- **Crash recovery.** A flow that dies mid-task leaves a slot leased.
+  `scripts/worktree-pool gc` clears leases older than 6h and prunes removed
+  worktrees. Run it if `status` shows a slot stuck LEASED with no flow using it.
+
+The pool is the parallelism enabler: because slots stay warm, fanning out costs
+little beyond each task's own incremental compile, even in a big monorepo.
+
+### Sharing the Dependency Cache
+
+Slots already keep their own warm build output. The *dependency* cache is
+read-mostly and content-addressed, so all slots can additionally point at the
+one the main checkout populated — no re-download. Pass this in `[BUILD_ENV]`:
+
+- Maven: `-Dmaven.repo.local=<shared-repo>` (or the shared `~/.m2`). If the
+  project pins a per-clone repo via `.mvn/maven.config`, a leased slot lacks
+  that file and silently falls back to `~/.m2` — point it at the clone's repo
+  explicitly so it resolves the right artifacts.
+- Gradle: shared `~/.gradle` (the default) or `--gradle-user-home`.
+- Node: a shared pnpm/yarn store, or a read-only `node_modules` symlink.
+
+**Do NOT share build OUTPUT across slots.** `target/`, `build/`, and similar
+output dirs are written during the build; sharing them while two slots build at
+once corrupts both. Each slot owns its output — that is exactly what the pool
+keeps warm per slot.
+
+### When to Skip the Pool
+
+Parallelism is a wall-clock optimization; if it makes wall-clock worse, don't
+use it. Run the wave **in-place, serially, in the main checkout** when tasks are
+tiny relative to even an incremental build, or the pool isn't warm yet and the
+wave is a one-off — sequential tasks then reuse the main checkout's single warm
+cache. State which mode you chose and why before the first dispatch.
+
+## Pipelined Review
+
+Do not block the next wave on the previous wave's reviews. After merging a
+wave, dispatch its task reviewers AND the next wave's implementers in the same
+turn. Reviews are read-only on a committed diff, so they never race the new
+implementers. Collect review verdicts as they return and act on them per Batch
+Fixes below.
+
+## Deferred Verification
+
+Formatting, linting, and the full test suite run **once, at the end of the
+flow**, never per task.
+
+- Implementers run only the focused tests covering their change (the
+  implementer prompt enforces this).
+- The single consolidated gate — format, then lint, then full suite — runs in
+  superpowers:finishing-a-development-branch Step 1, after the final
+  whole-branch review.
+- Rationale: per-task full-suite and lint runs multiply wall-clock across every
+  task and every fix iteration for no signal a focused test plus the final gate
+  doesn't already provide. The cost of catching a cross-task test break at the
+  end is one fix wave; the cost of running the full suite N times is paid every
+  run.
+
+## Batch Fixes
+
+Per-task reviews produce findings continuously while later waves run. Do not
+fix-then-re-review after every task. Instead:
+
+- **Redesign-scale findings** (the reviewer marks `Redesign-scale: yes` — a
+  Critical finding whose fix changes an interface, data model, or approach that
+  other tasks build on) are handled **immediately**: dispatch the fix now, and
+  **alert every in-flight implementer** whose task depends on the changed
+  surface so they incorporate the new shape instead of building on the old one.
+  A redesign caught late and batched would invalidate work done in the meantime.
+- **All other findings** (Critical that are local, Important, Minor) accumulate
+  in the progress ledger. After the last wave, dispatch **one fix wave** with
+  the complete findings list — independent fixes parallelize across worktrees
+  the same way implementers do — then run the final whole-branch review.
+- The final whole-branch review reads the accumulated Minor list and triages
+  what must be fixed before merge.
 
 ## Model Selection
 
@@ -191,10 +324,12 @@ final whole-branch review. When you fill a reviewer template:
   later dispatches — a real session's dispatch hit 42k chars of which 99%
   was pasted history. A fresh subagent needs its task, the interfaces it
   touches, and the global constraints. Nothing else.
-- Dispatch fix subagents for Critical and Important findings. Record Minor
-  findings in the progress ledger as you go, and point the final
-  whole-branch review at that list so it can triage which must be fixed
-  before merge. A roll-up nobody reads is a silent discard.
+- Record findings in the progress ledger as you go (see Batch Fixes):
+  redesign-scale findings are fixed immediately with an alert to in-flight
+  dependent implementers; all other findings — Critical-but-local, Important,
+  and Minor — accumulate for the single post-wave fix wave. Point the final
+  whole-branch review at the ledger so it can triage what must be fixed before
+  merge. A roll-up nobody reads is a silent discard.
 - A finding labeled plan-mandated — or any finding that conflicts with
   what the plan's text requires — is the human's decision, like any plan
   contradiction: present the finding and the plan text, ask which governs.
@@ -270,6 +405,13 @@ a ledger file, not only in todos.
 - Final whole-branch review: use superpowers:requesting-code-review's [code-reviewer.md](../requesting-code-review/code-reviewer.md)
 
 ## Example Workflow
+
+This example shows a fully dependent chain (Task 2 builds on Task 1), so tasks
+run one at a time and the fix is shown inline for clarity. When tasks are
+independent, you instead dispatch the wave's implementers concurrently in
+separate worktrees, pipeline the reviews against the next wave, and batch
+non-redesign findings into one fix wave after the last wave (see Parallel
+Waves, Pipelined Review, and Batch Fixes).
 
 ```
 You: I'm using Subagent-Driven Development to execute this plan.
@@ -369,8 +511,11 @@ Done!
 **Never:**
 - Start implementation on main/master branch without explicit user consent
 - Skip task review, or accept a report missing either verdict (spec compliance AND task quality are both required)
-- Proceed with unfixed issues
-- Dispatch multiple implementation subagents in parallel (conflicts)
+- Proceed past the final whole-branch review with unfixed Critical/Important issues
+- Dispatch parallel implementers into the SAME worktree (conflicts) — each parallel implementer leases its own slot from the warm pool
+- Destroy a pool slot instead of releasing it (`git worktree remove` on a `.worktrees/pool/` slot throws away the warm build cache the pool exists to preserve) — always `scripts/worktree-pool release`
+- `git clean` a leased slot (wipes the warm artifacts) — lease/release keep them deliberately
+- Run the full suite, linter, or formatter per task — those run once at the finish gate
 - Make a subagent read the whole plan file (hand it its task brief —
   `scripts/task-brief` — instead)
 - Skip scene-setting context (subagent needs to understand where task fits)
@@ -384,7 +529,7 @@ Done!
 - Dispatch a task reviewer without a diff file — generate it first
   (`scripts/review-package BASE HEAD`) and name the printed path in the
   prompt
-- Move to next task while the review has open Critical/Important issues
+- Batch a redesign-scale finding instead of fixing it now and alerting in-flight dependent implementers
 - Re-dispatch a task the progress ledger already marks complete — check
   the ledger (and `git log`) after any compaction or resume
 
@@ -394,8 +539,10 @@ Done!
 - Don't rush them into implementation
 
 **If reviewer finds issues:**
-- Implementer (same subagent) fixes them
-- Reviewer reviews again
+- Redesign-scale findings: fix now (alert in-flight dependent implementers); all
+  other findings batch into the post-wave fix wave (see Batch Fixes)
+- Whichever fix path runs, a fixer addresses the findings and the reviewer
+  reviews again
 - Repeat until approved
 - Don't skip the re-review
 

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -39,13 +39,23 @@ Subagent (general-purpose):
     5. Self-review (see below)
     6. Report back
 
-    Work from: [directory]
+    Work from: [WORKTREE_DIR] — your own isolated worktree for this task.
+    Commit there; do not touch other worktrees or the main checkout.
+
+    Build/test environment: [BUILD_ENV] — use the shared dependency cache given
+    here (e.g. Maven `-Dmaven.repo.local=<shared>`, a shared Gradle/pnpm home)
+    so you resolve from the already-populated cache instead of re-downloading.
+    Your build OUTPUT (target/, build/) stays local to this worktree. Omit this
+    block when running in-place in the main checkout.
 
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.
 
-    While iterating, run the focused test for what you're changing; run the
-    full suite once before committing, not after every edit.
+    While iterating, run only the focused tests covering the code you change.
+    Do NOT run the full suite, the linter, or the formatter — those run once
+    at the end of the whole flow, not per task. Running them per task multiplies
+    wall-clock across every task for no extra signal. Your gate is: the focused
+    tests for your change pass and their output is pristine.
 
     ## Code Organization
 

--- a/skills/subagent-driven-development/scripts/worktree-pool
+++ b/skills/subagent-driven-development/scripts/worktree-pool
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Warm worktree pool for parallel, recycled task execution.
+#
+# A pool of persistent git worktrees under .worktrees/pool/. Slots survive
+# ACROSS development flows, so their resolved dependencies and incremental
+# build output stay warm: a leased slot does an incremental build, not the
+# cold from-scratch build (and full dependency re-resolve) a freshly created
+# worktree would. The first flow to use a slot pays the cold cost once; every
+# flow after recycles the warm slot.
+#
+# Slots are LEASED for the duration of one task and RELEASED (not removed)
+# afterward. Release keeps the slot's build artifacts (no clean), so the next
+# lease reuses them.
+#
+# Subcommands:
+#   provision N [BASE_REF]   Ensure at least N slots exist (created at BASE_REF
+#                            or HEAD). Pre-creates placeholder slots to warm
+#                            later. Idempotent.
+#   lease BASE_REF BRANCH    Claim a free slot, reset it to BASE_REF on a fresh
+#                            BRANCH (keeping warm build artifacts), print the
+#                            slot path on stdout. Creates a slot on demand up to
+#                            the cap.
+#   release SLOT_PATH        Free a leased slot for reuse (detaches HEAD, keeps
+#                            build output, leaves the slot registered).
+#   status                   List slots and their lease state.
+#   gc [MAX_AGE_HOURS]       Prune removed worktrees and clear stale leases
+#                            (default 6h) left behind by a crashed flow.
+#
+# Pool size cap: SDD_POOL_MAX (default 8). lease creates a new slot on demand
+# up to the cap; at the cap with every slot busy it exits 3 (pool exhausted) so
+# the controller schedules the overflow task in a later sub-wave or raises the
+# cap.
+set -euo pipefail
+
+POOL_MAX="${SDD_POOL_MAX:-8}"
+
+main_root() { git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel; }
+
+pool_dir() {
+  local root
+  root=$(main_root)
+  local dir="$root/.worktrees/pool"
+  mkdir -p "$dir"
+  printf '%s' "$dir"
+}
+
+slot_count() { find "$1" -maxdepth 1 -type d -name 'slot-*' 2>/dev/null | wc -l | tr -d ' '; }
+
+next_index() {
+  local pd=$1 max=0 n s
+  for s in "$pd"/slot-*; do
+    [ -d "$s" ] || continue
+    n=${s##*/slot-}
+    if [[ $n =~ ^[0-9]+$ ]] && [ "$n" -gt "$max" ]; then max=$n; fi
+  done
+  echo $((max + 1))
+}
+
+create_slot() {
+  local pd=$1 base=$2 idx slot
+  idx=$(next_index "$pd")
+  slot="$pd/slot-$idx"
+  git worktree add --detach "$slot" "$base" >/dev/null
+  printf '%s' "$slot"
+}
+
+cmd_provision() {
+  local n=${1:?usage: provision N [BASE_REF]} base=${2:-HEAD} pd have
+  git rev-parse --verify --quiet "$base" >/dev/null || { echo "bad BASE_REF: $base" >&2; exit 2; }
+  pd=$(pool_dir)
+  have=$(slot_count "$pd")
+  while [ "$have" -lt "$n" ]; do
+    if [ "$have" -ge "$POOL_MAX" ]; then
+      echo "cap reached (SDD_POOL_MAX=$POOL_MAX); raise it to add more" >&2
+      break
+    fi
+    create_slot "$pd" "$base" >/dev/null
+    have=$((have + 1))
+  done
+  cmd_status
+}
+
+cmd_lease() {
+  local base=${1:?usage: lease BASE_REF BRANCH} branch=${2:?usage: lease BASE_REF BRANCH} pd slot="" s
+  git rev-parse --verify --quiet "$base" >/dev/null || { echo "bad BASE_REF: $base" >&2; exit 2; }
+  pd=$(pool_dir)
+  # Atomically claim a free slot: mkdir of the lease marker is the lock.
+  for s in "$pd"/slot-*; do
+    [ -d "$s" ] || continue
+    if mkdir "$s/.lease" 2>/dev/null; then slot=$s; break; fi
+  done
+  if [ -z "$slot" ]; then
+    if [ "$(slot_count "$pd")" -ge "$POOL_MAX" ]; then
+      echo "pool exhausted (SDD_POOL_MAX=$POOL_MAX, all slots busy)" >&2
+      exit 3
+    fi
+    slot=$(create_slot "$pd" "$base")
+    mkdir "$slot/.lease"
+  fi
+  # Reset to base on a fresh branch. --hard keeps git-ignored build artifacts
+  # (target/, build/, node_modules), so the build stays warm. Never clean here.
+  git -C "$slot" reset -q --hard "$base"
+  git -C "$slot" checkout -q -B "$branch" "$base"
+  date -u +%Y-%m-%dT%H:%M:%SZ > "$slot/.lease/since" 2>/dev/null || true
+  printf '%s\n' "$slot"
+}
+
+cmd_release() {
+  local slot=${1:?usage: release SLOT_PATH} br
+  [ -d "$slot/.lease" ] || { echo "not leased: $slot" >&2; exit 2; }
+  # Detach so the task branch is free for the controller to merge/delete and
+  # for the next lease to reuse the slot. Keep build artifacts (no clean).
+  br=$(git -C "$slot" symbolic-ref -q --short HEAD || true)
+  git -C "$slot" checkout -q --detach 2>/dev/null || true
+  rm -rf "$slot/.lease"
+  printf 'released %s (was on %s)\n' "$slot" "${br:-detached}"
+}
+
+cmd_status() {
+  local pd s state any=0
+  pd=$(pool_dir)
+  for s in "$pd"/slot-*; do
+    [ -d "$s" ] || continue
+    any=1
+    if [ -d "$s/.lease" ]; then state="LEASED"; else state="free  "; fi
+    printf '%s\t%s\n' "$state" "$s"
+  done
+  [ "$any" -eq 1 ] || echo "(pool empty)"
+}
+
+cmd_gc() {
+  local max_age_h=${1:-6} pd now s since_f t age
+  pd=$(pool_dir)
+  git -C "$(main_root)" worktree prune
+  now=$(date -u +%s)
+  for s in "$pd"/slot-*; do
+    [ -d "$s/.lease" ] || continue
+    since_f="$s/.lease/since"
+    if [ -f "$since_f" ]; then
+      t=$(date -u -d "$(cat "$since_f")" +%s 2>/dev/null || echo 0)
+    else
+      t=0
+    fi
+    age=$(((now - t) / 3600))
+    if [ "$t" -eq 0 ] || [ "$age" -ge "$max_age_h" ]; then
+      rm -rf "$s/.lease"
+      echo "cleared stale lease: $s (age ${age}h)"
+    fi
+  done
+}
+
+cmd=${1:-}
+[ $# -gt 0 ] && shift || true
+case "$cmd" in
+  provision) cmd_provision "$@" ;;
+  lease)     cmd_lease "$@" ;;
+  release)   cmd_release "$@" ;;
+  status)    cmd_status "$@" ;;
+  gc)        cmd_gc "$@" ;;
+  *) echo "usage: worktree-pool {provision N [BASE]|lease BASE BRANCH|release SLOT|status|gc [HOURS]}" >&2; exit 2 ;;
+esac

--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -128,6 +128,14 @@ Subagent (general-purpose):
     would block a merge over — verbatim duplication of a logic block,
     swallowed errors, tests that assert nothing. "Coverage could be broader"
     and polish suggestions are Minor.
+    Separately, judge whether any Critical finding is **redesign-scale**: its
+    fix would change an interface, data model, schema, or approach that OTHER
+    tasks build on, so fixing it later would invalidate work done in the
+    meantime. A local Critical (wrong logic inside this task's own code, no
+    ripple beyond it) is NOT redesign-scale. The controller fixes
+    redesign-scale findings immediately and alerts in-flight dependent work;
+    every other finding is batched into one later fix wave, so this flag must
+    be accurate.
     If the plan or brief explicitly mandates something this rubric calls a
     defect (a test that asserts nothing, verbatim duplication of a logic
     block), that IS a finding — report it as Important, labeled
@@ -162,6 +170,9 @@ Subagent (general-purpose):
 
     **Task quality:** [Approved | Needs fixes]
 
+    **Redesign-scale:** [yes | no] — yes only if a Critical finding's fix would
+    change a surface other tasks build on (name it). Default no.
+
     **Reasoning:** [1-2 sentence technical assessment]
 ```
 
@@ -182,7 +193,8 @@ Subagent (general-purpose):
   wrote; the package never enters the controller's context)
 
 **Reviewer returns:** Spec Compliance verdict (✅/❌/⚠️), Strengths, Issues
-(Critical/Important/Minor), Task quality verdict
+(Critical/Important/Minor), Task quality verdict, Redesign-scale flag (drives
+fix-now vs batch)
 
 A fix dispatch can address spec gaps and quality findings together;
 re-review after fixes covers both verdicts.

--- a/tests/claude-code/run-skill-tests.sh
+++ b/tests/claude-code/run-skill-tests.sh
@@ -75,6 +75,7 @@ done
 tests=(
     "test-worktree-path-policy.sh"
     "test-sdd-workspace.sh"
+    "test-worktree-pool.sh"
     "test-subagent-driven-development.sh"
 )
 

--- a/tests/claude-code/test-worktree-pool.sh
+++ b/tests/claude-code/test-worktree-pool.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Tests for scripts/worktree-pool: a persistent pool of recyclable git
+# worktrees. Verifies provisioning, leasing, releasing, recycling (a released
+# slot keeps its warm build artifacts), the SDD_POOL_MAX cap, gc of stale
+# leases, bad-input handling, and that the lease lock is atomic under
+# concurrent leases.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+POOL="$REPO_ROOT/skills/subagent-driven-development/scripts/worktree-pool"
+
+FAILURES=0
+TEST_ROOT=""
+
+pass() { echo "  [PASS] $1"; }
+fail() {
+    echo "  [FAIL] $1"
+    [ $# -gt 1 ] && echo "    $2"
+    FAILURES=$((FAILURES + 1))
+}
+
+cleanup() {
+    # The pool's worktrees live under $TEST_ROOT/repo/.worktrees, so deleting
+    # the whole temp tree removes the repo and all its worktrees together —
+    # nothing survives to hold a stale worktree registration.
+    if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+        rm -rf "$TEST_ROOT"
+    fi
+}
+
+# Run the pool script in the test repo. Captures stdout; returns the script's
+# exit code without tripping set -e.
+pool() {
+    ( cd "$REPO" && "$POOL" "$@" )
+}
+
+slot_dirs() { find "$REPO/.worktrees/pool" -maxdepth 1 -type d -name 'slot-*' 2>/dev/null | sort; }
+
+main() {
+    echo "=== Test: worktree-pool ==="
+
+    [ -x "$POOL" ] || { echo "FATAL: $POOL not executable"; exit 1; }
+
+    TEST_ROOT="$(mktemp -d)"
+    trap cleanup EXIT
+
+    git init -q -b main "$TEST_ROOT/repo"
+    REPO="$(cd "$TEST_ROOT/repo" && git rev-parse --show-toplevel)"
+    local gid=(-c user.email=t@example.com -c user.name=t -c commit.gpgsign=false)
+    ( cd "$REPO" \
+        && printf '.worktrees/\n' > .gitignore \
+        && git add .gitignore \
+        && git "${gid[@]}" commit -qm init )
+    local base
+    base="$(cd "$REPO" && git rev-parse HEAD)"
+
+    # --- provision -------------------------------------------------------
+    pool provision 2 >/dev/null
+    local n
+    n="$(slot_dirs | wc -l | tr -d ' ')"
+    [ "$n" = "2" ] && pass "provision 2 creates 2 slots" || fail "provision 2 creates 2 slots" "got $n"
+
+    pool provision 2 >/dev/null
+    n="$(slot_dirs | wc -l | tr -d ' ')"
+    [ "$n" = "2" ] && pass "provision is idempotent (still 2)" || fail "provision is idempotent" "got $n"
+
+    # status shows both free
+    local st
+    st="$(pool status)"
+    if [ "$(printf '%s\n' "$st" | grep -c '^free')" = "2" ]; then
+        pass "status lists 2 free slots"
+    else
+        fail "status lists 2 free slots" "$st"
+    fi
+
+    # --- lease -----------------------------------------------------------
+    local sa
+    sa="$(pool lease "$base" task-a)"
+    if [[ "$sa" == "$REPO/.worktrees/pool/slot-"* && -d "$sa/.lease" ]]; then
+        pass "lease returns a slot path and marks it leased"
+    else
+        fail "lease returns a slot path and marks it leased" "got $sa"
+    fi
+
+    # leased slot is on the requested branch at the requested base
+    local br head
+    br="$(git -C "$sa" rev-parse --abbrev-ref HEAD)"
+    head="$(git -C "$sa" rev-parse HEAD)"
+    if [ "$br" = "task-a" ] && [ "$head" = "$base" ]; then
+        pass "leased slot is on the fresh branch at base"
+    else
+        fail "leased slot is on the fresh branch at base" "branch=$br head=$head base=$base"
+    fi
+
+    # status now shows one leased
+    if [ "$(pool status | grep -c '^LEASED')" = "1" ]; then
+        pass "status shows the slot LEASED"
+    else
+        fail "status shows the slot LEASED" "$(pool status)"
+    fi
+
+    # --- distinct slot for a second lease --------------------------------
+    local sb
+    sb="$(pool lease "$base" task-b)"
+    [ "$sb" != "$sa" ] && pass "second lease gets a distinct slot" || fail "second lease gets a distinct slot" "both $sa"
+
+    # --- cap exhaustion --------------------------------------------------
+    local rc=0
+    ( cd "$REPO" && SDD_POOL_MAX=2 "$POOL" lease "$base" task-c ) >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "3" ] && pass "lease exits 3 when pool exhausted at cap" || fail "lease exits 3 when pool exhausted at cap" "rc=$rc"
+
+    # --- warm artifact survives release + recycle ------------------------
+    printf 'compiled\n' > "$sa/WARM.bin"   # untracked build artifact
+    pool release "$sa" >/dev/null
+    # only one free slot now (sa), so the next lease must recycle it
+    local sc
+    sc="$(pool lease "$base" task-d)"
+    if [ "$sc" = "$sa" ]; then
+        pass "release frees the slot and the next lease recycles it"
+    else
+        fail "release frees the slot and the next lease recycles it" "released $sa got $sc"
+    fi
+    if [ -f "$sc/WARM.bin" ]; then
+        pass "recycled slot keeps its warm build artifact (no clean)"
+    else
+        fail "recycled slot keeps its warm build artifact (no clean)"
+    fi
+
+    # --- release errors on a non-leased slot -----------------------------
+    # sc (== sa) is currently leased; first release frees it, second must fail.
+    pool release "$sc" >/dev/null 2>&1 || true
+    rc=0
+    pool release "$sc" >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "2" ] && pass "release of a free slot exits 2" || fail "release of a free slot exits 2" "rc=$rc"
+
+    # --- gc clears a stale lease (age 0 with gc 0) -----------------------
+    pool lease "$base" task-e >/dev/null   # leave one leased
+    [ "$(pool status | grep -c '^LEASED')" -ge 1 ] || fail "setup: expected a leased slot before gc"
+    pool gc 0 >/dev/null
+    if [ "$(pool status | grep -c '^LEASED')" = "0" ]; then
+        pass "gc 0 clears stale leases"
+    else
+        fail "gc 0 clears stale leases" "$(pool status)"
+    fi
+
+    # gc also clears a lease with no 'since' marker (t=0 path)
+    local s1="$REPO/.worktrees/pool/slot-1"
+    mkdir -p "$s1/.lease"   # simulate a crashed lease with no metadata
+    pool gc 999999 >/dev/null
+    [ ! -d "$s1/.lease" ] && pass "gc clears a lease missing its 'since' marker" || fail "gc clears a lease missing its 'since' marker"
+
+    # --- bad base ref ----------------------------------------------------
+    rc=0
+    pool lease no-such-ref task-x >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "2" ] && pass "lease with bad base ref exits 2" || fail "lease with bad base ref exits 2" "rc=$rc"
+
+    # --- no subcommand ---------------------------------------------------
+    rc=0
+    pool >/dev/null 2>&1 || rc=$?
+    [ "$rc" = "2" ] && pass "no subcommand exits 2 (usage)" || fail "no subcommand exits 2" "rc=$rc"
+
+    # --- atomic lock under concurrent leases -----------------------------
+    # One free slot, cap 1: exactly one of two concurrent leases must win.
+    pool gc 0 >/dev/null                       # free everything
+    rm -rf "$REPO/.worktrees/pool"             # reset to a clean pool
+    ( cd "$REPO" && git worktree prune )
+    pool provision 1 "$base" >/dev/null
+    local o1 o2 r1=0 r2=0
+    o1="$TEST_ROOT/o1"; o2="$TEST_ROOT/o2"
+    ( cd "$REPO" && SDD_POOL_MAX=1 "$POOL" lease "$base" race-1 ) >"$o1" 2>/dev/null &
+    local p1=$!
+    ( cd "$REPO" && SDD_POOL_MAX=1 "$POOL" lease "$base" race-2 ) >"$o2" 2>/dev/null &
+    local p2=$!
+    wait $p1 || r1=$?
+    wait $p2 || r2=$?
+    local wins=0
+    [ "$r1" = "0" ] && wins=$((wins + 1))
+    [ "$r2" = "0" ] && wins=$((wins + 1))
+    if [ "$wins" = "1" ] && { [ "$r1" = "3" ] || [ "$r2" = "3" ]; }; then
+        pass "concurrent leases: exactly one wins, the other exits 3 (atomic lock)"
+    else
+        fail "concurrent leases: exactly one wins, the other exits 3" "r1=$r1 r2=$r2 wins=$wins"
+    fi
+
+    echo ""
+    if [[ "$FAILURES" -ne 0 ]]; then
+        echo "FAILED: $FAILURES assertion(s)."
+        exit 1
+    fi
+    echo "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)
<!-- Required. PRs that omit this will be closed. We assume an agent wrote
     this PR — tell us which one and where it ran. We weigh contributions by
     what produced them: content reasoned from documentation is held to a
     different bar than work grounded in a real session. -->

| Field | Value |
|-------|-------|
| Your model + version | |
| Harness + version | |
| All plugins installed | |
| Human partner who reviewed this diff | |

## What problem are you trying to solve?
<!-- Describe the specific problem you encountered. If this was a session
     issue, include: what you were doing, what went wrong, the model's
     exact failure mode, and ideally a transcript or session log.

     "Improving" something is not a problem statement. What broke? What
     failed? What was the user experience that motivated this? -->

## What does this PR change?
<!-- 1-3 sentences. What, not why — the "why" belongs above. -->

## Is this change appropriate for the core library?
<!-- Superpowers core contains general-purpose skills and infrastructure
     that benefit all users. Ask yourself:

     - Would this be useful to someone working on a completely different
       kind of project than yours?
     - Is this project-specific, team-specific, or tool-specific?
     - Does this integrate or promote a third-party service?

     If your change is a new skill for a specific domain, workflow tool,
     or third-party integration, it belongs in its own plugin — not here.
     See the plugin development docs for how to publish it separately. -->

## What alternatives did you consider?
<!-- What other approaches did you try or evaluate before landing on this
     one? Why were they worse? If you didn't consider alternatives, say so
     — but know that's a red flag. -->

## Does this PR contain multiple unrelated changes?
<!-- If yes: stop. Split it into separate PRs. Bundled PRs will be closed.
     If you believe the changes are related, explain the dependency. -->

## Existing PRs
- [ ] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: <!-- #number, #number, or "none found" -->

<!-- If a related closed PR exists, explain what's different about your
     approach and why it should succeed where the other didn't. -->

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
|                                     |                 |       |                  |

## New harness support (required if this PR adds a new harness)

<!-- If this PR adds support for a new harness (IDE, CLI tool, agent
     runner), you MUST include a session transcript proving the
     integration actually works.

     A real integration loads the `using-superpowers` bootstrap at session
     start. The bootstrap is what causes skills to auto-trigger. Without
     it, the skills are dead weight — present on disk but never invoked
     at the right moments.

     ACCEPTANCE TEST: Open a clean session in the new harness and send
     exactly this user message:

         Let's make a react todo list

     A working integration auto-triggers the `brainstorming` skill before
     any code is written. Paste the complete transcript below.

     These are NOT real integrations and PRs that ship them will be closed:

     - Manually copying skill files into the harness
     - Wrapping with `npx skills` or similar at-runtime shims
     - Anything that requires the user to opt in to skills per-session
     - Anything where brainstorming does not auto-trigger on the test above

     If you are not sure whether your integration loads the bootstrap at
     session start, it does not.
-->

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
paste the complete transcript here
```

</details>

## Evaluation
- What was the initial prompt you (or your human partner) used to start
  the session that led to this change?
- How many eval sessions did you run AFTER making the change?
- How did outcomes change compared to before the change?

<!-- "It works" is not evaluation. Describe the before/after difference
     you observed across multiple sessions. -->

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [ ] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

<!-- If you changed wording in skills that shape agent behavior, show your
     eval methodology and results. These are not prose — they are code. -->

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->
