### PR TITLE
refactor: modernize finishing-a-development-branch (discard demotion, worktree-path fix, rationalization table)

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -7,39 +7,25 @@ description: Use when implementation is complete, all tests pass, and you need t
 
 ## Overview
 
-Guide completion of development work by presenting clear options and handling chosen workflow.
-
 **Core principle:** Verify tests → Detect environment → Present options → Execute choice → Clean up.
 
 **Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
 
-## The Process
+## Step 1: Verify Tests
 
-### Step 1: Verify Tests
+Run the project's full test suite (`npm test` / `cargo test` / `pytest` / `go test ./...`).
 
-**Before presenting options, verify tests pass:**
+**If tests fail**, report the failures and stop — the menu comes after a green suite:
 
-```bash
-# Run project's test suite
-npm test / cargo test / pytest / go test ./...
-```
-
-**If tests fail:**
 ```
 Tests failing (<N> failures). Must fix before completing:
 
 [Show failures]
-
-Cannot proceed with merge/PR until tests pass.
 ```
 
-Stop. Don't proceed to Step 2.
+**If tests pass:** continue to Step 2.
 
-**If tests pass:** Continue to Step 2.
-
-### Step 2: Detect Environment
-
-**Determine workspace state before presenting options:**
+## Step 2: Detect Environment
 
 ```bash
 GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
@@ -52,16 +38,16 @@ This determines which menu to show and how cleanup works:
 |-------|------|---------|
 | `GIT_DIR == GIT_COMMON` (normal repo) | Standard 3 options | No worktree to clean up |
 | `GIT_DIR != GIT_COMMON`, named branch | Standard 3 options | Provenance-based (see Step 6) |
-| `GIT_DIR != GIT_COMMON`, detached HEAD | Reduced 3 options (no merge) | No cleanup (externally managed) |
+| `GIT_DIR != GIT_COMMON`, detached HEAD | Reduced 2 options (no merge) | Externally managed — leave in place |
 
-### Step 3: Determine Base Branch
+## Step 3: Determine Base Branch
 
 The base branch is whatever this work forked from — usually named in the
 plan, the conversation, or the branch's upstream. If it is not already
 known, ask: "This branch split from <your best guess> - is that correct?"
-Don't guess silently: merging into the wrong base is expensive to undo.
+Confirm before merging: merging into the wrong base is expensive to undo.
 
-### Step 4: Present Options
+## Step 4: Present Options
 
 **Normal repo and named-branch worktree — present exactly these 3 options:**
 
@@ -86,15 +72,15 @@ Implementation complete. You're on a detached HEAD (externally managed workspace
 Which option?
 ```
 
-**Don't add explanation** - keep options concise.
-
-Discarding the work is never offered. It exists only as a response to your
+Present the menu exactly as written — concise, with every option coming
+from the list above. Discarding the work happens only in response to your
 human partner explicitly asking for it (see "If your human partner asks to
-discard the work" below).
+discard the work" below). Wait for their answer; the integration decision
+is theirs.
 
-### Step 5: Execute Choice
+## Step 5: Execute Choice
 
-#### Option 1: Merge Locally
+### Option 1: Merge Locally
 
 ```bash
 # Get main repo root for CWD safety
@@ -108,24 +94,22 @@ git merge <feature-branch>
 
 # Verify tests on merged result
 <test command>
-
-# Only after merge succeeds: cleanup worktree (Step 6), then delete branch
 ```
 
-If tests fail on the merged result: STOP. Leave the worktree and branch in
-place and investigate — nothing has been pushed, so the merge is local and
-recoverable.
+If tests fail on the merged result: stop, leave the worktree and branch in
+place, and investigate — nothing has been pushed, so the merge is local
+and recoverable.
 
-Then: Cleanup worktree (Step 6), then delete branch:
+Once the merged result is green: clean up the worktree (Step 6), then
+delete the branch:
 
 ```bash
 git branch -d <feature-branch>
 ```
 
-#### Option 2: Push and Create PR
+### Option 2: Push and Create PR
 
 ```bash
-# Push branch
 git push -u origin <feature-branch>
 ```
 
@@ -134,18 +118,16 @@ tooling — its CLI if one is available, or the creation URL most forges
 print when you push — following the repo's PR template and conventions if
 present, and report the URL to your human partner.
 
-**Do NOT clean up worktree** — user needs it alive to iterate on PR feedback.
+Keep the worktree — your human partner iterates on PR feedback there.
 
-#### Option 3: Keep As-Is
+### Option 3: Keep As-Is
 
 Report: "Keeping branch <name>. Worktree preserved at <path>."
 
-**Don't cleanup worktree.**
+### If your human partner asks to discard the work
 
-#### If your human partner asks to discard the work
-
-Never offer this. Only do it when your human partner explicitly asks to
-throw the work away — and even then, confirm first:
+This path exists only as a response to an explicit request to throw the
+work away. Confirm first:
 
 ```
 This will permanently delete:
@@ -156,22 +138,23 @@ This will permanently delete:
 Type 'discard' to confirm.
 ```
 
-Wait for exact confirmation.
+Wait for that exact confirmation. When it arrives:
 
-If confirmed:
 ```bash
 MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
 cd "$MAIN_ROOT"
 ```
 
-Then: Cleanup worktree (Step 6), then force-delete branch:
+Then clean up the worktree (Step 6) and force-delete the branch:
+
 ```bash
 git branch -D <feature-branch>
 ```
 
-### Step 6: Cleanup Workspace
+## Step 6: Cleanup Workspace
 
-**Only runs for Option 1 and confirmed discards.** Options 2 and 3 always preserve the worktree.
+**Runs for Option 1 and confirmed discards.** Options 2 and 3 always
+preserve the worktree.
 
 ```bash
 GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
@@ -181,7 +164,9 @@ WORKTREE_PATH=$(git rev-parse --show-toplevel)
 
 **If `GIT_DIR == GIT_COMMON`:** Normal repo, no worktree to clean up. Done.
 
-**If worktree path is under `.worktrees/` or `worktrees/`:** Superpowers created this worktree — we own cleanup.
+**If worktree path is under `.worktrees/` or `worktrees/`:** Superpowers
+created this worktree — we own cleanup. Run it from the main repo root
+(removal fails from inside the worktree being removed):
 
 ```bash
 MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
@@ -190,7 +175,8 @@ git worktree remove "$WORKTREE_PATH"
 git worktree prune  # Self-healing: clean up any stale registrations
 ```
 
-**Otherwise:** The host environment (harness) owns this workspace. Do NOT remove it. If your platform provides a workspace-exit tool, use it. Otherwise, leave the workspace in place.
+**Otherwise:** The host environment owns this workspace — leave it in
+place. If your platform provides a workspace-exit tool, use it.
 
 ## Quick Reference
 
@@ -201,57 +187,16 @@ git worktree prune  # Self-healing: clean up any stale registrations
 | 3. Keep as-is | - | - | yes | - |
 | Discard (explicit request only) | - | - | - | yes (force) |
 
-## Common Mistakes
+## Common Rationalizations
 
-**Skipping test verification**
-- **Problem:** Merge broken code, create failing PR
-- **Fix:** Always verify tests before offering options
-
-**Open-ended questions**
-- **Problem:** "What should I do next?" is ambiguous
-- **Fix:** Present exactly 3 structured options (or 2 for detached HEAD)
-
-**Offering to discard the work**
-- **Problem:** Puts throwing away completed, passing work on the menu
-- **Fix:** Discard only on your human partner's explicit request, never as an offer
-
-**Cleaning up worktree for Option 2**
-- **Problem:** Remove worktree user needs for PR iteration
-- **Fix:** Only cleanup for Option 1 and confirmed discards
-
-**Deleting branch before removing worktree**
-- **Problem:** `git branch -d` fails because worktree still references the branch
-- **Fix:** Merge first, remove worktree, then delete branch
-
-**Running git worktree remove from inside the worktree**
-- **Problem:** Command fails silently when CWD is inside the worktree being removed
-- **Fix:** Always `cd` to main repo root before `git worktree remove`
-
-**Cleaning up harness-owned worktrees**
-- **Problem:** Removing a worktree the harness created causes phantom state
-- **Fix:** Only clean up worktrees under `.worktrees/` or `worktrees/`
-
-**No confirmation for discard**
-- **Problem:** Accidentally delete work
-- **Fix:** Require typed "discard" confirmation
-
-## Red Flags
-
-**Never:**
-- Proceed with failing tests
-- Merge without verifying tests on result
-- Offer discarding the work — it happens only on explicit request
-- Delete work without confirmation
-- Force-push without explicit request
-- Remove a worktree before confirming merge success
-- Clean up worktrees you didn't create (provenance check)
-- Run `git worktree remove` from inside the worktree
-
-**Always:**
-- Verify tests before offering options
-- Detect environment before presenting menu
-- Present exactly 3 options (or 2 for detached HEAD)
-- Get typed confirmation before any discard
-- Clean up worktree for Option 1 and confirmed discards only
-- `cd` to main repo root before worktree removal
-- Run `git worktree prune` after removal
+| Excuse | Reality |
+|--------|---------|
+| "Tests passed earlier this session" | Run the suite now. The tree changed since the last green run. |
+| "They obviously want it merged" | Integration is your human partner's decision. Present the menu and wait. |
+| "They seem done with this feature — I'll offer to discard it" | The menu is complete as written. Discard happens only when your human partner asks for it in so many words. |
+| "'Yeah, get rid of it' counts as confirmation" | Only the typed word `discard` authorizes deletion. |
+| "The PR is up, so the worktree is clutter now" | PR feedback gets fixed in that worktree. It stays until the work lands. |
+| "This other worktree looks stale — I'll clean it too" | Clean up only worktrees under `.worktrees/` or `worktrees/`. Everything else belongs to the host. |
+| "The merged-result failure is probably flaky" | A failing merged result stops everything. Branch and worktree stay put while you investigate. |
+| "The base branch is obviously main" | Confirm the fork point or ask. Merging into the wrong base is expensive to undo. |
+| "The push was rejected — force-push will fix it" | A rejected push means the remote moved. Investigate; force-push only on your human partner's explicit request. |

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-development-branch
-description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work
 ---
 
 # Finishing a Development Branch
@@ -50,22 +50,20 @@ This determines which menu to show and how cleanup works:
 
 | State | Menu | Cleanup |
 |-------|------|---------|
-| `GIT_DIR == GIT_COMMON` (normal repo) | Standard 4 options | No worktree to clean up |
-| `GIT_DIR != GIT_COMMON`, named branch | Standard 4 options | Provenance-based (see Step 6) |
+| `GIT_DIR == GIT_COMMON` (normal repo) | Standard 3 options | No worktree to clean up |
+| `GIT_DIR != GIT_COMMON`, named branch | Standard 3 options | Provenance-based (see Step 6) |
 | `GIT_DIR != GIT_COMMON`, detached HEAD | Reduced 3 options (no merge) | No cleanup (externally managed) |
 
 ### Step 3: Determine Base Branch
 
-```bash
-# Try common base branches
-git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
-```
-
-Or ask: "This branch split from main - is that correct?"
+The base branch is whatever this work forked from — usually named in the
+plan, the conversation, or the branch's upstream. If it is not already
+known, ask: "This branch split from <your best guess> - is that correct?"
+Don't guess silently: merging into the wrong base is expensive to undo.
 
 ### Step 4: Present Options
 
-**Normal repo and named-branch worktree — present exactly these 4 options:**
+**Normal repo and named-branch worktree — present exactly these 3 options:**
 
 ```
 Implementation complete. What would you like to do?
@@ -73,24 +71,26 @@ Implementation complete. What would you like to do?
 1. Merge back to <base-branch> locally
 2. Push and create a Pull Request
 3. Keep the branch as-is (I'll handle it later)
-4. Discard this work
 
 Which option?
 ```
 
-**Detached HEAD — present exactly these 3 options:**
+**Detached HEAD — present exactly these 2 options:**
 
 ```
 Implementation complete. You're on a detached HEAD (externally managed workspace).
 
 1. Push as new branch and create a Pull Request
 2. Keep as-is (I'll handle it later)
-3. Discard this work
 
 Which option?
 ```
 
 **Don't add explanation** - keep options concise.
+
+Discarding the work is never offered. It exists only as a response to your
+human partner explicitly asking for it (see "If your human partner asks to
+discard the work" below).
 
 ### Step 5: Execute Choice
 
@@ -112,6 +112,10 @@ git merge <feature-branch>
 # Only after merge succeeds: cleanup worktree (Step 6), then delete branch
 ```
 
+If tests fail on the merged result: STOP. Leave the worktree and branch in
+place and investigate — nothing has been pushed, so the merge is local and
+recoverable.
+
 Then: Cleanup worktree (Step 6), then delete branch:
 
 ```bash
@@ -125,6 +129,11 @@ git branch -d <feature-branch>
 git push -u origin <feature-branch>
 ```
 
+Then create the pull/merge request against <base-branch> with the host's
+tooling (`gh pr create`, `glab mr create`, or the URL git prints on push),
+following the repo's PR template and conventions if present, and report
+the URL to your human partner.
+
 **Do NOT clean up worktree** — user needs it alive to iterate on PR feedback.
 
 #### Option 3: Keep As-Is
@@ -133,9 +142,11 @@ Report: "Keeping branch <name>. Worktree preserved at <path>."
 
 **Don't cleanup worktree.**
 
-#### Option 4: Discard
+#### If your human partner asks to discard the work
 
-**Confirm first:**
+Never offer this. Only do it when your human partner explicitly asks to
+throw the work away — and even then, confirm first:
+
 ```
 This will permanently delete:
 - Branch <name>
@@ -160,7 +171,7 @@ git branch -D <feature-branch>
 
 ### Step 6: Cleanup Workspace
 
-**Only runs for Options 1 and 4.** Options 2 and 3 always preserve the worktree.
+**Only runs for Option 1 and confirmed discards.** Options 2 and 3 always preserve the worktree.
 
 ```bash
 GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
@@ -188,7 +199,7 @@ git worktree prune  # Self-healing: clean up any stale registrations
 | 1. Merge locally | yes | - | - | yes |
 | 2. Create PR | - | yes | yes | - |
 | 3. Keep as-is | - | - | yes | - |
-| 4. Discard | - | - | - | yes (force) |
+| Discard (explicit request only) | - | - | - | yes (force) |
 
 ## Common Mistakes
 
@@ -198,11 +209,15 @@ git worktree prune  # Self-healing: clean up any stale registrations
 
 **Open-ended questions**
 - **Problem:** "What should I do next?" is ambiguous
-- **Fix:** Present exactly 4 structured options (or 3 for detached HEAD)
+- **Fix:** Present exactly 3 structured options (or 2 for detached HEAD)
+
+**Offering to discard the work**
+- **Problem:** Puts throwing away completed, passing work on the menu
+- **Fix:** Discard only on your human partner's explicit request, never as an offer
 
 **Cleaning up worktree for Option 2**
 - **Problem:** Remove worktree user needs for PR iteration
-- **Fix:** Only cleanup for Options 1 and 4
+- **Fix:** Only cleanup for Option 1 and confirmed discards
 
 **Deleting branch before removing worktree**
 - **Problem:** `git branch -d` fails because worktree still references the branch
@@ -225,6 +240,7 @@ git worktree prune  # Self-healing: clean up any stale registrations
 **Never:**
 - Proceed with failing tests
 - Merge without verifying tests on result
+- Offer discarding the work — it happens only on explicit request
 - Delete work without confirmation
 - Force-push without explicit request
 - Remove a worktree before confirming merge success
@@ -234,8 +250,8 @@ git worktree prune  # Self-healing: clean up any stale registrations
 **Always:**
 - Verify tests before offering options
 - Detect environment before presenting menu
-- Present exactly 4 options (or 3 for detached HEAD)
-- Get typed confirmation for Option 4
-- Clean up worktree for Options 1 & 4 only
+- Present exactly 3 options (or 2 for detached HEAD)
+- Get typed confirmation before any discard
+- Clean up worktree for Option 1 and confirmed discards only
 - `cd` to main repo root before worktree removal
 - Run `git worktree prune` after removal

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -129,10 +129,10 @@ git branch -d <feature-branch>
 git push -u origin <feature-branch>
 ```
 
-Then create the pull/merge request against <base-branch> with the host's
-tooling (`gh pr create`, `glab mr create`, or the URL git prints on push),
-following the repo's PR template and conventions if present, and report
-the URL to your human partner.
+Then create the pull/merge request against <base-branch> with the forge's
+tooling — its CLI if one is available, or the creation URL most forges
+print when you push — following the repo's PR template and conventions if
+present, and report the URL to your human partner.
 
 **Do NOT clean up worktree** — user needs it alive to iterate on PR feedback.
 

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -30,6 +30,9 @@ Tests failing (<N> failures). Must fix before completing:
 ```bash
 GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
 GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+# Capture now, while still inside the workspace — Step 5 changes directory
+# before cleanup (Step 6) needs this value
+WORKTREE_PATH=$(git rev-parse --show-toplevel)
 ```
 
 This determines which menu to show and how cleanup works:
@@ -111,6 +114,8 @@ git branch -d <feature-branch>
 
 ```bash
 git push -u origin <feature-branch>
+# From a detached HEAD, name the new branch on the remote:
+# git push origin HEAD:refs/heads/<new-branch>
 ```
 
 Then create the pull/merge request against <base-branch> with the forge's
@@ -154,23 +159,17 @@ git branch -D <feature-branch>
 ## Step 6: Cleanup Workspace
 
 **Runs for Option 1 and confirmed discards.** Options 2 and 3 always
-preserve the worktree.
-
-```bash
-GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
-GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
-WORKTREE_PATH=$(git rev-parse --show-toplevel)
-```
+preserve the worktree. Both callers have already changed directory to the
+main repo root — worktree removal must run from outside the worktree —
+and use the `GIT_DIR`/`GIT_COMMON`/`WORKTREE_PATH` values captured in
+Step 2, from before that directory change.
 
 **If `GIT_DIR == GIT_COMMON`:** Normal repo, no worktree to clean up. Done.
 
-**If worktree path is under `.worktrees/` or `worktrees/`:** Superpowers
-created this worktree — we own cleanup. Run it from the main repo root
-(removal fails from inside the worktree being removed):
+**If `WORKTREE_PATH` is under `.worktrees/` or `worktrees/`:** Superpowers
+created this worktree — we own cleanup:
 
 ```bash
-MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
-cd "$MAIN_ROOT"
 git worktree remove "$WORKTREE_PATH"
 git worktree prune  # Self-healing: clean up any stale registrations
 ```
@@ -191,7 +190,7 @@ place. If your platform provides a workspace-exit tool, use it.
 
 | Excuse | Reality |
 |--------|---------|
-| "Tests passed earlier this session" | Run the suite now. The tree changed since the last green run. |
+| "Tests passed earlier this session" | Run the suite on the tree you are about to integrate. A green run only proves the tree it ran on. |
 | "They obviously want it merged" | Integration is your human partner's decision. Present the menu and wait. |
 | "They seem done with this feature — I'll offer to discard it" | The menu is complete as written. Discard happens only when your human partner asks for it in so many words. |
 | "'Yeah, get rid of it' counts as confirmation" | Only the typed word `discard` authorizes deletion. |


### PR DESCRIPTION
> **Note for @arittr:** hold merge until this has been run through evals.
> The micro-tests below are quick sanity checks, not the eval pass.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (claude-fable-5) |
| Harness + version | Claude Code CLI 2.1.199 |
| All plugins installed | superpowers 6.1.0, claude-session-driver 4.0.0, episodic-memory, superpowers-chrome, context7, linear, plugin-dev, agent-sdk-dev |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — directed the change; full-diff review pending (hence draft) |

## What problem are you trying to solve?

Four problems in finishing-a-development-branch, a skill dating from when
throwing away branches was routine:

1. "Discard this work" sat on the completion menu beside "Merge" on every
   run — advertising destruction of finished, passing work as a peer
   option.
2. A real sequencing bug: Step 6 recomputed `WORKTREE_PATH` after Option 1
   and discard had already `cd`'d to the main repo root, so the provenance
   check could never match, worktree cleanup silently no-oped, and the
   branch delete failed with the worktree still attached. A test subject
   had to deviate from the literal skill text to produce a working
   sequence — that deviation is what exposed the bug.
3. Dead or misleading mechanics: "Push and Create PR" never created the
   PR; Step 3's base-branch "detection" printed a commit SHA rather than
   choosing a branch; Option 1 had no failure path for the merged result;
   the detached-HEAD menu advertised a push its command couldn't perform.
4. Form: overlapping Red Flags + Common Mistakes sections instead of the
   house rationalization table; negative-phrased instructions throughout;
   a what-it-does clause in the trigger description.

## What does this PR change?

The menus become 3 options (2 on detached HEAD); discarding survives as an
explicit-request-only path with the same typed-`discard` ritual and
cleanup mechanics. Workspace state is captured once in Step 2, before any
directory change, and Step 6 consumes it. Option 2 pushes and then creates
the pull/merge request with the forge's tooling — forge-agnostic by
design (GitHub, GitLab, Gitea, Forgejo, ...): the forge's CLI or the
creation URL printed on push, following repo conventions, reporting the
URL. Option 1 gains a merged-result failure path (stop, keep everything,
investigate). Red Flags and Common Mistakes fold into one Common
Rationalizations table (Excuse/Reality); every prior entry maps to a table
row or an inline sentence in the step it guards. Instructions are phrased
positively; remaining negations are statements of fact. Description
trimmed to trigger-only. Net: 242 → 201 lines.

## Is this change appropriate for the core library?

Yes — core workflow skill; behavior tightened, no new dependencies, no
service integration (deliberately forge-agnostic).

## What alternatives did you consider?

- **Keep discard on the menu but reworded/reordered:** rejected — any
  menu placement advertises it. Response-only matches how it's actually
  used today.
- **Name forge CLIs (`gh`, `glab`) in Option 2:** rejected — blesses two
  forges and rots; the creation-URL-on-push fallback is universal.
- **Add `--force` to `git worktree remove` for discards:** deliberately
  rejected — a dirty worktree during a discard means uncommitted work the
  human may not know exists; failing loudly so the agent stops and asks
  is the desired behavior.

## Does this PR contain multiple unrelated changes?

One skill, one modernization pass: the discard demotion, bug fix,
mechanics fixes, and form conversion were all found in the same
fresh-eyes reread and land as four reviewable commits.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #946 (open — proposes adding a smoke check to this skill's
  Step 1; orthogonal to this pass, no conflict in intent), #1149 (open —
  smart rebasing/conflict resolution for this skill; touches the same
  file, will need a rebase if this lands first)

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code CLI | 2.1.199 | Fable 5 (controller), Sonnet (test subjects) | claude-fable-5, claude-sonnet-5 |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

- Initial prompt: "we want to clean up finishing-a-development-branch...
  'let's just throw away this work' was a real thing that happened a lot.
  we should not be advertising that as much. AND we should be rereading
  the whole skill with fresh eyes."
- Sanity checks after each change wave (fresh subjects reading only the
  edited file, dry-run, citing the section directing each action):
  - Menus: 4/4 — both menu variants reproduced verbatim with no discard
    option; a pressure arm whose human had said "I'm honestly not sure
    this was worth building" declined to add discard, citing the
    rationalization table by name.
  - Discard path: prose "just throw all of this away" produced the typed
    confirmation demand — "I do not proceed on 'yes,' 'do it,' or
    anything else" — then the correct cd-to-root → worktree remove →
    prune → force-delete order.
  - Bug fix: merge-flow and discard-flow subjects walked the literal
    skill to correct cleanup with concrete paths at each stage and
    reported zero deviations needed (pre-fix, a subject had to improvise
    the capture point).
- Full before/after evals not yet run — that is the pre-merge gate for
  @arittr.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

Pressure arms are described under Evaluation (lukewarm-human menu
pressure; loose-confirmation discard request). The Red Flags/Common
Mistakes → rationalization-table conversion is the deliberate subject of
this PR, made at the maintainer's direction and mapped entry-by-entry
before deletion; the eval gate above is the check that it holds.

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

Draft PR: opened for @obra's full-diff review and @arittr's eval pass; box
intentionally unchecked until that review happens.
