### PR TITLE
brainstorming: require design-doc claims to be verified or labeled assumptions

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -27,7 +27,7 @@ You MUST create a task for each of these items and complete them in order:
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
 6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope, evidence (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
@@ -99,6 +99,21 @@ digraph brainstorming {
 - Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.
 - Don't propose unrelated refactoring. Stay focused on what serves the current goal.
 
+**Ground every claim in evidence:**
+
+A design doc makes claims about the current system ("the API validates X", "clients send the full record on save", "the existing setup pattern covers this"). Every such claim must be one of:
+
+1. **Verified** — you read the relevant code this session. Cite the file (and symbol) in the doc.
+2. **A labeled assumption** — written as "Assumed — confirm during implementation", not stated as fact.
+
+Unverified claims cluster in predictable places. Check these deliberately before writing:
+
+- **Negative space** — claims about what the system does NOT do or already prevents ("existing validation rejects malformed input"). Plausibility tells you nothing here; only reading the code does.
+- **Integration seams** — when extending a resource, schema, or API, enumerate every existing reader and writer of it and walk each one against the change. Partial writers are the classic trap: a client that sends only some fields will silently clobber new ones unless replace-vs-merge semantics are designed explicitly.
+- **Runtime wiring** — file and directory names are not evidence of routes, entry points, or execution paths. Read the actual wiring (router, build, and test-runner configuration) before naming a URL, command, or path in the doc.
+- **"Follows the existing pattern"** — valid only after confirming the pattern covers the new case (e.g., create-if-missing setup logic cannot modify artifacts that already exist).
+- **Helpers reused in a new context** — code built to be forgiving (best-effort lookup, silent fallback) cannot back a strict guarantee (validation, verification). Check the helper's actual semantics against the new context's correctness requirements.
+
 ## After the Design
 
 **Documentation:**
@@ -115,6 +130,7 @@ After writing the spec document, look at it with fresh eyes:
 2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
 3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
 4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+5. **Evidence check:** Every claim about current-system behavior is either verified against code read this session (cited) or explicitly labeled as an assumption. Scrutinize negative-space claims ("the system already validates/handles/rejects…") hardest.
 
 Fix any issues inline. No need to re-review — just fix and move on.
 


### PR DESCRIPTION
## What

Adds a **"Ground every claim in evidence"** contract to the brainstorming skill's "Working in existing codebases" guidance, plus a fifth **Evidence check** item in the Spec Self-Review (and the matching word in checklist item 7).

The contract: every claim a design doc makes about the *current* system must be either **verified** (code read this session, file cited) or an explicitly **labeled assumption** ("Assumed — confirm during implementation") — never plausible inference stated as fact. It also names the five places unverified claims predictably cluster: negative space (what the system does NOT do), integration seams (existing readers/writers of a resource being extended, especially partial writers and replace-vs-merge), runtime wiring (routes/commands inferred from file names), "follows the existing pattern" (without confirming the pattern covers the new case), and forgiving helpers reused to back strict guarantees.

## Why (RED baseline — real production failure)

A design spec written under this skill accumulated 5 blocking defects caught only by a 6-round external cross-model review, all with one mechanism: current-behavior claims written from plausible inference rather than evidence. Concretely: a route asserted from a filename that didn't exist; "existing validation rejects malformed payloads" when it accepted empty selectors; new fields designed onto a resource whose partial-payload client save would have silently clobbered them; "follow the existing migration pattern" where the pattern (create-if-not-exists) couldn't add columns; and a forgiving lookup helper proposed to back a strict verification contract. Each landed in one of the five cluster spots the new guidance names.

## Testing (per writing-skills TDD)

- Failure classified as wrong-shaped output (compliant spec, missing required property), so the fix is a positive contract + structural checklist slot, not prohibitions — per "Match the Form to the Failure".
- Micro-tested the wording: same spec-writing task on the same repo, 1 no-guidance control + 2 guided reps. Both guided reps converged on cite-or-label behavior and explicitly flagged the one unverifiable claim as "Assumed — confirm during implementation"; the control asserted that same negative-space claim (schema uniqueness) as unverified fact. No degradation in the guided outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)