### PR TITLE
docs(codex): document deferred tool mapping

### DIFF
--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -1,3 +1,15 @@
+## Tool Mapping
+
+Codex tool availability varies by surface. Some tools are available at session
+start; others are deferred and must be discovered before use.
+
+- Treat older `TodoWrite` references as the task-list action. In Codex, use
+  `update_plan` when it is available.
+- For multi-agent work, use `tool_search` to discover and expose the current
+  multi-agent tools before naming specific dispatch commands.
+- Only call `spawn_agent`, `wait_agent`, `close_agent`, or similarly named
+  multi-agent tools after they are actually present in the active tool list.
+
 ## Subagent dispatch requires multi-agent support
 
 Add to your Codex config (`~/.codex/config.toml`):


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 |
| Harness + version | Codex desktop app (exact app version not exposed in this session) |
| All plugins installed | Codex app tools exposed in this session, including GitHub/tool discovery capable workflows and local shell access |
| Human partner who reviewed this diff | Anita |

## What problem are you trying to solve?

Codex-visible Superpowers skills can refer to legacy or deferred tool names. Issue #1883 notes that Codex sessions may need host-specific adapter wording for cases like `TodoWrite`, deferred multi-agent tools, and tool discovery.

The existing Codex reference already documents config for multi-agent support, but it names `spawn_agent`, `wait_agent`, and `close_agent` directly without first telling Codex agents to discover deferred tools through `tool_search`, and it does not document the `TodoWrite` to `update_plan` mapping.

## What does this PR change?

Adds a small Tool Mapping section to `skills/using-superpowers/references/codex-tools.md` documenting Codex-specific handling for task tracking and deferred multi-agent tools.

## Is this change appropriate for the core library?

Yes. This is host-adapter documentation for Codex-visible Superpowers skills and belongs in the existing Codex reference file rather than in a project-specific plugin.

## What alternatives did you consider?

I considered updating each active skill body, but that would broaden the change and risk disturbing behavior-shaping instructions. Keeping this in the Codex-specific reference file is smaller and follows the existing platform-adaptation structure.

## Does this PR contain multiple unrelated changes?

No. It only updates the Codex platform reference with deferred tool and task-list mapping guidance.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for this specific Codex deferred-tool mapping docs change. Related issue: #1883.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app | exact app version not exposed | GPT-5 | GPT-5 |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable. This PR does not add a new harness.
```

</details>

## Evaluation

- Initial prompt: Anita asked for a PR contribution to `obra/superpowers`.
- Eval sessions run after the change: 0; docs-only Codex reference update.
- Before/after: before, the Codex reference documented multi-agent config but did not tell agents to discover deferred multi-agent tools with `tool_search` or map older `TodoWrite` references to `update_plan`. After, those mappings are explicit in the Codex host reference.

Verification run:

```bash
git diff --check
rg -n "TodoWrite|tool_search|spawn_agent|wait_agent|close_agent|update_plan" skills/using-superpowers/references/codex-tools.md
```

## Rigor

- [x] Scoped the change to the existing Codex platform reference
- [x] Checked open PRs for duplicate Codex host-adapter wording work
- [x] Ran whitespace validation with `git diff --check`

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
