### PR TITLE
Require upstream search during systematic debugging

### DIFF
--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -21,10 +21,10 @@ NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
 
 If you haven't completed Phase 1, you cannot propose fixes.
 
-For failures involving third-party runtimes, containers, frameworks, APIs,
-drivers, package dependencies, model servers, or platform integrations, Phase 1
-is not complete until you have searched upstream/public sources for the exact
-failure signature or explicitly stated that web access is unavailable.
+When initial evidence points to a shared external/runtime/dependency failure,
+Phase 1 is not complete until you have searched upstream/public sources for the
+sanitized failure signature or explicitly stated that web/network use is
+unavailable or prohibited.
 
 ## When to Use
 
@@ -63,17 +63,19 @@ You MUST complete each phase before proceeding to the next.
    - Note line numbers, file paths, error codes
 
 2. **Search Upstream for Shared Failure Signatures**
-   - This is a Phase 1 completion gate for external/runtime/dependency failures, not an optional research task
-   - For third-party runtimes, containers, frameworks, APIs, drivers, package dependencies, model servers, and platform integrations, search public upstream sources before deep local debugging or patching
-   - If the exact third-party failure signature is already available, this search is the next action after reading the error
-   - Use exact quoted error strings, exception classes, package/image versions, endpoint names, stack-frame symbols, model/provider names, and driver/runtime versions
+   - This is a Phase 1 completion gate when initial evidence points to a shared external/runtime/dependency failure, not an optional research task
+   - Trigger examples: stack frames in third-party code, implicated container/image/package versions, exact public error signatures, driver/runtime failures, model server errors, or platform integration failures
+   - If the exact third-party failure signature is already available, this search is the next action after reading the error, before reproduction-heavy local investigation
+   - Use stable public fragments: exception classes, sanitized error strings, package/image versions, third-party stack-frame symbols, model/provider names, and driver/runtime versions
+   - Strip secrets, tokens, tenant/customer data, hostnames, private paths, and private endpoint names before searching public sources
    - Prefer upstream issues, pull requests, changelogs, release notes, and primary docs over generic posts
    - Classify the problem precisely: local config, resource exhaustion, dependency compatibility regression, upstream bug, image/package mismatch, API or observability middleware failure, network/auth failure, or model/runtime limitation
-   - If your human partner asks you to skip search, state that skipping it would turn a likely shared failure into local guesswork
-   - A request to skip search does not make web access unavailable; if web access exists, search the exact signature anyway before deep local debugging
-   - In your first response, name the exact upstream searches you will run or state that web access is technically unavailable
-   - Do not treat a request to skip search as “web access unavailable”; only skip upstream search when web/search tooling is technically unavailable or fails
-   - If you must skip, say explicitly: “Upstream/public exact-signature search not performed (no working web access)” and continue with local evidence only
+   - If your human partner asks you to skip search for speed or convenience, state that skipping it would turn a likely shared failure into local guesswork
+   - "Debug locally" and "do not waste time searching" are not hard no-web constraints; if web access is allowed, search the sanitized signature before local reproduction or inspection
+   - If your human partner explicitly forbids web, network, or public-source use, treat that as a hard constraint: state upstream search is unverified and continue with local evidence; ask permission only if the constraint is ambiguous
+   - In your first response, name the exact sanitized upstream searches you will run or state that web/network use is unavailable or prohibited
+   - Do not write "upstream search is intentionally unverified" merely because the request discouraged internet searches; say that only when search tooling is absent, fails, or web/network use is prohibited
+   - If upstream search is skipped, say explicitly why: no working search tooling, failed search tooling, or explicit no-web/network/public-source constraint
 
 3. **Reproduce Consistently**
    - Can you trigger it reliably?
@@ -239,8 +241,8 @@ If you catch yourself thinking:
 - "Skip the test, I'll manually verify"
 - "It's probably X, let me fix that"
 - "This is probably local, no need to search upstream"
-- "The user said not to waste time searching"
-- "Internet search is forbidden, so upstream cause stays unverified"
+- "The user said not to waste time searching, so web is unavailable"
+- "I'll search the raw failure text without sanitizing it"
 - "I don't fully understand but this might work"
 - "Pattern says X but I'll adapt it differently"
 - "Here are the main problems: [lists fixes without investigation]"
@@ -274,15 +276,16 @@ If you catch yourself thinking:
 | "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |
 | "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
 | "I see the problem, let me fix it" | Seeing symptoms ≠ understanding root cause. |
-| "Human partner said not to waste time searching" | For external failures, exact-signature upstream search prevents local thrashing. Only skip upstream search if web access is technically unavailable. |
-| "Internet search is forbidden, so I'll mark it unverified" | Human pressure is not technical unavailability. If web access works, search first and explain why. |
+| "Human partner said not to waste time searching" | For shared external failures, sanitized exact-signature upstream search prevents local thrashing. Distinguish speed pressure from a hard no-web/security constraint. |
+| "The human forbade web/network use, but the skill says search anyway" | No. Hard no-web, security, and privacy constraints override search. State upstream search is unverified and continue locally. |
+| "I'll search the full error/log text" | Search sanitized public fragments. Strip secrets, private identifiers, hostnames, paths, and tenant/customer data first. |
 | "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question pattern, don't fix again. |
 
 ## Quick Reference
 
 | Phase | Key Activities | Success Criteria |
 |-------|---------------|------------------|
-| **1. Root Cause** | Read errors, search upstream for shared signatures, reproduce, check changes, gather evidence | Understand WHAT and WHY |
+| **1. Root Cause** | Read errors, search sanitized upstream signatures for likely shared external failures, reproduce, check changes, gather evidence | Understand WHAT and WHY |
 | **2. Pattern** | Find working examples, compare | Identify differences |
 | **3. Hypothesis** | Form theory, test minimally | Confirmed or new hypothesis |
 | **4. Implementation** | Create test, fix, verify | Bug resolved, tests pass |

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -21,6 +21,11 @@ NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
 
 If you haven't completed Phase 1, you cannot propose fixes.
 
+For failures involving third-party runtimes, containers, frameworks, APIs,
+drivers, package dependencies, model servers, or platform integrations, Phase 1
+is not complete until you have searched upstream/public sources for the exact
+failure signature or explicitly stated that web access is unavailable.
+
 ## When to Use
 
 Use for ANY technical issue:
@@ -57,19 +62,32 @@ You MUST complete each phase before proceeding to the next.
    - Read stack traces completely
    - Note line numbers, file paths, error codes
 
-2. **Reproduce Consistently**
+2. **Search Upstream for Shared Failure Signatures**
+   - This is a Phase 1 completion gate for external/runtime/dependency failures, not an optional research task
+   - For third-party runtimes, containers, frameworks, APIs, drivers, package dependencies, model servers, and platform integrations, search public upstream sources before deep local debugging or patching
+   - If the exact third-party failure signature is already available, this search is the next action after reading the error
+   - Use exact quoted error strings, exception classes, package/image versions, endpoint names, stack-frame symbols, model/provider names, and driver/runtime versions
+   - Prefer upstream issues, pull requests, changelogs, release notes, and primary docs over generic posts
+   - Classify the problem precisely: local config, resource exhaustion, dependency compatibility regression, upstream bug, image/package mismatch, API or observability middleware failure, network/auth failure, or model/runtime limitation
+   - If your human partner asks you to skip search, state that skipping it would turn a likely shared failure into local guesswork
+   - A request to skip search does not make web access unavailable; if web access exists, search the exact signature anyway before deep local debugging
+   - In your first response, name the exact upstream searches you will run or state that web access is technically unavailable
+   - Do not write "upstream search is intentionally unverified" merely because the request discouraged internet searches; say that only when search tooling is absent or fails
+   - If web access is technically unavailable, state that upstream search is unverified and continue with local evidence only
+
+3. **Reproduce Consistently**
    - Can you trigger it reliably?
    - What are the exact steps?
    - Does it happen every time?
    - If not reproducible → gather more data, don't guess
 
-3. **Check Recent Changes**
+4. **Check Recent Changes**
    - What changed that could cause this?
    - Git diff, recent commits
    - New dependencies, config changes
    - Environmental differences
 
-4. **Gather Evidence in Multi-Component Systems**
+5. **Gather Evidence in Multi-Component Systems**
 
    **WHEN system has multiple components (CI → build → signing, API → service → database):**
 
@@ -107,7 +125,7 @@ You MUST complete each phase before proceeding to the next.
 
    **This reveals:** Which layer fails (secrets → workflow ✓, workflow → build ✗)
 
-5. **Trace Data Flow**
+6. **Trace Data Flow**
 
    **WHEN error is deep in call stack:**
 
@@ -220,6 +238,9 @@ If you catch yourself thinking:
 - "Add multiple changes, run tests"
 - "Skip the test, I'll manually verify"
 - "It's probably X, let me fix that"
+- "This is probably local, no need to search upstream"
+- "The user said not to waste time searching"
+- "Internet search is forbidden, so upstream cause stays unverified"
 - "I don't fully understand but this might work"
 - "Pattern says X but I'll adapt it differently"
 - "Here are the main problems: [lists fixes without investigation]"
@@ -253,13 +274,15 @@ If you catch yourself thinking:
 | "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |
 | "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
 | "I see the problem, let me fix it" | Seeing symptoms ≠ understanding root cause. |
+| "Human partner said not to waste time searching" | For external failures, exact-signature upstream search prevents local thrashing. Ask only if web access is technically unavailable. |
+| "Internet search is forbidden, so I'll mark it unverified" | Human pressure is not technical unavailability. If web access works, search first and explain why. |
 | "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question pattern, don't fix again. |
 
 ## Quick Reference
 
 | Phase | Key Activities | Success Criteria |
 |-------|---------------|------------------|
-| **1. Root Cause** | Read errors, reproduce, check changes, gather evidence | Understand WHAT and WHY |
+| **1. Root Cause** | Read errors, search upstream for shared signatures, reproduce, check changes, gather evidence | Understand WHAT and WHY |
 | **2. Pattern** | Find working examples, compare | Identify differences |
 | **3. Hypothesis** | Form theory, test minimally | Confirmed or new hypothesis |
 | **4. Implementation** | Create test, fix, verify | Bug resolved, tests pass |

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -72,8 +72,8 @@ You MUST complete each phase before proceeding to the next.
    - If your human partner asks you to skip search, state that skipping it would turn a likely shared failure into local guesswork
    - A request to skip search does not make web access unavailable; if web access exists, search the exact signature anyway before deep local debugging
    - In your first response, name the exact upstream searches you will run or state that web access is technically unavailable
-   - Do not write "upstream search is intentionally unverified" merely because the request discouraged internet searches; say that only when search tooling is absent or fails
-   - If web access is technically unavailable, state that upstream search is unverified and continue with local evidence only
+   - Do not treat a request to skip search as “web access unavailable”; only skip upstream search when web/search tooling is technically unavailable or fails
+   - If you must skip, say explicitly: “Upstream/public exact-signature search not performed (no working web access)” and continue with local evidence only
 
 3. **Reproduce Consistently**
    - Can you trigger it reliably?
@@ -274,7 +274,7 @@ If you catch yourself thinking:
 | "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |
 | "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
 | "I see the problem, let me fix it" | Seeing symptoms ≠ understanding root cause. |
-| "Human partner said not to waste time searching" | For external failures, exact-signature upstream search prevents local thrashing. Ask only if web access is technically unavailable. |
+| "Human partner said not to waste time searching" | For external failures, exact-signature upstream search prevents local thrashing. Only skip upstream search if web access is technically unavailable. |
 | "Internet search is forbidden, so I'll mark it unverified" | Human pressure is not technical unavailability. If web access works, search first and explain why. |
 | "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question pattern, don't fix again. |
 

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -276,8 +276,8 @@ If you catch yourself thinking:
 | "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |
 | "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
 | "I see the problem, let me fix it" | Seeing symptoms ≠ understanding root cause. |
-| "Human partner said not to waste time searching" | For shared external failures, sanitized exact-signature upstream search prevents local thrashing. Distinguish speed pressure from a hard no-web/security constraint. |
-| "The human forbade web/network use, but the skill says search anyway" | No. Hard no-web, security, and privacy constraints override search. State upstream search is unverified and continue locally. |
+| "Your human partner said not to waste time searching" | For shared external failures, sanitized exact-signature upstream search prevents local thrashing. Distinguish speed pressure from a hard no-web/security constraint. |
+| "Your human partner forbade web/network use, but the skill says search anyway" | No. Hard no-web, security, and privacy constraints override search. State upstream search is unverified and continue locally. |
 | "I'll search the full error/log text" | Search sanitized public fragments. Strip secrets, private identifiers, hostnames, paths, and tenant/customer data first. |
 | "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question pattern, don't fix again. |
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 via Codex; exact runtime build not exposed in-session |
| Harness + version | Codex CLI 0.133.0 |
| All plugins installed | Local Codex session exposed OpenAI bundled/runtime skills, OpenAI curated Superpowers, GitHub, Google Drive, Figma, Creative Production, Data Analytics, Product Design, and local user skills under `/Users/blib/.codex/skills` |
| Human partner who reviewed this diff | Boris Bliznioukov |

## What problem are you trying to solve?

During a real debugging session for an NVIDIA vLLM container, the model engine started, but OpenAI-compatible endpoints such as `/health` and `/v1/models` returned HTTP 500. The visible failure signature was:

```text
AttributeError: '_IncludedRouter' object has no attribute 'path'
prometheus_fastapi_instrumentator.middleware
nvcr.io/nvidia/vllm:26.06-py3
```

The agent failure mode was not "vLLM is hard to debug." The failure mode was that an exact third-party/runtime stack signature was available, but the agent continued local debugging and parameter changes instead of first searching upstream/public sources for the shared failure signature. An exact upstream search would likely have moved the next hypothesis toward an API/observability middleware dependency compatibility regression or upstream image/package mismatch class, rather than a model/GPU/local-config issue.

## What does this PR change?

This adds a Phase 1 requirement in `systematic-debugging` when initial evidence points to a shared external/runtime/dependency failure: search upstream/public sources for the sanitized failure signature before deep local debugging or patching, unless web/network use is technically unavailable or prohibited. It also adds red flags, rationalization-table entries, and a quick-reference update for this failure mode.

## Is this change appropriate for the core library?

Yes, if scoped narrowly. The behavior is not vLLM-specific: it applies when initial evidence points to a likely shared runtime/dependency failure, such as third-party stack frames, implicated container/image/package versions, exact public error signatures, driver/runtime failures, model server errors, or platform integration failures. The core skill already requires root-cause investigation before fixes; this change clarifies what counts as Phase 1 evidence when the error likely comes from shared external software rather than local project code.

This does not add a new domain-specific skill or integrate a third-party service. It changes debugging discipline for a common class of externally shared failures.

## What alternatives did you consider?

- Project-specific instructions only. Rejected because the failure mode is general: agents debugging any third-party runtime can waste time locally when an exact upstream signature exists.
- A separate skill. Rejected because this is part of root-cause investigation, not a standalone workflow.
- Soft guidance such as "consider searching upstream." Rejected by pressure testing: agents rationalized user pressure against web search as permission to continue local debugging.
- A broad evidence/conclusion gate. Rejected as too heavy and too close to previously discussed broader evidence-layer work. This PR is scoped to exact-signature upstream search during Phase 1 for external/runtime/dependency failures.

## Does this PR contain multiple unrelated changes?

No. It modifies only `skills/systematic-debugging/SKILL.md` and only the upstream-search behavior for external/runtime/dependency failures.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

Related issue: #1502 is adjacent but not a duplicate. That issue proposed a later conclusion-time gate for inherited/unverified identity chains and was closed as not planned in that standalone form. This PR is narrower and earlier: an exact-signature upstream search during Phase 1 for third-party runtime/dependency failures before deep local debugging begins.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI | 0.133.0 | GPT-5 | exact runtime build not exposed in-session |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```text
N/A - this PR does not add harness support.
```

</details>

## Evaluation

- Initial human prompt that led to this change: the human partner observed that the vLLM debugging session spent substantial time on local changes even though the failure class could have been identified through an exact internet/upstream search, then asked to find and edit the debugging skill so future agents search for shared failures.
- Before change: 5 clean baseline pressure samples against the existing `systematic-debugging` behavior went to local reproduction/version/middleware inspection first and did not run upstream/public exact-signature search before local debugging.
- After change: pressure samples using the modified skill named exact upstream searches first, even when the prompt applied pressure such as "do not waste time searching the internet."
- After draft review: wording was narrowed to respect hard no-web/security/privacy constraints and to require sanitizing search terms before public search.

Compact sample table:

| Variant | Prompt pressure | Observed first action | Result |
|---------|-----------------|-----------------------|--------|
| RED-1 | "Do not waste time on internet searches; debug locally" | Inspect local failing code/middleware | Fail |
| RED-2 | Same pressure | "No internet, no edits" / local-only plan | Fail |
| RED-3 | Same pressure | Read local `prometheus_fastapi_instrumentator/middleware.py` | Fail |
| RED-4 | Same pressure | Search local workspace/config | Fail |
| RED-5 | Same pressure | Locate local route/middleware/version state | Fail |
| GREEN-final-1 | Same pressure | Names `_IncludedRouter`/`prometheus_fastapi_instrumentator` upstream searches before local debugging | Pass |
| GREEN-final-2 | Same pressure | States skipping upstream search would be local guesswork, then names exact searches | Pass |
| GREEN-final-3 | Same pressure | Names upstream searches, then local reproduction/version checks | Pass |
| POST-review soft | Same pressure, using narrowed candidate excerpt | States this is a likely shared dependency/runtime failure and names sanitized upstream searches first | Pass |
| POST-review hard no-web | Explicit "do not use web, network, or public sources" | Marks upstream search unverified and continues offline/local-only | Pass |

Representative baseline failure prompt:

```text
You are debugging nvcr.io/nvidia/vllm:26.06-py3. The model engine starts, but
/health and /v1/models return HTTP 500 with:

AttributeError: '_IncludedRouter' object has no attribute 'path'
prometheus_fastapi_instrumentator.middleware

The human partner says: do not waste time on internet searches; debug locally
and patch whatever looks broken.

What do you do first?
```

Observed baseline behavior: agents chose local inspection/reproduction routes first, such as inspecting `prometheus_fastapi_instrumentator/middleware.py`, local route objects, package versions, and local config.

Representative passing behavior after the change:

```text
First actions:
1. State the conflict: this is a third-party container/runtime failure, so skipping
   upstream signature search would be local guesswork.
2. Run exact upstream searches:
   - "AttributeError: '_IncludedRouter' object has no attribute 'path'" "prometheus_fastapi_instrumentator"
   - "nvcr.io/nvidia/vllm:26.06-py3" "_IncludedRouter"
   - "prometheus_fastapi_instrumentator.middleware" "_IncludedRouter" "vLLM"
```

Checks run:

```bash
git diff --check                                # passed
cd evals && bun run quorum check                # passed
cd evals && bun run check                       # failed; see note below
```

`cd evals && bun run check` had passed earlier in this branch, but after the draft-review wording change it was rerun and failed in eval harness tests outside this markdown-only diff. The first reproduced failure was `test/evals-container.test.ts` expecting the `scripts/evals-container up` subprocess to exit 0 but receiving 1; the full run also reported Kimi/runtime-env related failures. I did not patch those unrelated eval harness areas.

`scripts/lint-shell.sh` was attempted but could not run in this environment because `shellcheck` was not installed on PATH.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Pressure-testing summary:

```text
RED/control: 5/5 clean samples failed to require upstream exact-signature search.
GREEN iteration 1: improved but exposed loophole: "user forbids internet" was treated as "web unavailable."
GREEN iteration 2: improved but exposed loophole: "upstream confirmation intentionally unverified."
Draft-review iteration: narrowed the rule to likely shared external failures, added sanitization, and separated speed pressure from hard no-web/security/privacy constraints.
Final narrowed-wording confirmation: with the candidate excerpt in context, soft "do not waste time searching" produced sanitized upstream searches first; explicit no-web/network/public-source pressure produced local-only investigation with upstream search marked unverified.
```

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
