### PR TITLE
Document Pi mappings for legacy skill vocabulary

### DIFF
--- a/skills/using-superpowers/references/pi-tools.md
+++ b/skills/using-superpowers/references/pi-tools.md
@@ -4,8 +4,20 @@ Skills speak in actions ("dispatch a subagent", "create a todo", "read a file").
 
 | Action skills request | Pi equivalent |
 | --- | --- |
+| `Skill` / read a skill | Use Pi's file-reading capability to read the relevant `SKILL.md` |
+| Read a file | Use the available read-file tool |
+| Write a new file | Use the available write-file tool |
+| Edit an existing file | Use the available edit/patch tool |
+| Run a shell command | Use the available bash/shell command tool |
 | Dispatch a subagent (`Subagent (general-purpose):` template) | Use an installed subagent tool such as `subagent` from `pi-subagents` if available |
 | Task tracking ("create a todo", "mark complete") | Use an installed todo/task tool if available, otherwise track tasks in the plan or `TODO.md` |
+
+## Legacy skill vocabulary
+
+Older Superpowers docs may name Claude-style tools directly. Treat `Skill` as
+"read the skill file", `Task` as the subagent action below, `TodoWrite` as the
+task-list action below, and read/write/edit/bash as the corresponding Pi file or
+shell tools available in the current session.
 
 ## Subagents
 


### PR DESCRIPTION
# Document Pi mappings for legacy skill vocabulary

Base: `obra/superpowers:dev`  
Head: `msh01/superpowers:codex/document-pi-tool-mappings`

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub, OpenAI bundled browser/chrome/computer-use, OpenAI primary runtime document/pdf/spreadsheet/presentation/template tools, Cloudflare, HeyGen, Hugging Face, Neon Postgres, Notion, Vercel, and local custom HyperFrames/media skills |
| Human partner who reviewed this diff | msh01 |

## What problem are you trying to solve?

`node tests/pi/test-pi-extension.mjs` fails on `upstream/dev` because `skills/using-superpowers/references/pi-tools.md` does not document the legacy skill vocabulary the test expects (`Skill`, `Task`, `TodoWrite`, read/write/edit/bash mappings).

The failing assertion was:

```text
AssertionError [ERR_ASSERTION]: The input did not match the regular expression /write/
```

## What does this PR change?

Adds a compact Pi mapping table for legacy Claude-style tool names and a short "Legacy skill vocabulary" section that maps those names to Pi file/shell/subagent/task-list capabilities.

## Is this change appropriate for the core library?

Yes. Pi is already declared in `package.json` and tested in `tests/pi/`; this updates the existing Pi reference to satisfy the existing platform test.

## What alternatives did you consider?

I considered weakening the Pi test, but the test is guarding useful platform-adaptation documentation. The smaller fix is to document the expected vocabulary in the existing Pi reference.

## Does this PR contain multiple unrelated changes?

No. It only updates `pi-tools.md`.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #500 was an earlier closed Pi support PR. This PR does not add Pi support; it fills a tested documentation gap in the current Pi reference.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. Pi support already exists.

## Evaluation

- Initial prompt: user asked to find real, high-quality contribution candidates for Superpowers.
- Eval sessions run after the change: 0 LLM eval sessions; this is a reference mapping covered by the Pi node test.
- Before/after: before, `node tests/pi/test-pi-extension.mjs` failed on missing mapping vocabulary; after, it passed.

Verification run:

```bash
node tests/pi/test-pi-extension.mjs
bash tests/hooks/test-session-start.sh
git diff --check
```

## Rigor

- [x] Existing Pi regression test passes
- [x] This is a reference mapping update, not a new skill or behavior rewrite

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
