### PR TITLE
Document Codex mappings for legacy skill vocabulary

### DIFF
--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -9,6 +9,19 @@ multi_agent = true
 
 This enables `spawn_agent`, `wait_agent`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`. When using subagent-driven-development, you should always close implementer and reviewer subagents when they have finished all their work.
 
+## Legacy skill vocabulary
+
+Older Superpowers docs may name Claude-style tools directly. In Codex:
+
+| Legacy wording | Codex equivalent |
+| --- | --- |
+| `Skill` | Read the relevant `SKILL.md` from the installed skill roots |
+| `TodoWrite` | Use `update_plan` |
+| `Task` / subagent dispatch | Use `tool_search` to expose multi-agent tools, then use `spawn_agent` / `wait_agent` / `close_agent` when available |
+| `Read`, `Write`, `Edit`, `Bash` | Use the file and shell tools available in the current Codex session |
+
+Common Codex skill roots are `~/.codex/skills` and `~/.agents/skills`.
+
 ## Environment Detection
 
 Skills that create worktrees or finish branches should detect their

--- a/tests/codex/test-marketplace-manifest.sh
+++ b/tests/codex/test-marketplace-manifest.sh
@@ -72,5 +72,22 @@ assert_equal(
     "Codex manifest must declare empty hooks {} to suppress hooks/hooks.json auto-discovery",
 )
 
+codex_tools = repo_root / "skills" / "using-superpowers" / "references" / "codex-tools.md"
+if not codex_tools.exists():
+    raise AssertionError("Codex platform reference must exist")
+
+codex_reference = codex_tools.read_text(encoding="utf-8")
+for required_text in [
+    "TodoWrite",
+    "update_plan",
+    "Task",
+    "tool_search",
+    "Skill",
+    "~/.codex/skills",
+    "~/.agents/skills",
+]:
+    if required_text not in codex_reference:
+        raise AssertionError(f"Codex platform reference must document {required_text}")
+
 print("Codex marketplace manifest looks good")
 PY


### PR DESCRIPTION
# Document Codex mappings for legacy skill vocabulary

Base: `obra/superpowers:dev`  
Head: `msh01/superpowers:codex/document-codex-tool-adapter`

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub, OpenAI bundled browser/chrome/computer-use, OpenAI primary runtime document/pdf/spreadsheet/presentation/template tools, Cloudflare, HeyGen, Hugging Face, Neon Postgres, Notion, Vercel, and local custom HyperFrames/media skills |
| Human partner who reviewed this diff | msh01 |

## What problem are you trying to solve?

Issue #1883 reports that Codex-visible Superpowers skills can still contain legacy Claude-style operational vocabulary such as `TodoWrite`, `Task`, and `Skill`, which can mislead Codex agents unless the Codex platform reference maps that vocabulary to Codex equivalents.

## What does this PR change?

Adds a "Legacy skill vocabulary" section to `codex-tools.md` mapping:

- `Skill` → read installed `SKILL.md`
- `TodoWrite` → `update_plan`
- `Task` / subagent dispatch → `tool_search` plus multi-agent tools when available
- `Read`, `Write`, `Edit`, `Bash` → current Codex file/shell tools

It also adds test coverage that the Codex platform reference documents those key terms.

## Is this change appropriate for the core library?

Yes. Codex is a supported harness and this is a core platform-adaptation reference for Codex-visible skills.

## What alternatives did you consider?

I considered editing every skill body that contains legacy wording, but that would be broad and risky. Updating the Codex platform reference is a smaller, targeted adapter that fits the existing `using-superpowers` reference pattern.

## Does this PR contain multiple unrelated changes?

No. The test and reference update both cover Codex legacy vocabulary mapping.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for #1883 or Codex legacy vocabulary mapping. Nearby platform-neutral work includes #1486, but this PR only adds Codex-specific mapping coverage.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. Codex support already exists.

## Evaluation

- Initial prompt: user asked to find real, high-quality contribution candidates for Superpowers.
- Eval sessions run after the change: 0 LLM eval sessions; this is reference mapping plus a manifest/reference test.
- Before/after: before, the Codex reference did not mention the key legacy terms from #1883; after, it does and the Codex test asserts that coverage.

Verification run:

```bash
bash tests/codex/test-marketplace-manifest.sh
bash tests/hooks/test-session-start.sh
git diff --check
```

## Rigor

- [x] Added focused test coverage for the documented Codex mappings
- [x] Avoided a broad rewrite of behavior-shaping skill bodies

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
