### PR TITLE
[codex] Fix plugin manifest category

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -27,7 +27,7 @@
     "shortDescription": "Planning, TDD, debugging, and delivery workflows for coding agents",
     "longDescription": "Use Superpowers to guide agent work through brainstorming, implementation planning, test-driven development, systematic debugging, parallel execution, code review, and finish-the-branch workflows.",
     "developerName": "Jesse Vincent",
-    "category": "Coding",
+    "category": "Developer Tools",
     "capabilities": [
       "Interactive",
       "Read",


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 Codex |
| Harness + version | Codex desktop app/API; exact harness build not exposed in-session |
| All plugins installed | GitHub 0.1.5; Linear 5.0.0; Slack 0.1.2; Codex Security 0.1.10; primeradiant-ops 2.4.2; OpenAI bundled browser/documents/pdf/presentations/spreadsheets/template tooling; OpenAI primary runtime |
| Human partner who reviewed this diff | Drew Ritter |

## What problem are you trying to solve?

The Codex portal rejected the Superpowers 6.1 package with this validation error:

```text
Unsupported plugin category
.codex-plugin/plugin.json
`interface.category` must be `Productivity`, `Creativity`, `Developer Tools`, `Business & Operations`, `Data & Analytics`, `Communication`, `Education & Research`, `Security`, `Finance`, `Healthcare`, `Travel`, `Entertainment`, or `Other`.
```

Current `.codex-plugin/plugin.json` used `interface.category: "Coding"`, which is not in the portal's accepted category enum. The prior official Codex package sample used `Developer Tools`, and the repo's `.agents/plugins/marketplace.json` already uses `Developer Tools`, so the plugin manifest should match that supported category.

## What does this PR change?

Changes `.codex-plugin/plugin.json` from `Coding` to `Developer Tools`. Extends `tests/codex/test-marketplace-manifest.sh` so it asserts the plugin manifest category is portal-supported and matches the marketplace entry.

## Is this change appropriate for the core library?

Yes. This is release metadata for the existing core Superpowers Codex distribution path. It does not add a new skill, workflow, dependency, or third-party integration; it keeps the official Codex package uploadable.

## What alternatives did you consider?

- Change only the packaged archive during release: rejected because the repo manifest would remain wrong and future packages would regress.
- Use `Other`: rejected because the prior official package and current marketplace manifest both already use `Developer Tools`, which better describes Superpowers.
- Add the check only to the new packaging test from #1876: rejected because this manifest rule should be covered on `dev` even before the portal packaging script lands.

## Does this PR contain multiple unrelated changes?

No. Both changes address one validation failure: `.codex-plugin/plugin.json` used an unsupported Codex portal category.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1876, #1771, #1261, #1165

No duplicate PR was found for fixing the Codex plugin manifest category. Related PRs cover the new portal packaging script (#1876), old Codex sync payload exclusions (#1771), committed Codex plugin files in the old sync path (#1261), and earlier Codex plugin tooling mirroring (#1165). This PR is narrower: it fixes a portal enum validation error in the committed plugin manifest.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app/API | exact build not exposed in-session | GPT-5 Codex | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a new harness.

## Evaluation

- Initial prompt: Drew reported the Codex portal rejected the package because `.codex-plugin/plugin.json` used an unsupported `interface.category` value.
- Eval sessions after making the change: 0 formal skill-behavior eval sessions. This is release metadata, not behavior-shaping skill content.
- Before/after outcome: before this change, `tests/codex/test-marketplace-manifest.sh` did not check the plugin manifest category and the repo manifest used unsupported `Coding`. After this change, the manifest uses supported `Developer Tools`, and the test fails if the manifest category is outside the portal enum or diverges from the marketplace entry.

Verification run:

```text
bash tests/codex/test-marketplace-manifest.sh
scripts/lint-shell.sh tests/codex/test-marketplace-manifest.sh
git diff --check
```

Red/green evidence:

```text
Before manifest fix:
AssertionError: plugin manifest category: expected one of [...], got 'Coding'

After manifest fix:
Codex marketplace manifest looks good
Linting 1 shell files
```

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is not a skills-content change. The regression test explicitly covers the portal-supported category enum and asserts category parity between `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
