### PR TITLE
Scope SDD task briefs by plan file

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -234,7 +234,7 @@ and is re-read on every later turn. Hand artifacts over as files:
   report contract. Exact values (numbers, magic strings, signatures, test
   cases) appear only in the brief.
 - **Report file:** name the implementer's report file after the brief
-  (brief `…/task-N-brief.md` → report `…/task-N-report.md`) and put it in
+  (brief `…/<plan-slug>/task-N-brief.md` → report `…/<plan-slug>/task-N-report.md`) and put it in
   the dispatch prompt. The implementer writes the full report there and
   returns only status, commits, a one-line test summary, and concerns.
 - **Reviewer inputs:** the task reviewer gets three paths — the same brief

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -4,8 +4,8 @@
 # through the controller's context.
 #
 # Usage: task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
-# Default OUTFILE: <repo-root>/.superpowers/sdd/task-<N>-brief.md
-# (per worktree; concurrent runs in the same working tree share it).
+# Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-slug>/task-<N>-brief.md
+# (per plan file within the current worktree).
 set -euo pipefail
 
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then
@@ -21,7 +21,12 @@ if [ $# -eq 3 ]; then
   out=$3
 else
   dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace")
-  out="$dir/task-${n}-brief.md"
+  plan_name=$(basename "$plan")
+  plan_slug=${plan_name%.*}
+  plan_slug=$(printf '%s' "$plan_slug" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//')
+  [ -n "$plan_slug" ] || plan_slug="plan"
+  mkdir -p "$dir/$plan_slug"
+  out="$dir/$plan_slug/task-${n}-brief.md"
 fi
 
 awk -v n="$n" '

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -90,6 +90,24 @@ PLAN
             ;;
     esac
 
+    cat > "$repo/other-plan.md" <<'PLAN'
+# Other Plan
+
+## Task 1: Different first thing
+
+Do a different first thing.
+PLAN
+
+    local other_brief_out other_brief_path
+    other_brief_out="$(cd "$repo" && "$SDD_SCRIPTS/task-brief" other-plan.md 1)"
+    other_brief_path="$(printf '%s\n' "$other_brief_out" | sed -n 's/^wrote \(.*\): [0-9][0-9]* lines$/\1/p')"
+    if [[ "$other_brief_path" != "$brief_path" ]]; then
+        pass "task-brief namespaces default output by plan file"
+    else
+        fail "task-brief namespaces default output by plan file"
+        echo "    both wrote: $brief_path"
+    fi
+
     local git_id=(-c user.email=t@example.com -c user.name=t -c commit.gpgsign=false)
     ( cd "$repo" \
         && git add plan.md \


### PR DESCRIPTION
# Scope SDD task briefs by plan file

Base: `obra/superpowers:dev`  
Head: `msh01/superpowers:codex/scope-sdd-task-briefs-by-plan`

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub, OpenAI bundled browser/chrome/computer-use, OpenAI primary runtime document/pdf/spreadsheet/presentation/template tools, Cloudflare, HeyGen, Hugging Face, Neon Postgres, Notion, Vercel, and local custom HyperFrames/media skills |
| Human partner who reviewed this diff | msh01 |

## What problem are you trying to solve?

Issue #1888 reports that SDD scratch artifacts under `.superpowers/sdd/` silently collide across efforts. One concrete failure is that `task-brief PLAN 1` writes the default path `.superpowers/sdd/task-1-brief.md`, so starting Task 1 for a different plan in the same worktree overwrites the previous Task 1 brief.

I reproduced that narrow failure with a regression test: two different plan files in the same repo both wrote the same default brief path before this change.

## What does this PR change?

Namespaces the default `task-brief` output by plan filename slug:

```text
.superpowers/sdd/<plan-slug>/task-N-brief.md
```

Explicit `OUTFILE` behavior is unchanged.

## Is this change appropriate for the core library?

Yes. It affects core SDD scratch artifact handling and prevents a silent overwrite/data-loss mode for any project using SDD.

## What alternatives did you consider?

I considered solving all of #1888 at once with cleanup and stale-ledger behavior, but that would be a larger behavioral change. This PR takes the narrow, test-backed slice that prevents default task brief collisions across plan files.

## Does this PR contain multiple unrelated changes?

No. The script, test, and SDD wording all describe the same plan-scoped default brief path.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for #1888 or plan-scoped SDD task brief paths.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable.

## Evaluation

- Initial prompt: user asked to find real, high-quality contribution candidates for Superpowers.
- Eval sessions run after the change: 0 LLM eval sessions; this is deterministic script behavior covered by a shell regression test.
- Before/after: before, two different plan files' Task 1 briefs wrote the same path; after, the paths differ by plan slug.

Verification run:

```bash
bash tests/claude-code/test-sdd-workspace.sh
bash tests/shell-lint/test-lint-shell.sh
```

Note: `bash tests/codex/test-package-codex-plugin.sh` still fails on `upstream/dev` in this timezone because of the timestamp issue fixed separately in `codex/fix-codex-package-timestamps`; that unrelated fix is intentionally not bundled here.

## Rigor

- [x] Added a failing regression test first and confirmed it failed before the script change
- [x] Focused on one concrete #1888 failure mode rather than bundling cleanup/stale-ledger behavior

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
