### PR TITLE
Use portable timeout helper in test scripts

### DIFF
--- a/tests/claude-code/run-skill-tests.sh
+++ b/tests/claude-code/run-skill-tests.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WITH_TIMEOUT="$SCRIPT_DIR/../support/with-timeout.sh"
 cd "$SCRIPT_DIR"
 
 echo "========================================"
@@ -120,7 +121,7 @@ for test in "${tests[@]}"; do
     start_time=$(date +%s)
 
     if [ "$VERBOSE" = true ]; then
-        if timeout "$TIMEOUT" bash "$test_path"; then
+        if "$WITH_TIMEOUT" "$TIMEOUT" bash "$test_path"; then
             end_time=$(date +%s)
             duration=$((end_time - start_time))
             echo ""
@@ -140,7 +141,7 @@ for test in "${tests[@]}"; do
         fi
     else
         # Capture output for non-verbose mode
-        if output=$(timeout "$TIMEOUT" bash "$test_path" 2>&1); then
+        if output=$("$WITH_TIMEOUT" "$TIMEOUT" bash "$test_path" 2>&1); then
             end_time=$(date +%s)
             duration=$((end_time - start_time))
             echo "  [PASS] (${duration}s)"

--- a/tests/claude-code/test-helpers.sh
+++ b/tests/claude-code/test-helpers.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Helper functions for Claude Code skill tests
 
+HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WITH_TIMEOUT="$HELPER_DIR/../support/with-timeout.sh"
+
 # Run Claude Code with a prompt and capture output
 # Usage: run_claude "prompt text" [timeout_seconds] [allowed_tools]
 run_claude() {
@@ -16,7 +19,7 @@ run_claude() {
     fi
 
     # Run Claude in headless mode with timeout
-    if timeout "$timeout" "${cmd[@]}" > "$output_file" 2>&1; then
+    if "$WITH_TIMEOUT" "$timeout" "${cmd[@]}" > "$output_file" 2>&1; then
         cat "$output_file"
         rm -f "$output_file"
         return 0

--- a/tests/claude-code/test-subagent-driven-development-integration.sh
+++ b/tests/claude-code/test-subagent-driven-development-integration.sh
@@ -15,6 +15,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WITH_TIMEOUT="$SCRIPT_DIR/../support/with-timeout.sh"
 source "$SCRIPT_DIR/test-helpers.sh"
 
 echo "========================================"
@@ -164,7 +165,7 @@ PLUGIN_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
 # other concurrent claude sessions.
 echo "Running Claude (plugin-dir: $PLUGIN_DIR, cwd: $TEST_PROJECT)..."
 echo "================================================================================"
-cd "$TEST_PROJECT" && timeout 1800 claude -p "$PROMPT" --plugin-dir "$PLUGIN_DIR" --allowed-tools=all --permission-mode bypassPermissions 2>&1 | tee "$OUTPUT_FILE" || {
+cd "$TEST_PROJECT" && "$WITH_TIMEOUT" 1800 claude -p "$PROMPT" --plugin-dir "$PLUGIN_DIR" --allowed-tools=all --permission-mode bypassPermissions 2>&1 | tee "$OUTPUT_FILE" || {
     echo ""
     echo "================================================================================"
     echo "EXECUTION FAILED (exit code: $?)"

--- a/tests/explicit-skill-requests/run-test.sh
+++ b/tests/explicit-skill-requests/run-test.sh
@@ -23,6 +23,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the superpowers plugin root (two levels up)
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WITH_TIMEOUT="$SCRIPT_DIR/../support/with-timeout.sh"
 
 TIMESTAMP=$(date +%s)
 OUTPUT_DIR="/tmp/superpowers-tests/${TIMESTAMP}/explicit-skill-requests/${SKILL_NAME}"
@@ -68,7 +69,7 @@ echo "Running claude -p with explicit skill request..."
 echo "Prompt: $PROMPT"
 echo ""
 
-timeout 300 claude -p "$PROMPT" \
+"$WITH_TIMEOUT" 300 claude -p "$PROMPT" \
     --plugin-dir "$PLUGIN_DIR" \
     --dangerously-skip-permissions \
     --max-turns "$MAX_TURNS" \

--- a/tests/opencode/test-priority.sh
+++ b/tests/opencode/test-priority.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WITH_TIMEOUT="$SCRIPT_DIR/../support/with-timeout.sh"
 OPENCODE_TEST_TIMEOUT_SECONDS="${OPENCODE_TEST_TIMEOUT_SECONDS:-120}"
 
 echo "=== Test: Skill Priority Resolution ==="
@@ -107,7 +108,7 @@ run_opencode() {
     local exit_code
 
     set +e
-    command_output=$(cd "$dir" && timeout "${OPENCODE_TEST_TIMEOUT_SECONDS}s" opencode run --print-logs --format json "$prompt" 2>&1)
+    command_output=$(cd "$dir" && "$WITH_TIMEOUT" "${OPENCODE_TEST_TIMEOUT_SECONDS}s" opencode run --print-logs --format json "$prompt" 2>&1)
     exit_code=$?
     set -e
 

--- a/tests/opencode/test-tools.sh
+++ b/tests/opencode/test-tools.sh
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WITH_TIMEOUT="$SCRIPT_DIR/../support/with-timeout.sh"
 OPENCODE_TEST_TIMEOUT_SECONDS="${OPENCODE_TEST_TIMEOUT_SECONDS:-120}"
 
 echo "=== Test: Tools Functionality ==="
@@ -31,7 +32,7 @@ run_opencode() {
     local exit_code
 
     set +e
-    command_output=$(cd "$dir" && timeout "${OPENCODE_TEST_TIMEOUT_SECONDS}s" opencode run --print-logs --format json "$prompt" 2>&1)
+    command_output=$(cd "$dir" && "$WITH_TIMEOUT" "${OPENCODE_TEST_TIMEOUT_SECONDS}s" opencode run --print-logs --format json "$prompt" 2>&1)
     exit_code=$?
     set -e
 

--- a/tests/support/with-timeout.sh
+++ b/tests/support/with-timeout.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 SECONDS COMMAND [ARG...]" >&2
+  exit 2
+fi
+
+duration="$1"
+shift
+
+if command -v timeout >/dev/null 2>&1; then
+  exec timeout "$duration" "$@"
+fi
+
+if command -v gtimeout >/dev/null 2>&1; then
+  exec gtimeout "$duration" "$@"
+fi
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "ERROR: timeout/gtimeout not found and python3 is unavailable" >&2
+  exit 127
+}
+
+exec python3 - "$duration" "$@" <<'PY'
+import subprocess
+import sys
+
+raw_duration = sys.argv[1]
+command = sys.argv[2:]
+
+try:
+    timeout_seconds = float(raw_duration[:-1] if raw_duration.endswith("s") else raw_duration)
+except ValueError:
+    print(f"ERROR: invalid timeout duration: {raw_duration}", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    completed = subprocess.run(command, timeout=timeout_seconds)
+except subprocess.TimeoutExpired:
+    print(f"ERROR: command timed out after {raw_duration}", file=sys.stderr)
+    sys.exit(124)
+except FileNotFoundError:
+    print(f"ERROR: command not found: {command[0]}", file=sys.stderr)
+    sys.exit(127)
+
+if completed.returncode < 0:
+    sys.exit(128 + abs(completed.returncode))
+sys.exit(completed.returncode)
+PY


### PR DESCRIPTION
# Use portable timeout helper in test scripts

Base: `obra/superpowers:dev`  
Head: `msh01/superpowers:codex/use-portable-test-timeout`

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub, OpenAI bundled browser/chrome/computer-use, OpenAI primary runtime document/pdf/spreadsheet/presentation/template tools, Cloudflare, HeyGen, Hugging Face, Neon Postgres, Notion, Vercel, and local custom HyperFrames/media skills |
| Human partner who reviewed this diff | msh01 |

## What problem are you trying to solve?

On macOS, several Claude/OpenCode test scripts assume the GNU `timeout` command exists. In the clean `upstream/dev` worktree, `bash tests/claude-code/test-worktree-native-preference.sh` failed immediately with:

```text
tests/claude-code/test-helpers.sh: line 19: timeout: command not found
```

That prevents the test from reaching its actual Claude Code behavior checks. The same hard dependency appears in the Claude Code test runner, the explicit skill request test harness, and OpenCode integration helpers.

## What does this PR change?

Adds `tests/support/with-timeout.sh`, a small wrapper that uses `timeout`, `gtimeout`, or a Python 3 fallback. Updates the affected test scripts to call that wrapper instead of invoking `timeout` directly.

## Is this change appropriate for the core library?

Yes. This is cross-platform test infrastructure for the core repository and does not add a runtime dependency to Superpowers itself.

## What alternatives did you consider?

I considered documenting GNU coreutils as a prerequisite, but these are contributor tests and the repo already uses Python in tests. A tiny local wrapper keeps the scripts usable on macOS without requiring contributors to install extra tools.

## Does this PR contain multiple unrelated changes?

No. Every changed file removes the same GNU `timeout` assumption from test scripts.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1603 added cross-harness portability linting, but I found no open or closed PR specifically replacing GNU `timeout` in these test scripts. Search also found older unrelated broad test PRs (#664, #398).

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable.

## Evaluation

- Initial prompt: user asked to find real, high-quality contribution candidates for Superpowers.
- Eval sessions run after the change: 0; this is test harness portability, not skill behavior.
- Before/after: before, macOS test execution stopped at `timeout: command not found`; after, the timeout wrapper runs and the same Claude test reaches the actual missing-`claude` precondition instead of failing on `timeout`.

Verification run:

```bash
tests/support/with-timeout.sh 2 bash -c 'echo ok'
bash tests/shell-lint/test-lint-shell.sh
bash tests/opencode/run-tests.sh
bash tests/claude-code/test-worktree-native-preference.sh
git diff --check
```

Notes:

- `bash tests/claude-code/test-worktree-native-preference.sh` now fails with `ERROR: command not found: claude` in this environment, which is the real missing CLI precondition. It no longer fails on `timeout`.

## Rigor

- [x] Reproduced the macOS `timeout: command not found` failure on clean `upstream/dev`
- [x] Verified the new wrapper path reaches the actual test command
- [x] No skill behavior changed

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
