### PR TITLE
[codex] Add agent workflow orchestration metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,13 @@ The Pi package loads the Superpowers skills and a small extension that injects t
 
 4. **subagent-driven-development** or **executing-plans** - Activates with plan. Dispatches fresh subagent per task with two-stage review (spec compliance, then code quality), or executes in batches with human checkpoints.
 
-5. **test-driven-development** - Activates during implementation. Enforces RED-GREEN-REFACTOR: write failing test, watch it fail, write minimal code, watch it pass, commit. Deletes code written before tests.
+5. **cross-model-review** or **external-model-workers** - Activates when you want opt-in external Claude/Gemini review or task execution. External review stays read-only; external workers run in isolated worktrees with write-scope enforcement.
 
-6. **requesting-code-review** - Activates between tasks. Reviews against plan, reports issues by severity. Critical issues block progress.
+6. **test-driven-development** - Activates during implementation. Enforces RED-GREEN-REFACTOR: write failing test, watch it fail, write minimal code, watch it pass, commit. Deletes code written before tests.
 
-7. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
+7. **requesting-code-review** - Activates between tasks. Reviews against plan, reports issues by severity. Critical issues block progress.
+
+8. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
 
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
 
@@ -219,6 +221,8 @@ The Pi package loads the Superpowers skills and a small extension that injects t
 - **writing-plans** - Detailed implementation plans
 - **executing-plans** - Batch execution with checkpoints
 - **dispatching-parallel-agents** - Concurrent subagent workflows
+- **cross-model-review** - Read-only Claude/Gemini review for specs, plans, diffs, and release checks
+- **external-model-workers** - Opt-in Claude/Gemini worker orchestration in isolated task worktrees
 - **requesting-code-review** - Pre-review checklist
 - **receiving-code-review** - Responding to feedback
 - **using-git-worktrees** - Parallel development branches

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The Pi package loads the Superpowers skills and a small extension that injects t
 
 4. **subagent-driven-development** or **executing-plans** - Activates with plan. Dispatches fresh subagent per task with two-stage review (spec compliance, then code quality), or executes in batches with human checkpoints.
 
-5. **cross-model-review** or **external-model-workers** - Activates when you want opt-in external Claude/Gemini review or task execution. External review stays read-only; external workers run in isolated worktrees with write-scope enforcement.
+5. **cross-model-review** or **external-model-workers** - Activates when you want opt-in external Claude/Gemini review or task execution. External review stays read-only; external workers run in isolated worktrees with write-scope enforcement, local verification, and controller-managed merge-back.
 
 6. **test-driven-development** - Activates during implementation. Enforces RED-GREEN-REFACTOR: write failing test, watch it fail, write minimal code, watch it pass, commit. Deletes code written before tests.
 
@@ -222,7 +222,7 @@ The Pi package loads the Superpowers skills and a small extension that injects t
 - **executing-plans** - Batch execution with checkpoints
 - **dispatching-parallel-agents** - Concurrent subagent workflows
 - **cross-model-review** - Read-only Claude/Gemini review for specs, plans, diffs, and release checks
-- **external-model-workers** - Opt-in Claude/Gemini worker orchestration in isolated task worktrees
+- **external-model-workers** - Opt-in Claude/Gemini worker orchestration in isolated task worktrees, including a controller wrapper for end-to-end task execution
 - **requesting-code-review** - Pre-review checklist
 - **receiving-code-review** - Responding to feedback
 - **using-git-worktrees** - Parallel development branches

--- a/docs/reports/2026-07-07-phase1-agent-workflow-orchestration-report.md
+++ b/docs/reports/2026-07-07-phase1-agent-workflow-orchestration-report.md
@@ -1,0 +1,240 @@
+# Phase 1 Agent Workflow Orchestration Report
+
+Date: 2026-07-07
+
+## Scope completed
+
+Phase 1 is implemented for the Superpowers workflow changes described in
+`docs/superpowers/specs/2026-07-06-agent-workflow-orchestration-design.md`.
+
+Included:
+
+- task metadata in implementation plans
+- dependency validation rules
+- write-scope enforcement rules
+- deterministic sequential versus parallel routing
+- read-only Claude/Gemini review wrappers
+- isolated-worktree Claude/Gemini worker wrappers
+- controller-backed external task orchestration with validation, local
+  verification, commit, and merge-back
+
+Excluded by design:
+
+- native internal Claude/Gemini worker orchestration
+- replacing subagent-driven-development with Claude/Gemini workers
+
+Claude and Gemini remain external reviewers or external worker CLIs only.
+
+## Exact file changes
+
+### Plan and routing rules
+
+- `skills/writing-plans/SKILL.md`
+  - requires `task_metadata` blocks in implementation plans
+  - requires `id`, `depends_on`, `write_scope`, `risk_level`,
+    `review_required`, and `external_review`
+  - prohibits hand-authored parallel eligibility
+- `skills/subagent-driven-development/SKILL.md`
+  - adds controller rules for dependency validation, write-scope
+    enforcement, and external-review boundaries
+- `skills/dispatching-parallel-agents/SKILL.md`
+  - adds deterministic routing rules derived from task metadata
+
+### Validation and controller scripts
+
+- `skills/subagent-driven-development/scripts/validate-plan-metadata.ps1`
+  - validates task metadata shape
+  - rejects missing dependencies and dependency cycles
+  - rejects overlapping parallel write scopes
+  - rejects out-of-scope changed files for an active task
+  - computes sequential versus parallel routing from metadata
+- `skills/cross-model-review/scripts/review-with-model.ps1`
+  - wraps Claude or Gemini for read-only spec, plan, diff, and release review
+- `skills/external-model-workers/scripts/run-worker-with-model.ps1`
+  - wraps Claude or Gemini for implementer, spec-reviewer, and
+    code-quality-reviewer roles inside an isolated worktree
+- `skills/external-model-workers/scripts/orchestrate-external-task.ps1`
+  - creates the worktree
+  - dispatches the external worker
+  - validates changed files against `write_scope`
+  - runs the local verification command
+  - commits successful changes
+  - fast-forward merges the task branch back into the repo branch
+
+### New and updated skills
+
+- `skills/cross-model-review/SKILL.md`
+  - adds read-only Claude/Gemini review workflow guidance
+- `skills/cross-model-review/references/prompts.md`
+  - stores prompt guidance for review modes
+- `skills/external-model-workers/SKILL.md`
+  - documents the low-level worker wrapper
+  - documents the controller wrapper for end-to-end task execution
+- `skills/using-superpowers/references/gemini-tools.md`
+  - restores Gemini bootstrap documentation used by `GEMINI.md`
+
+### Tests and documentation
+
+- `tests/phase1-orchestration.test.ps1`
+  - verifies task metadata requirements and validator behavior
+- `tests/external-model-orchestration.test.ps1`
+  - verifies wrapper scripts exist
+  - verifies prompt contracts
+  - verifies the controller script can create a worktree, validate scope,
+    verify output, commit, and merge in a temp repo
+- `README.md`
+  - documents the new external review and worker orchestration path
+- `docs/testing.md`
+  - documents the new PowerShell orchestration tests
+
+## Verification evidence
+
+The following commands were run against the current branch and completed
+successfully:
+
+### Repository tests
+
+```powershell
+& tests/phase1-orchestration.test.ps1
+& tests/external-model-orchestration.test.ps1
+```
+
+Observed results:
+
+- `Phase 1 orchestration checks passed.`
+- `External model orchestration checks passed.`
+
+### Live Claude and Gemini review smoke tests
+
+```powershell
+.\skills\cross-model-review\scripts\review-with-model.ps1 `
+  -Provider claude `
+  -Mode release `
+  -InputPath $env:TEMP\superpowers-phase1-release-summary.md `
+  -RepoRoot .
+
+.\skills\cross-model-review\scripts\review-with-model.ps1 `
+  -Provider gemini `
+  -Mode release `
+  -InputPath $env:TEMP\superpowers-phase1-release-summary.md `
+  -RepoRoot .
+```
+
+Observed results:
+
+- Gemini returned a release review with `Blockers`, `Warnings`, and
+  `Recommended Follow-Up`.
+- Claude returned a release review response under the wrapper entrypoint.
+
+### Live Claude external worker orchestration smoke test
+
+A temp git repo was created with one tracked file, `app.txt`, containing
+`hello`.
+
+Command shape:
+
+```powershell
+.\skills\external-model-workers\scripts\orchestrate-external-task.ps1 `
+  -Provider claude `
+  -PlanPath <temp-plan> `
+  -TaskId task-1 `
+  -TaskBriefPath <temp-brief> `
+  -RepoRoot <temp-repo> `
+  -VerificationCommand "Get-Content -Raw app.txt" `
+  -CommitMessage "test: live claude orchestration"
+```
+
+Observed results:
+
+- changed files: `app.txt`
+- verification output: `hello world`
+- resulting git log included `test: live claude orchestration`
+
+### Live Gemini external worker orchestration smoke test
+
+The same temp-repo scenario was run with Gemini.
+
+Command shape:
+
+```powershell
+.\skills\external-model-workers\scripts\orchestrate-external-task.ps1 `
+  -Provider gemini `
+  -PlanPath <temp-plan> `
+  -TaskId task-1 `
+  -TaskBriefPath <temp-brief> `
+  -RepoRoot <temp-repo> `
+  -VerificationCommand "Get-Content -Raw app.txt" `
+  -CommitMessage "test: live gemini orchestration"
+```
+
+Observed results:
+
+- changed files: `app.txt`
+- verification output: `hello world`
+- resulting git log included `test: live gemini orchestration`
+
+## Usage examples
+
+### 1. Validate task metadata and routing
+
+```powershell
+.\skills\subagent-driven-development\scripts\validate-plan-metadata.ps1 `
+  -PlanPath .superpowers\plans\feature-plan.md `
+  -Json
+```
+
+### 2. Ask Claude for a read-only plan review
+
+```powershell
+.\skills\cross-model-review\scripts\review-with-model.ps1 `
+  -Provider claude `
+  -Mode plan `
+  -InputPath .superpowers\plans\feature-plan.md `
+  -RepoRoot .
+```
+
+### 3. Ask Gemini for a read-only diff review
+
+```powershell
+.\skills\cross-model-review\scripts\review-with-model.ps1 `
+  -Provider gemini `
+  -Mode diff `
+  -RepoRoot .
+```
+
+### 4. Dispatch a low-level external implementer
+
+Use this only when a controller already created the worktree and selected
+the role.
+
+```powershell
+.\skills\external-model-workers\scripts\run-worker-with-model.ps1 `
+  -Provider claude `
+  -Role implementer `
+  -TaskBriefPath .superpowers\sdd\task-2-brief.md `
+  -RepoRoot . `
+  -WorktreePath C:\worktrees\feature-task-2 `
+  -WriteScope src\feature.ts,tests\feature.test.ts `
+  -ReportFile .superpowers\sdd\task-2-report.md `
+  -FocusedTestCommand "npm test -- feature"
+```
+
+### 5. Run the full controller-backed external task flow
+
+```powershell
+.\skills\external-model-workers\scripts\orchestrate-external-task.ps1 `
+  -Provider gemini `
+  -PlanPath .superpowers\plans\feature-plan.md `
+  -TaskId task-2 `
+  -TaskBriefPath .superpowers\sdd\task-2-brief.md `
+  -RepoRoot . `
+  -VerificationCommand "npm test -- feature" `
+  -CommitMessage "task(task-2): implement feature"
+```
+
+## Git state
+
+This work was pushed to branch:
+
+- `codex/phase-1-agent-workflow-orchestration`
+

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,24 +2,27 @@
 
 Superpowers has two distinct kinds of tests, each in its own directory:
 
-- **`tests/`** — does the plugin's non-LLM code work? Bash + node + python integration tests for brainstorm-server JS, OpenCode plugin loading, codex-plugin sync, and analysis utilities.
-- **`evals/`** — do agents behave correctly on real LLM sessions? Python harness driving real tmux sessions of Claude Code / Codex / Gemini CLI, with an LLM actor and verifier judging skill compliance.
+- **`tests/`** - does the plugin's non-LLM code work? Bash, node, python, and PowerShell tests for brainstorm-server JS, OpenCode plugin loading, codex-plugin sync, wrapper scripts, and analysis utilities.
+- **`evals/`** - do agents behave correctly on real LLM sessions? Python harness driving real tmux sessions of Claude Code and Codex, with an LLM actor and verifier judging skill compliance.
 
 ## Plugin tests
 
 Live in `tests/`. Currently:
 
-- `tests/brainstorm-server/` — node test suite for the brainstorm server JS code.
-- `tests/opencode/` — bash tests for OpenCode plugin loading, bootstrap caching, and tool registration.
-- `tests/codex-plugin-sync/` — bash sync verification.
-- `tests/kimi/` — bash/Python checks for Kimi plugin manifest wiring.
-- `tests/claude-code/test-helpers.sh`, `analyze-token-usage.py` — utilities used by remaining bash tests.
-- `tests/claude-code/test-subagent-driven-development.sh` — agent-can-describe-SDD test (no drill counterpart; tests description-recall, not behavior).
-- `tests/claude-code/test-subagent-driven-development-integration.sh` — extended SDD integration with token analysis (drill covers the YAGNI subset; bash adds commit-count, Claude Code task-tracking, and token telemetry assertions).
-- `tests/claude-code/test-worktree-native-preference.sh` — RED-GREEN-REFACTOR validation for worktree skill (drill covers the PRESSURE phase; bash also covers RED/GREEN baselines).
-- `tests/explicit-skill-requests/` — Haiku-specific, multi-turn, and skill-name-prompted tests not covered by drill.
+- `tests/brainstorm-server/` - node test suite for the brainstorm server JS code.
+- `tests/opencode/` - bash tests for OpenCode plugin loading, bootstrap caching, and tool registration.
+- `tests/codex-plugin-sync/` - bash sync verification.
+- `tests/kimi/` - bash/Python checks for Kimi plugin manifest wiring.
+- `tests/claude-code/test-helpers.sh`, `analyze-token-usage.py` - utilities used by remaining bash tests.
+- `tests/claude-code/test-subagent-driven-development.sh` - agent-can-describe-SDD test (no drill counterpart; tests description-recall, not behavior).
+- `tests/claude-code/test-subagent-driven-development-integration.sh` - extended SDD integration with token analysis (drill covers the YAGNI subset; bash adds commit-count, Claude Code task-tracking, and token telemetry assertions).
+- `tests/claude-code/test-worktree-native-preference.sh` - RED-GREEN-REFACTOR validation for worktree skill (drill covers the PRESSURE phase; bash also covers RED/GREEN baselines).
+- `tests/explicit-skill-requests/` - Haiku-specific, multi-turn, and skill-name-prompted tests not covered by drill.
+- `tests/phase1-orchestration.test.ps1` - task metadata, deterministic routing, and write-scope validation checks.
+- `tests/external-model-orchestration.test.ps1` - cross-model review and external worker wrapper checks with mock providers.
 
-Run plugin tests via the relevant directory's `run-*.sh` or `npm test`.
+Run plugin tests via the relevant directory's `run-*.sh`, `npm test`, or the
+PowerShell script directly when the test is a `.ps1`.
 
 ## Skill behavior evals
 

--- a/skills/cross-model-review/SKILL.md
+++ b/skills/cross-model-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cross-model-review
+description: Use Claude CLI or Gemini CLI as an independent reviewer for specs, plans, diffs, and release-readiness checks while keeping code changes in the controller's hands.
+---
+
+# Cross-Model Review
+
+Use this skill when you want a second-model critique without giving that
+model write access to the repo.
+
+## Workflow
+
+1. Identify the review target:
+   - Use the user-supplied file path for `spec`, `plan`, or `release`.
+   - Use the current git diff for `diff` review when no file is supplied.
+   - Prefer one precise artifact over broad repository context.
+2. Select provider:
+   - Use `claude` when the user asks for Claude.
+   - Use `gemini` when the user asks for Gemini.
+   - If unspecified, prefer Claude for prose/spec review and Gemini for
+     plan/diff sanity checks when both are installed.
+3. Select mode:
+   - `spec`: requirements, contradictions, acceptance criteria, edge cases,
+     implementation risks, testability.
+   - `plan`: sequencing, dependencies, missing tests, vague steps,
+     compatibility or migration gaps.
+   - `diff`: bugs, regressions, data loss, race conditions,
+     security/privacy issues, test gaps.
+   - `release`: readiness, verification, docs, rollback, remaining risk.
+4. Run `scripts/review-with-model.ps1`.
+5. Summarize the external output as findings-first feedback.
+
+## Guardrails
+
+- Treat Claude/Gemini as reviewers, not authorities.
+- Do not let external models edit files or execute project mutations.
+- Do not pass secrets, `.env` files, token files, private keys,
+  recordings, databases, or unrelated folders.
+- Validate every external finding against the repo or spec before applying it.
+- If the user asks for implementation, Codex still makes the edits and runs
+  the verification.
+
+## Wrapper
+
+```powershell
+.\skills\cross-model-review\scripts\review-with-model.ps1 `
+  -Provider claude `
+  -Mode spec `
+  -InputPath docs\superpowers\specs\example.md `
+  -RepoRoot .
+```
+
+For current diff review:
+
+```powershell
+.\skills\cross-model-review\scripts\review-with-model.ps1 `
+  -Provider gemini `
+  -Mode diff `
+  -RepoRoot .
+```
+
+## Output Handling
+
+Return a concise synthesis:
+
+- Findings ordered by severity
+- Open questions that block implementation
+- Suggested spec, plan, or code changes
+- Explicitly say when the external review found no major issues
+
+Do not paste long raw transcripts unless your human partner asks for them.

--- a/skills/cross-model-review/references/prompts.md
+++ b/skills/cross-model-review/references/prompts.md
@@ -1,0 +1,83 @@
+# Cross-Model Review Prompts
+
+## spec
+
+You are reviewing a product or technical spec.
+
+Return findings only if they are actionable.
+Order findings by severity.
+Focus on:
+- missing requirements
+- contradictions
+- unclear acceptance criteria
+- edge cases and failure states
+- implementation risks
+- testability gaps
+
+Do not rewrite the spec.
+Do not suggest unrelated features.
+Do not assume access to files not provided.
+
+Output:
+Findings
+Open Questions
+Suggested Edits
+
+## plan
+
+You are reviewing an implementation plan.
+
+Focus on:
+- wrong sequencing
+- missing dependencies
+- missing tests
+- migration or compatibility risk
+- steps too vague to execute
+- verification gaps
+
+Do not implement anything.
+Do not rewrite the plan unless suggesting a specific edit.
+
+Output:
+Findings
+Open Questions
+Suggested Plan Changes
+
+## diff
+
+You are reviewing a code diff.
+
+Prioritize:
+- bugs
+- regressions
+- data loss
+- race conditions
+- security/privacy issues
+- missing tests
+
+Do not comment on style unless it affects behavior.
+Return file or line references when possible.
+
+Output:
+Findings
+Test Gaps
+Residual Risk
+
+## release
+
+You are reviewing release readiness.
+
+Focus on:
+- missing verification
+- documentation gaps
+- rollback risk
+- user-impacting behavior changes
+- migration or setup risk
+- unresolved high-risk TODOs
+
+Do not suggest broad new product work.
+
+Output:
+Blockers
+Warnings
+Recommended Follow-Up

--- a/skills/cross-model-review/scripts/review-with-model.ps1
+++ b/skills/cross-model-review/scripts/review-with-model.ps1
@@ -1,0 +1,259 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("claude", "gemini")]
+  [string]$Provider,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("spec", "plan", "diff", "release")]
+  [string]$Mode,
+
+  [string]$InputPath = "",
+  [string]$RepoRoot = ".",
+  [string]$ClaudeModel = "opus",
+
+  [ValidateSet("low", "medium", "high", "xhigh", "max")]
+  [string]$ClaudeEffort = "max",
+
+  [string]$GeminiModel = "gemini-2.5-pro",
+  [string]$CommandOverride = "",
+  [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-StrictPath {
+  param([string]$Path)
+
+  return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+}
+
+function Get-PromptTemplate {
+  param([string]$PromptMode)
+
+  switch ($PromptMode) {
+    "spec" {
+      return @"
+You are reviewing a product/technical spec.
+
+Return findings only if they are actionable.
+Order findings by severity.
+Focus on missing requirements, contradictions, unclear acceptance criteria, edge cases, implementation risks, and testability gaps.
+
+Do not rewrite the spec.
+Do not suggest unrelated features.
+Do not assume access to files not provided.
+
+Output:
+Findings
+Open Questions
+Suggested Edits
+"@
+    }
+    "plan" {
+      return @"
+You are reviewing an implementation plan.
+
+Focus on wrong sequencing, missing dependencies, missing tests, migration or compatibility risk, vague execution steps, and verification gaps.
+
+Do not implement anything.
+Do not rewrite the plan unless suggesting a specific edit.
+
+Output:
+Findings
+Open Questions
+Suggested Plan Changes
+"@
+    }
+    "diff" {
+      return @"
+You are reviewing a code diff.
+
+Prioritize bugs, regressions, data loss, race conditions, security/privacy issues, and missing tests.
+Do not comment on style unless it affects behavior.
+Return file/line references when possible.
+
+Output:
+Findings
+Test Gaps
+Residual Risk
+"@
+    }
+    "release" {
+      return @"
+You are reviewing release readiness.
+
+Focus on missing verification, documentation gaps, rollback risk, user-impacting behavior changes, migration/setup risk, and unresolved high-risk TODOs.
+Do not suggest broad new product work.
+
+Output:
+Blockers
+Warnings
+Recommended Follow-Up
+"@
+    }
+  }
+}
+
+function Get-ArtifactText {
+  param(
+    [string]$PromptMode,
+    [string]$Path,
+    [string]$Root
+  )
+
+  if ($PromptMode -eq "diff" -and [string]::IsNullOrWhiteSpace($Path)) {
+    Push-Location $Root
+    try {
+      $diff = git diff -- . ':!*.lock' ':!*.png' ':!*.jpg' ':!*.jpeg' ':!*.gif' ':!*.wav' ':!*.mp3' ':!*.mp4' ':!*.sqlite'
+      if ([string]::IsNullOrWhiteSpace($diff)) {
+        throw "No git diff found in $Root."
+      }
+      return $diff
+    }
+    finally {
+      Pop-Location
+    }
+  }
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    throw "InputPath is required for mode '$PromptMode'."
+  }
+
+  $resolvedInput = Resolve-StrictPath $Path
+  $item = Get-Item -LiteralPath $resolvedInput
+  if ($item.PSIsContainer) {
+    throw "InputPath must be a file, not a directory."
+  }
+  if ($item.Length -gt 2MB) {
+    throw "Input file is larger than 2MB. Pass a narrower artifact."
+  }
+  if ($item.Name -match '(^\.env|secret|token|credential|private|key)' -or $item.Extension -in @(".pem", ".key", ".pfx", ".sqlite", ".db", ".wav", ".mp3", ".mp4")) {
+    throw "Refusing to send likely secret, database, binary, or recording file: $($item.Name)"
+  }
+
+  return Get-Content -LiteralPath $resolvedInput -Raw -Encoding UTF8
+}
+
+function Invoke-Provider {
+  param(
+    [string]$Prompt,
+    [string]$ProviderName,
+    [string]$Override,
+    [string]$ClaudeModelName,
+    [string]$ClaudeEffortLevel,
+    [string]$GeminiModelName,
+    [string]$WorkingDirectory
+  )
+
+  Push-Location $WorkingDirectory
+  try {
+    if (-not [string]::IsNullOrWhiteSpace($Override)) {
+      $psi = New-Object System.Diagnostics.ProcessStartInfo
+      $psi.FileName = "powershell.exe"
+      $psi.Arguments = "-NoProfile -Command $Override"
+      $psi.WorkingDirectory = $WorkingDirectory
+      $psi.UseShellExecute = $false
+      $psi.RedirectStandardInput = $true
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError = $true
+
+      $process = New-Object System.Diagnostics.Process
+      $process.StartInfo = $psi
+      $null = $process.Start()
+      $process.StandardInput.Write($Prompt)
+      $process.StandardInput.Close()
+      $stdout = $process.StandardOutput.ReadToEnd()
+      $stderr = $process.StandardError.ReadToEnd()
+      $process.WaitForExit()
+
+      if ($stdout) {
+        Write-Output $stdout.TrimEnd()
+      }
+      if ($process.ExitCode -ne 0) {
+        throw "Override command failed with exit code $($process.ExitCode): $stderr"
+      }
+      return
+    }
+
+    $providerCommand = Get-Command $ProviderName -ErrorAction SilentlyContinue
+    if (-not $providerCommand) {
+      throw "$ProviderName CLI is not installed or not on PATH."
+    }
+
+    if ($ProviderName -eq "claude") {
+      $Prompt | claude -p --model $ClaudeModelName --effort $ClaudeEffortLevel --tools "" --permission-mode plan --no-session-persistence
+    }
+    elseif ($ProviderName -eq "gemini") {
+      $preferredGeminiCommand = if ($env:OS -eq "Windows_NT") { "gemini.cmd" } else { "gemini" }
+      $geminiCommand = Get-Command $preferredGeminiCommand -ErrorAction SilentlyContinue
+      if (-not $geminiCommand) {
+        $geminiCommand = Get-Command "gemini" -ErrorAction SilentlyContinue
+      }
+      if (-not $geminiCommand) {
+        throw "gemini CLI is not installed or not on PATH."
+      }
+
+      $psi = New-Object System.Diagnostics.ProcessStartInfo
+      if ($env:OS -eq "Windows_NT" -and $geminiCommand.Source.ToLowerInvariant().EndsWith(".cmd")) {
+        $psi.FileName = "powershell.exe"
+        $psi.Arguments = "-NoProfile -Command & '$($geminiCommand.Source)' --model $GeminiModelName --skip-trust --prompt 'Review the artifact from stdin. Follow the requested output format exactly.' --approval-mode plan --output-format text"
+      }
+      else {
+        $psi.FileName = $geminiCommand.Source
+        $psi.Arguments = "--model $GeminiModelName --skip-trust --prompt ""Review the artifact from stdin. Follow the requested output format exactly."" --approval-mode plan --output-format text"
+      }
+      $psi.WorkingDirectory = $WorkingDirectory
+      $psi.UseShellExecute = $false
+      $psi.RedirectStandardInput = $true
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError = $true
+
+      $process = New-Object System.Diagnostics.Process
+      $process.StartInfo = $psi
+      $null = $process.Start()
+      $process.StandardInput.Write($Prompt)
+      $process.StandardInput.Close()
+      $stdout = $process.StandardOutput.ReadToEnd()
+      $stderr = $process.StandardError.ReadToEnd()
+      $process.WaitForExit()
+
+      if ($stdout) {
+        Write-Output $stdout.TrimEnd()
+      }
+      if ($process.ExitCode -ne 0) {
+        throw "gemini command failed with exit code $($process.ExitCode): $stderr"
+      }
+    }
+  }
+  finally {
+    Pop-Location
+  }
+}
+
+$repo = Resolve-StrictPath $RepoRoot
+$template = Get-PromptTemplate $Mode
+$artifact = Get-ArtifactText -PromptMode $Mode -Path $InputPath -Root $repo
+$prompt = @"
+$template
+
+Artifact begins:
+
+$artifact
+
+Artifact ends.
+"@
+
+Invoke-Provider -Prompt $prompt -ProviderName $Provider -Override $CommandOverride -ClaudeModelName $ClaudeModel -ClaudeEffortLevel $ClaudeEffort -GeminiModelName $GeminiModel -WorkingDirectory $repo
+
+$result = [pscustomobject]@{
+  provider = $Provider
+  mode = $Mode
+  repo_root = $repo
+}
+
+if ($Json) {
+  $result | ConvertTo-Json -Depth 4
+}
+else {
+  Write-Output "Review request sent to $Provider for $Mode."
+}

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -13,6 +13,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+For implementation-plan tasks, parallel_safe is computed, never authored. The controller must derive parallel eligibility from `task_metadata` before dispatch.
+
 ## When to Use
 
 ```dot
@@ -38,11 +40,28 @@ digraph when_to_use {
 - Multiple subsystems broken independently
 - Each problem can be understood without context from others
 - No shared state between investigations
+- Implementation-plan tasks have no dependency relationship, no overlapping write_scope entries, and risk_level is low
+- medium risk tasks are parallel only when they do not touch shared contracts, shared architecture, APIs, schemas, migrations, storage, security, or deletion behavior
 
 **Don't use when:**
 - Failures are related (fix one might fix others)
 - Need to understand full system state
 - Agents would interfere with each other
+- Any task is high risk, depends on unfinished work, defines a shared contract, or may change downstream requirements
+
+## Parallel Eligibility Gate
+
+Before dispatching implementation tasks in parallel:
+
+1. Run metadata validation on the plan.
+2. Confirm every candidate's dependencies are complete.
+3. Confirm candidates have no dependency relationship with each other.
+4. Confirm candidates have no overlapping write_scope entries.
+5. Confirm each candidate can be verified independently.
+6. Confirm risk_level is low, or for medium risk tasks confirm they do not touch shared contracts or shared architecture.
+7. Reject all high-risk tasks from the parallel batch and route them through sequential subagent-driven-development.
+
+If any check fails, do not dispatch in parallel. Use sequential execution until the dependency or scope conflict is resolved.
 
 ## The Pattern
 

--- a/skills/external-model-workers/SKILL.md
+++ b/skills/external-model-workers/SKILL.md
@@ -49,6 +49,9 @@ task is a good fit for an external model.
 
 ## Wrapper
 
+Use the low-level worker wrapper when a controller already created the
+worktree and chose the role:
+
 ```powershell
 .\skills\external-model-workers\scripts\run-worker-with-model.ps1 `
   -Provider claude `
@@ -59,6 +62,24 @@ task is a good fit for an external model.
   -WriteScope src\feature.ts,tests\feature.test.ts `
   -ReportFile .superpowers\sdd\task-2-report.md
 ```
+
+Use the controller wrapper when you want the full external task lifecycle:
+worktree creation, worker dispatch, write-scope validation, local
+verification, commit, and merge-back.
+
+```powershell
+.\skills\external-model-workers\scripts\orchestrate-external-task.ps1 `
+  -Provider gemini `
+  -PlanPath .superpowers\plans\feature-plan.md `
+  -TaskId task-2 `
+  -TaskBriefPath .superpowers\sdd\task-2-brief.md `
+  -RepoRoot . `
+  -VerificationCommand "npm test -- feature" `
+  -CommitMessage "task(task-2): implement feature"
+```
+
+The controller reads `write_scope` from the plan metadata and rejects
+out-of-scope file changes before merge.
 
 ## Worker Roles
 

--- a/skills/external-model-workers/SKILL.md
+++ b/skills/external-model-workers/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: external-model-workers
+description: Use Claude CLI or Gemini CLI as opt-in external implementers or task reviewers in isolated worktrees with write-scope enforcement and local verification.
+---
+
+# External Model Workers
+
+Use this skill when you want to delegate a task to an external model CLI
+while keeping orchestration, git safety, and final verification in the
+controller.
+
+This is an opt-in execution path. It does not replace
+`subagent-driven-development`; it is a worker backend you can use when a
+task is a good fit for an external model.
+
+## Workflow
+
+1. Choose the task:
+   - Delegate only tasks with a clear brief and explicit write scope.
+   - Keep high-risk tasks sequential unless your human partner has asked
+     for external worker mode anyway.
+2. Create isolated worktrees:
+   - Use one worktree per delegated task.
+   - Do not share a writable checkout across multiple active external workers.
+3. Send role-specific prompts:
+   - `implementer`
+   - `spec-reviewer`
+   - `code-quality-reviewer`
+4. Require strict output:
+   - Status line
+   - Tests run
+   - Files changed
+   - Report path
+5. Inspect diffs after the worker returns.
+6. Run tests locally.
+7. Enforce write scope with the task metadata validator.
+8. Merge only after verification.
+
+## Guardrails
+
+- External workers are optional and explicit.
+- Controllers keep responsibility for routing, diff inspection, and merge.
+- Workers must stay inside declared write scope.
+- If write scope is violated, pause and review before continuing.
+- If the provider CLI is unavailable, fall back to native subagents or
+  same-session work.
+- Gemini can be used if a working `gemini` executable is installed, even
+  though Superpowers no longer ships Gemini as a native harness integration.
+
+## Wrapper
+
+```powershell
+.\skills\external-model-workers\scripts\run-worker-with-model.ps1 `
+  -Provider claude `
+  -Role implementer `
+  -TaskBriefPath .superpowers\sdd\task-2-brief.md `
+  -RepoRoot . `
+  -WorktreePath C:\worktrees\feature-task-2 `
+  -WriteScope src\feature.ts,tests\feature.test.ts `
+  -ReportFile .superpowers\sdd\task-2-report.md
+```
+
+## Worker Roles
+
+`implementer`
+- Builds the task in its isolated worktree
+- Runs the requested tests
+- Writes a detailed report
+
+`spec-reviewer`
+- Reads the task brief and diff
+- Checks requested behavior only
+
+`code-quality-reviewer`
+- Reads the task brief and diff
+- Checks correctness, tests, maintainability, and safety

--- a/skills/external-model-workers/scripts/orchestrate-external-task.ps1
+++ b/skills/external-model-workers/scripts/orchestrate-external-task.ps1
@@ -1,0 +1,210 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("claude", "gemini")]
+  [string]$Provider,
+
+  [Parameter(Mandatory = $true)]
+  [string]$PlanPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$TaskId,
+
+  [Parameter(Mandatory = $true)]
+  [string]$TaskBriefPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$RepoRoot,
+
+  [Parameter(Mandatory = $true)]
+  [string]$VerificationCommand,
+
+  [string]$CommitMessage = "",
+  [string]$WorktreePath = "",
+  [string]$BranchName = "",
+  [string]$ReportFile = "",
+  [string]$CommandOverride = "",
+  [string]$ClaudeModel = "opus",
+
+  [ValidateSet("low", "medium", "high", "xhigh", "max")]
+  [string]$ClaudeEffort = "max",
+
+  [string]$GeminiModel = "gemini-2.5-pro",
+  [switch]$KeepWorktree,
+  [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-StrictPath {
+  param([string]$Path)
+
+  return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+}
+
+function Get-TaskMetadata {
+  param(
+    [string]$FilePath,
+    [string]$TargetTaskId
+  )
+
+  $content = Get-Content -LiteralPath $FilePath -Raw -Encoding UTF8
+  $blocks = [regex]::Matches($content, '(?ms)```yaml\s*task_metadata:\s*(?<body>.*?)```')
+
+  foreach ($block in $blocks) {
+    $body = $block.Groups["body"].Value
+    $idMatch = [regex]::Match($body, '(?m)^\s*id:\s*(?<id>[^\r\n]+)')
+    if (-not $idMatch.Success -or $idMatch.Groups["id"].Value.Trim() -ne $TargetTaskId) {
+      continue
+    }
+
+    $titleMatch = [regex]::Match($body, '(?m)^\s*title:\s*(?<title>[^\r\n]+)')
+    $scopeSection = [regex]::Match($body, '(?ms)^\s*write_scope:\s*\r?\n(?<items>(?:\s*-\s*[^\r\n]+\r?\n?)*)')
+    $scopeItems = New-Object System.Collections.Generic.List[string]
+
+    if ($scopeSection.Success) {
+      $itemMatches = [regex]::Matches($scopeSection.Groups["items"].Value, '(?m)^\s*-\s*(?<item>[^\r\n]+)')
+      foreach ($itemMatch in $itemMatches) {
+        $scopeItems.Add($itemMatch.Groups["item"].Value.Trim())
+      }
+    }
+
+    return [pscustomobject]@{
+      id = $idMatch.Groups["id"].Value.Trim()
+      title = if ($titleMatch.Success) { $titleMatch.Groups["title"].Value.Trim() } else { $TargetTaskId }
+      write_scope = @($scopeItems)
+    }
+  }
+
+  throw "Task metadata not found for $TargetTaskId in $FilePath"
+}
+
+function Invoke-StrictCommand {
+  param(
+    [string]$FileName,
+    [string[]]$Arguments,
+    [string]$WorkingDirectory
+  )
+
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName = $FileName
+  if ($Arguments.Count -gt 0) {
+    $psi.Arguments = [string]::Join(" ", $Arguments)
+  }
+  $psi.WorkingDirectory = $WorkingDirectory
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  $process = New-Object System.Diagnostics.Process
+  $process.StartInfo = $psi
+  $null = $process.Start()
+  $stdout = $process.StandardOutput.ReadToEnd()
+  $stderr = $process.StandardError.ReadToEnd()
+  $process.WaitForExit()
+
+  if ($process.ExitCode -ne 0) {
+    throw "$FileName $([string]::Join(' ', $Arguments)) failed with exit code $($process.ExitCode): $stderr"
+  }
+
+  return [pscustomobject]@{
+    StdOut = $stdout.TrimEnd()
+    StdErr = $stderr.TrimEnd()
+  }
+}
+
+$repo = Resolve-StrictPath $RepoRoot
+$plan = Resolve-StrictPath $PlanPath
+$brief = Resolve-StrictPath $TaskBriefPath
+$metadata = Get-TaskMetadata -FilePath $plan -TargetTaskId $TaskId
+
+$currentBranch = (git -C $repo branch --show-current).Trim()
+if ([string]::IsNullOrWhiteSpace($currentBranch)) {
+  throw "RepoRoot must be on a named branch before orchestrating an external task."
+}
+
+if ([string]::IsNullOrWhiteSpace($BranchName)) {
+  $BranchName = "external-$TaskId-" + [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+}
+
+if ([string]::IsNullOrWhiteSpace($WorktreePath)) {
+  $repoParent = Split-Path -Parent $repo
+  $repoName = Split-Path -Leaf $repo
+  $worktreeRoot = Join-Path $repoParent ($repoName + "-external-worktrees")
+  New-Item -ItemType Directory -Path $worktreeRoot -Force | Out-Null
+  $WorktreePath = Join-Path $worktreeRoot $TaskId
+}
+
+if (Test-Path -LiteralPath $WorktreePath) {
+  throw "Worktree path already exists: $WorktreePath"
+}
+
+if ([string]::IsNullOrWhiteSpace($ReportFile)) {
+  $reportDir = Join-Path $env:TEMP "superpowers-external-model-workers"
+  New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+  $ReportFile = Join-Path $reportDir ($TaskId + "-report.md")
+}
+
+if ([string]::IsNullOrWhiteSpace($CommitMessage)) {
+  $CommitMessage = "external-worker: $TaskId"
+}
+
+$workerScript = Join-Path $PSScriptRoot "run-worker-with-model.ps1"
+$validatorScript = Join-Path (Split-Path -Parent $PSScriptRoot) "..\subagent-driven-development\scripts\validate-plan-metadata.ps1"
+$validatorScript = Resolve-StrictPath $validatorScript
+
+git -C $repo worktree add $WorktreePath -b $BranchName | Out-Null
+
+try {
+  & $workerScript `
+    -Provider $Provider `
+    -Role implementer `
+    -TaskBriefPath $brief `
+    -RepoRoot $repo `
+    -WorktreePath $WorktreePath `
+    -WriteScope $metadata.write_scope `
+    -ReportFile $ReportFile `
+    -FocusedTestCommand $VerificationCommand `
+    -CommandOverride $CommandOverride `
+    -ClaudeModel $ClaudeModel `
+    -ClaudeEffort $ClaudeEffort `
+    -GeminiModel $GeminiModel | Out-Null
+
+  $changedFiles = @(git -C $WorktreePath diff --name-only --relative)
+  if ($changedFiles.Count -eq 0) {
+    throw "External worker produced no file changes."
+  }
+
+  & $validatorScript -PlanPath $plan -ActiveTaskIds $TaskId -ChangedFiles $changedFiles | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "Write-scope validation failed for task $TaskId."
+  }
+
+  $verification = Invoke-StrictCommand -FileName "powershell.exe" -Arguments @("-NoProfile", "-Command", $VerificationCommand) -WorkingDirectory $WorktreePath
+
+  git -C $WorktreePath add -- $changedFiles | Out-Null
+  git -C $WorktreePath commit -m $CommitMessage | Out-Null
+  git -C $repo merge --ff-only $BranchName | Out-Null
+
+  $result = [pscustomobject]@{
+    provider = $Provider
+    task_id = $TaskId
+    branch = $BranchName
+    worktree_path = $WorktreePath
+    changed_files = @($changedFiles)
+    report_file = $ReportFile
+    verification_output = $verification.StdOut
+  }
+
+  if ($Json) {
+    $result | ConvertTo-Json -Depth 6
+  }
+  else {
+    Write-Output "External task $TaskId completed on branch $BranchName."
+  }
+}
+finally {
+  if (-not $KeepWorktree -and (Test-Path -LiteralPath $WorktreePath)) {
+    git -C $repo worktree remove $WorktreePath --force | Out-Null
+    git -C $repo branch -D $BranchName 2>$null | Out-Null
+  }
+}

--- a/skills/external-model-workers/scripts/run-worker-with-model.ps1
+++ b/skills/external-model-workers/scripts/run-worker-with-model.ps1
@@ -1,0 +1,320 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("claude", "gemini")]
+  [string]$Provider,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("implementer", "spec-reviewer", "code-quality-reviewer")]
+  [string]$Role,
+
+  [Parameter(Mandatory = $true)]
+  [string]$TaskBriefPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$RepoRoot,
+
+  [Parameter(Mandatory = $true)]
+  [string]$WorktreePath,
+
+  [string[]]$WriteScope = @(),
+  [string]$ReportFile = "",
+  [string]$DiffFile = "",
+  [string]$ImplementerReportFile = "",
+  [string]$FocusedTestCommand = "",
+  [string]$BaseSha = "",
+  [string]$HeadSha = "",
+  [string]$ClaudeModel = "opus",
+
+  [ValidateSet("low", "medium", "high", "xhigh", "max")]
+  [string]$ClaudeEffort = "max",
+
+  [string]$GeminiModel = "gemini-2.5-pro",
+  [string]$CommandOverride = "",
+  [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-StrictPath {
+  param([string]$Path)
+
+  return (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+}
+
+function Assert-FileExists {
+  param(
+    [string]$Path,
+    [string]$Label
+  )
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    throw "$Label not found: $Path"
+  }
+}
+
+function Invoke-Provider {
+  param(
+    [string]$Prompt,
+    [string]$ProviderName,
+    [string]$Override,
+    [string]$ClaudeModelName,
+    [string]$ClaudeEffortLevel,
+    [string]$GeminiModelName,
+    [string]$WorkingDirectory
+  )
+
+  Push-Location $WorkingDirectory
+  try {
+    if (-not [string]::IsNullOrWhiteSpace($Override)) {
+      $psi = New-Object System.Diagnostics.ProcessStartInfo
+      $psi.FileName = "powershell.exe"
+      $psi.Arguments = "-NoProfile -Command $Override"
+      $psi.WorkingDirectory = $WorkingDirectory
+      $psi.UseShellExecute = $false
+      $psi.RedirectStandardInput = $true
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError = $true
+
+      $process = New-Object System.Diagnostics.Process
+      $process.StartInfo = $psi
+      $null = $process.Start()
+      $process.StandardInput.Write($Prompt)
+      $process.StandardInput.Close()
+      $stdout = $process.StandardOutput.ReadToEnd()
+      $stderr = $process.StandardError.ReadToEnd()
+      $process.WaitForExit()
+
+      if ($stdout) {
+        Write-Output $stdout.TrimEnd()
+      }
+      if ($process.ExitCode -ne 0) {
+        throw "Override command failed with exit code $($process.ExitCode): $stderr"
+      }
+      return
+    }
+
+    $providerCommand = Get-Command $ProviderName -ErrorAction SilentlyContinue
+    if (-not $providerCommand) {
+      throw "$ProviderName CLI is not installed or not on PATH."
+    }
+
+    if ($ProviderName -eq "claude") {
+      $Prompt | claude -p --model $ClaudeModelName --effort $ClaudeEffortLevel --allowedTools all --permission-mode bypassPermissions --no-session-persistence
+    }
+    elseif ($ProviderName -eq "gemini") {
+      $preferredGeminiCommand = if ($env:OS -eq "Windows_NT") { "gemini.cmd" } else { "gemini" }
+      $geminiCommand = Get-Command $preferredGeminiCommand -ErrorAction SilentlyContinue
+      if (-not $geminiCommand) {
+        $geminiCommand = Get-Command "gemini" -ErrorAction SilentlyContinue
+      }
+      if (-not $geminiCommand) {
+        throw "gemini CLI is not installed or not on PATH."
+      }
+
+      $psi = New-Object System.Diagnostics.ProcessStartInfo
+      if ($env:OS -eq "Windows_NT" -and $geminiCommand.Source.ToLowerInvariant().EndsWith(".cmd")) {
+        $psi.FileName = "powershell.exe"
+        $psi.Arguments = "-NoProfile -Command & '$($geminiCommand.Source)' --model $GeminiModelName --skip-trust --prompt 'Execute the task from stdin. Follow the requested output format exactly.' --approval-mode yolo --output-format text"
+      }
+      else {
+        $psi.FileName = $geminiCommand.Source
+        $psi.Arguments = "--model $GeminiModelName --skip-trust --prompt ""Execute the task from stdin. Follow the requested output format exactly."" --approval-mode yolo --output-format text"
+      }
+      $psi.WorkingDirectory = $WorkingDirectory
+      $psi.UseShellExecute = $false
+      $psi.RedirectStandardInput = $true
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError = $true
+
+      $process = New-Object System.Diagnostics.Process
+      $process.StartInfo = $psi
+      $null = $process.Start()
+      $process.StandardInput.Write($Prompt)
+      $process.StandardInput.Close()
+      $stdout = $process.StandardOutput.ReadToEnd()
+      $stderr = $process.StandardError.ReadToEnd()
+      $process.WaitForExit()
+
+      if ($stdout) {
+        Write-Output $stdout.TrimEnd()
+      }
+      if ($process.ExitCode -ne 0) {
+        throw "gemini command failed with exit code $($process.ExitCode): $stderr"
+      }
+    }
+  }
+  finally {
+    Pop-Location
+  }
+}
+
+function Build-ImplementerPrompt {
+  param(
+    [string]$BriefText,
+    [string]$Worktree,
+    [string[]]$Scope,
+    [string]$ReportPath,
+    [string]$TestCommand
+  )
+
+  $scopeText = if ($Scope.Count -gt 0) { ($Scope | ForEach-Object { "- $_" }) -join "`n" } else { "- No write scope was provided." }
+  $testLine = if ([string]::IsNullOrWhiteSpace($TestCommand)) { "Run the focused tests you judge necessary and report them." } else { "Run this focused test command before reporting: $TestCommand" }
+
+  return @"
+You are an external implementer working inside an isolated task worktree.
+
+Task brief:
+
+$BriefText
+
+Worktree path:
+$Worktree
+
+Allowed write scope:
+$scopeText
+
+Rules:
+- Do not edit files outside the allowed write scope.
+- Do not change git remotes, branch topology, or merge history.
+- Run tests inside the worktree.
+- If the task forces out-of-scope edits, stop and report that explicitly.
+
+$testLine
+
+Write your full report to:
+$ReportPath
+
+Your report must include:
+- Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+- What you changed
+- Tests run and results
+- Files changed
+- Concerns or blockers
+
+After writing the report, print a short terminal summary with:
+- Status
+- Test summary
+- Report path
+"@
+}
+
+function Build-SpecReviewerPrompt {
+  param(
+    [string]$BriefText,
+    [string]$DiffPath,
+    [string]$ImplementerReportPath,
+    [string]$Base,
+    [string]$Head
+  )
+
+  return @"
+You are an external spec reviewer.
+
+Task brief:
+
+$BriefText
+
+Implementer report:
+$ImplementerReportPath
+
+Diff under review:
+- Base: $Base
+- Head: $Head
+- Diff file: $DiffPath
+
+Read the task brief, implementer report, and diff. Stay read-only.
+
+Return:
+- Spec compliance verdict
+- Missing requirements
+- Extra behavior
+- Misunderstandings
+- File/line references where possible
+"@
+}
+
+function Build-QualityReviewerPrompt {
+  param(
+    [string]$BriefText,
+    [string]$DiffPath,
+    [string]$ImplementerReportPath,
+    [string]$Base,
+    [string]$Head
+  )
+
+  return @"
+You are an external code-quality reviewer.
+
+Task brief:
+
+$BriefText
+
+Implementer report:
+$ImplementerReportPath
+
+Diff under review:
+- Base: $Base
+- Head: $Head
+- Diff file: $DiffPath
+
+Read the task brief, implementer report, and diff. Stay read-only.
+
+Check:
+- bugs
+- regressions
+- weak tests
+- maintainability risks
+- safety issues
+
+Return:
+- Quality verdict
+- Findings by severity
+- File/line references where possible
+"@
+}
+
+$repo = Resolve-StrictPath $RepoRoot
+$worktree = Resolve-StrictPath $WorktreePath
+$brief = Resolve-StrictPath $TaskBriefPath
+Assert-FileExists $brief "Task brief"
+
+$briefText = Get-Content -LiteralPath $brief -Raw -Encoding UTF8
+
+if ($Role -eq "implementer") {
+  if ([string]::IsNullOrWhiteSpace($ReportFile)) {
+    throw "ReportFile is required for implementer role."
+  }
+  if ($WriteScope.Count -eq 0) {
+    throw "WriteScope is required for implementer role."
+  }
+  $prompt = Build-ImplementerPrompt -BriefText $briefText -Worktree $worktree -Scope $WriteScope -ReportPath $ReportFile -TestCommand $FocusedTestCommand
+}
+elseif ($Role -eq "spec-reviewer") {
+  if ([string]::IsNullOrWhiteSpace($DiffFile) -or [string]::IsNullOrWhiteSpace($ImplementerReportFile)) {
+    throw "DiffFile and ImplementerReportFile are required for reviewer roles."
+  }
+  $prompt = Build-SpecReviewerPrompt -BriefText $briefText -DiffPath $DiffFile -ImplementerReportPath $ImplementerReportFile -Base $BaseSha -Head $HeadSha
+}
+else {
+  if ([string]::IsNullOrWhiteSpace($DiffFile) -or [string]::IsNullOrWhiteSpace($ImplementerReportFile)) {
+    throw "DiffFile and ImplementerReportFile are required for reviewer roles."
+  }
+  $prompt = Build-QualityReviewerPrompt -BriefText $briefText -DiffPath $DiffFile -ImplementerReportPath $ImplementerReportFile -Base $BaseSha -Head $HeadSha
+}
+
+Invoke-Provider -Prompt $prompt -ProviderName $Provider -Override $CommandOverride -ClaudeModelName $ClaudeModel -ClaudeEffortLevel $ClaudeEffort -GeminiModelName $GeminiModel -WorkingDirectory $worktree
+
+$result = [pscustomobject]@{
+  provider = $Provider
+  role = $Role
+  repo_root = $repo
+  worktree_path = $worktree
+  report_file = $ReportFile
+}
+
+if ($Json) {
+  $result | ConvertTo-Json -Depth 4
+}
+else {
+  Write-Output "External worker request sent to $Provider for $Role."
+}

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -96,6 +96,46 @@ before execution begins, not one interrupt per discovery mid-plan. If the
 scan is clean, proceed without comment. The review loop remains the net for
 conflicts that only emerge from implementation.
 
+## Controller Metadata Validation
+
+Before dispatching any implementation task, validate the plan metadata:
+
+- all task IDs are unique
+- all depends_on references exist
+- dependency graph has no circular dependencies
+- write_scope is present for every implementation task
+- risk_level is one of `low`, `medium`, or `high`
+- high-risk tasks require both `spec` and `code_quality` review
+- high-risk tasks are never dispatched in parallel
+- external_review only creates review gates; Claude and Gemini remain external reviewers only
+
+Use `scripts/validate-plan-metadata.ps1 -PlanPath <plan>` when PowerShell is available. If the script reports errors, stop execution and fix the implementation plan before dispatch.
+
+## Deterministic Routing
+
+Compute routing from task metadata; never trust a hand-written `parallel_safe` flag.
+
+Use sequential subagent-driven-development when:
+
+- a task has `risk_level: high`
+- a task depends on unfinished work
+- a task defines or touches shared contracts, APIs, schemas, migrations, storage, security, or deletion behavior
+- review feedback may change downstream tasks
+- a task's write_scope overlaps any other active task
+
+Parallel dispatch is allowed only after metadata validation confirms complete dependencies, non-overlapping write_scope, independently verifiable tasks, and a risk profile that allows parallel work.
+
+## Write-Scope Enforcement
+
+Each implementer prompt must include the task's declared write_scope and state that edits outside it are forbidden unless the controller updates the plan first.
+
+After each task, inspect the actual changed files with `git diff --name-only <base>..<head>` or pass the changed files to `scripts/validate-plan-metadata.ps1 -PlanPath <plan> -ActiveTaskIds <task-id> -ChangedFiles <files>`. If any file is outside write_scope:
+
+- pause the task
+- review the out-of-scope change
+- either update metadata and re-approve the task
+- or reject the out-of-scope change before continuing
+
 ## Model Selection
 
 Use the least powerful model that can handle each role to conserve cost and increase speed.

--- a/skills/subagent-driven-development/scripts/validate-plan-metadata.ps1
+++ b/skills/subagent-driven-development/scripts/validate-plan-metadata.ps1
@@ -1,0 +1,369 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PlanPath,
+
+  [string[]]$ActiveTaskIds = @(),
+  [string[]]$CompletedTaskIds = @(),
+  [string[]]$ChangedFiles = @(),
+  [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+function Split-IdList {
+  param([string[]]$Values)
+
+  $result = New-Object System.Collections.Generic.List[string]
+  foreach ($value in $Values) {
+    foreach ($part in ($value -split ",")) {
+      $trimmed = $part.Trim()
+      if ($trimmed.Length -gt 0) {
+        $result.Add($trimmed)
+      }
+    }
+  }
+  return @($result)
+}
+
+function Normalize-ScopePath {
+  param([string]$Path)
+
+  return ($Path.Trim() -replace "\\", "/").TrimEnd("/").ToLowerInvariant()
+}
+
+function New-MetadataObject {
+  param([hashtable]$Metadata)
+
+  return [pscustomobject]@{
+    id = $Metadata["id"]
+    title = $Metadata["title"]
+    depends_on = @($Metadata["depends_on"])
+    write_scope = @($Metadata["write_scope"])
+    risk_level = $Metadata["risk_level"]
+    review_required = @($Metadata["review_required"])
+    external_review = $Metadata["external_review"]
+  }
+}
+
+function Test-SharedContractScope {
+  param($Task)
+
+  if (@($Task.review_required) -contains "spec") {
+    return $true
+  }
+
+  foreach ($scope in @($Task.write_scope)) {
+    $normalized = Normalize-ScopePath $scope
+    if ($normalized -match "(^|/)(api|apis|contract|contracts|schema|schemas|migration|migrations|database|db|storage|security|auth|delete|deletion|types?)(/|\.|$)") {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function Test-ChangedFileAllowed {
+  param(
+    [string]$ChangedFile,
+    [string[]]$AllowedScopes
+  )
+
+  $changed = Normalize-ScopePath $ChangedFile
+  foreach ($scope in $AllowedScopes) {
+    $allowed = Normalize-ScopePath $scope
+    if ($changed -eq $allowed -or $changed.StartsWith("$allowed/")) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+if (-not (Test-Path $PlanPath)) {
+  throw "Plan file not found: $PlanPath"
+}
+
+$lines = Get-Content -Path $PlanPath
+$tasks = New-Object System.Collections.Generic.List[object]
+$current = $null
+$currentField = $null
+
+foreach ($line in $lines) {
+  if ($line -match "^\s*task_metadata:\s*$") {
+    if ($null -ne $current) {
+      $tasks.Add((New-MetadataObject $current))
+    }
+
+    $current = @{
+      depends_on = @()
+      write_scope = @()
+      review_required = @()
+      external_review = @{}
+    }
+    $currentField = $null
+    continue
+  }
+
+  if ($null -eq $current) {
+    continue
+  }
+
+  if ($line -match "^\s*```\s*$") {
+    $tasks.Add((New-MetadataObject $current))
+    $current = $null
+    $currentField = $null
+    continue
+  }
+
+  if ($line -match "^\s{2}([A-Za-z_]+):\s*(.*)\s*$") {
+    $field = $Matches[1]
+    $value = $Matches[2].Trim()
+    $currentField = $field
+
+    if ($field -in @("depends_on", "write_scope", "review_required")) {
+      if ($value -eq "[]") {
+        $current[$field] = @()
+        $currentField = $null
+      }
+      else {
+        $current[$field] = @()
+      }
+    }
+    elseif ($field -eq "external_review") {
+      $current[$field] = @{}
+    }
+    else {
+      $current[$field] = $value.Trim("'`"")
+      $currentField = $null
+    }
+
+    continue
+  }
+
+  if ($line -match "^\s{4}-\s*(.+?)\s*$") {
+    if ($currentField -in @("depends_on", "write_scope", "review_required")) {
+      $current[$currentField] += $Matches[1].Trim()
+    }
+    continue
+  }
+
+  if ($line -match "^\s{4}([A-Za-z_]+):\s*(true|false)\s*$") {
+    if ($currentField -eq "external_review") {
+      $current["external_review"][$Matches[1]] = [bool]::Parse($Matches[2])
+    }
+  }
+}
+
+if ($null -ne $current) {
+  $tasks.Add((New-MetadataObject $current))
+}
+
+$errors = New-Object System.Collections.Generic.List[string]
+$tasksById = @{}
+
+if ($tasks.Count -eq 0) {
+  $errors.Add("no task_metadata blocks found")
+}
+
+foreach ($task in $tasks) {
+  foreach ($required in @("id", "title", "risk_level")) {
+    if ([string]::IsNullOrWhiteSpace($task.$required)) {
+      $errors.Add("task metadata missing required field: $required")
+    }
+  }
+
+  if ($null -eq $task.depends_on) {
+    $errors.Add("task $($task.id) missing depends_on")
+  }
+
+  if (@($task.write_scope).Count -eq 0) {
+    $errors.Add("task $($task.id) missing write_scope")
+  }
+
+  if (@($task.review_required).Count -eq 0) {
+    $errors.Add("task $($task.id) missing review_required")
+  }
+
+  if ($null -eq $task.external_review -or -not $task.external_review.ContainsKey("claude") -or -not $task.external_review.ContainsKey("gemini")) {
+    $errors.Add("task $($task.id) missing external_review claude/gemini flags")
+  }
+
+  if ($task.risk_level -and $task.risk_level -notin @("low", "medium", "high")) {
+    $errors.Add("task $($task.id) has invalid risk_level: $($task.risk_level)")
+  }
+
+  if ($task.id) {
+    if ($tasksById.ContainsKey($task.id)) {
+      $errors.Add("duplicate task id: $($task.id)")
+    }
+    else {
+      $tasksById[$task.id] = $task
+    }
+  }
+
+  if ($task.risk_level -eq "high") {
+    if (-not (@($task.review_required) -contains "spec") -or -not (@($task.review_required) -contains "code_quality")) {
+      $errors.Add("high-risk task $($task.id) must require spec and code_quality review")
+    }
+  }
+}
+
+foreach ($task in $tasks) {
+  foreach ($dependency in @($task.depends_on)) {
+    if (-not $tasksById.ContainsKey($dependency)) {
+      $errors.Add("task $($task.id) depends_on missing task id: $dependency")
+    }
+  }
+}
+
+$visitState = @{}
+function Visit-Task {
+  param(
+    [string]$TaskId,
+    [string[]]$Stack
+  )
+
+  if (-not $tasksById.ContainsKey($TaskId)) {
+    return
+  }
+
+  if ($visitState[$TaskId] -eq "visiting") {
+    $cycle = (@($Stack) + $TaskId) -join " -> "
+    $errors.Add("circular dependency: $cycle")
+    return
+  }
+
+  if ($visitState[$TaskId] -eq "visited") {
+    return
+  }
+
+  $visitState[$TaskId] = "visiting"
+  foreach ($dependency in @($tasksById[$TaskId].depends_on)) {
+    Visit-Task $dependency (@($Stack) + $TaskId)
+  }
+  $visitState[$TaskId] = "visited"
+}
+
+foreach ($taskId in $tasksById.Keys) {
+  Visit-Task $taskId @()
+}
+
+$activeIds = Split-IdList $ActiveTaskIds
+$completedIds = Split-IdList $CompletedTaskIds
+$completedSet = @{}
+foreach ($id in $completedIds) {
+  $completedSet[$id] = $true
+}
+
+foreach ($id in $activeIds) {
+  if (-not $tasksById.ContainsKey($id)) {
+    $errors.Add("active task id does not exist: $id")
+  }
+}
+
+if ($activeIds.Count -gt 1) {
+  foreach ($id in $activeIds) {
+    if (-not $tasksById.ContainsKey($id)) {
+      continue
+    }
+
+    $task = $tasksById[$id]
+    if ($task.risk_level -eq "high") {
+      $errors.Add("high-risk tasks are never dispatched in parallel: $id")
+    }
+
+    foreach ($dependency in @($task.depends_on)) {
+      if ($activeIds -contains $dependency) {
+        $errors.Add("dependency relationship between active tasks: $id depends on $dependency")
+      }
+      elseif ($completedIds.Count -gt 0 -and -not $completedSet.ContainsKey($dependency)) {
+        $errors.Add("unfinished dependency: $id depends on $dependency")
+      }
+    }
+  }
+
+  for ($i = 0; $i -lt $activeIds.Count; $i++) {
+    for ($j = $i + 1; $j -lt $activeIds.Count; $j++) {
+      if (-not $tasksById.ContainsKey($activeIds[$i]) -or -not $tasksById.ContainsKey($activeIds[$j])) {
+        continue
+      }
+
+      $left = $tasksById[$activeIds[$i]]
+      $right = $tasksById[$activeIds[$j]]
+      $leftScopes = @($left.write_scope) | ForEach-Object { Normalize-ScopePath $_ }
+      $rightScopes = @($right.write_scope) | ForEach-Object { Normalize-ScopePath $_ }
+
+      foreach ($scope in $leftScopes) {
+        if ($rightScopes -contains $scope) {
+          $errors.Add("overlapping write_scope: $scope used by $($left.id) and $($right.id)")
+        }
+      }
+    }
+  }
+}
+
+if ($ChangedFiles.Count -gt 0) {
+  if ($activeIds.Count -ne 1) {
+    $errors.Add("ChangedFiles enforcement requires exactly one ActiveTaskIds value")
+  }
+  elseif ($tasksById.ContainsKey($activeIds[0])) {
+    $task = $tasksById[$activeIds[0]]
+    foreach ($file in $ChangedFiles) {
+      if (-not (Test-ChangedFileAllowed $file @($task.write_scope))) {
+        $errors.Add("out-of-scope change: $file is not in write_scope for $($task.id)")
+      }
+    }
+  }
+}
+
+$routing = foreach ($task in $tasks) {
+  $route = "parallel_candidate"
+  $reason = "risk_level is low"
+
+  if ($task.risk_level -eq "high") {
+    $route = "sequential"
+    $reason = "high risk"
+  }
+  elseif ($task.risk_level -eq "medium" -and (Test-SharedContractScope $task)) {
+    $route = "sequential"
+    $reason = "medium risk touches shared contracts or requires spec review"
+  }
+  elseif (@($task.depends_on).Count -gt 0) {
+    $reason = "parallel only after dependencies complete"
+  }
+
+  [pscustomobject]@{
+    id = $task.id
+    route = $route
+    reason = $reason
+  }
+}
+
+$result = [pscustomobject]@{
+  plan = (Resolve-Path $PlanPath).Path
+  task_count = $tasks.Count
+  errors = @($errors)
+  routing = @($routing)
+}
+
+if ($Json) {
+  $result | ConvertTo-Json -Depth 8
+}
+elseif ($errors.Count -eq 0) {
+  Write-Output "Plan metadata valid: $($tasks.Count) task(s)."
+  foreach ($item in $routing) {
+    Write-Output "$($item.id): $($item.route) ($($item.reason))"
+  }
+}
+else {
+  foreach ($errorMessage in $errors) {
+    Write-Output "ERROR: $errorMessage"
+  }
+}
+
+if ($errors.Count -gt 0) {
+  $global:LASTEXITCODE = 1
+  return
+}
+
+$global:LASTEXITCODE = 0

--- a/skills/using-superpowers/references/gemini-tools.md
+++ b/skills/using-superpowers/references/gemini-tools.md
@@ -1,0 +1,40 @@
+# Gemini CLI Tool Mapping
+
+Skills use Claude Code tool names. When you encounter these in a skill, use
+the Gemini CLI equivalent:
+
+| Skill references | Gemini CLI equivalent |
+|-----------------|----------------------|
+| `Read` (file reading) | `read_file` |
+| `Write` (file creation) | `write_file` |
+| `Edit` (file editing) | `replace` |
+| `Bash` (run commands) | `run_shell_command` |
+| `Grep` (search file content) | `grep_search` |
+| `Glob` (search files by name) | `glob` |
+| `TodoWrite` (task tracking) | `write_todos` |
+| `Skill` tool (invoke a skill) | `activate_skill` |
+| `WebSearch` | `google_web_search` |
+| `WebFetch` | `web_fetch` |
+| `Task` tool (dispatch subagent) | `@generalist` with the prompt from the skill |
+
+## Subagent support
+
+Gemini CLI supports subagents through `@` dispatch. When a skill asks you to
+dispatch a subagent, use `@generalist` with the fully filled prompt template.
+
+- Keep dependent tasks sequential.
+- Independent tasks may be dispatched in parallel.
+- If a skill requires a named reviewer or implementer prompt, pass that full
+  prompt to `@generalist`.
+
+## Additional Gemini CLI tools
+
+These tools exist in Gemini CLI but may not have a direct Claude Code name:
+
+| Tool | Purpose |
+|------|---------|
+| `list_directory` | List files and subdirectories |
+| `save_memory` | Persist facts to `GEMINI.md` across sessions |
+| `ask_user` | Request structured input from the user |
+| `tracker_create_task` | Rich task management |
+| `enter_plan_mode` / `exit_plan_mode` | Switch to read-only planning mode |

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -42,6 +42,48 @@ deliverable needs them; split only where a reviewer could meaningfully
 reject one task while approving its neighbor. Each task ends with an
 independently testable deliverable.
 
+## Task Metadata
+
+Every implementation task MUST start with parser-friendly metadata before
+the **Files** block. The controller uses this metadata to validate
+dependencies, enforce write scope, compute routing, and decide whether
+external review is required. Do not write `parallel_safe` in plans; controllers compute parallel eligibility from metadata.
+
+```yaml
+task_metadata:
+  id: task-1
+  title: Add streaming chat events
+  depends_on: []
+  write_scope:
+    - worker/meeting_cockpit/chat.py
+    - worker/tests/test_chat_events.py
+  risk_level: high
+  review_required:
+    - spec
+    - code_quality
+  external_review:
+    claude: false
+    gemini: false
+```
+
+Field rules:
+
+- `id`: unique stable task identifier, formatted as `task-N`.
+- `title`: human-readable task title matching the task heading.
+- `depends_on`: list of task IDs that must complete before this task can start; use `[]` when there are none.
+- `write_scope`: exact files or narrow directories this task may create or modify.
+- `risk_level`: one of `low`, `medium`, or `high`.
+- `review_required`: include `spec`, `code_quality`, or both; high-risk tasks require both.
+- `external_review`: set `claude` or `gemini` to `true` only for external reviewer gates. Claude and Gemini are reviewers only; they do not implement or mutate files.
+
+Risk rules:
+
+- `low`: may run in parallel when dependencies are complete and write scopes do not overlap.
+- `medium`: may run in parallel only when it does not touch shared contracts, shared architecture, APIs, schemas, migrations, storage, security, or deletion behavior.
+- `high`: always sequential. Requires spec review and code-quality review, with optional external Claude/Gemini review.
+
+Metadata Validation: During plan self-review, confirm all task IDs are unique, all depends_on references exist, the dependency graph has no circular dependencies, every implementation task has write_scope, high-risk tasks require spec and code_quality review, and no task authors `parallel_safe`.
+
 ## Bite-Sized Task Granularity
 
 **Each step is one action (2-5 minutes):**
@@ -80,6 +122,23 @@ include this section.]
 
 ````markdown
 ### Task N: [Component Name]
+
+```yaml
+task_metadata:
+  id: task-N
+  title: Component Name
+  depends_on: []
+  write_scope:
+    - exact/path/to/file.py
+    - tests/exact/path/to/test.py
+  risk_level: low
+  review_required:
+    - spec
+    - code_quality
+  external_review:
+    claude: false
+    gemini: false
+```
 
 **Files:**
 - Create: `exact/path/to/file.py`

--- a/tests/external-model-orchestration.test.ps1
+++ b/tests/external-model-orchestration.test.ps1
@@ -6,6 +6,7 @@ $reviewSkill = Join-Path $root "skills/cross-model-review/SKILL.md"
 $reviewScript = Join-Path $root "skills/cross-model-review/scripts/review-with-model.ps1"
 $workerSkill = Join-Path $root "skills/external-model-workers/SKILL.md"
 $workerScript = Join-Path $root "skills/external-model-workers/scripts/run-worker-with-model.ps1"
+$orchestratorScript = Join-Path $root "skills/external-model-workers/scripts/orchestrate-external-task.ps1"
 
 function Assert-True {
   param(
@@ -34,6 +35,7 @@ Assert-True (Test-Path $reviewSkill) "cross-model-review skill must exist."
 Assert-True (Test-Path $reviewScript) "review-with-model.ps1 must exist."
 Assert-True (Test-Path $workerSkill) "external-model-workers skill must exist."
 Assert-True (Test-Path $workerScript) "run-worker-with-model.ps1 must exist."
+Assert-True (Test-Path $orchestratorScript) "orchestrate-external-task.ps1 must exist."
 Assert-True (Test-Path $geminiReference) "Gemini bootstrap reference file must exist for GEMINI.md imports."
 
 $reviewText = Get-Content -Raw $reviewSkill
@@ -121,6 +123,7 @@ Report path: mocked
     git init | Out-Null
     git config user.name "Codex"
     git config user.email "codex@example.com"
+    git config core.autocrlf false
     New-Item -ItemType Directory -Path (Join-Path $repoRoot "src") | Out-Null
     Set-Content -Path (Join-Path $repoRoot "src/worker.ts") -Value "export const worker = 1`n" -Encoding UTF8
     git add .
@@ -161,6 +164,109 @@ Report path: mocked
   Assert-Contains $workerPrompt "You are an external implementer working inside an isolated task worktree." "worker script must send the implementer prompt."
   Assert-Contains $workerPrompt "Allowed write scope:" "worker script must include write scope."
   Assert-Contains $workerPrompt "Write your full report to:" "worker script must include the report contract."
+
+  $orchestratorProvider = Join-Path $temp "orchestrator-provider.ps1"
+  @(
+    'param()',
+    '',
+    '$prompt = [Console]::In.ReadToEnd()',
+    '$worktreeMatch = [regex]::Match($prompt, "Worktree path:\s*(?<path>[^\r\n]+)")',
+    '$reportMatch = [regex]::Match($prompt, "Write your full report to:\s*(?<path>[^\r\n]+)")',
+    'if (-not $worktreeMatch.Success -or -not $reportMatch.Success) {',
+    '  throw "mock provider could not find worktree or report path"',
+    '}',
+    '',
+    '$worktree = $worktreeMatch.Groups["path"].Value.Trim()',
+    '$report = $reportMatch.Groups["path"].Value.Trim()',
+    '$utf8NoBom = New-Object System.Text.UTF8Encoding($false)',
+    '[System.IO.File]::WriteAllText((Join-Path $worktree "app.txt"), "hello world`n", $utf8NoBom)',
+    '@''',
+    'Status: DONE',
+    'Tests run: verification deferred to controller',
+    'Files changed:',
+    '- app.txt',
+    '''@ | Set-Content -Path $report -Encoding UTF8',
+    '@"',
+    'Status: DONE',
+    'Test summary: mocked',
+    'Report path: $report',
+    '"@'
+  ) | Set-Content -Path $orchestratorProvider -Encoding UTF8
+
+  $orchestratorPlan = Join-Path $temp "orchestrator-plan.md"
+  @'
+# Orchestrator Plan
+
+### Task 1: Greeting
+
+```yaml
+task_metadata:
+  id: task-1
+  title: Greeting
+  depends_on: []
+  write_scope:
+    - app.txt
+  risk_level: low
+  review_required:
+    - spec
+    - code_quality
+  external_review:
+    claude: false
+    gemini: false
+```
+'@ | Set-Content -Path $orchestratorPlan -Encoding UTF8
+
+  $repo2 = Join-Path $temp "repo-orchestrator"
+  New-Item -ItemType Directory -Path $repo2 | Out-Null
+  Push-Location $repo2
+  try {
+    git init | Out-Null
+    git config user.name "Codex"
+    git config user.email "codex@example.com"
+    git config core.autocrlf false
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText((Join-Path $repo2 "app.txt"), "hello`n", $utf8NoBom)
+    git add app.txt
+    git commit -m "init" | Out-Null
+  }
+  finally {
+    Pop-Location
+  }
+
+  $orchestratorBrief = Join-Path $temp "orchestrator-brief.md"
+  @'
+### Task 1: Greeting
+
+Change `app.txt` so its contents become exactly `hello world` followed by a newline.
+'@ | Set-Content -Path $orchestratorBrief -Encoding UTF8
+
+  & $orchestratorScript `
+    -Provider claude `
+    -PlanPath $orchestratorPlan `
+    -TaskId task-1 `
+    -TaskBriefPath $orchestratorBrief `
+    -RepoRoot $repo2 `
+    -VerificationCommand "Get-Content -Raw app.txt" `
+    -CommitMessage "test: orchestrate external task" `
+    -CommandOverride "powershell -File `"$orchestratorProvider`"" `
+    -Json | Out-Null
+
+  Assert-True ($LASTEXITCODE -eq 0) "orchestrator should complete successfully with a mock provider."
+
+  Push-Location $repo2
+  try {
+    $finalContents = Get-Content -Raw "app.txt"
+    if ($finalContents -ne "hello world`n") {
+      throw "orchestrator must merge the worker change back into the repo root."
+    }
+    $history = git log --oneline -1
+    if ($history -notmatch "test: orchestrate external task") {
+      throw "orchestrator must create a merge-ready commit."
+    }
+  }
+  finally {
+    Pop-Location
+  }
 }
 finally {
   Remove-Item -Recurse -Force $temp

--- a/tests/external-model-orchestration.test.ps1
+++ b/tests/external-model-orchestration.test.ps1
@@ -1,0 +1,169 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+$geminiReference = Join-Path $root "skills/using-superpowers/references/gemini-tools.md"
+$reviewSkill = Join-Path $root "skills/cross-model-review/SKILL.md"
+$reviewScript = Join-Path $root "skills/cross-model-review/scripts/review-with-model.ps1"
+$workerSkill = Join-Path $root "skills/external-model-workers/SKILL.md"
+$workerScript = Join-Path $root "skills/external-model-workers/scripts/run-worker-with-model.ps1"
+
+function Assert-True {
+  param(
+    [bool]$Condition,
+    [string]$Message
+  )
+
+  if (-not $Condition) {
+    throw $Message
+  }
+}
+
+function Assert-Contains {
+  param(
+    [string]$Text,
+    [string]$Pattern,
+    [string]$Message
+  )
+
+  if ($Text -notmatch [regex]::Escape($Pattern)) {
+    throw $Message
+  }
+}
+
+Assert-True (Test-Path $reviewSkill) "cross-model-review skill must exist."
+Assert-True (Test-Path $reviewScript) "review-with-model.ps1 must exist."
+Assert-True (Test-Path $workerSkill) "external-model-workers skill must exist."
+Assert-True (Test-Path $workerScript) "run-worker-with-model.ps1 must exist."
+Assert-True (Test-Path $geminiReference) "Gemini bootstrap reference file must exist for GEMINI.md imports."
+
+$reviewText = Get-Content -Raw $reviewSkill
+Assert-Contains $reviewText "Use Claude CLI or Gemini CLI as an independent reviewer" "cross-model-review skill must describe external reviewers."
+Assert-Contains $reviewText "Do not let external models edit files or execute project mutations." "cross-model-review skill must keep reviews read-only."
+$reviewScriptText = Get-Content -Raw $reviewScript
+Assert-Contains $reviewScriptText "--skip-trust" "review wrapper must opt Gemini into trusted headless execution."
+
+$workerText = Get-Content -Raw $workerSkill
+Assert-Contains $workerText "create isolated worktrees" "external-model-workers skill must require isolated worktrees."
+Assert-Contains $workerText "inspect diffs" "external-model-workers skill must require diff inspection."
+Assert-Contains $workerText "run tests" "external-model-workers skill must require tests."
+Assert-Contains $workerText "enforce write scope" "external-model-workers skill must require write-scope enforcement."
+$workerScriptText = Get-Content -Raw $workerScript
+Assert-Contains $workerScriptText "--skip-trust" "worker wrapper must opt Gemini into trusted headless execution."
+
+$temp = Join-Path ([System.IO.Path]::GetTempPath()) ("superpowers-external-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $temp | Out-Null
+
+try {
+  $providerScript = Join-Path $temp "fake-provider.ps1"
+  $providerOutput = Join-Path $temp "provider-output.txt"
+  $providerInvocations = Join-Path $temp "provider-invocations.log"
+  $planFile = Join-Path $temp "plan.md"
+  $artifactFile = Join-Path $temp "artifact.md"
+  $taskBrief = Join-Path $temp "task-1-brief.md"
+  $reportFile = Join-Path $temp "task-1-report.md"
+  $repoRoot = Join-Path $temp "repo"
+  $worktree = Join-Path $temp "repo"
+
+  New-Item -ItemType Directory -Path $repoRoot | Out-Null
+  @'
+# Sample artifact
+
+The task metadata is valid.
+'@ | Set-Content -Path $artifactFile -Encoding UTF8
+
+  @'
+# Sample plan
+
+### Task 1: Worker
+
+```yaml
+task_metadata:
+  id: task-1
+  title: Worker
+  depends_on: []
+  write_scope:
+    - src/worker.ts
+  risk_level: low
+  review_required:
+    - spec
+    - code_quality
+  external_review:
+    claude: true
+    gemini: true
+```
+'@ | Set-Content -Path $planFile -Encoding UTF8
+
+  @'
+### Task 1: Worker
+
+Implement the worker.
+'@ | Set-Content -Path $taskBrief -Encoding UTF8
+
+  @'
+param(
+  [string]$OutputPath,
+  [string]$InvocationLogPath
+)
+
+$inputText = [Console]::In.ReadToEnd()
+Set-Content -Path $OutputPath -Value $inputText -Encoding UTF8
+Add-Content -Path $InvocationLogPath -Value ("ARGS=" + ($args -join " "))
+@"
+Status: DONE
+Commits created: none
+Test summary: mocked
+Report path: mocked
+"@
+'@ | Set-Content -Path $providerScript -Encoding UTF8
+
+  Push-Location $repoRoot
+  try {
+    git init | Out-Null
+    git config user.name "Codex"
+    git config user.email "codex@example.com"
+    New-Item -ItemType Directory -Path (Join-Path $repoRoot "src") | Out-Null
+    Set-Content -Path (Join-Path $repoRoot "src/worker.ts") -Value "export const worker = 1`n" -Encoding UTF8
+    git add .
+    git commit -m "init" | Out-Null
+  }
+  finally {
+    Pop-Location
+  }
+
+  & $reviewScript `
+    -Provider claude `
+    -Mode spec `
+    -InputPath $artifactFile `
+    -RepoRoot $repoRoot `
+    -CommandOverride "powershell -File `"$providerScript`" -OutputPath `"$providerOutput`" -InvocationLogPath `"$providerInvocations`"" `
+    -Json | Out-Null
+
+  Assert-True ($LASTEXITCODE -eq 0) "review-with-model.ps1 should succeed with a mock provider."
+  $reviewPrompt = Get-Content -Raw $providerOutput
+  Assert-Contains $reviewPrompt "You are reviewing a product/technical spec." "review script must send the spec prompt."
+  Assert-Contains $reviewPrompt "Artifact begins:" "review script must include artifact boundaries."
+
+  Remove-Item $providerOutput
+
+  & $workerScript `
+    -Provider gemini `
+    -Role implementer `
+    -TaskBriefPath $taskBrief `
+    -RepoRoot $repoRoot `
+    -WorktreePath $worktree `
+    -WriteScope "src/worker.ts" `
+    -ReportFile $reportFile `
+    -CommandOverride "powershell -File `"$providerScript`" -OutputPath `"$providerOutput`" -InvocationLogPath `"$providerInvocations`"" `
+    -Json | Out-Null
+
+  Assert-True ($LASTEXITCODE -eq 0) "run-worker-with-model.ps1 should succeed with a mock provider."
+  $workerPrompt = Get-Content -Raw $providerOutput
+  Assert-Contains $workerPrompt "You are an external implementer working inside an isolated task worktree." "worker script must send the implementer prompt."
+  Assert-Contains $workerPrompt "Allowed write scope:" "worker script must include write scope."
+  Assert-Contains $workerPrompt "Write your full report to:" "worker script must include the report contract."
+}
+finally {
+  Remove-Item -Recurse -Force $temp
+}
+
+Write-Host "External model orchestration checks passed."

--- a/tests/phase1-orchestration.test.ps1
+++ b/tests/phase1-orchestration.test.ps1
@@ -1,0 +1,160 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+$writingPlans = Get-Content -Raw (Join-Path $root "skills/writing-plans/SKILL.md")
+$sdd = Get-Content -Raw (Join-Path $root "skills/subagent-driven-development/SKILL.md")
+$parallel = Get-Content -Raw (Join-Path $root "skills/dispatching-parallel-agents/SKILL.md")
+$validator = Join-Path $root "skills/subagent-driven-development/scripts/validate-plan-metadata.ps1"
+
+function Assert-Contains {
+  param(
+    [string]$Text,
+    [string]$Pattern,
+    [string]$Message
+  )
+
+  if ($Text -notmatch [regex]::Escape($Pattern)) {
+    throw $Message
+  }
+}
+
+foreach ($field in @("task_metadata:", "id:", "depends_on:", "write_scope:", "risk_level:", "review_required:", "external_review:")) {
+  Assert-Contains $writingPlans $field "writing-plans must require metadata field '$field'."
+}
+
+Assert-Contains $writingPlans 'Do not write `parallel_safe` in plans; controllers compute parallel eligibility from metadata.' "writing-plans must prohibit manual parallel_safe metadata."
+Assert-Contains $writingPlans "Metadata Validation" "writing-plans must add a metadata validation self-review gate."
+
+foreach ($rule in @(
+  "all task IDs are unique",
+  "all depends_on references exist",
+  "dependency graph has no circular dependencies",
+  "write_scope is present for every implementation task",
+  "high-risk tasks are never dispatched in parallel",
+  "Claude and Gemini remain external reviewers only"
+)) {
+  Assert-Contains $sdd $rule "subagent-driven-development must include controller rule: $rule"
+}
+
+foreach ($rule in @(
+  "parallel_safe is computed, never authored",
+  "no dependency relationship",
+  "no overlapping write_scope entries",
+  "risk_level is low",
+  "medium risk tasks are parallel only when they do not touch shared contracts"
+)) {
+  Assert-Contains $parallel $rule "dispatching-parallel-agents must include routing rule: $rule"
+}
+
+if (-not (Test-Path $validator)) {
+  throw "metadata validator script is missing: $validator"
+}
+
+$sampleDir = Join-Path ([System.IO.Path]::GetTempPath()) ("superpowers-phase1-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $sampleDir | Out-Null
+
+try {
+  $validPlan = Join-Path $sampleDir "valid-plan.md"
+  @'
+# Valid Plan
+
+### Task 1: Core Contract
+
+```yaml
+task_metadata:
+  id: task-1
+  title: Core Contract
+  depends_on: []
+  write_scope:
+    - src/contract.ts
+  risk_level: high
+  review_required:
+    - spec
+    - code_quality
+  external_review:
+    claude: true
+    gemini: true
+```
+
+### Task 2: UI Copy
+
+```yaml
+task_metadata:
+  id: task-2
+  title: UI Copy
+  depends_on:
+    - task-1
+  write_scope:
+    - src/copy.ts
+  risk_level: low
+  review_required:
+    - code_quality
+  external_review:
+    claude: false
+    gemini: false
+```
+'@ | Set-Content -Path $validPlan -Encoding UTF8
+
+  & $validator -PlanPath $validPlan -Json | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "validator should accept valid metadata."
+  }
+
+  $invalidPlan = Join-Path $sampleDir "invalid-plan.md"
+  @'
+# Invalid Plan
+
+### Task 1: One
+
+```yaml
+task_metadata:
+  id: task-1
+  title: One
+  depends_on:
+    - task-2
+  write_scope:
+    - src/shared.ts
+  risk_level: low
+  review_required:
+    - code_quality
+  external_review:
+    claude: false
+    gemini: false
+```
+
+### Task 2: Two
+
+```yaml
+task_metadata:
+  id: task-2
+  title: Two
+  depends_on:
+    - task-1
+  write_scope:
+    - src/shared.ts
+  risk_level: low
+  review_required:
+    - code_quality
+  external_review:
+    claude: false
+    gemini: false
+```
+'@ | Set-Content -Path $invalidPlan -Encoding UTF8
+
+  $output = & $validator -PlanPath $invalidPlan -ActiveTaskIds task-1,task-2 2>&1
+  if ($LASTEXITCODE -eq 0) {
+    throw "validator should reject circular dependencies and overlapping active write scopes."
+  }
+
+  $joined = $output -join "`n"
+  foreach ($expected in @("circular dependency", "overlapping write_scope")) {
+    if ($joined -notmatch [regex]::Escape($expected)) {
+      throw "validator output should mention '$expected'. Actual output: $joined"
+    }
+  }
+}
+finally {
+  Remove-Item -Recurse -Force $sampleDir
+}
+
+Write-Host "Phase 1 orchestration checks passed."


### PR DESCRIPTION
﻿## Summary

Adds Phase 1 agent workflow orchestration guidance to Superpowers:

- requires task metadata in implementation plans
- adds controller validation and deterministic routing rules
- adds write-scope enforcement guidance
- keeps Claude/Gemini as external reviewers only
- adds a PowerShell metadata validator and regression test

## Validation

- `tests/phase1-orchestration.test.ps1`
- `git diff --check`
