### PR TITLE
[codex] Preserve hooks in Codex package manifest

### DIFF
--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -243,7 +243,9 @@ VERSION="$(jq -r '.version // empty' "$STAGE/.codex-plugin/plugin.json")"
 [[ -n "$VERSION" ]] || die "could not read version from .codex-plugin/plugin.json"
 
 if jq -e 'has("hooks")' "$STAGE/.codex-plugin/plugin.json" >/dev/null; then
-  die "Codex manifest must not declare hooks for the portal package"
+  manifest_tmp="$WORK_DIR/plugin-manifest.json"
+  jq 'del(.hooks)' "$STAGE/.codex-plugin/plugin.json" >"$manifest_tmp"
+  mv "$manifest_tmp" "$STAGE/.codex-plugin/plugin.json"
 fi
 
 if [[ -z "$OUTPUT" ]]; then

--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -242,12 +242,6 @@ git -C "$REPO_ROOT" archive --format=tar "$REF" -- \
 VERSION="$(jq -r '.version // empty' "$STAGE/.codex-plugin/plugin.json")"
 [[ -n "$VERSION" ]] || die "could not read version from .codex-plugin/plugin.json"
 
-if jq -e 'has("hooks")' "$STAGE/.codex-plugin/plugin.json" >/dev/null; then
-  manifest_tmp="$WORK_DIR/plugin-manifest.json"
-  jq 'del(.hooks)' "$STAGE/.codex-plugin/plugin.json" >"$manifest_tmp"
-  mv "$manifest_tmp" "$STAGE/.codex-plugin/plugin.json"
-fi
-
 if [[ -z "$OUTPUT" ]]; then
   case "$FORMAT" in
     zip)

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -140,6 +140,9 @@ extracted="$TEST_ROOT/extracted"
 tar_extracted="$TEST_ROOT/tar-extracted"
 write_metadata_fixture "$metadata_source"
 
+source_hooks="$(python3 -c 'import json; print(json.load(open("'"$REPO_ROOT"'/.codex-plugin/plugin.json")).get("hooks"))')"
+assert_equals "$source_hooks" "{}" "source Codex manifest suppresses local hook auto-discovery"
+
 if output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_source" --output "$archive" 2>&1)"; then
   pass "package script exits successfully"
 else

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -173,7 +173,7 @@ assert_contains "$archive_paths" "assets/superpowers-small.svg" "archive include
 
 manifest_summary="$(read_archive_file "$archive" .codex-plugin/plugin.json | python3 -c 'import json,sys; data=json.load(sys.stdin); print("\t".join([data["name"], data["version"], data["skills"], str(data.get("hooks"))]))')"
 expected_version="$(python3 -c 'import json; print(json.load(open("'"$REPO_ROOT"'/.codex-plugin/plugin.json"))["version"])')"
-assert_equals "$manifest_summary" "superpowers	$expected_version	./skills/	None" "archive manifest is current and hook-free"
+assert_equals "$manifest_summary" "superpowers	$expected_version	./skills/	$source_hooks" "archive manifest preserves source hooks"
 
 skill_count="$(find "$extracted/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
 metadata_count="$(find "$extracted/skills" -path '*/agents/openai.yaml' -type f | wc -l | tr -d ' ')"


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 Codex |
| Harness + version | Codex desktop app, version not exposed in this session |
| All plugins installed | GitHub 0.1.5; Linear 5.0.0; Codex Security 0.1.10; Slack 0.1.2; Primeradiant Ops 2.4.2; Browser 26.623.70822; OpenAI bundled document/pdf/presentation/spreadsheet/template tooling; local Superpowers skills |
| Human partner who reviewed this diff | Drew Ritter reviewed the direction and requested the package manifest match the source manifest instead of stripping hooks |

## What problem are you trying to solve?

After #1876 added the Codex package script and #1879 made the repo Codex manifest declare `hooks: {}` to suppress local Codex hook auto-discovery, the package script on `dev` rejected any manifest with a `hooks` key:

```text
ERROR: Codex manifest must not declare hooks for the portal package
```

Drew clarified that the generated package manifest should match the source manifest here. The package should preserve `hooks: {}` rather than stripping or rejecting it.

## What does this PR change?

This updates `scripts/package-codex-plugin.sh` so it no longer rejects or mutates a staged `.codex-plugin/plugin.json` that contains `hooks`.

It also updates `tests/codex/test-package-codex-plugin.sh` to assert both sides of the intended contract:

- the source Codex manifest intentionally has `hooks: {}`
- the generated archive manifest preserves the same hooks value

The archive still uses the existing runtime payload whitelist. This PR does not add the repository's `hooks/` directory to the package.

## Is this change appropriate for the core library?

Yes. This is core packaging infrastructure for the Codex distribution artifact. It is not project-specific, team-specific, or a third-party service integration.

## What alternatives did you consider?

One option was to strip `hooks` only from the staged package manifest. Drew rejected that direction because it makes the package manifest differ from the source manifest. Another option was to remove `hooks: {}` from `.codex-plugin/plugin.json`, but that would regress #1879 and reintroduce local Codex hook auto-discovery behavior.

## Does this PR contain multiple unrelated changes?

No. Both file changes are part of the same packaging contract: source manifest keeps local hook suppression and the archive manifest preserves it.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1876, #1879

I searched open and closed PRs for `package-codex-plugin hooks`, `Codex portal hooks`, and `hook-free`. I found no direct duplicate. #1876 introduced the package script/test; #1879 introduced the source manifest `hooks: {}` behavior. This PR reconciles those two merged changes by preserving the source manifest value in the archive.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app | version not exposed in this session | GPT-5 Codex | GPT-5 Codex |

## New harness support (required if this PR adds a new harness)

This PR does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Not applicable; this PR does not add harness support.

</details>

## Evaluation
- Initial prompt: Drew asked to fix the package/hook contradiction in the relevant new PR after PR #1877 exposed the failing package test on `dev`.
- Eval sessions after making the change: 0 agent-behavior eval sessions; this is shell packaging infrastructure, not behavior-shaping skill content.
- Before/after: before the final change, the script rejected or stripped the source `hooks` key. After the change, the package test passes and asserts that the generated archive manifest preserves the source `hooks: {}` value.

## Rigor

- [x] This is not a skills content change, so `superpowers:writing-skills` and adversarial skill evals do not apply
- [x] This change was tested on the failure path that motivated it, plus adjacent packaging/manifest checks
- [x] I did not modify behavior-shaping skill content

Verification run:

```text
tests/codex/test-package-codex-plugin.sh
tests/codex/test-marketplace-manifest.sh
scripts/lint-shell.sh scripts/package-codex-plugin.sh tests/codex/test-package-codex-plugin.sh
git diff --check
```

## Human review
- [x] A human has reviewed the intended behavior and requested the archive manifest match the source manifest
