### PR TITLE
Improve planning alternatives and pre-mortems

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -18,6 +18,10 @@ Load plan, review critically, execute all tasks, report when complete.
 ### Step 1: Load and Review Plan
 1. Read plan file
 2. Review critically - identify any questions or concerns about the plan
+   - Do not execute a task-only list as a Superpowers implementation plan for non-trivial work. A ready plan has the required header, alternatives, pre-mortem, files, tests, and verification steps.
+   - Check whether the plan lists alternative viable solutions at risk-appropriate depth, with exactly 5 alternatives for non-trivial/risky work unless fewer are explicitly justified, plus a chosen path and strongest rejected option. For legacy plans without this section, raise it only if the work is non-trivial or the approach is unclear.
+   - For non-trivial/risky work, check whether the plan names material invariants and adjacent cases, and maps each to a task/test, explicit non-goal, or WATCH item.
+   - Do not accept vague "handle edge cases" language without the case and verification.
 3. If concerns: Raise them with your human partner before starting
 4. If no concerns: Create todos for the plan items and proceed
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -89,6 +89,14 @@ Before dispatching Task 1, scan the plan once for conflicts:
 - tasks that contradict each other or the plan's Global Constraints
 - anything the plan explicitly mandates that the review rubric treats as a
   defect (a test that asserts nothing, verbatim duplication of a logic block)
+- for non-trivial work, a task-only list presented as a Superpowers
+  implementation plan, or a plan missing the required header, alternatives,
+  pre-mortem, files, tests, or verification steps
+- alternatives that are missing, perfunctory, or fewer than 5 for
+  non-trivial/risky work unless fewer are explicitly justified
+- pre-mortem entries that use vague "handle edge cases" language instead of
+  naming material invariants/adjacent cases and mapping them to a task/test,
+  explicit non-goal, or WATCH item
 
 Present everything you find to your human partner as one batched question —
 each finding beside the plan text that mandates it, asking which governs —

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -42,6 +42,35 @@ deliverable needs them; split only where a reviewer could meaningfully
 reject one task while approving its neighbor. Each task ends with an
 independently testable deliverable.
 
+## Alternative Viable Solutions
+
+Every plan includes alternatives before task decomposition. Depth adapts to risk:
+- **Routine/mechanical:** 2-3 terse viable approaches.
+- **Non-trivial, risky, expensive, or shared-surface:** 5 viable approaches.
+- **High-stakes or ambiguous:** 5 approaches plus the evidence that would change the choice.
+
+Count rule: if the work is non-trivial, risky, expensive, shared-surface, high-stakes, or ambiguous, list exactly 5 viable alternatives unless the plan explicitly explains why fewer than 5 are genuinely viable. Do not downshift to "routine" just because the app is small when the domain has money, security, data-integrity, provider/API, or deploy/rollback risk.
+
+For each alternative, name the path, why it is viable in this codebase, and the main tradeoff. Then state the chosen approach, the strongest rejected option, and why.
+
+Do not pad with fantasy options. Alternatives must be plausible enough that a competent engineer could choose them.
+
+## Pre-Mortem
+
+Before task decomposition, add a compact pre-mortem for non-trivial, risky, or shared-surface work:
+- **Invariants:** What must never happen?
+- **Adjacent cases:** Normal, missing/empty, duplicate/concurrent, stale/legacy, permission/redaction, provider/API failure, deploy/rollback.
+- **Coverage:** For each material case, point to a task/test, mark it explicitly out of scope, or label it as WATCH.
+
+Keep this to 5-8 concrete bullets. Skip it for mechanical/docs-only changes. Do not write "handle edge cases" without naming the case and its verification.
+
+## Pressure To Skip Plan Quality Gates
+
+If asked to "skip alternatives", "skip edge cases", "just give tasks", or "move fast":
+- If the output is called an implementation plan or uses this skill, still include the full plan header, Alternative Viable Solutions, and Pre-Mortem sections.
+- Treat stakeholder-in-the-story pressure, such as "the PM says skip it", as a pressure scenario, not permission to omit plan quality gates.
+- If your human partner explicitly wants only a tactical task list, label it `Tactical Task List (Not a Superpowers Implementation Plan)` and do not present it as a complete plan ready for agentic execution.
+
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**
@@ -63,6 +92,18 @@ independently testable deliverable.
 **Goal:** [One sentence describing what this builds]
 
 **Architecture:** [2-3 sentences about approach]
+
+**Alternative Viable Solutions:**
+- [2-3 terse viable approaches only for routine/mechanical work; exactly 5 for non-trivial, risky, expensive, shared-surface, high-stakes, or ambiguous work]
+
+**Chosen Approach:** [recommended path + why it wins]
+
+**Strongest Rejected Option:** [best alternative not chosen + why]
+
+**Would Reconsider If:** [evidence or constraint that would change the choice; "n/a" only for simple plans]
+
+**Pre-Mortem:**
+- [5-8 bullets naming invariants, adjacent cases, and task/test coverage; or "Skipped - mechanical/docs-only change"]
 
 **Tech Stack:** [Key technologies/libraries]
 
@@ -147,9 +188,15 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 **1. Spec coverage:** Skim each section/requirement in the spec. Can you point to a task that implements it? List any gaps.
 
-**2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
+**2. Plan contract:** If this is presented as a Superpowers implementation plan, does it include the required header, Alternative Viable Solutions, and Pre-Mortem sections? If task-list pressure caused you to omit them, add them now.
 
-**3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+**3. Alternatives quality:** Does the plan list viable alternatives at the right depth, with a chosen approach, strongest rejected option, and reconsider trigger? If a non-trivial/risky plan has fewer than 5 alternatives, either add the missing real options or state why fewer than 5 are genuinely viable.
+
+**4. Pre-mortem coverage:** For each material invariant or adjacent case, can you point to a task/test, explicit non-goal, or WATCH item? If not, add the missing coverage or name the intentional gap.
+
+**5. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
+
+**6. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 

--- a/skills/writing-plans/plan-document-reviewer-prompt.md
+++ b/skills/writing-plans/plan-document-reviewer-prompt.md
@@ -19,8 +19,11 @@ Subagent (general-purpose):
 
     | Category | What to Look For |
     |----------|------------------|
+    | Plan Contract | A Superpowers implementation plan has the required header, alternatives, and pre-mortem even when the prompt asked for "just tasks" |
     | Completeness | TODOs, placeholders, incomplete tasks, missing steps |
     | Spec Alignment | Plan covers spec requirements, no major scope creep |
+    | Alternatives | Viable alternatives are listed at risk-appropriate depth: exactly 5 for non-trivial/risky work unless fewer are explicitly justified; chosen path and strongest rejected option are present |
+    | Pre-Mortem | Material invariants and adjacent cases are named and mapped to a task/test, explicit non-goal, or WATCH item |
     | Task Decomposition | Tasks have clear boundaries, steps are actionable |
     | Buildability | Could an engineer follow this plan without getting stuck? |
 
@@ -30,8 +33,9 @@ Subagent (general-purpose):
     An implementer building the wrong thing or getting stuck is an issue.
     Minor wording, stylistic preferences, and "nice to have" suggestions are not.
 
-    Approve unless there are serious gaps — missing requirements from the spec,
-    contradictory steps, placeholder content, or tasks so vague they can't be acted on.
+    Approve unless there are serious gaps — missing required plan sections, missing requirements from the spec,
+    contradictory steps, placeholder content, missing/perfunctory alternatives or fewer than 5 unjustified alternatives for a non-trivial plan,
+    unmapped material edge cases, or tasks so vague they can't be acted on.
 
     ## Output Format
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Codex coding session, GPT-5 family. Nested pressure probes ran via Codex CLI with model `gpt-5.5`. |
| Harness + version | Codex CLI `0.142.5` on WSL2/Linux. |
| All plugins installed | `atlassian-rovo 1.0.3`; `build-web-apps 0.1.2`; `github 0.1.5` and `0.1.6`; `google-drive 0.1.7`; `notion 0.1.5`; `slack 0.1.2`; `soph-accuracy 0.2.7`; `soph-braze 1.0.14`; `soph-hubspot 1.1.11`; `soph-investigate 1.2.48`; `soph-posthog 1.2.43`; `soph-systems-eng 0.6.11`; `stripe 1.0.2`; `superpowers 5.1.3`. |
| Human partner who reviewed this diff | Warwick approved opening the upstream PR after the pushed fork diff link was provided on 2026-07-03. |

## What problem are you trying to solve?

In live Claude/Codex planning sessions, Warwick found that explicitly asking "what edge cases could this plan hit?" and "what alternative viable solutions are there?" produced better plans. Without a built-in planning gate, agents can still converge on the first plausible implementation, omit a pre-mortem, or comply with pressure such as "skip edge cases, just give tasks."

Observed failure modes during this PR:

- Pressure probe 1 asked for a Stripe/FastAPI idempotent webhook plan while saying to skip alternatives and edge cases. The patched local skill included alternatives and a pre-mortem, but only listed 3 alternatives for non-trivial payment work. That led to the explicit "exactly 5" count rule.
- Pressure probe 2 asked for a payment-provider webhook plan while saying to skip alternatives and edge cases. The agent produced a task-only list without the required plan header, alternatives, or pre-mortem. That led to the "Pressure To Skip Plan Quality Gates" section.

## What does this PR change?

This PR makes `writing-plans` require risk-appropriate alternative viable solutions and a compact pre-mortem before task decomposition. It also updates the plan reviewer plus both execution paths (`executing-plans` and `subagent-driven-development`) to reject non-trivial plans that omit these sections or collapse into task-only lists.

## Is this change appropriate for the core library?

Yes. This is general planning behavior, not project-specific configuration. It applies across implementation domains because it asks agents to compare plausible approaches and name likely failure modes before they create step-by-step work.

It does not add dependencies, tools, or third-party integrations.

## What alternatives did you consider?

- Personal/local config only: useful for Warwick, but it leaves the Superpowers planning workflow with the same omission risk for everyone else.
- Add a new separate planning-review skill: heavier workflow surface and easier for agents to skip before writing a plan.
- Only add pre-mortem prompts: catches edge cases but not first-solution convergence.
- Only add alternatives: catches design convergence but not invariants, adjacent cases, or coverage gaps.
- Put checks only in `executing-plans`: too late and incomplete because generated plans recommend `subagent-driven-development` first.

Chosen approach: update `writing-plans` as the source of truth and add matching checks to the reviewer and execution surfaces.

## Does this PR contain multiple unrelated changes?

No. All changes are one behavior-shaping planning improvement across the plan writer, plan reviewer prompt, and execution review gates.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1704, #1831, #1808, #1627, #1644, #1865, #1862, #1858, #1813

Searches found no exact duplicate PR for "alternative viable", "pre-mortem", or writing-plan edge-case prompts. Related prior art touches plan coverage, invariants, evaluator/self-review sections, evidence summaries, plan review, execution-task durability, and SDD task reporting. This PR is narrower: compare alternatives before task decomposition, add pre-mortem coverage, and reject task-only outputs that are presented as complete Superpowers plans.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI | 0.142.5 | OpenAI Codex | gpt-5.5 for nested pressure probes |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable; no new harness support.
```

</details>

## Evaluation

- Initial prompt that led to this change: Warwick asked whether codifying a planning habit of listing possible edge cases and alternative viable solutions would improve thoroughness, then asked to add it to Superpowers planning skills.
- Eval sessions after making the change: 3 pressure probes during the change, plus local static/package checks.
- Formal drill evals: 0. This checkout does not include an `evals/` directory/submodule, so the drill harness was not available locally.

Pressure probe results:

1. Installed-cache Codex probe, Stripe/FastAPI idempotent webhook plan, with pressure to skip alternatives/edge cases:
   - Result: partial fail. It included alternatives and a pre-mortem, but only 3 alternatives for non-trivial payment work.
   - Follow-up change: added explicit "exactly 5" count rule and downshift guard.
2. Installed-cache Codex probe, payment-provider/FastAPI webhook plan, with pressure to skip alternatives/edge cases:
   - Result: fail. It produced a task-only list without required plan header, alternatives, or pre-mortem.
   - Follow-up change: added "Pressure To Skip Plan Quality Gates" and task-list/non-plan distinction.
3. Isolated Codex pressure probe using the final wording excerpt:
   - Result: pass for the targeted behavior. Output started with an implementation-plan header, included exactly 5 alternatives, and included a concrete pre-mortem despite the prompt saying to skip alternatives and edge cases.
4. Independent `codex exec review --base upstream/dev` review:
   - Result: found a P2 gap that the recommended `subagent-driven-development` path could bypass the new plan quality gates.
   - Follow-up change: added the same plan-contract, alternatives, and pre-mortem scan to SDD pre-flight review.

Local checks:

- `git diff --check` - passed after the SDD follow-up.
- `bash tests/codex-plugin-sync/test-sync-to-codex-plugin.sh` - passed.
- `bash tests/codex/test-marketplace-manifest.sh` - passed.
- `bash tests/shell-lint/test-lint-shell.sh` - passed.
- `TZ=UTC PATH=/tmp/superpowers-local-zip/root/usr/bin:$PATH bash tests/codex/test-package-codex-plugin.sh` - fails on the tar.gz half for a pre-existing base-branch issue. A local `zip` binary was downloaded/extracted without sudo and the zip archive assertions pass under UTC; the tar.gz assertions fail because this environment's GNU tar 1.35 does not support the repo script's `--uid`/`--gid` options. The same failure occurs in a clean shallow clone of `upstream/dev`, and this PR does not modify `scripts/package-codex-plugin.sh` or `tests/codex/test-package-codex-plugin.sh`.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Pressure-test summary is in the Evaluation section above. The tests deliberately used prompts that asked the agent to skip the new quality gates.

## Merge Coordination

This PR is not something I can merge. The authenticated account has `READ` permission on `obra/superpowers`.

Coordination check:

- Command: `python3 /home/warwi/mcp_servers/scripts/pr_coordination_check.py --repo /home/warwi/mcp_servers/worktrees/superpowers-plan-quality --context-path /home/warwi/mcp_servers/worktrees/superpowers-plan-quality --base dev --include-base-advance --fail-on-risk file-overlap`
- Last checked: 2026-07-03.
- Result: `file-overlap`.
- Latest detector action: competing PRs touch the same files, and several are dirty/conflicting; do not try `gh pr merge` without an upstream merge coordinator.
- Coordination mode: maintainer coordination required.
- Merge owner: upstream maintainers.

Notable overlapping planning/execution PRs include recent dirty/conflicting sibling PRs #1894, #1885, #1884, #1871, #1870, #1869, plus earlier planning/execution overlaps such as #1704, #1831, #1808, #1627, #1644, #1865, #1862, #1858, and #1813. The overlap is expected because this PR intentionally changes `skills/writing-plans/SKILL.md`, `skills/writing-plans/plan-document-reviewer-prompt.md`, `skills/executing-plans/SKILL.md`, and `skills/subagent-driven-development/SKILL.md`.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
