### PR TITLE
Document Antigravity tool mappings for skill loading

### DIFF
--- a/skills/using-superpowers/references/antigravity-tools.md
+++ b/skills/using-superpowers/references/antigravity-tools.md
@@ -4,8 +4,24 @@ Skills speak in actions ("dispatch a subagent", "create a todo", "read a file").
 
 | Action skills request | Antigravity CLI equivalent |
 |----------------------|----------------------|
+| Read a skill or file | `view_file`; when loading a skill, read its `SKILL.md` with `IsSkillFile: true` |
+| Write a new file | `write_to_file` |
+| Edit an existing file | `replace_file_content` or `multi_replace_file_content` |
+| Run a shell command | `run_command` |
+| Search files | `grep_search` |
 | Dispatch a subagent (`Subagent (general-purpose):` template) | `invoke_subagent` with a built-in `TypeName` — `self` for full-capability work, `research` for read-only (see [Subagent support](#subagent-support)) |
 | Task tracking ("create a todo", "mark complete") | a **task artifact** — `write_to_file` with `IsArtifact: true` and `ArtifactType: "task"` (see [Task tracking](#task-tracking)). **Not** `manage_task`, which manages background processes. |
+
+## Skill loading
+
+Antigravity has no `Skill` tool. When a skill applies, read that skill's
+`SKILL.md` with `view_file` and set `IsSkillFile: true`, then follow the
+instructions from the file.
+
+## Subagent support
+
+Use `invoke_subagent` with Antigravity's built-in `self` type for
+full-capability implementation work and `research` for read-only investigation.
 
 ## Task tracking
 


### PR DESCRIPTION
# Document Antigravity tool mappings for skill loading

Base: `obra/superpowers:dev`  
Head: `msh01/superpowers:codex/document-antigravity-tool-mappings`

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub, OpenAI bundled browser/chrome/computer-use, OpenAI primary runtime document/pdf/spreadsheet/presentation/template tools, Cloudflare, HeyGen, Hugging Face, Neon Postgres, Notion, Vercel, and local custom HyperFrames/media skills |
| Human partner who reviewed this diff | msh01 |

## What problem are you trying to solve?

`bash tests/antigravity/run-tests.sh` fails on `upstream/dev` because `skills/using-superpowers/references/antigravity-tools.md` does not document the Antigravity skill-load/tool mapping expected by the test:

```text
FAIL: mapping does not document view_file as the file/skill-read tool
```

The test expects the platform reference to describe how Antigravity loads skill files without a `Skill` tool and to list the core Antigravity tools used by Superpowers workflows.

## What does this PR change?

Adds the missing Antigravity mapping rows for `view_file`, `write_to_file`, `replace_file_content`, `run_command`, `grep_search`, and `invoke_subagent`, plus short sections for skill loading and subagent support.

## Is this change appropriate for the core library?

Yes. This updates an existing core platform reference for a supported harness and makes the existing Antigravity regression test pass.

## What alternatives did you consider?

I considered changing the test, but the test describes the intended Antigravity behavior: no `Skill` tool, read `SKILL.md` with `view_file` and `IsSkillFile`. Updating the reference is the direct fix.

## Does this PR contain multiple unrelated changes?

No. It only updates the Antigravity tool mapping reference.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1657 added Antigravity CLI support. Older closed attempts include #535, #682, and #192. This PR does not add Antigravity support; it fills missing mapping details in the existing reference so the current test passes.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. Antigravity support already exists.

## Evaluation

- Initial prompt: user asked to find real, high-quality contribution candidates for Superpowers.
- Eval sessions run after the change: 0 LLM eval sessions; this is a platform reference backed by an existing shell test.
- Before/after: before, `tests/antigravity/run-tests.sh` failed on missing `view_file`; after, it passed.

Verification run:

```bash
bash tests/antigravity/run-tests.sh
bash tests/hooks/test-session-start.sh
git diff --check
```

## Rigor

- [x] This change was tested against the existing Antigravity regression test
- [x] This is a reference mapping update, not behavior-shaping skill philosophy

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
