### PR TITLE
fix: use relative Claude hook command

### DIFF
--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -392,12 +392,14 @@ Claude Code shape is universal. Compare `hooks/hooks.json` and
 Claude Code uses. Match your `hooks-<harness>.json` to whichever existing file is
 closest, not to a single canonical template.
 
-The hook **command string references a harness-provided plugin-root variable**,
-and its name differs per harness: `hooks.json` uses `${CLAUDE_PLUGIN_ROOT}`,
-`hooks-cursor.json` uses a relative path. Use
-whatever your harness exports. (The `session-start` script re-derives the root
-itself via `dirname`, so the script body doesn't depend on this — but the
-command in the manifest does.)
+The hook **command string is interpreted by the harness's shell**. Prefer a
+relative command when the harness resolves it from the plugin root, as
+`hooks.json` and `hooks-cursor.json` do with `./hooks/run-hook.cmd`; this keeps
+Windows `cmd.exe` from parsing metacharacters in the expanded install path.
+When a harness requires an explicit plugin-root variable, use whatever that
+harness exports. (The `session-start` script re-derives the root itself via
+`dirname`, so the script body doesn't depend on this — but the command in the
+manifest does.)
 
 **Discovering the harness's contract.** The three facts above — env var, JSON
 field/nesting, matcher strings — are the harness's contract, not Superpowers',

--- a/docs/windows/polyglot-hooks.md
+++ b/docs/windows/polyglot-hooks.md
@@ -41,7 +41,7 @@ hooks/
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "command": "./hooks/run-hook.cmd session-start",
             "async": false
           }
         ]
@@ -51,7 +51,9 @@ hooks/
 }
 ```
 
-The path is quoted because `${CLAUDE_PLUGIN_ROOT}` may contain spaces.
+The command is relative to the plugin root so the outer shell never sees the
+expanded plugin install path. On Windows, that avoids `cmd.exe` metacharacter
+parsing for user profile paths that contain characters such as parentheses.
 
 ## How `run-hook.cmd` Works at a High Level
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "command": "./hooks/run-hook.cmd session-start",
             "async": false
           }
         ]

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOOK_UNDER_TEST="$REPO_ROOT/hooks/session-start"
 WRAPPER_UNDER_TEST="$REPO_ROOT/hooks/run-hook.cmd"
+HOOK_CONFIG_UNDER_TEST="$REPO_ROOT/hooks/hooks.json"
 
 FAILURES=0
 TEST_ROOT="$(mktemp -d)"
@@ -141,7 +142,26 @@ for (const forbiddenText of forbiddenTexts) {
     fi
 }
 
+assert_claude_hook_command_is_relative() {
+    local command
+
+    command="$(node -e '
+const fs = require("fs");
+const hooks = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+process.stdout.write(hooks.hooks.SessionStart[0].hooks[0].command);
+' "$HOOK_CONFIG_UNDER_TEST")"
+
+    if [[ "$command" == './hooks/run-hook.cmd session-start' ]]; then
+        pass "Claude Code hook command is relative to avoid cmd.exe metacharacters in plugin paths"
+    else
+        fail "Claude Code hook command is relative to avoid cmd.exe metacharacters in plugin paths"
+        echo "    got: $command"
+    fi
+}
+
 echo "SessionStart hook output tests"
+
+assert_claude_hook_command_is_relative
 
 claude_home="$(make_home claude-code)"
 assert_command_output \
@@ -162,6 +182,16 @@ assert_command_output \
     "$wrapper_home" \
     CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
     bash "$WRAPPER_UNDER_TEST" session-start
+
+relative_wrapper_home="$(make_home run-hook-relative)"
+assert_command_output \
+    "relative hook command dispatches from the plugin root" \
+    "nested" \
+    "" \
+    "" \
+    "$relative_wrapper_home" \
+    CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
+    bash -c 'cd "$1" && ./hooks/run-hook.cmd session-start' _ "$REPO_ROOT"
 
 cursor_home="$(make_home cursor)"
 assert_command_output \


### PR DESCRIPTION
## Summary
- switch the Claude Code SessionStart hook command to `./hooks/run-hook.cmd session-start`
- add regression coverage that the Claude hook command remains relative and dispatches from the plugin root
- update the Windows hook docs and harness porting guidance

## Why
When `${CLAUDE_PLUGIN_ROOT}` is expanded into the outer hook command on Windows, `cmd.exe` can parse metacharacters in the install path before `run-hook.cmd` starts. A user profile path containing `(` breaks the command at the outer invocation layer, so SessionStart context injection is skipped.

Using the same relative dispatcher style as the Cursor hook keeps the expanded install path out of the outer command. The wrapper still derives its own directory and runs the extensionless hook script.

Fixes #1918

## Testing
- `bash tests/hooks/test-session-start.sh`
- `bash tests/codex/test-marketplace-manifest.sh`
- `bash tests/kimi/test-plugin-manifest.sh`
- `bash tests/shell-lint/test-lint-shell.sh`
- `bash -n hooks/session-start hooks/run-hook.cmd tests/hooks/test-session-start.sh`
- `node -e 'JSON.parse(require("fs").readFileSync("hooks/hooks.json", "utf8")); JSON.parse(require("fs").readFileSync("hooks/hooks-cursor.json", "utf8"));'`\n- `git diff --check`