### PR TITLE
Fix eval harness README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ The general contribution process for Superpowers is below. Keep in mind that we 
 4. Follow the `writing-skills` skill for creating and testing new and modified skills
 5. Submit a PR, being sure to fill in the pull request template.
 
-Skill-behavior tests use the drill eval harness from [superpowers-evals](https://github.com/prime-radiant-inc/superpowers-evals/), cloned into `evals/` — see `evals/README.md` for setup. Plugin-infrastructure tests live at `tests/` and run via the relevant `run-*.sh` or `npm test`.
+Skill-behavior tests use the drill eval harness from [superpowers-evals](https://github.com/prime-radiant-inc/superpowers-evals/), cloned into `evals/` — see the [superpowers-evals README](https://github.com/prime-radiant-inc/superpowers-evals/blob/main/README.md) for setup. Plugin-infrastructure tests live at `tests/` and run via the relevant `run-*.sh` or `npm test`.
 
 See `skills/writing-skills/SKILL.md` for the complete guide.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,7 +23,7 @@ Run plugin tests via the relevant directory's `run-*.sh` or `npm test`.
 
 ## Skill behavior evals
 
-Live in `evals/`. Drill is the harness; scenarios live at `evals/scenarios/*.yaml`. See `evals/README.md` for setup. Quick start:
+Live in `evals/`. Drill is the harness; scenarios live at `evals/scenarios/*.yaml`. See the [superpowers-evals README](https://github.com/prime-radiant-inc/superpowers-evals/blob/main/README.md) for setup. Quick start:
 
 ```bash
 cd evals


### PR DESCRIPTION
# Fix eval harness README links

Base: `obra/superpowers:dev`  
Head: `msh01/superpowers:codex/fix-evals-readme-links`

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub, OpenAI bundled browser/chrome/computer-use, OpenAI primary runtime document/pdf/spreadsheet/presentation/template tools, Cloudflare, HeyGen, Hugging Face, Neon Postgres, Notion, Vercel, and local custom HyperFrames/media skills |
| Human partner who reviewed this diff | msh01 |

## What problem are you trying to solve?

`README.md` and `docs/testing.md` tell contributors to see `evals/README.md`, but this checkout has no tracked `evals/` directory or `.gitmodules`. A contributor following the local docs hits a local path that does not exist.

## What does this PR change?

Changes those references to link to the external `superpowers-evals` README on GitHub while preserving the instruction to clone the eval harness into `evals/`.

## Is this change appropriate for the core library?

Yes. This fixes contributor documentation in the core repository without changing behavior.

## What alternatives did you consider?

I considered adding an `evals/` placeholder, but the docs already identify `superpowers-evals` as the source. Linking to that README is the smallest accurate fix.

## Does this PR contain multiple unrelated changes?

No. It only fixes the eval harness README references.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1488 lifted drill/evals into the repository history. I found no PR specifically fixing these current local `evals/README.md` references after `evals/` stopped being present in this checkout.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable.

## Evaluation

- Initial prompt: user asked to find real, high-quality contribution candidates for Superpowers.
- Eval sessions run after the change: 0; documentation link fix only.
- Before/after: before, `rg "evals/README.md"` found local links to a missing path; after, those local missing-path references are gone.

Verification run:

```bash
ls -la evals .gitmodules 2>&1 || true
rg -n "evals/README\\.md" README.md docs/testing.md docs/porting-to-a-new-harness.md skills || true
bash tests/kimi/run-tests.sh
bash tests/codex/test-marketplace-manifest.sh
git diff --check
```

## Rigor

- [x] Verified the local path is absent in the current checkout
- [x] Replaced it with the authoritative external README for the named eval harness

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
