### PR TITLE
fix: narrow using-superpowers trigger scope

### DIFF
--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -703,8 +703,10 @@ Then:
     unrecognized.
   - **Otherwise lean on the installed `using-superpowers` skill itself.** If the
     harness surfaces each installed skill's name + description at session start,
-    the `using-superpowers` description ("Use when starting any conversation…")
-    can prompt the model to load it — installing the skill *is* the bootstrap.
+    the `using-superpowers` description ("Use when a user asks to implement,
+    debug, review, plan, research, automate, or modify files and a specialized
+    skill may apply") can prompt the model to load it — installing the skill *is*
+    the bootstrap.
     Softer (no guaranteed wrapper; it carries triggering but not the tool mapping
     — see Step 5), so prefer the declared context file when available.
   - If neither works, the harness cannot be cleanly supported yet — **say so**

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-superpowers
-description: Use when starting any conversation - establishes how to find and use skills, requiring skill invocation before ANY response including clarifying questions
+description: Use when a user asks to implement, debug, review, plan, research, automate, or modify files and a specialized skill may apply
 ---
 
 <SUBAGENT-STOP>
@@ -8,46 +8,40 @@ If you were dispatched as a subagent to execute a specific task, ignore this ski
 </SUBAGENT-STOP>
 
 <EXTREMELY-IMPORTANT>
-If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+Invoke a skill when the user request clearly matches a skill description or explicitly names a skill.
 
-IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+If no skill clearly applies, respond normally.
 
-This is not negotiable. You cannot rationalize your way out of this.
+When a skill does clearly apply, use it before taking task actions.
 </EXTREMELY-IMPORTANT>
 
 ## The Rule
 
-**Invoke relevant or requested skills BEFORE any response or action** — including clarifying questions, exploring the codebase, or checking files. If it turns out wrong for the situation, you don't have to use it.
+Use skills for concrete work where their descriptions match the request: implementation, debugging, reviews, planning, research, automation, file edits, publishing, or domain-specific workflows.
 
-**Before entering plan mode:** if you haven't already brainstormed, invoke the brainstorming skill first.
+For lightweight conversation, greetings, simple explanations, or requests that do not clearly map to a skill, answer directly.
 
-Then announce "Using [skill] to [purpose]" and follow the skill exactly. If it has a checklist, create a todo per item.
+Before entering plan mode, if the user request calls for design or planning and you have not already brainstormed, invoke the brainstorming skill first.
+
+When you invoke a skill, keep any user-facing note brief and useful. Follow the skill exactly. If it has a checklist, create a todo per item.
 
 ## Skill Priority
 
-When multiple skills apply, process skills come first — they set the approach, then implementation skills (frontend-design, etc.) carry it out. Brainstorming and systematic-debugging are Superpowers' most common process skills, but the rule holds for any of them.
+When multiple skills clearly apply, process skills come first because they set the approach, then implementation skills carry it out. Brainstorming and systematic-debugging are Superpowers' most common process skills, but the rule holds for any of them.
 
-- "Let's build X" → superpowers:brainstorming first, then implementation skills.
-- "Fix this bug" → superpowers:systematic-debugging first, then domain skills.
+- "Let's build X" -> superpowers:brainstorming first, then implementation skills.
+- "Fix this bug" -> superpowers:systematic-debugging first, then domain skills.
 
-## Red Flags
+## Common Mistakes
 
-These thoughts mean STOP—you're rationalizing:
+Avoid both failure modes:
 
-| Thought | Reality |
-|---------|---------|
-| "This is just a simple question" | Questions are tasks. Check for skills. |
-| "I need more context first" | Skill check comes BEFORE clarifying questions. |
-| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
-| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
-| "Let me gather information first" | Skills tell you HOW to gather information. |
-| "This doesn't need a formal skill" | If a skill exists, use it. |
-| "I remember this skill" | Skills evolve. Read current version. |
-| "This doesn't count as a task" | Action = task. Check for skills. |
-| "The skill is overkill" | Simple things become complex. Use it. |
-| "I'll just do this one thing first" | Check BEFORE doing anything. |
-| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
-| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+| Mistake | Correct behavior |
+|---------|------------------|
+| Treating every conversation as a skill trigger | Use skills only for clear matches or explicit skill requests. |
+| Skipping a clearly matching skill because the task seems quick | Invoke the matching skill before task actions. |
+| Relying on memory of a skill | Read the current skill instructions when using it. |
+| Announcing noisy process details | Keep skill-use notes brief and helpful. |
 
 ## Platform Adaptation
 

--- a/tests/using-superpowers/test-trigger-scope.ps1
+++ b/tests/using-superpowers/test-trigger-scope.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$skill = Join-Path $repoRoot "skills\using-superpowers\SKILL.md"
+$content = Get-Content -LiteralPath $skill -Raw
+
+function Fail($message) {
+  Write-Error "FAIL: $message"
+  exit 1
+}
+
+if ($content -notmatch [regex]::Escape("description: Use when a user asks to implement, debug, review, plan, research, automate, or modify files and a specialized skill may apply")) {
+  Fail "using-superpowers description should be scoped to concrete work where a specialized skill may apply"
+}
+
+if ($content -notmatch [regex]::Escape("Invoke a skill when the user request clearly matches a skill description or explicitly names a skill.")) {
+  Fail "using-superpowers rule should invoke skills on clear matches or explicit skill requests"
+}
+
+if ($content -match [regex]::Escape("Use when starting any conversation")) {
+  Fail "using-superpowers should not trigger on every conversation start"
+}
+
+if ($content -match [regex]::Escape("1% chance")) {
+  Fail "using-superpowers should not use the broad 1% chance trigger"
+}
+
+if ($content -match [regex]::Escape("This is just a simple question")) {
+  Fail "using-superpowers should not frame every simple question as requiring a skill check"
+}
+
+Write-Output "PASS: using-superpowers trigger scope is concrete and explicit"


### PR DESCRIPTION
## Summary
- Narrow using-superpowers discovery so it applies to concrete work where a specialized skill may apply.
- Replace the broad 1% trigger with clear-match or explicit-skill-request guidance.
- Add a PowerShell regression check for the trigger wording and update harness porting docs.

## Validation
- powershell -NoProfile -ExecutionPolicy Bypass -File tests\\using-superpowers\\test-trigger-scope.ps1
- git diff --check

## Note
Direct push to obra/superpowers main was attempted but rejected with 403 for this GitHub account, so this PR is opened from a fork.