### PR TITLE
Allow Codex packaging from linked worktrees

### DIFF
--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -140,7 +140,8 @@ if [[ "$FORMAT" == "zip" ]]; then
   command -v unzip >/dev/null || die "unzip not found in PATH"
 fi
 
-[[ -d "$REPO_ROOT/.git" ]] || die "repo root is not a git checkout: $REPO_ROOT"
+git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+  die "repo root is not a git checkout: $REPO_ROOT"
 git -C "$REPO_ROOT" rev-parse --verify "$REF^{commit}" >/dev/null ||
   die "git ref does not resolve to a commit: $REF"
 

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -136,8 +136,10 @@ echo "Codex package archive tests"
 metadata_source="$TEST_ROOT/metadata-source"
 archive="$TEST_ROOT/superpowers"
 tar_archive="$TEST_ROOT/superpowers.tar.gz"
+worktree_archive="$TEST_ROOT/superpowers-from-worktree.zip"
 extracted="$TEST_ROOT/extracted"
 tar_extracted="$TEST_ROOT/tar-extracted"
+linked_worktree="$TEST_ROOT/linked-worktree"
 write_metadata_fixture "$metadata_source"
 
 source_hooks="$(python3 -c 'import json; print(json.load(open("'"$REPO_ROOT"'/.codex-plugin/plugin.json")).get("hooks"))')"
@@ -159,6 +161,17 @@ fi
 assert_contains "$output" "Archive:" "reports archive path"
 assert_contains "$output" "Format:  zip" "reports default zip format"
 assert_contains "$output" "SHA-256:" "reports archive checksum"
+
+if git -C "$REPO_ROOT" worktree add --detach "$linked_worktree" HEAD >/dev/null 2>&1; then
+  if output="$("$linked_worktree/scripts/package-codex-plugin.sh" --metadata-source "$metadata_source" --output "$worktree_archive" 2>&1)"; then
+    pass "package script accepts a linked worktree checkout"
+  else
+    fail "package script accepts a linked worktree checkout"
+    printf '%s\n' "$output" | sed 's/^/      /'
+  fi
+else
+  fail "create linked worktree fixture"
+fi
 
 extract_archive "$archive" "$extracted"
 


### PR DESCRIPTION
# Allow Codex packaging from linked worktrees

Base: `obra/superpowers:dev`  
Head: `msh01/superpowers:codex/allow-codex-package-from-worktree`

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub, OpenAI bundled browser/chrome/computer-use, OpenAI primary runtime document/pdf/spreadsheet/presentation/template tools, Cloudflare, HeyGen, Hugging Face, Neon Postgres, Notion, Vercel, and local custom HyperFrames/media skills |
| Human partner who reviewed this diff | msh01 |

## What problem are you trying to solve?

When the repository is checked out as a Git linked worktree, `scripts/package-codex-plugin.sh` rejects it before doing any packaging:

```text
ERROR: repo root is not a git checkout: /private/tmp/superpowers-upstream-check
```

The script checks `[[ -d "$REPO_ROOT/.git" ]]`, but linked worktrees have a `.git` file that points at the common git dir. The checkout is valid, and subsequent `git -C "$REPO_ROOT"` commands work.

## What does this PR change?

Replaces the `.git` directory check with `git -C "$REPO_ROOT" rev-parse --is-inside-work-tree`, and adds a regression assertion that the Codex package script accepts a linked worktree checkout.

## Is this change appropriate for the core library?

Yes. This is a core packaging script used to prepare the Codex portal artifact, plus a test for a valid Git checkout shape.

## What alternatives did you consider?

I considered allowing either `.git` directory or `.git` file manually, but asking Git whether the path is inside a work tree is the more accurate check and handles normal checkouts, linked worktrees, and future Git layout details.

## Does this PR contain multiple unrelated changes?

No. It only changes the repository validity check for Codex packaging and adds a matching regression assertion.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1876 added the Codex portal package script. I found no open or closed PR specifically making that package script accept linked worktree checkouts.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable.

## Evaluation

- Initial prompt: user asked to find real, high-quality contribution candidates for Superpowers.
- Eval sessions run after the change: 0; packaging script bugfix only.
- Before/after: before, running the package test from a linked worktree failed at the repo-root check. After, the new linked-worktree assertion passes.

Verification run:

```bash
TZ=UTC bash tests/codex/test-package-codex-plugin.sh
bash tests/shell-lint/test-lint-shell.sh
git diff --check
```

Notes:

- In this macOS environment, the full Codex package test still fails later on the pre-existing tar timestamp display assertion (`expected: Dec 31 1969`, `actual: Jan 1 1970`). The new linked-worktree assertion passes. The timestamp issue is separate and is covered by the `codex/fix-codex-package-timestamps` candidate.

## Rigor

- [x] Reproduced the linked-worktree rejection on clean `upstream/dev`
- [x] Added a regression assertion that creates and packages from a linked worktree
- [x] Kept the change scoped to Codex packaging

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
