### PR TITLE
[codex] Add Codex portal package script

### DIFF
--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# Package the Superpowers Codex plugin as a rootless .tar.gz for portal upload.
+#
+# The Codex portal artifact differs from the old openai/plugins sync flow:
+# it is a standalone archive, but it still needs the OpenAI-owned
+# skills/*/agents/openai.yaml metadata that used to be preserved from the
+# destination plugin repo. Seed that metadata from a prior official package.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REF="HEAD"
+OUTPUT=""
+METADATA_SOURCE=""
+ALLOW_DIRTY=0
+KEEP_STAGE=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/package-codex-plugin.sh [options]
+
+Options:
+  --output PATH            Write archive to PATH.
+                           Default: ../_tmp/sup-codex-packaging/superpowers-VERSION.tar.gz
+  --metadata-source PATH   Prior official package directory or .tar.gz used to
+                           seed skills/*/agents/openai.yaml.
+                           Default: ../_tmp/sup-codex-packaging/superpowers,
+                           falling back to ../_tmp/sup-codex-packaging/superpowers.tar.gz
+  --ref REF                Git ref to package. Default: HEAD.
+  --allow-dirty            Permit a dirty working tree. The archive still uses --ref.
+  --keep-stage             Print and keep the temporary staging directory.
+  -h, --help               Show this help.
+
+The archive is rootless: .codex-plugin/, assets/, skills/, README.md, LICENSE,
+and CODE_OF_CONDUCT.md sit at the tar root. Source-only repo files, hooks, tests,
+docs, and other harness manifests are intentionally not shipped.
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      [[ $# -ge 2 ]] || die "--output requires a path"
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --metadata-source)
+      [[ $# -ge 2 ]] || die "--metadata-source requires a path"
+      METADATA_SOURCE="$2"
+      shift 2
+      ;;
+    --ref)
+      [[ $# -ge 2 ]] || die "--ref requires a value"
+      REF="$2"
+      shift 2
+      ;;
+    --allow-dirty)
+      ALLOW_DIRTY=1
+      shift
+      ;;
+    --keep-stage)
+      KEEP_STAGE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+command -v git >/dev/null || die "git not found in PATH"
+command -v jq >/dev/null || die "jq not found in PATH"
+command -v tar >/dev/null || die "tar not found in PATH"
+command -v gzip >/dev/null || die "gzip not found in PATH"
+command -v shasum >/dev/null || die "shasum not found in PATH"
+
+[[ -d "$REPO_ROOT/.git" ]] || die "repo root is not a git checkout: $REPO_ROOT"
+git -C "$REPO_ROOT" rev-parse --verify "$REF^{commit}" >/dev/null ||
+  die "git ref does not resolve to a commit: $REF"
+
+if [[ "$ALLOW_DIRTY" -ne 1 ]]; then
+  dirty_status="$(git -C "$REPO_ROOT" status --porcelain --untracked-files=all)"
+  if [[ -n "$dirty_status" ]]; then
+    echo "Working tree has uncommitted changes:" >&2
+    printf '%s\n' "$dirty_status" | sed 's/^/  /' >&2
+    die "commit or stash changes first, or pass --allow-dirty to package $REF anyway"
+  fi
+fi
+
+if [[ -z "$METADATA_SOURCE" ]]; then
+  if [[ -d "$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers" ]]; then
+    METADATA_SOURCE="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers"
+  elif [[ -f "$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers.tar.gz" ]]; then
+    METADATA_SOURCE="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers.tar.gz"
+  else
+    die "no metadata source found; pass --metadata-source <prior package dir or tar.gz>"
+  fi
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/superpowers-codex-package.XXXXXX")"
+STAGE="$WORK_DIR/payload"
+METADATA_WORK="$WORK_DIR/metadata"
+TAR_LIST="$WORK_DIR/tar-list"
+
+cleanup() {
+  if [[ "$KEEP_STAGE" -eq 1 ]]; then
+    echo "Keeping staging directory: $WORK_DIR" >&2
+  else
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$STAGE" "$METADATA_WORK"
+
+metadata_root_from_dir() {
+  local candidate="$1"
+  local nested
+
+  if [[ -d "$candidate/skills" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  nested="$(find "$candidate" -mindepth 2 -maxdepth 2 -type d -name skills -print | head -n 1)"
+  if [[ -n "$nested" ]]; then
+    dirname "$nested"
+    return 0
+  fi
+
+  return 1
+}
+
+prepare_metadata_root() {
+  local source="$1"
+  local root
+
+  if [[ -d "$source" ]]; then
+    root="$(cd "$source" && pwd)"
+  elif [[ -f "$source" ]]; then
+    case "$source" in
+      *.tar.gz|*.tgz)
+        tar -xzf "$source" -C "$METADATA_WORK"
+        root="$METADATA_WORK"
+        ;;
+      *)
+        die "metadata source must be a directory or .tar.gz: $source"
+        ;;
+    esac
+  else
+    die "metadata source does not exist: $source"
+  fi
+
+  metadata_root_from_dir "$root" ||
+    die "metadata source does not contain a skills/ directory: $source"
+}
+
+METADATA_ROOT="$(prepare_metadata_root "$METADATA_SOURCE")"
+
+git -C "$REPO_ROOT" archive --format=tar "$REF" -- \
+  .codex-plugin \
+  CODE_OF_CONDUCT.md \
+  LICENSE \
+  README.md \
+  assets \
+  skills \
+  | tar -xf - -C "$STAGE"
+
+VERSION="$(jq -r '.version // empty' "$STAGE/.codex-plugin/plugin.json")"
+[[ -n "$VERSION" ]] || die "could not read version from .codex-plugin/plugin.json"
+
+if jq -e 'has("hooks")' "$STAGE/.codex-plugin/plugin.json" >/dev/null; then
+  die "Codex manifest must not declare hooks for the portal package"
+fi
+
+if [[ -z "$OUTPUT" ]]; then
+  OUTPUT="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers-$VERSION.tar.gz"
+fi
+mkdir -p "$(dirname "$OUTPUT")"
+OUTPUT="$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")"
+
+missing_metadata=0
+while IFS= read -r skill_dir; do
+  skill_name="${skill_dir##*/}"
+  metadata_file="$METADATA_ROOT/skills/$skill_name/agents/openai.yaml"
+
+  if [[ ! -f "$metadata_file" ]]; then
+    echo "Missing OpenAI agent metadata for skill: $skill_name" >&2
+    missing_metadata=1
+    continue
+  fi
+
+  mkdir -p "$skill_dir/agents"
+  cp "$metadata_file" "$skill_dir/agents/openai.yaml"
+done < <(find "$STAGE/skills" -mindepth 1 -maxdepth 1 -type d -print | sort)
+
+if [[ "$missing_metadata" -ne 0 ]]; then
+  die "metadata source is incomplete"
+fi
+
+skill_count="$(find "$STAGE/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+metadata_count="$(find "$STAGE/skills" -path '*/agents/openai.yaml' -type f | wc -l | tr -d ' ')"
+[[ "$skill_count" == "$metadata_count" ]] ||
+  die "metadata count mismatch: $metadata_count metadata files for $skill_count skills"
+
+# Match the prior official archive's deterministic tar entry metadata.
+TZ=UTC find "$STAGE" -exec touch -t 197001010000 {} +
+
+(
+  cd "$STAGE"
+  {
+    find . -mindepth 1 -type d | sed 's#^\./##' | LC_ALL=C sort
+    find . -mindepth 1 -type f | sed 's#^\./##' | LC_ALL=C sort
+  } >"$TAR_LIST"
+
+  rm -f "$OUTPUT"
+  COPYFILE_DISABLE=1 tar -cnf - --format ustar --uid 0 --gid 0 --uname '' --gname '' -T "$TAR_LIST" |
+    gzip -9n >"$OUTPUT"
+)
+
+if command -v xattr >/dev/null 2>&1; then
+  xattr -c "$OUTPUT" 2>/dev/null || true
+fi
+
+unexpected_paths="$(
+  tar -tzf "$OUTPUT" |
+    grep -E '(^superpowers/|^\.agents/|^hooks/|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)' || true
+)"
+if [[ -n "$unexpected_paths" ]]; then
+  printf '%s\n' "$unexpected_paths" | sed 's/^/  /' >&2
+  die "archive contains source-only paths"
+fi
+
+entry_count="$(tar -tzf "$OUTPUT" | wc -l | tr -d ' ')"
+checksum="$(shasum -a 256 "$OUTPUT" | awk '{print $1}')"
+
+echo "Archive: $OUTPUT"
+echo "Version: $VERSION"
+echo "Entries: $entry_count"
+echo "Skills:  $skill_count"
+echo "SHA-256: $checksum"

--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -137,7 +137,7 @@ metadata_root_from_dir() {
     return 0
   fi
 
-  nested="$(find "$candidate" -mindepth 2 -maxdepth 2 -type d -name skills -print | head -n 1)"
+  nested="$(find "$candidate" -mindepth 2 -maxdepth 2 -type d -name skills -print -quit)"
   if [[ -n "$nested" ]]; then
     dirname "$nested"
     return 0
@@ -229,7 +229,7 @@ TZ=UTC find "$STAGE" -exec touch -t 197001010000 {} +
   } >"$TAR_LIST"
 
   rm -f "$OUTPUT"
-  COPYFILE_DISABLE=1 tar -cnf - --format ustar --uid 0 --gid 0 --uname '' --gname '' -T "$TAR_LIST" |
+  COPYFILE_DISABLE=1 tar -cf - --no-recursion --format ustar --uid 0 --gid 0 --uname '' --gname '' -T "$TAR_LIST" |
     gzip -9n >"$OUTPUT"
 )
 

--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Package the Superpowers Codex plugin as a rootless .tar.gz for portal upload.
+# Package the Superpowers Codex plugin as a rootless archive for portal upload.
 #
 # The Codex portal artifact differs from the old openai/plugins sync flow:
 # it is a standalone archive, but it still needs the OpenAI-owned
@@ -14,6 +14,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 REF="HEAD"
 OUTPUT=""
+FORMAT=""
 METADATA_SOURCE=""
 ALLOW_DIRTY=0
 KEEP_STAGE=0
@@ -25,18 +26,21 @@ Usage:
 
 Options:
   --output PATH            Write archive to PATH.
-                           Default: ../_tmp/sup-codex-packaging/superpowers-VERSION.tar.gz
-  --metadata-source PATH   Prior official package directory or .tar.gz used to
+                           Default: ../_tmp/sup-codex-packaging/superpowers-VERSION.zip
+  --format FORMAT          Archive format: zip or tar.gz. Default: zip.
+                           If --output ends in .zip, .tar.gz, or .tgz, that
+                           extension is used when --format is omitted.
+  --metadata-source PATH   Prior official package directory, .zip, or .tar.gz used to
                            seed skills/*/agents/openai.yaml.
                            Default: ../_tmp/sup-codex-packaging/superpowers,
-                           falling back to ../_tmp/sup-codex-packaging/superpowers.tar.gz
+                           falling back to superpowers.zip, then superpowers.tar.gz
   --ref REF                Git ref to package. Default: HEAD.
   --allow-dirty            Permit a dirty working tree. The archive still uses --ref.
   --keep-stage             Print and keep the temporary staging directory.
   -h, --help               Show this help.
 
 The archive is rootless: .codex-plugin/, assets/, skills/, README.md, LICENSE,
-and CODE_OF_CONDUCT.md sit at the tar root. Source-only repo files, hooks, tests,
+and CODE_OF_CONDUCT.md sit at the archive root. Source-only repo files, hooks, tests,
 docs, and other harness manifests are intentionally not shipped.
 EOF
 }
@@ -51,6 +55,21 @@ while [[ $# -gt 0 ]]; do
     --output)
       [[ $# -ge 2 ]] || die "--output requires a path"
       OUTPUT="$2"
+      shift 2
+      ;;
+    --format)
+      [[ $# -ge 2 ]] || die "--format requires a value"
+      case "$2" in
+        zip)
+          FORMAT="zip"
+          ;;
+        tar.gz|tgz)
+          FORMAT="tar.gz"
+          ;;
+        *)
+          die "--format must be zip or tar.gz"
+          ;;
+      esac
       shift 2
       ;;
     --metadata-source)
@@ -83,11 +102,43 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+infer_format_from_output() {
+  local output_path="$1"
+
+  case "$output_path" in
+    *.tar.gz|*.tgz)
+      printf '%s\n' "tar.gz"
+      ;;
+    *.zip)
+      printf '%s\n' "zip"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [[ -z "$FORMAT" ]]; then
+  FORMAT="$(infer_format_from_output "$OUTPUT" || true)"
+  if [[ -z "$FORMAT" ]]; then
+    FORMAT="zip"
+  fi
+else
+  output_format="$(infer_format_from_output "$OUTPUT" || true)"
+  if [[ -n "$output_format" && "$output_format" != "$FORMAT" ]]; then
+    die "--output extension does not match --format $FORMAT: $OUTPUT"
+  fi
+fi
+
 command -v git >/dev/null || die "git not found in PATH"
 command -v jq >/dev/null || die "jq not found in PATH"
 command -v tar >/dev/null || die "tar not found in PATH"
 command -v gzip >/dev/null || die "gzip not found in PATH"
 command -v shasum >/dev/null || die "shasum not found in PATH"
+if [[ "$FORMAT" == "zip" ]]; then
+  command -v zip >/dev/null || die "zip not found in PATH"
+  command -v unzip >/dev/null || die "unzip not found in PATH"
+fi
 
 [[ -d "$REPO_ROOT/.git" ]] || die "repo root is not a git checkout: $REPO_ROOT"
 git -C "$REPO_ROOT" rev-parse --verify "$REF^{commit}" >/dev/null ||
@@ -105,17 +156,19 @@ fi
 if [[ -z "$METADATA_SOURCE" ]]; then
   if [[ -d "$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers" ]]; then
     METADATA_SOURCE="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers"
+  elif [[ -f "$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers.zip" ]]; then
+    METADATA_SOURCE="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers.zip"
   elif [[ -f "$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers.tar.gz" ]]; then
     METADATA_SOURCE="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers.tar.gz"
   else
-    die "no metadata source found; pass --metadata-source <prior package dir or tar.gz>"
+    die "no metadata source found; pass --metadata-source <prior package dir, zip, or tar.gz>"
   fi
 fi
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/superpowers-codex-package.XXXXXX")"
 STAGE="$WORK_DIR/payload"
 METADATA_WORK="$WORK_DIR/metadata"
-TAR_LIST="$WORK_DIR/tar-list"
+ARCHIVE_LIST="$WORK_DIR/archive-list"
 
 cleanup() {
   if [[ "$KEEP_STAGE" -eq 1 ]]; then
@@ -158,8 +211,13 @@ prepare_metadata_root() {
         tar -xzf "$source" -C "$METADATA_WORK"
         root="$METADATA_WORK"
         ;;
+      *.zip)
+        command -v unzip >/dev/null || die "unzip not found in PATH"
+        unzip -q "$source" -d "$METADATA_WORK"
+        root="$METADATA_WORK"
+        ;;
       *)
-        die "metadata source must be a directory or .tar.gz: $source"
+        die "metadata source must be a directory, .zip, or .tar.gz: $source"
         ;;
     esac
   else
@@ -189,7 +247,14 @@ if jq -e 'has("hooks")' "$STAGE/.codex-plugin/plugin.json" >/dev/null; then
 fi
 
 if [[ -z "$OUTPUT" ]]; then
-  OUTPUT="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers-$VERSION.tar.gz"
+  case "$FORMAT" in
+    zip)
+      OUTPUT="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers-$VERSION.zip"
+      ;;
+    tar.gz)
+      OUTPUT="$REPO_ROOT/../_tmp/sup-codex-packaging/superpowers-$VERSION.tar.gz"
+      ;;
+  esac
 fi
 mkdir -p "$(dirname "$OUTPUT")"
 OUTPUT="$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")"
@@ -218,27 +283,51 @@ metadata_count="$(find "$STAGE/skills" -path '*/agents/openai.yaml' -type f | wc
 [[ "$skill_count" == "$metadata_count" ]] ||
   die "metadata count mismatch: $metadata_count metadata files for $skill_count skills"
 
-# Match the prior official archive's deterministic tar entry metadata.
-TZ=UTC find "$STAGE" -exec touch -t 197001010000 {} +
-
 (
   cd "$STAGE"
   {
     find . -mindepth 1 -type d | sed 's#^\./##' | LC_ALL=C sort
     find . -mindepth 1 -type f | sed 's#^\./##' | LC_ALL=C sort
-  } >"$TAR_LIST"
-
-  rm -f "$OUTPUT"
-  COPYFILE_DISABLE=1 tar -cf - --no-recursion --format ustar --uid 0 --gid 0 --uname '' --gname '' -T "$TAR_LIST" |
-    gzip -9n >"$OUTPUT"
+  } >"$ARCHIVE_LIST"
 )
+
+case "$FORMAT" in
+  zip)
+    # ZIP cannot represent dates earlier than 1980.
+    TZ=UTC find "$STAGE" -exec touch -t 198001010000 {} +
+    (
+      cd "$STAGE"
+      rm -f "$OUTPUT"
+      COPYFILE_DISABLE=1 zip -X -q - -@ <"$ARCHIVE_LIST" >"$OUTPUT"
+    )
+    ;;
+  tar.gz)
+    # Match the prior official archive's deterministic tar entry metadata.
+    TZ=UTC find "$STAGE" -exec touch -t 197001010000 {} +
+    (
+      cd "$STAGE"
+      rm -f "$OUTPUT"
+      COPYFILE_DISABLE=1 tar -cf - --no-recursion --format ustar --uid 0 --gid 0 --uname '' --gname '' -T "$ARCHIVE_LIST" |
+        gzip -9n >"$OUTPUT"
+    )
+    ;;
+esac
 
 if command -v xattr >/dev/null 2>&1; then
   xattr -c "$OUTPUT" 2>/dev/null || true
 fi
 
+case "$FORMAT" in
+  zip)
+    archive_paths="$(unzip -Z1 "$OUTPUT" | sed 's#/$##')"
+    ;;
+  tar.gz)
+    archive_paths="$(tar -tzf "$OUTPUT")"
+    ;;
+esac
+
 unexpected_paths="$(
-  tar -tzf "$OUTPUT" |
+  printf '%s\n' "$archive_paths" |
     grep -E '(^superpowers/|^\.agents/|^hooks/|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)' || true
 )"
 if [[ -n "$unexpected_paths" ]]; then
@@ -246,10 +335,11 @@ if [[ -n "$unexpected_paths" ]]; then
   die "archive contains source-only paths"
 fi
 
-entry_count="$(tar -tzf "$OUTPUT" | wc -l | tr -d ' ')"
+entry_count="$(printf '%s\n' "$archive_paths" | wc -l | tr -d ' ')"
 checksum="$(shasum -a 256 "$OUTPUT" | awk '{print $1}')"
 
 echo "Archive: $OUTPUT"
+echo "Format:  $FORMAT"
 echo "Version: $VERSION"
 echo "Entries: $entry_count"
 echo "Skills:  $skill_count"

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/package-codex-plugin.sh"
+
+FAILURES=0
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+pass() {
+  echo "  [PASS] $1"
+}
+
+fail() {
+  echo "  [FAIL] $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+assert_equals() {
+  local actual="$1"
+  local expected="$2"
+  local description="$3"
+
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$description"
+  else
+    fail "$description"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local description="$3"
+
+  if printf '%s' "$haystack" | grep -Fq -- "$needle"; then
+    pass "$description"
+  else
+    fail "$description"
+    echo "    expected to find: $needle"
+  fi
+}
+
+assert_not_matches() {
+  local haystack="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if printf '%s' "$haystack" | grep -Eq -- "$pattern"; then
+    fail "$description"
+    echo "    did not expect to match: $pattern"
+  else
+    pass "$description"
+  fi
+}
+
+write_metadata_fixture() {
+  local destination="$1"
+  local skill
+
+  while IFS= read -r skill; do
+    mkdir -p "$destination/skills/$skill/agents"
+    cat >"$destination/skills/$skill/agents/openai.yaml" <<EOF
+interface:
+  display_name: "$skill"
+  short_description: "Fixture metadata for $skill"
+EOF
+  done < <(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 1 -type d -print | sed 's#.*/##' | sort)
+}
+
+echo "Codex package archive tests"
+
+metadata_source="$TEST_ROOT/metadata-source"
+archive="$TEST_ROOT/superpowers.tar.gz"
+extracted="$TEST_ROOT/extracted"
+write_metadata_fixture "$metadata_source"
+
+if output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_source" --output "$archive" 2>&1)"; then
+  pass "package script exits successfully"
+else
+  fail "package script exits successfully"
+  printf '%s\n' "$output" | sed 's/^/      /'
+fi
+
+if [[ -f "$archive" ]]; then
+  pass "package script writes archive"
+else
+  fail "package script writes archive"
+fi
+
+assert_contains "$output" "Archive:" "reports archive path"
+assert_contains "$output" "SHA-256:" "reports archive checksum"
+
+mkdir -p "$extracted"
+tar -xzf "$archive" -C "$extracted"
+
+archive_paths="$(tar -tzf "$archive" | sort)"
+unexpected_pattern='(^superpowers/|^\.agents/|^hooks/|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)'
+assert_not_matches "$archive_paths" "$unexpected_pattern" "archive excludes source-only paths"
+assert_contains "$archive_paths" ".codex-plugin/plugin.json" "archive includes Codex manifest"
+assert_contains "$archive_paths" "skills/brainstorming/SKILL.md" "archive includes skills"
+assert_contains "$archive_paths" "skills/brainstorming/agents/openai.yaml" "archive includes OpenAI skill metadata"
+assert_contains "$archive_paths" "assets/app-icon.png" "archive includes app icon"
+assert_contains "$archive_paths" "assets/superpowers-small.svg" "archive includes composer icon"
+
+manifest_summary="$(tar -xOf "$archive" .codex-plugin/plugin.json | python3 -c 'import json,sys; data=json.load(sys.stdin); print("\t".join([data["name"], data["version"], data["skills"], str(data.get("hooks"))]))')"
+expected_version="$(python3 -c 'import json; print(json.load(open("'"$REPO_ROOT"'/.codex-plugin/plugin.json"))["version"])')"
+assert_equals "$manifest_summary" "superpowers	$expected_version	./skills/	None" "archive manifest is current and hook-free"
+
+skill_count="$(find "$extracted/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+metadata_count="$(find "$extracted/skills" -path '*/agents/openai.yaml' -type f | wc -l | tr -d ' ')"
+assert_equals "$metadata_count" "$skill_count" "every packaged skill has OpenAI metadata"
+
+task_brief_mode="$(tar -tzvf "$archive" skills/subagent-driven-development/scripts/task-brief | awk '{print $1}')"
+assert_equals "$task_brief_mode" "-rwxr-xr-x" "archive preserves executable script mode"
+
+metadata_times="$(tar -tzvf "$archive" | awk '{print $6, $7, $8}' | sort -u)"
+assert_equals "$metadata_times" "Dec 31 1969" "archive normalizes entry timestamps"
+
+if [[ "$FAILURES" -eq 0 ]]; then
+  echo "All Codex package archive tests passed"
+else
+  echo "$FAILURES Codex package archive test(s) failed"
+  exit 1
+fi

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -62,6 +62,61 @@ assert_not_matches() {
   fi
 }
 
+list_archive() {
+  local archive_path="$1"
+
+  case "$archive_path" in
+    *.tar.gz|*.tgz)
+      tar -tzf "$archive_path"
+      ;;
+    *.zip)
+      unzip -Z1 "$archive_path"
+      ;;
+    *)
+      unzip -Z1 "$archive_path"
+      ;;
+  esac
+}
+
+normalize_archive_paths() {
+  sed 's#/$##' | LC_ALL=C sort
+}
+
+extract_archive() {
+  local archive_path="$1"
+  local destination="$2"
+
+  mkdir -p "$destination"
+  case "$archive_path" in
+    *.tar.gz|*.tgz)
+      tar -xzf "$archive_path" -C "$destination"
+      ;;
+    *.zip)
+      unzip -q "$archive_path" -d "$destination"
+      ;;
+    *)
+      unzip -q "$archive_path" -d "$destination"
+      ;;
+  esac
+}
+
+read_archive_file() {
+  local archive_path="$1"
+  local file_path="$2"
+
+  case "$archive_path" in
+    *.tar.gz|*.tgz)
+      tar -xOf "$archive_path" "$file_path"
+      ;;
+    *.zip)
+      unzip -p "$archive_path" "$file_path"
+      ;;
+    *)
+      unzip -p "$archive_path" "$file_path"
+      ;;
+  esac
+}
+
 write_metadata_fixture() {
   local destination="$1"
   local skill
@@ -79,8 +134,10 @@ EOF
 echo "Codex package archive tests"
 
 metadata_source="$TEST_ROOT/metadata-source"
-archive="$TEST_ROOT/superpowers.tar.gz"
+archive="$TEST_ROOT/superpowers"
+tar_archive="$TEST_ROOT/superpowers.tar.gz"
 extracted="$TEST_ROOT/extracted"
+tar_extracted="$TEST_ROOT/tar-extracted"
 write_metadata_fixture "$metadata_source"
 
 if output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_source" --output "$archive" 2>&1)"; then
@@ -97,12 +154,12 @@ else
 fi
 
 assert_contains "$output" "Archive:" "reports archive path"
+assert_contains "$output" "Format:  zip" "reports default zip format"
 assert_contains "$output" "SHA-256:" "reports archive checksum"
 
-mkdir -p "$extracted"
-tar -xzf "$archive" -C "$extracted"
+extract_archive "$archive" "$extracted"
 
-archive_paths="$(tar -tzf "$archive" | sort)"
+archive_paths="$(list_archive "$archive" | normalize_archive_paths)"
 unexpected_pattern='(^superpowers/|^\.agents/|^hooks/|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)'
 assert_not_matches "$archive_paths" "$unexpected_pattern" "archive excludes source-only paths"
 assert_contains "$archive_paths" ".codex-plugin/plugin.json" "archive includes Codex manifest"
@@ -111,7 +168,7 @@ assert_contains "$archive_paths" "skills/brainstorming/agents/openai.yaml" "arch
 assert_contains "$archive_paths" "assets/app-icon.png" "archive includes app icon"
 assert_contains "$archive_paths" "assets/superpowers-small.svg" "archive includes composer icon"
 
-manifest_summary="$(tar -xOf "$archive" .codex-plugin/plugin.json | python3 -c 'import json,sys; data=json.load(sys.stdin); print("\t".join([data["name"], data["version"], data["skills"], str(data.get("hooks"))]))')"
+manifest_summary="$(read_archive_file "$archive" .codex-plugin/plugin.json | python3 -c 'import json,sys; data=json.load(sys.stdin); print("\t".join([data["name"], data["version"], data["skills"], str(data.get("hooks"))]))')"
 expected_version="$(python3 -c 'import json; print(json.load(open("'"$REPO_ROOT"'/.codex-plugin/plugin.json"))["version"])')"
 assert_equals "$manifest_summary" "superpowers	$expected_version	./skills/	None" "archive manifest is current and hook-free"
 
@@ -119,17 +176,48 @@ skill_count="$(find "$extracted/skills" -mindepth 1 -maxdepth 1 -type d | wc -l 
 metadata_count="$(find "$extracted/skills" -path '*/agents/openai.yaml' -type f | wc -l | tr -d ' ')"
 assert_equals "$metadata_count" "$skill_count" "every packaged skill has OpenAI metadata"
 
-task_brief_mode="$(tar -tzvf "$archive" skills/subagent-driven-development/scripts/task-brief | awk '{print $1}')"
-assert_equals "$task_brief_mode" "-rwxr-xr-x" "archive preserves executable script mode"
+if [[ -x "$extracted/skills/subagent-driven-development/scripts/task-brief" ]]; then
+  pass "archive preserves executable script mode"
+else
+  fail "archive preserves executable script mode"
+fi
 
-metadata_times="$(tar -tzvf "$archive" | awk '{print $6, $7, $8}' | sort -u)"
-assert_equals "$metadata_times" "Dec 31 1969" "archive normalizes entry timestamps"
+zip_times="$(python3 - "$archive" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    print("\n".join(sorted({str(info.date_time) for info in archive.infolist()})))
+PY
+)"
+assert_equals "$zip_times" "(1980, 1, 1, 0, 0, 0)" "zip archive normalizes entry timestamps"
+
+if tar_output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_source" --format tar.gz --output "$tar_archive" 2>&1)"; then
+  pass "package script writes explicit tar.gz archive"
+else
+  fail "package script writes explicit tar.gz archive"
+  printf '%s\n' "$tar_output" | sed 's/^/      /'
+fi
+assert_contains "$tar_output" "Format:  tar.gz" "reports explicit tar.gz format"
+
+extract_archive "$tar_archive" "$tar_extracted"
+tar_archive_paths="$(list_archive "$tar_archive" | normalize_archive_paths)"
+assert_equals "$tar_archive_paths" "$archive_paths" "zip and tar.gz archives contain the same paths"
+
+tar_task_brief_mode="$(tar -tzvf "$tar_archive" skills/subagent-driven-development/scripts/task-brief | awk '{print $1}')"
+assert_equals "$tar_task_brief_mode" "-rwxr-xr-x" "tar.gz archive preserves executable script mode"
+
+tar_metadata_times="$(tar -tzvf "$tar_archive" | awk '{print $6, $7, $8}' | sort -u)"
+assert_equals "$tar_metadata_times" "Dec 31 1969" "tar.gz archive normalizes entry timestamps"
 
 metadata_archive="$TEST_ROOT/metadata-source.tar.gz"
-archive_from_tar_source="$TEST_ROOT/superpowers-from-tar-source.tar.gz"
+metadata_zip="$TEST_ROOT/metadata-source.zip"
+archive_from_tar_source="$TEST_ROOT/superpowers-from-tar-source.zip"
+archive_from_zip_source="$TEST_ROOT/superpowers-from-zip-source.zip"
 (
   cd "$metadata_source"
   tar -czf "$metadata_archive" .
+  zip -X -q -r "$metadata_zip" .
 )
 
 if output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_archive" --output "$archive_from_tar_source" 2>&1)"; then
@@ -143,6 +231,19 @@ if cmp -s "$archive" "$archive_from_tar_source"; then
   pass "tarball metadata source produces identical archive"
 else
   fail "tarball metadata source produces identical archive"
+fi
+
+if output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_zip" --output "$archive_from_zip_source" 2>&1)"; then
+  pass "package script accepts zip metadata source"
+else
+  fail "package script accepts zip metadata source"
+  printf '%s\n' "$output" | sed 's/^/      /'
+fi
+
+if cmp -s "$archive" "$archive_from_zip_source"; then
+  pass "zip metadata source produces identical archive"
+else
+  fail "zip metadata source produces identical archive"
 fi
 
 incomplete_metadata="$TEST_ROOT/incomplete-metadata"
@@ -169,7 +270,7 @@ dirty_output="$(
   cd "$dirty_repo"
   scripts/package-codex-plugin.sh \
     --metadata-source "$metadata_source" \
-    --output "$TEST_ROOT/dirty.tar.gz" 2>&1
+    --output "$TEST_ROOT/dirty.zip" 2>&1
 )"
 dirty_status=$?
 set -e

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -125,6 +125,61 @@ assert_equals "$task_brief_mode" "-rwxr-xr-x" "archive preserves executable scri
 metadata_times="$(tar -tzvf "$archive" | awk '{print $6, $7, $8}' | sort -u)"
 assert_equals "$metadata_times" "Dec 31 1969" "archive normalizes entry timestamps"
 
+metadata_archive="$TEST_ROOT/metadata-source.tar.gz"
+archive_from_tar_source="$TEST_ROOT/superpowers-from-tar-source.tar.gz"
+(
+  cd "$metadata_source"
+  tar -czf "$metadata_archive" .
+)
+
+if output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_archive" --output "$archive_from_tar_source" 2>&1)"; then
+  pass "package script accepts tarball metadata source"
+else
+  fail "package script accepts tarball metadata source"
+  printf '%s\n' "$output" | sed 's/^/      /'
+fi
+
+if cmp -s "$archive" "$archive_from_tar_source"; then
+  pass "tarball metadata source produces identical archive"
+else
+  fail "tarball metadata source produces identical archive"
+fi
+
+incomplete_metadata="$TEST_ROOT/incomplete-metadata"
+mkdir -p "$incomplete_metadata/skills/brainstorming/agents"
+cp "$metadata_source/skills/brainstorming/agents/openai.yaml" \
+  "$incomplete_metadata/skills/brainstorming/agents/openai.yaml"
+
+set +e
+missing_output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$incomplete_metadata" --output "$TEST_ROOT/missing.tar.gz" 2>&1)"
+missing_status=$?
+set -e
+if [[ "$missing_status" -ne 0 ]]; then
+  pass "package script rejects incomplete metadata source"
+else
+  fail "package script rejects incomplete metadata source"
+fi
+assert_contains "$missing_output" "ERROR: metadata source is incomplete" "incomplete metadata reports clear error"
+
+dirty_repo="$TEST_ROOT/dirty-repo"
+git clone -q --no-local "$REPO_ROOT" "$dirty_repo"
+printf '\n# dirty fixture\n' >>"$dirty_repo/README.md"
+set +e
+dirty_output="$(
+  cd "$dirty_repo"
+  scripts/package-codex-plugin.sh \
+    --metadata-source "$metadata_source" \
+    --output "$TEST_ROOT/dirty.tar.gz" 2>&1
+)"
+dirty_status=$?
+set -e
+if [[ "$dirty_status" -ne 0 ]]; then
+  pass "package script rejects dirty worktree by default"
+else
+  fail "package script rejects dirty worktree by default"
+fi
+assert_contains "$dirty_output" "Working tree has uncommitted changes:" "dirty worktree reports changed files"
+
 if [[ "$FAILURES" -eq 0 ]]; then
   echo "All Codex package archive tests passed"
 else


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 Codex |
| Harness + version | Codex desktop app/API; exact harness build not exposed in-session |
| All plugins installed | GitHub 0.1.5; Linear 5.0.0; Slack 0.1.2; Codex Security 0.1.10; primeradiant-ops 2.4.2; OpenAI bundled browser/documents/pdf/presentations/spreadsheets/template tooling; OpenAI primary runtime |
| Human partner who reviewed this diff | Drew Ritter |

## What problem are you trying to solve?

Superpowers 6.1 needs to be distributed to Codex through the new portal upload process instead of the older `openai/plugins` repository sync flow. The old script pushed a synchronized plugin directory into a separate repo; the new process needs a standalone portal archive. The portal upload currently wants `.zip`, while `.tar.gz` is still useful as a compatibility/review artifact, so the checked-in command should support both without changing the package bill of materials.

The archive must match the prior official Codex package payload, including OpenAI-owned `skills/*/agents/openai.yaml` metadata, normalized archive metadata, and no source-repo-only files.

This came from a real packaging session for v6.1.0. We compared the prior official package sample at `../_tmp/sup-codex-packaging`, built candidate archives, diffed their BOM against the old archive, and verified the local plugin validator accepted the extracted package.

## What does this PR change?

Adds `scripts/package-codex-plugin.sh`, a rootless Codex portal archive builder. It defaults to `.zip`, supports explicit `--format tar.gz`, infers format from `.zip`, `.tar.gz`, or `.tgz` output paths, and can seed OpenAI skill metadata from a prior package directory, `.zip`, or `.tar.gz`.

Adds `tests/codex/test-package-codex-plugin.sh`, which verifies the archive contract: current hook-free Codex manifest, runtime payload only, seeded OpenAI skill metadata, executable mode preservation, normalized archive timestamps, zip/tar.gz payload parity, metadata-source archive support, and dirty-worktree rejection.

## Is this change appropriate for the core library?

Yes. This is release infrastructure for the existing core Superpowers Codex distribution path. It does not add a domain-specific skill, team-specific workflow, or third-party integration; it makes the official Codex package reproducible for all Superpowers releases.

## What alternatives did you consider?

- Keep using `scripts/sync-to-codex-plugin.sh`: rejected because the process changed from opening PRs against `openai/plugins` to uploading a standalone archive through a portal.
- Hand-build each archive from the shell recipe: rejected because it is easy to include staging files, omit OpenAI-owned agent metadata, or drift from the old BOM.
- Generate `skills/*/agents/openai.yaml` from skill metadata: rejected for now because the prior official package already contains the OpenAI-owned metadata, and preserving that source is less speculative.
- Ship only `.tar.gz`: rejected after portal testing showed the upload path expects `.zip`.

## Does this PR contain multiple unrelated changes?

No. Both files are for one task: producing and testing the Codex portal archive artifact.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1770, #1771, #1261, #1165

No duplicate PR was found for a portal archive packaging script. Related prior work covers packaged Codex version fallback (#1770), excluding source metadata from the old Codex sync (#1771), committed Codex plugin files in the old sync path (#1261), and earlier Codex plugin tooling mirroring (#1165). This PR is different because it packages the current repo into an uploadable archive rather than synchronizing into another repository.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app/API | exact build not exposed in-session | GPT-5 Codex | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a new harness.

## Evaluation

- Initial prompt: Drew asked to package Superpowers 6.1 for Codex distribution under the changed process, compare against the prior package sample at `../_tmp/sup-codex-packaging`, and determine what was needed to emit a correct portal archive. Follow-up portal testing showed the upload wants `.zip`, so the script now defaults to zip while preserving tar.gz support.
- Eval sessions after making the change: 0 formal skill-behavior eval sessions. This is release tooling, not behavior-shaping skill content.
- Before/after outcome: before this PR, the repo had an old `scripts/sync-to-codex-plugin.sh` flow for pushing to `openai/plugins` and no checked-in command for producing the portal archive. After this PR, `scripts/package-codex-plugin.sh` emits a deterministic rootless zip by default and can also emit a tar.gz with the same payload; in the implementation session, the tar.gz compatibility artifact matched the previously reviewed tar archive byte-for-byte.

Verification run:

```text
bash tests/codex/test-package-codex-plugin.sh
bash tests/codex/test-marketplace-manifest.sh
scripts/lint-shell.sh scripts/package-codex-plugin.sh tests/codex/test-package-codex-plugin.sh
git diff --check
scripts/package-codex-plugin.sh --allow-dirty
scripts/package-codex-plugin.sh --allow-dirty --format tar.gz --output ../_tmp/sup-codex-packaging/tar-compat-review.tar.gz
cmp -s ../_tmp/sup-codex-packaging/final-review.tar.gz ../_tmp/sup-codex-packaging/tar-compat-review.tar.gz
python3 -m zipfile --test ../_tmp/sup-codex-packaging/superpowers-6.1.0.zip
```

Observed archive evidence:

```text
ZIP archive: ../_tmp/sup-codex-packaging/superpowers-6.1.0.zip
Format:  zip
Entries: 103
Skills:  14
SHA-256: bfd28b54e3b13128cbe9c690fe64915f04e3b23c64699792adff532804af3e37

TAR compatibility archive: ../_tmp/sup-codex-packaging/tar-compat-review.tar.gz
Format:  tar.gz
Entries: 103
Skills:  14
SHA-256: 43312bb72c3e9b8b3c9ed5b4ccea395552a47947e09264dbef6acd1496eccdbb

tar.gz compatibility archive matches the previously reviewed tarball byte-for-byte
zip archive integrity check completed with: Done testing
```

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is not a skills-content change. The package test uses a temporary metadata fixture and asserts exclusion of source-only paths, hook-free manifest state, per-skill OpenAI metadata coverage, executable mode preservation, normalized timestamps, zip/tar.gz payload parity, accepted metadata archive sources, and dirty-worktree rejection.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
