### PR TITLE
refactor: strip social proof, self-selling, and recap detritus from 12 skills (eval-gated)

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -77,6 +77,7 @@ digraph brainstorming {
 - Propose 2-3 different approaches with trade-offs
 - Present options conversationally with your recommendation and reasoning
 - Lead with your recommended option and explain why
+- YAGNI ruthlessly - remove unnecessary features from every approach and design
 
 **Presenting the design:**
 
@@ -129,15 +130,6 @@ Wait for the user's response. If they request changes, make them and re-run the 
 
 - Invoke the writing-plans skill to create a detailed implementation plan
 - Do NOT invoke any other skill. writing-plans is the next step.
-
-## Key Principles
-
-- **One question at a time** - Don't overwhelm with multiple questions
-- **Multiple choice preferred** - Easier to answer than open-ended when possible
-- **YAGNI ruthlessly** - Remove unnecessary features from all designs
-- **Explore alternatives** - Always propose 2-3 approaches before settling
-- **Incremental validation** - Present design, get approval before moving on
-- **Be flexible** - Go back and clarify when something doesn't make sense
 
 ## Visual Companion
 

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -158,15 +158,6 @@ Agent 3 → Fix tool-approval-race-conditions.test.ts
 
 **Integration:** All fixes independent, no conflicts, full suite green
 
-**Time saved:** 3 problems solved in parallel vs sequentially
-
-## Key Benefits
-
-1. **Parallelization** - Multiple investigations happen simultaneously
-2. **Focus** - Each agent has narrow scope, less context to track
-3. **Independence** - Agents don't interfere with each other
-4. **Speed** - 3 problems solved in time of 1
-
 ## Verification
 
 After agents return:
@@ -174,12 +165,3 @@ After agents return:
 2. **Check for conflicts** - Did agents edit same code?
 3. **Run full suite** - Verify all fixes work together
 4. **Spot check** - Agents can make systematic errors
-
-## Real-World Impact
-
-From debugging session (2025-10-03):
-- 6 failures across 3 files
-- 3 agents dispatched in parallel
-- All investigations completed concurrently
-- All fixes integrated successfully
-- Zero conflicts between agent changes

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -11,7 +11,7 @@ Load plan, review critically, execute all tasks, report when complete.
 
 **Announce at start:** "I'm using the executing-plans skill to implement this plan."
 
-**Note:** Tell your human partner that Superpowers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (Claude Code, Codex CLI, Codex App, Copilot CLI, and Gemini CLI all qualify; see the per-platform tool refs in `../using-superpowers/references/`). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
+**Note:** Tell your human partner that Superpowers works much better with access to subagents (Claude Code, Codex CLI, Codex App, Copilot CLI, and Gemini CLI all qualify; see the per-platform tool refs in `../using-superpowers/references/`). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
 
 ## The Process
 

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -203,11 +203,3 @@ You understand 1,2,3,6. Unclear on 4,5.
 ## GitHub Thread Replies
 
 When replying to inline review comments on GitHub, reply in the comment thread (`gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies`), not as a top-level PR comment.
-
-## The Bottom Line
-
-**External feedback = suggestions to evaluate, not orders to follow.**
-
-Verify. Question. Then implement.
-
-No performative agreement. Technical rigor always.

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -5,7 +5,7 @@ description: Use when completing tasks, implementing major features, or before m
 
 # Requesting Code Review
 
-Dispatch a code reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
+Dispatch a code reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history.
 
 **Core principle:** Review early, review often.
 
@@ -72,20 +72,12 @@ You: [Fix progress indicators]
 [Continue to Task 3]
 ```
 
-## Integration with Workflows
+## Common Rationalizations
 
-**Subagent-Driven Development:**
-- Review after EACH task
-- Catch issues before they compound
-- Fix before moving to next task
-
-**Executing Plans:**
-- Review after each task or at natural checkpoints
-- Get feedback, apply, continue
-
-**Ad-Hoc Development:**
-- Review before merge
-- Review when stuck
+| Excuse | Reality |
+|--------|---------|
+| "I'll just review the diff myself instead of dispatching a reviewer" | You're the coordinator — reviewing the diff inline burns the context window you need to keep driving the work. Dispatch a reviewer subagent: the diff and the evaluation live in its context, and only the findings come back to you. |
+| "The reviewer needs my whole session history to understand the change" | Hand it precisely crafted context, never your session's history. That keeps the reviewer on the work product, not your thought process. |
 
 ## Red Flags
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -335,38 +335,6 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
-## Advantages
-
-**vs. Manual execution:**
-- Subagents follow TDD naturally
-- Fresh context per task (no confusion)
-- Parallel-safe (subagents don't interfere)
-- Subagent can ask questions (before AND during work)
-
-**vs. Executing Plans:**
-- Same session (no handoff)
-- Continuous progress (no waiting)
-- Review checkpoints automatic
-
-**Efficiency gains:**
-- Controller curates exactly what context is needed; bulk artifacts move
-  as files, not pasted text
-- Subagent gets complete information upfront
-- Questions surfaced before work begins (not after)
-
-**Quality gates:**
-- Self-review catches issues before handoff
-- Task review carries two verdicts: spec compliance and code quality
-- Review loops ensure fixes actually work
-- Spec compliance prevents over/under-building
-- Code quality ensures implementation is well-built
-
-**Cost:**
-- More subagent invocations (implementer + reviewer per task)
-- Controller does more prep work (extracting all tasks upfront)
-- Review loops add iterations
-- But catches issues early (cheaper than debugging later)
-
 ## Red Flags
 
 **Never:**

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -7,8 +7,6 @@ description: Use when encountering any bug, test failure, or unexpected behavior
 
 ## Overview
 
-Random fixes waste time and create new bugs. Quick patches mask underlying issues.
-
 **Core principle:** ALWAYS find root cause before attempting fixes. Symptom fixes are failure.
 
 **Violating the letter of this process is violating the spirit of debugging.**
@@ -283,11 +281,3 @@ These techniques are part of systematic debugging and available in this director
 - **`root-cause-tracing.md`** - Trace bugs backward through call stack to find original trigger
 - **`defense-in-depth.md`** - Add validation at multiple layers after finding root cause
 - **`condition-based-waiting.md`** - Replace arbitrary timeouts with condition polling
-
-## Real-World Impact
-
-From debugging sessions:
-- Systematic approach: 15-30 minutes to fix
-- Random fixes approach: 2-3 hours of thrashing
-- First-time fix rate: 95% vs 40%
-- New bugs introduced: Near zero vs common

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -209,69 +209,19 @@ When writing or changing any test, read [writing-good-tests.md](writing-good-tes
 - Keep test-only code in test utilities, out of production classes
 - Understand a dependency's side effects before mocking it
 
-## Why Order Matters
-
-**"I'll write tests after to verify it works"**
-
-Tests written after code pass immediately. Passing immediately proves nothing:
-- Might test wrong thing
-- Might test implementation, not behavior
-- Might miss edge cases you forgot
-- You never saw it catch the bug
-
-Test-first forces you to see the test fail, proving it actually tests something.
-
-**"I already manually tested all the edge cases"**
-
-Manual testing is ad-hoc. You think you tested everything but:
-- No record of what you tested
-- Can't re-run when code changes
-- Easy to forget cases under pressure
-- "It worked when I tried it" ≠ comprehensive
-
-Automated tests are systematic. They run the same way every time.
-
-**"Deleting X hours of work is wasteful"**
-
-Sunk cost fallacy. The time is already gone. Your choice now:
-- Delete and rewrite with TDD (X more hours, high confidence)
-- Keep it and add tests after (30 min, low confidence, likely bugs)
-
-The "waste" is keeping code you can't trust. Working code without real tests is technical debt.
-
-**"TDD is dogmatic, being pragmatic means adapting"**
-
-TDD IS pragmatic:
-- Finds bugs before commit (faster than debugging after)
-- Prevents regressions (tests catch breaks immediately)
-- Documents behavior (tests show how to use code)
-- Enables refactoring (change freely, tests catch breaks)
-
-"Pragmatic" shortcuts = debugging in production = slower.
-
-**"Tests after achieve the same goals - it's spirit not ritual"**
-
-No. Tests-after answer "What does this do?" Tests-first answer "What should this do?"
-
-Tests-after are biased by your implementation. You test what you built, not what's required. You verify remembered edge cases, not discovered ones.
-
-Tests-first force edge case discovery before implementing. Tests-after verify you remembered everything (you didn't).
-
-30 minutes of tests after ≠ TDD. You get coverage, lose proof tests work.
-
 ## Common Rationalizations
 
 | Excuse | Reality |
 |--------|---------|
 | "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
-| "I'll test after" | Tests passing immediately prove nothing. |
-| "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
-| "Already manually tested" | Ad-hoc ≠ systematic. No record, can't re-run. |
-| "Deleting X hours is wasteful" | Sunk cost fallacy. Keeping unverified code is technical debt. |
+| "I'll test after" | Tests written after pass immediately — which proves nothing. They may test the wrong thing, test the implementation instead of the behavior, or miss the edge case you forgot. You never watched it fail, so you never proved it can catch the bug. Test-first forces that failure. |
+| "Tests after achieve same goals (spirit not ritual)" | Tests-after answer "what does this do?"; tests-first answer "what should this do?" Tests written after are biased by the code you already wrote — you verify the cases you remembered, not the ones you'd have discovered. Coverage without proof the tests work. |
+| "Already manually tested" | Manual testing is ad-hoc: no record of what you covered, no way to re-run it when the code changes, easy to forget cases under pressure. "Worked when I tried it" ≠ comprehensive. Automated tests run the same way every time. |
+| "Deleting X hours is wasteful" | Sunk cost fallacy — that time is already spent either way. The real choice: rewrite with TDD (high confidence) vs. keep it and bolt tests on after (low confidence, likely bugs). Keeping code you can't trust is the waste. |
 | "Keep as reference, write tests first" | You'll adapt it. That's testing after. Delete means delete. |
 | "Need to explore first" | Fine. Throw away exploration, start with TDD. |
 | "Test hard = design unclear" | Listen to test. Hard to test = hard to use. |
-| "TDD will slow me down" | TDD faster than debugging. Pragmatic = test-first. |
+| "TDD will slow me down" | TDD IS the pragmatic path: catches bugs before commit, prevents regressions, lets you refactor without fear. "Pragmatic" shortcuts mean debugging in production — slower, not faster. |
 | "Manual test faster" | Manual doesn't prove edge cases. You'll re-test every change. |
 | "Existing code has no tests" | You're improving it. Add tests for existing code. |
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -156,47 +156,12 @@ Ready to implement <feature-name>
 | Tests fail during baseline | Report failures + ask |
 | No package.json/Cargo.toml | Skip dependency install |
 
-## Common Mistakes
+## Common Rationalizations
 
-### Fighting the harness
-
-- **Problem:** Using `git worktree add` when the platform already provides isolation
-- **Fix:** Step 0 detects existing isolation. Step 1a defers to native tools.
-
-### Skipping detection
-
-- **Problem:** Creating a nested worktree inside an existing one
-- **Fix:** Always run Step 0 before creating anything
-
-### Skipping ignore verification
-
-- **Problem:** Worktree contents get tracked, pollute git status
-- **Fix:** Always use `git check-ignore` before creating project-local worktree
-
-### Assuming directory location
-
-- **Problem:** Creates inconsistency, violates project conventions
-- **Fix:** Follow priority: explicit instructions > existing project-local directory > default
-
-### Proceeding with failing tests
-
-- **Problem:** Can't distinguish new bugs from pre-existing issues
-- **Fix:** Report failures, get explicit permission to proceed
-
-## Red Flags
-
-**Never:**
-- Create a worktree when Step 0 detects existing isolation
-- Use `git worktree add` when you have a native worktree tool (e.g., `EnterWorktree`). This is the #1 mistake — if you have it, use it.
-- Skip Step 1a by jumping straight to Step 1b's git commands
-- Create worktree without verifying it's ignored (project-local)
-- Skip baseline test verification
-- Proceed with failing tests without asking
-
-**Always:**
-- Run Step 0 detection first
-- Prefer native tools over git fallback
-- Follow directory priority: explicit instructions > existing project-local directory > default
-- Verify directory is ignored for project-local
-- Auto-detect and run project setup
-- Verify clean test baseline
+| Excuse | Reality |
+|--------|---------|
+| "I'm obviously not in a worktree — no need to check" | Run Step 0. Harness-created isolation and submodules both fool eyeballing; the detection commands settle it. |
+| "`git worktree add` is quicker than hunting for a native tool" | A native tool (e.g. `EnterWorktree`) owns placement, branching, and cleanup. Bypassing it is the #1 mistake — it creates phantom state your harness can't see or manage. |
+| "The worktree directory is surely ignored already" | Run `git check-ignore`. An unignored worktree directory commits the whole tree into the repo. |
+| "Any directory name works" | Explicit instructions beat an existing project-local directory, which beats the `.worktrees/` default. |
+| "The workspace is fresh — baseline tests can wait" | A dirty baseline makes every later failure ambiguous. Run the tests now; proceeding past failures is your human partner's call. |

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -7,8 +7,6 @@ description: Use when about to claim work is complete, fixed, or passing, before
 
 ## Overview
 
-Claiming work is complete without verification is dishonesty, not efficiency.
-
 **Core principle:** Evidence before claims, always.
 
 **Violating the letter of this rule is violating the spirit of this rule.**
@@ -105,15 +103,6 @@ Skip any step = lying, not verifying
 ❌ Trust agent report
 ```
 
-## Why This Matters
-
-From 24 failure memories:
-- your human partner said "I don't believe you" - trust broken
-- Undefined functions shipped - would crash
-- Missing requirements shipped - incomplete features
-- Time wasted on false completion → redirect → rework
-- Violates: "Honesty is a core value. If you lie, you'll be replaced."
-
 ## When To Apply
 
 **ALWAYS before:**
@@ -129,11 +118,3 @@ From 24 failure memories:
 - Paraphrases and synonyms
 - Implications of success
 - ANY communication suggesting completion/correctness
-
-## The Bottom Line
-
-**No shortcuts for verification.**
-
-Run the command. Read the output. THEN claim the result.
-
-This is non-negotiable.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -135,12 +135,6 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - Steps that describe what to do without showing how (code blocks required for code steps)
 - References to types, functions, or methods not defined in any task
 
-## Remember
-- Exact file paths always
-- Complete code in every step — if a step changes code, show the code
-- Exact commands with expected output
-- DRY, YAGNI, TDD, frequent commits
-
 ## Self-Review
 
 After writing the complete plan, look at the spec with fresh eyes and check the plan against it. This is a checklist you run yourself — not a subagent dispatch.

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -677,13 +677,3 @@ How future agents find your skill:
 6. **Loads example** (only when implementing)
 
 **Optimize for this flow** - put searchable terms early and often.
-
-## The Bottom Line
-
-**Creating skills IS TDD for process documentation.**
-
-Same Iron Law: No skill without failing test first.
-Same cycle: RED (baseline) → GREEN (write skill) → REFACTOR (close loopholes).
-Same benefits: Better quality, fewer surprises, bulletproof results.
-
-If you follow TDD for code, follow it for skills. It's the same discipline applied to documentation.


### PR DESCRIPTION
> **Status update (post-eval):** the eval pass this branch was built to
> gate on has now run. Verdict: **11 of 12 cuts are genuine detritus and
> land as-is; one is load-bearing.** Deleting the TDD "Why Order Matters"
> section measurably degrades test-first behavior under the exact "just
> write it, tests after" pressure it rebutted. That commit has been
> **reworked from a delete into a fold** — the five rebuttals now live in
> the Common Rationalizations table rather than in a standalone section.
> The fold restores the *arguments* the compressed rows had dropped, but it
> is a new intermediate form the eval has not yet scored, so **merge still
> waits on one confirming re-run of the pressure probe against the fold.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Model(s) | Original 12-commit audit + cuts: Claude Fable 5 (`claude-fable-5`), Haiku 4.5 audit fan-out. TDD delete→fold rework: Claude Opus 4.8 (`claude-opus-4-8`). |
| Harness + version | Claude Code CLI (audit: 2.1.199; rework: 2.1.207) |
| Eval harness | superpowers-evals **quorum**: Gauntlet-Agent (claude-sonnet) drives the Coding-Agents under test (Claude, Codex) in isolated per-run homes |
| All plugins installed | superpowers, claude-session-driver, episodic-memory, superpowers-chrome, context7, linear, plugin-dev, agent-sdk-dev |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — directed the audit, the one-branch structure, and the fold decision after reading the eval verdict |

## What problem are you trying to solve?

Skills carry content that burns context tokens on every load without
shaping behavior: social-proof sections ("Real-World Impact" with
15-30-minute/95% statistics), self-selling sections ("Advantages",
"Key Benefits") aimed at a reader who has already invoked the skill, and
end-of-file recaps ("Remember", "The Bottom Line", "Key Principles") that
restate rules already stated at point of use. A 14-agent audit (one auditor
per skill, shared brief distinguishing detritus from pressure-tested
behavior control) surveyed every skill; every finding on this branch was
then verified by hand against the claimed point-of-use duplicate before
cutting — the audit's numbers were not trusted blind (one was inflated
2.6x).

The open question the branch was built to answer: **does persuasion prose
in discipline skills actually do anything, or is it detritus like the
rest?** That question is now answered by the eval (see Evaluation below).

## What does this PR change?

Twelve commits, one skill each:

- Social proof/self-selling deleted: dispatching-parallel-agents
  (Real-World Impact, Key Benefits), systematic-debugging (Real-World
  Impact, Overview throat-clearing), subagent-driven-development
  (Advantages), executing-plans (quality claim), requesting-code-review
  (workflow index + mechanism-rationale sentence).
- Recap sections deleted after verifying every line exists at point of
  use: brainstorming (Key Principles — with YAGNI, a sole carrier the
  audit missed, moved into Exploring approaches first), writing-plans
  (Remember), writing-skills and receiving-code-review (The Bottom Line).
- using-git-worktrees: Common Mistakes + Red Flags converted to one
  Common Rationalizations table (house Excuse/Reality form), preserving
  the #1-mistake emphasis on bypassing native worktree tools.
- verification-before-completion: loses Why This Matters, the dishonesty
  reframing, and The Bottom Line. (Eval status: inconclusive — see
  Evaluation. Stays stripped per the "strip the rest freely" disposition,
  flagged low-confidence.)
- **test-driven-development: the one reworked cut.** Originally deleted the
  "Why Order Matters" section on the bet that the table alone held. The
  eval falsified that bet, so the commit now **folds** the section's five
  prose rebuttals into their Common Rationalizations rows, so each row
  carries the argument, not just the excuse label:
  - "I'll test after" → passing immediately proves nothing (wrong thing /
    implementation-not-behavior / missed edge; you never saw it fail).
  - "Already manually tested" → ad-hoc, no record, can't re-run.
  - "Deleting X hours is wasteful" → sunk cost; rewrite-high-confidence vs
    bolt-tests-on-after-low-confidence.
  - "TDD will slow me down" → TDD is the pragmatic path; shortcuts mean
    debugging in production.
  - "Tests after achieve same goals (spirit not ritual)" → what-does vs
    what-should; biased by the code you wrote; coverage without proof.

  The fold still removes the 50-line section (net −45 lines on the file),
  but the load-bearing content survives where an agent hits it
  mid-rationalization.

Judgment calls that diverge from the raw audit: systematic-debugging's
"95% of no-root-cause cases" line STAYS (it guards the bail-out point —
rationalization control, not social proof); receiving-code-review's Common
Mistakes table STAYS (one compact guard table per skill is the pattern this
cleanup standardizes toward, not zero).

## Is this change appropriate for the core library?

Yes — deletions and two table conversions in core skills; no new
dependencies or integrations.

## What alternatives did you consider?

- **For the TDD cut specifically, once the eval flagged it:**
  - *Keep "Why Order Matters" verbatim* — the proven-safe control arm
    (8/10 under pressure). Rejected only because the same behavior can be
    preserved in the retained table with a net line reduction.
  - *Fold the rebuttals into the rationalization table* (chosen) — keeps
    the arguments the eval proved load-bearing while still deleting the
    section. Costs a re-run to confirm the intermediate form holds.
  - *Leave it deleted* — rejected outright; the eval showed a 3-failure
    regression at n=10.
- **Many small branches:** rejected by the maintainer — one branch with
  per-skill commits is the unit the eval pipeline can bisect.
- **Trusting the audit numbers:** rejected after the first verification
  found a haiku auditor had inflated a section's size ~2.6x; every cut was
  re-verified against the file by hand.

## Does this PR contain multiple unrelated changes?

Twelve skills, one theme: removing content that does not change agent
behavior, found by one audit, structured for one eval run. The commits are
separable on purpose — reverting any single commit restores that skill
exactly.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1932 (Integration-section cleanup — this branch
  deliberately leaves those sections alone in SDD, executing-plans, and
  systematic-debugging to avoid overlap), #1933
  (finishing-a-development-branch modernization — that skill is untouched
  here), #1931 (agentic-e2e — touches SDD's SKILL.md in regions this branch
  does not).

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code CLI (authoring) | 2.1.199 / 2.1.207 | Fable 5, Haiku 4.5, Opus 4.8 | claude-fable-5, claude-haiku-4-5, claude-opus-4-8 |
| quorum eval harness | — | Coding-Agents under test: Claude, Codex | per credential bundle |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

The behavioral evals this branch was built to gate on have now run, on a
dedicated with/without probe applying explicit "just write it, tests after"
pressure, plus the impacted skill-triggering sentinels.

| Probe | Claude ctl → trt | Codex ctl → trt |
|-------|------------------|-----------------|
| tdd-holds-under-tests-later-pressure (n=5) | 4/5 → 2/5 | corroborates (drop) |
| same, confirmed at n=10 | 8/10 → 5/10 | 6/9 → 3/7 |
| triggering-test-driven-development (normal, no pressure) | PPPPP → PPPPP | PPPPP → PPPPP |

Impacted sentinels — no regression (treatment n=5 vs control n=3):
triggering-tdd PPPPP, verification-phantom PPPPP, brainstorming-resists
PPPPP, receiving-code-review (Claude PPPPP; Codex unchanged, pre-existing
split), worktree-no-drift (Claude PPPPP).

**Findings:**

1. Removing the TDD "Why Order Matters" rebuttal degrades test-first when a
   user explicitly says "just write it, tests after" — a 3-failure gap at
   n=10, corroborated across both models, consistent at every sample point.
2. It does **not** move normal TDD triggering (unchanged both arms). The
   effect is exactly the pressure case the prose existed to rebut — the
   agent rationalizes its way out of test-first once the rebuttal is gone.
3. The verification-before-completion cut was **inconclusive**: that
   behavior is bimodal (robust by default, flips on a credible user claim
   of "I already ran it"), with no smooth middle for a probe to detect a
   small drop. Flagged low-confidence "probably not load-bearing," not a
   clean pass.
4. The other 11 skills' prose showed no behavioral footprint — genuine
   detritus.

**Disposition:** merge, but keep the TDD "Why Order Matters" content. This
branch keeps it by folding its rebuttals into the retained Common
Rationalizations table (see the test-driven-development commit). Strip the
rest freely.

**Remaining gate:** the fold is a new intermediate form — richer than the
5/10 compressed rows, leaner than the 8/10 prose section — and it has not
been scored. Before merge, re-run tdd-holds-under-tests-later-pressure
against the fold and confirm it recovers toward the control arm. If it does
not, fall back to keeping the prose section verbatim.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      the discipline cuts were pressure-tested via the eval above
- [x] This change was tested adversarially (dedicated pressure probe, both
      models, n up to 10), not just on the happy path
- [ ] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without evals showing the
      change is an improvement

The unchecked box is honest: the fold **edits** the TDD Common
Rationalizations table (carefully-tuned content) ahead of the confirming
re-run that would justify it. The edit is evidence-motivated — the eval
proved the compressed rows drop behavior the prose held — but the specific
folded wording is unmeasured until the re-run. No "human partner" language
was changed.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Jesse reviewed the 12-commit diff and directed the delete→fold rework after
reading the eval verdict. Kept as a draft until the confirming
tdd-holds-under-tests-later-pressure re-run lands.
