### PR TITLE
fix(brainstorming): triggerable description, resolvable paths, orphan prompt, exclusions

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorming
-description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+description: "Use when starting creative work — new features, components, added functionality, or behavior changes — that lacks an approved design or spec. Explores user intent, requirements and design before implementation. Not for bug fixes (use systematic-debugging), executing an existing plan (use executing-plans), or pure research questions."
 ---
 
 # Brainstorming Ideas Into Designs
@@ -16,6 +16,14 @@ Do NOT invoke any implementation skill, write any code, scaffold any project, or
 ## Anti-Pattern: "This Is Too Simple To Need A Design"
 
 Every project goes through this process. A todo list, a single-function utility, a config change — all of them. "Simple" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+
+## When NOT to Use
+
+Brainstorming is for creative work that lacks an approved design. Skip it when:
+
+- **Fixing a bug or investigating a failure** — use the systematic-debugging skill instead
+- **Executing an already-approved plan or spec** — use the executing-plans skill instead
+- **Answering a pure research or explanation question** — no design is being produced, so just answer it
 
 ## Checklist
 
@@ -118,6 +126,8 @@ After writing the spec document, look at it with fresh eyes:
 
 Fix any issues inline. No need to re-review — just fix and move on.
 
+For high-stakes or complex specs, you can optionally dispatch a fresh-eyes subagent review instead, using the prompt template in `{baseDir}/spec-document-reviewer-prompt.md`.
+
 **User Review Gate:**
 After the spec review loop passes, ask the user to review the written spec before proceeding:
 
@@ -156,4 +166,4 @@ A browser-based companion for showing mockups, diagrams, and visual options duri
 A question about a UI topic is not automatically a visual question. "What does personality mean in this context?" is a conceptual question — use the terminal. "Which wizard layout works better?" is a visual question — use the browser.
 
 If they agree to the companion, read the detailed guide before proceeding:
-`skills/brainstorming/visual-companion.md`
+`{baseDir}/visual-companion.md`

--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -35,7 +35,7 @@ The server watches a directory for HTML files and serves the newest one to the b
 ```bash
 # Start AFTER the user approves the companion. --open auto-opens their browser on
 # the first screen; --project-dir persists mockups and enables same-port restart.
-scripts/start-server.sh --project-dir /path/to/project --open
+{baseDir}/scripts/start-server.sh --project-dir /path/to/project --open
 
 # Returns: {"type":"server-started","port":52341,
 #           "url":"http://localhost:52341/?key=ab12…",
@@ -62,7 +62,7 @@ without repeating it.
 **Claude Code:**
 ```bash
 # Default mode works — the script backgrounds the server itself.
-scripts/start-server.sh --project-dir /path/to/project --open
+{baseDir}/scripts/start-server.sh --project-dir /path/to/project --open
 ```
 
 On Windows, the script auto-detects and switches to foreground mode (which blocks the tool call). Use `run_in_background: true` on the Bash tool call so the server survives across conversation turns, then read `$STATE_DIR/server-info` on the next turn to get the URL and port.
@@ -71,7 +71,7 @@ On Windows, the script auto-detects and switches to foreground mode (which block
 ```bash
 # Codex reaps background processes. The script auto-detects CODEX_CI and
 # switches to foreground mode. Run it normally — no extra flags needed.
-scripts/start-server.sh --project-dir /path/to/project --open
+{baseDir}/scripts/start-server.sh --project-dir /path/to/project --open
 ```
 
 **Copilot CLI:**
@@ -79,7 +79,7 @@ scripts/start-server.sh --project-dir /path/to/project --open
 # Use --foreground and start the server via the bash tool with mode: "async"
 # so the process survives across turns. Capture the returned shellId for
 # read_bash / stop_bash if you need to interact with it later.
-scripts/start-server.sh --project-dir /path/to/project --open --foreground
+{baseDir}/scripts/start-server.sh --project-dir /path/to/project --open --foreground
 ```
 
 **Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.
@@ -87,7 +87,7 @@ scripts/start-server.sh --project-dir /path/to/project --open --foreground
 If the URL is unreachable from your browser (common in remote/containerized setups), bind a non-loopback host:
 
 ```bash
-scripts/start-server.sh \
+{baseDir}/scripts/start-server.sh \
   --project-dir /path/to/project \
   --host 0.0.0.0 \
   --url-host localhost
@@ -280,12 +280,12 @@ If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser 
 ## Cleaning Up
 
 ```bash
-scripts/stop-server.sh $SESSION_DIR
+{baseDir}/scripts/stop-server.sh $SESSION_DIR
 ```
 
 If the session used `--project-dir`, mockup files persist in `.superpowers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
 
 ## Reference
 
-- Frame template (CSS reference): `scripts/frame-template.html`
-- Helper script (client-side): `scripts/helper.js`
+- Frame template (CSS reference): `{baseDir}/scripts/frame-template.html`
+- Helper script (client-side): `{baseDir}/scripts/helper.js`


### PR DESCRIPTION
# fix(brainstorming): triggerable description, resolvable paths, orphan prompt, exclusions

## Problem

Four structural defects in `skills/brainstorming/`, found during a structured skill-design audit:

1. **The description is the skill's only activation signal, and the current one over-fires with zero exclusions.** `"You MUST use this before any creative work..."` is second-person policy aimed at the agent *after* loading, not a triggering condition the harness can match *before* loading. As written it claims every creative task unconditionally — including bug fixes, plan execution, and research questions that other superpowers skills (systematic-debugging, executing-plans) explicitly own, and including work that already has an approved design.

2. **Plugin-root-relative paths don't resolve from normal working directories.** `SKILL.md` points to `skills/brainstorming/visual-companion.md`, and `visual-companion.md` invokes `scripts/start-server.sh`, `scripts/stop-server.sh`, and references `scripts/frame-template.html` / `scripts/helper.js`. These paths are relative to the plugin root, but the agent's cwd during a brainstorming session is the user's project — so following them as written fails (or worse, silently reads/executes the wrong file if the user's repo happens to have a `scripts/` dir).

3. **`spec-document-reviewer-prompt.md` is orphaned.** When the subagent spec-review loop was replaced by the inline Spec Self-Review, nothing in SKILL.md referenced the prompt file anymore — it ships in the skill directory with no way to be discovered.

4. **No "When NOT to Use" guidance in the body**, compounding the over-firing from (1).

## Fix

- **Description rewritten** as third-person triggering conditions with the same trigger breadth plus exclusions: *"Use when starting creative work — new features, components, added functionality, or behavior changes — that lacks an approved design or spec. Explores user intent, requirements and design before implementation. Not for bug fixes (use systematic-debugging), executing an existing plan (use executing-plans), or pure research questions."*
- **`{baseDir}` used for all skill-internal paths** so they resolve regardless of cwd: `{baseDir}/visual-companion.md` in SKILL.md; `{baseDir}/scripts/start-server.sh`, `{baseDir}/scripts/stop-server.sh`, `{baseDir}/scripts/frame-template.html`, `{baseDir}/scripts/helper.js` in visual-companion.md.
- **Orphan resolved by re-linking, not deleting:** the Spec Self-Review section now offers an optional deep-review path — dispatch a fresh-eyes subagent using the template in `{baseDir}/spec-document-reviewer-prompt.md`. Kept rather than deleted because `skills/writing-plans/` still ships its sibling `plan-document-reviewer-prompt.md`, so retaining the file is the consistent choice.
- **Added a "When NOT to Use" section** to the SKILL.md body naming the alternatives (systematic-debugging for bugs, executing-plans for approved plans, plain answers for research questions).

## Scope

Two files, docs-only, no behavior/script changes:

```
 skills/brainstorming/SKILL.md            | 14 ++++++++++++--
 skills/brainstorming/visual-companion.md | 16 ++++++++--------
 2 files changed, 20 insertions(+), 10 deletions(-)
```

These findings came out of a structured skill-design audit (description-as-trigger, path resolvability, orphan-file, and exclusion checks applied across a skill library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
