### PR TITLE
ci: add codex-plugin-scanner workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,38 @@
+name: Codex Plugin Scanner CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Plugin Scanner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Run scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@486d62021d7db1d3027942c92a9d45a5c3c02921
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical


### PR DESCRIPTION
I ran the scanner against this repo because an agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.

What stood out from the repo:
- An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows
- We're hiring someone to help out full time with Superpowers community and code work
- If this sounds like someone you know, definitely send them our way

Local scanner result: 55/100 (grade F).

First-pass findings worth tightening:
- MEDIUM: Dependency manifest is missing a lockfile
- MEDIUM: Dependency manifest is missing a lockfile
- MEDIUM: Marketplace source shape is invalid

This PR only adds the scanner workflow. It does not touch runtime code or release behavior.
If you would rather wire it in a different workflow file, I can adjust the branch.

Note: 48 high-severity findings were left out of this first contact summary because they mostly look like documentation or reference-file patterns.