### PR TITLE
fix(codex): suppress SessionStart hook auto-discovery with empty hooks object

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,6 +21,7 @@
     "workflow"
   ],
   "skills": "./skills/",
+  "hooks": {},
   "interface": {
     "displayName": "Superpowers",
     "shortDescription": "Planning, TDD, debugging, and delivery workflows for coding agents",

--- a/tests/codex/test-marketplace-manifest.sh
+++ b/tests/codex/test-marketplace-manifest.sh
@@ -51,10 +51,25 @@ if not plugin_manifest.exists():
 
 manifest = json.loads(plugin_manifest.read_text(encoding="utf-8"))
 assert_equal(manifest.get("name"), plugin.get("name"), "plugin manifest name")
+
+# Codex auto-discovers a plugin's hooks/hooks.json whenever the Codex manifest
+# has no `hooks` field: load_plugin_hooks falls back to a hardcoded
+# DEFAULT_HOOKS_CONFIG_FILE = "hooks/hooks.json" and registers it. That file is
+# the Claude Code SessionStart hook, it is tracked in this repo, and this
+# marketplace installs the whole repo root (source url "./"), so on Codex the
+# fallback re-registers the SessionStart hook and its install-time trust prompt.
+# Declaring an empty inline hooks object ({}) parses as an empty inline hook set
+# and suppresses the auto-discovery. An absent field, an empty array ([]), and
+# an empty inline list all collapse back to the fallback, so the value must be
+# exactly an empty object.
+hooks_config = repo_root / "hooks" / "hooks.json"
+if not hooks_config.exists():
+    raise AssertionError("hooks/hooks.json must exist (Claude Code SessionStart hook)")
+
 assert_equal(
     manifest.get("hooks"),
-    None,
-    "Codex manifest ships no hooks",
+    {},
+    "Codex manifest must declare empty hooks {} to suppress hooks/hooks.json auto-discovery",
 )
 
 print("Codex marketplace manifest looks good")


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (1M context) — `claude-opus-4-8[1m]` |
| Harness + version | Claude Code 2.1.197 |
| All plugins installed | superpowers@superpowers-dev, superpowers-chrome, elements-of-style, episodic-memory, cloud-build, decision-log, greenfield, iterative-development, linear, primeradiant-ops, unifi-network |
| Human partner who reviewed this diff | Drew Ritter (drew@primeradiant.com) — directed the fix and reviewed the complete diff in-session |

## What problem are you trying to solve?

Real session, not theoretical. Installing superpowers v6.1.0 into Codex (codex-cli 0.142.0) from the marketplace —

```
codex plugin marketplace add obra/superpowers
codex plugin add superpowers --marketplace superpowers-dev
```

— makes Codex prompt to **approve a SessionStart hook** at session start:

```
SessionStart hooks — 1 hook needs review before it can run.
Event    SessionStart
Matcher  startup|clear|compact
Command  ".../superpowers/6.1.0/hooks/run-hook.cmd" session-start
```

v6.1.0 was supposed to ship **no** Codex hook (#1845 "Remove Codex hooks").

**Root cause** (confirmed in the Codex source and reproduced live, not inferred): Codex auto-discovers a plugin's `hooks/hooks.json` whenever the Codex manifest has no `hooks` field. In `codex-rs/core-plugins/src/loader.rs`, `load_plugin_hooks` falls back to a hardcoded `DEFAULT_HOOKS_CONFIG_FILE = "hooks/hooks.json"` (loader.rs:60) in the `None` branch (loader.rs:1100-1112) and registers it if the file exists. `hooks/hooks.json` is the **Claude Code** SessionStart hook, it is git-tracked, and `.agents/plugins/marketplace.json` installs the whole repo root (`source.url: "./"`), so the fallback finds it. #1845 removed the Codex-specific `hooks-codex.json` and the manifest `hooks` pointer — which is exactly what dropped the manifest into the `None` branch and handed control to the fallback. The command in the prompt is `session-start` (the Claude script), **not** the removed `session-start-codex`, confirming it is the auto-discovered Claude `hooks/hooks.json`.

OpenAI's own docs confirm the behavior (developers.openai.com/codex/plugins/build): *"If your plugin stores hooks at ./hooks/hooks.json, you do not need a hooks entry in .codex-plugin/plugin.json; Codex checks that default file automatically."*

## What does this PR change?

Adds `"hooks": {}` to `.codex-plugin/plugin.json`. An empty inline hooks object parses as an empty inline hook set in Codex's `resolve_manifest_hooks`, which stops the loader reaching the `hooks/hooks.json` auto-discovery fallback — so Codex registers zero hooks and no longer prompts. The Codex manifest test is updated to assert `hooks: {}` (and that `hooks/hooks.json` exists, which is what makes the declaration necessary) instead of asserting the field is absent — the old assertion passed *while the hook was still being auto-discovered*.

## Is this change appropriate for the core library?

Yes. It is packaging metadata for the Codex distribution of superpowers core itself — not project-, team-, or domain-specific, and no third-party dependency. It changes only how Codex loads the core plugin, and benefits every Codex user of superpowers.

## What alternatives did you consider?

- **`"hooks": []` (empty array)** — tested live, does **not** work. An empty array (and an empty inline list) collapses back to `None` in `resolve_manifest_hooks` (manifest.rs) and re-triggers the auto-discovery fallback; the hook still fired. Only an empty **object** stays as `Some(Inline)`.
- **Make the hook a no-op on Codex** (detect Codex, emit nothing) — rejected. The trust prompt is computed from a hash of the registered command *before* the hook runs (`codex-rs/hooks/src/engine/discovery.rs`); a registered-but-empty hook still prompts. Only registering zero hooks removes the prompt.
- **Exclude/rename `hooks/hooks.json` for Codex** — rejected. Claude Code requires `hooks/hooks.json` at that exact path (it auto-discovers it too), and the direct `url: "./"` install ships the whole repo, so per-file exclusion isn't available on that install path. The empty-object opt-out is surgical and harness-isolated: Codex reads `.codex-plugin/plugin.json` first (`utils/plugins/src/plugin_namespace.rs` probes `.codex-plugin/` then `.claude-plugin/`), so `hooks: {}` is invisible to Claude Code, which reads `.claude-plugin/plugin.json` and keeps auto-discovering `hooks/hooks.json` exactly as before.

## Does this PR contain multiple unrelated changes?

No — one manifest field plus its test, for one problem (the Codex SessionStart-hook leak). (Out of scope, noted for a follow-up: `hooks/session-start-codex` is now orphaned — nothing has wired it up since #1845.)

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: **#1845 (Remove Codex hooks, MERGED)** — this is the PR whose removal exposed the auto-discovery fallback; this PR is the direct follow-up fix. Also lineage: #1540 (native Codex plugin hooks), #1838 (stop SessionStart re-firing on resume), #1829 (Add Codex marketplace manifest with `url: "./"`). #1877 (OPEN) also edits `.codex-plugin/plugin.json` but a different field (`category`) — not a duplicate, minor merge-adjacency only.

No PR proposing to suppress the auto-discovered `hooks/hooks.json` (or declare empty manifest hooks) exists, open or closed.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (authoring) | 2.1.197 | Opus 4.8 (1M context) | `claude-opus-4-8[1m]` |
| Codex CLI (runtime under test) | 0.142.0 | — | — |

Live verification — installed the committed branch into an isolated `CODEX_HOME` on real Codex 0.142.0 and ran `codex exec`:

- **Before** (manifest with no `hooks` key): stderr logs `hook: SessionStart` and the session rollout contains the injected `<EXTREMELY_IMPORTANT> You have superpowers …` bootstrap developer-message.
- **`"hooks": []`** (negative control): still fires — proves the array form does not suppress.
- **After (`"hooks": {}`)**: no `hook: SessionStart`, zero bootstrap injection; the plugin still loads and the model autonomously reads the `using-superpowers` skill via Codex's native skill discovery (the desired behavior).
- Test suites pass: `tests/codex/test-marketplace-manifest.sh`, `tests/codex-plugin-sync/test-sync-to-codex-plugin.sh`, `tests/hooks/test-session-start.sh`.

## New harness support (required if this PR adds a new harness)

N/A — this fixes the existing Codex integration; no new harness is added.

## Evaluation
- **Initial prompt that led here:** Drew asked why fresh Codex installs of v6.1.0 prompt to approve a SessionStart hook (with a screenshot of the trust prompt).
- **Sessions run after the change:** end-to-end Codex install + `codex exec` repro across three manifest variants (absent / `[]` / `{}`), each in a fresh isolated `CODEX_HOME`.
- **Outcome change:** `absent` and `[]` → SessionStart hook registered + bootstrap injected (and, interactively, the trust prompt). `{}` → no hook registered, no prompt, and skills still surface natively. A binary, observable before/after — not "it works".

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` … — **N/A, not a skills change**
- [x] This change was tested adversarially, not just on the happy path (three manifest variants; found `[]` silently fails)
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language)

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
