### PR TITLE
Fix Codex package timestamp normalization across timezones

### DIFF
--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -294,7 +294,7 @@ case "$FORMAT" in
     (
       cd "$STAGE"
       rm -f "$OUTPUT"
-      COPYFILE_DISABLE=1 zip -X -q - -@ <"$ARCHIVE_LIST" >"$OUTPUT"
+      TZ=UTC COPYFILE_DISABLE=1 zip -X -q - -@ <"$ARCHIVE_LIST" >"$OUTPUT"
     )
     ;;
   tar.gz)
@@ -303,7 +303,7 @@ case "$FORMAT" in
     (
       cd "$STAGE"
       rm -f "$OUTPUT"
-      COPYFILE_DISABLE=1 tar -cf - --no-recursion --format ustar --uid 0 --gid 0 --uname '' --gname '' -T "$ARCHIVE_LIST" |
+      TZ=UTC COPYFILE_DISABLE=1 tar -cf - --no-recursion --format ustar --uid 0 --gid 0 --uname '' --gname '' -T "$ARCHIVE_LIST" |
         gzip -9n >"$OUTPUT"
     )
     ;;

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -210,8 +210,15 @@ assert_equals "$tar_archive_paths" "$archive_paths" "zip and tar.gz archives con
 tar_task_brief_mode="$(tar -tzvf "$tar_archive" skills/subagent-driven-development/scripts/task-brief | awk '{print $1}')"
 assert_equals "$tar_task_brief_mode" "-rwxr-xr-x" "tar.gz archive preserves executable script mode"
 
-tar_metadata_times="$(tar -tzvf "$tar_archive" | awk '{print $6, $7, $8}' | sort -u)"
-assert_equals "$tar_metadata_times" "Dec 31 1969" "tar.gz archive normalizes entry timestamps"
+tar_metadata_times="$(python3 - "$tar_archive" <<'PY'
+import sys
+import tarfile
+
+with tarfile.open(sys.argv[1], "r:gz") as archive:
+    print("\n".join(sorted({str(member.mtime) for member in archive.getmembers()})))
+PY
+)"
+assert_equals "$tar_metadata_times" "0" "tar.gz archive normalizes entry timestamps"
 
 metadata_archive="$TEST_ROOT/metadata-source.tar.gz"
 metadata_zip="$TEST_ROOT/metadata-source.zip"


### PR DESCRIPTION
# Fix Codex package timestamp normalization across timezones

Base: `obra/superpowers:dev`  
Head: `msh01/superpowers:codex/fix-codex-package-timestamps`

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub, OpenAI bundled browser/chrome/computer-use, OpenAI primary runtime document/pdf/spreadsheet/presentation/template tools, Cloudflare, HeyGen, Hugging Face, Neon Postgres, Notion, Vercel, and local custom HyperFrames/media skills |
| Human partner who reviewed this diff | msh01 |

## What problem are you trying to solve?

On a machine using the Asia/Shanghai timezone, `bash tests/codex/test-package-codex-plugin.sh` fails on the archive timestamp assertions even though the package script intends to normalize archive entry timestamps.

Observed failures:

```text
[FAIL] zip archive normalizes entry timestamps
  expected: (1980, 1, 1, 0, 0, 0)
  actual:   (1980, 1, 1, 8, 0, 0)
[FAIL] tar.gz archive normalizes entry timestamps
  expected: Dec 31 1969
  actual:   Jan 1 1970
```

The root cause is timezone handling. The script sets `TZ=UTC` for `touch`, but not for the subsequent `zip` / `tar` archive creation process. The tar test also asserted localized `tar -tv` display text instead of archive metadata.

## What does this PR change?

Runs the `zip` and `tar` archive creation commands with `TZ=UTC`, and changes the tar timestamp test to inspect member `mtime` metadata directly.

## Is this change appropriate for the core library?

Yes. This is a deterministic packaging fix for the core Codex portal package script and its regression test.

## What alternatives did you consider?

I considered changing only the test expectations for the local timezone, but that would leave archive creation dependent on the caller's environment. Setting `TZ=UTC` during archive creation preserves the package script's deterministic archive contract.

## Does this PR contain multiple unrelated changes?

No. Both changed files address the same Codex package timestamp normalization failure.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1876 added the Codex portal package script. I found no open or closed PR specifically fixing timezone-dependent timestamp normalization.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable.

## Evaluation

- Initial prompt: user asked to find real, high-quality contribution candidates for Superpowers.
- Eval sessions run after the change: 0 LLM eval sessions; this is packaging script behavior, not skill behavior.
- Before/after: before, `tests/codex/test-package-codex-plugin.sh` failed in Asia/Shanghai. After, the same test passed in Asia/Shanghai, UTC, and America/Los_Angeles.

Verification run:

```bash
bash tests/codex/test-package-codex-plugin.sh
TZ=UTC bash tests/codex/test-package-codex-plugin.sh
TZ=America/Los_Angeles bash tests/codex/test-package-codex-plugin.sh
bash tests/shell-lint/test-lint-shell.sh
bash tests/codex/test-marketplace-manifest.sh
bash tests/kimi/run-tests.sh
bash tests/opencode/run-tests.sh
cd tests/brainstorm-server && npm ci && npm test
```

## Rigor

- [x] This change was tested adversarially, not just on the happy path
- [x] This is not a skills change

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
