### PR TITLE
refactor: fold index-style Integration sections into points of use

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -16,10 +16,11 @@ Load plan, review critically, execute all tasks, report when complete.
 ## The Process
 
 ### Step 1: Load and Review Plan
-1. Read plan file
-2. Review critically - identify any questions or concerns about the plan
-3. If concerns: Raise them with your human partner before starting
-4. If no concerns: Create todos for the plan items and proceed
+1. Ensure an isolated workspace: use superpowers:using-git-worktrees to create one or verify the existing one
+2. Read plan file
+3. Review critically - identify any questions or concerns about the plan
+4. If concerns: Raise them with your human partner before starting
+5. If no concerns: Create todos for the plan items and proceed
 
 ### Step 2: Execute Tasks
 
@@ -61,10 +62,3 @@ After all tasks complete and verified:
 - Reference skills when plan says to
 - Stop when blocked, don't guess
 - Never start implementation on main/master branch without explicit user consent
-
-## Integration
-
-**Required workflow skills:**
-- **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one or verifies existing)
-- **superpowers:writing-plans** - Creates the plan this skill executes
-- **superpowers:finishing-a-development-branch** - Complete development after all tasks

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -84,6 +84,9 @@ digraph process {
 
 ## Pre-Flight Plan Review
 
+Ensure the work happens in an isolated workspace: use
+superpowers:using-git-worktrees to create one or verify the existing one.
+
 Before dispatching Task 1, scan the plan once for conflicts:
 
 - tasks that contradict each other or the plan's Global Constraints
@@ -402,17 +405,3 @@ Done!
 **If subagent fails task:**
 - Dispatch fix subagent with specific instructions
 - Don't try to fix manually (context pollution)
-
-## Integration
-
-**Required workflow skills:**
-- **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one or verifies existing)
-- **superpowers:writing-plans** - Creates the plan this skill executes
-- **superpowers:requesting-code-review** - Code review template for the final whole-branch review
-- **superpowers:finishing-a-development-branch** - Complete development after all tasks
-
-**Subagents should use:**
-- **superpowers:test-driven-development** - Subagents follow TDD for each task
-
-**Alternative workflow:**
-- **superpowers:executing-plans** - Use for parallel session instead of same-session execution

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -188,6 +188,7 @@ You MUST complete each phase before proceeding to the next.
    - Test passes now?
    - No other tests broken?
    - Issue actually resolved?
+   - Use the `superpowers:verification-before-completion` skill before claiming success
 
 4. **If Fix Doesn't Work**
    - STOP
@@ -282,10 +283,6 @@ These techniques are part of systematic debugging and available in this director
 - **`root-cause-tracing.md`** - Trace bugs backward through call stack to find original trigger
 - **`defense-in-depth.md`** - Add validation at multiple layers after finding root cause
 - **`condition-based-waiting.md`** - Replace arbitrary timeouts with condition polling
-
-**Related skills:**
-- **superpowers:test-driven-development** - For creating failing test case (Phase 4, Step 1)
-- **superpowers:verification-before-completion** - Verify fix worked before claiming success
 
 ## Real-World Impact
 


### PR DESCRIPTION
> **Note for @arittr:** hold merge until this has been run through evals.
> The micro-tests below are quick sanity checks, not the eval pass.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (claude-fable-5) |
| Harness + version | Claude Code CLI 2.1.199 |
| All plugins installed | superpowers 6.1.0, claude-session-driver 4.0.0, episodic-memory, superpowers-chrome, context7, linear, plugin-dev, agent-sdk-dev |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — directed the change; full-diff review pending (hence draft) |

## What problem are you trying to solve?

The list-style "Integration" sections at the bottom of several skills are
indexes, not behavior: nearly every entry duplicates a reference that
already exists at its point of use (process digraph, When to Use, prompt
templates, numbered steps), agents navigate by the point-of-use references
rather than an end-of-file list, and the sections rot — e.g.
requesting-code-review's workflow bullets describe SDD as per-task review
only, predating its final whole-branch review. Worse, two entries were
*sole carriers* of real requirements buried where the flow never looks:
the using-git-worktrees isolated-workspace requirement (SDD and
executing-plans) and systematic-debugging's
verification-before-completion handoff appeared nowhere else in their
skills.

## What does this PR change?

Deletes the index-style Integration/Related-skills blocks from
subagent-driven-development, executing-plans, and systematic-debugging,
and moves each sole-carrier line to its point of use: the worktree
requirement into SDD's Pre-Flight Plan Review and executing-plans' Step 1
item 1; the verification-before-completion handoff into
systematic-debugging's Phase 4 "Verify Fix" step. Net −20 lines; no other
wording changes.

## Is this change appropriate for the core library?

Yes — it edits core skills only, removing duplication rather than adding
behavior.

## What alternatives did you consider?

- **Keep the sections, fix the rot:** rejected — the entries would remain
  duplicates requiring a second edit site for every future integration
  change (the agentic-e2e branch, #1931, paid exactly that cost).
- **Delete without moving anything:** rejected — the worktree and
  verification lines are sole carriers; deleting them silently drops real
  requirements.
- **Also trim requesting-code-review's "Integration with Workflows":**
  deliberately left out. It is prose, half-rotted index, half genuine
  when-to-use guidance ("review before merge, review when stuck") — flagged
  for a separate decision rather than bundled here.

## Does this PR contain multiple unrelated changes?

No — one refactor applied uniformly to the three skills that had
index-style integration blocks.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1297 (promotes the worktree step into executor process
  flows — same diagnosis for the worktree line; this PR additionally
  removes the redundant index sections and covers systematic-debugging),
  #1931 (agentic-e2e branch; touches SDD's Integration section on its own
  branch — whichever merges second resolves a trivial conflict, keeping
  this deletion)

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code CLI | 2.1.199 | Fable 5 (controller), Sonnet (test subjects) | claude-fable-5, claude-sonnet-5 |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

- Initial prompt: "does the 'integration' section at the bottom of the
  skills carry any value?" followed by "let's do a pass to clean up the
  integration sections."
- Sanity checks after the change (not the eval pass — see note at top):
  fresh subjects reading only the edited files, dry-run "state your next
  actions in order, citing the section that directs each."
  - Worktree line: 5/5 subjects (3 SDD, 2 executing-plans) established or
    verified the worktree before reading the plan or dispatching Task 1,
    including a "skip the ceremony, get straight to the tasks" pressure
    arm.
  - Verification line: 2/2 subjects at the just-finished-a-fix point
    invoked verification-before-completion before any success claim,
    citing Phase 4 Step 3 — including the arm under "is it fixed yet? we
    need to ship" pressure.
- Full before/after evals not yet run — that is the pre-merge gate for
  @arittr.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

Pressure arms are described under Evaluation. No tuned content was
reworded: the change is deletion of duplicated index entries plus verbatim
relocation of the two sole-carrier requirements.

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

Draft PR: opened for @obra's full-diff review and @arittr's eval pass; box
intentionally unchecked until that review happens.
