### PR TITLE
SDD: add a reasoning-effort dimension to subagent dispatch (implements #1747)

### DIFF
--- a/agents/worker-high-effort.md
+++ b/agents/worker-high-effort.md
@@ -1,0 +1,7 @@
+---
+name: worker-high-effort
+description: Effort-pinned general-purpose worker running at high reasoning effort. Explicit dispatch target for superpowers dispatch skills (subagent-driven-development, dispatching-parallel-agents) when the caller has judged the task to need real judgment, such as design work or the final whole-branch review. The caller supplies the role, task, and model at dispatch. This agent only fixes the reasoning effort the Task tool cannot set per invocation. Not for automatic delegation.
+effort: high
+---
+
+You are a general-purpose worker running at high reasoning effort. Your role, task, and instructions come entirely from the dispatch prompt you were given. Take the time the task needs, state your reasoning, and flag any uncertainty explicitly rather than smoothing over a gap to produce a tidier answer. Follow the prompt exactly and do not expand scope.

--- a/agents/worker-low-effort.md
+++ b/agents/worker-low-effort.md
@@ -1,0 +1,7 @@
+---
+name: worker-low-effort
+description: Effort-pinned general-purpose worker running at low reasoning effort. Explicit dispatch target for superpowers dispatch skills (subagent-driven-development, dispatching-parallel-agents) when the caller has judged the task transcription-grade or mechanical. The caller supplies the role, task, and model at dispatch. This agent only fixes the reasoning effort the Task tool cannot set per invocation. Not for automatic delegation.
+effort: low
+---
+
+You are a general-purpose worker running at low reasoning effort. Your role, task, and instructions come entirely from the dispatch prompt you were given. Follow it exactly and do not expand scope. If the task turns out to need more reasoning than low effort supports, say so plainly and stop, so the caller can re-dispatch you at a higher tier.

--- a/agents/worker-medium-effort.md
+++ b/agents/worker-medium-effort.md
@@ -1,0 +1,7 @@
+---
+name: worker-medium-effort
+description: Effort-pinned general-purpose worker running at medium reasoning effort. Explicit dispatch target for superpowers dispatch skills (subagent-driven-development, dispatching-parallel-agents) when the caller has judged the task standard implementation or integration work. The caller supplies the role, task, and model at dispatch. This agent only fixes the reasoning effort the Task tool cannot set per invocation. Not for automatic delegation.
+effort: medium
+---
+
+You are a general-purpose worker running at medium reasoning effort. Your role, task, and instructions come entirely from the dispatch prompt you were given. Take the reasoning the task needs without over-investing, follow the prompt exactly, and do not expand scope. If the task turns out to need more reasoning than medium effort supports, say so plainly and stop, so the caller can re-dispatch you at a higher tier.

--- a/docs/superpowers/specs/2026-07-06-sdd-effort-dimension-design.md
+++ b/docs/superpowers/specs/2026-07-06-sdd-effort-dimension-design.md
@@ -1,0 +1,250 @@
+# SDD Effort Dimension Design
+
+**Status:** Proposed. Ships the effort-control mechanism and dispatch
+guidance. Makes no measured cost claim (see Validation).
+**Issue:** obra/superpowers#1747.
+**Objective:** give SDD a per-role reasoning-effort dial, so a subagent's
+effort matches its task instead of inheriting the session's.
+
+## Overview
+
+SDD dispatches every subagent (implementer, task reviewer, fix, final
+reviewer) at the session's reasoning effort, because effort cannot be set at
+dispatch. A high-effort session spends high-effort reasoning transcribing a
+plan that already contains the code. A default-effort session runs the final
+whole-branch review, which SDD pins to the most capable model, at default
+effort. SDD already matches the *model* to the task (the Model Selection
+section, from the #1744 cost-tiering work). Effort is the same dial's second
+axis, fixed at the session level today.
+
+This design adds effort as an explicit SDD dispatch dimension. On Claude Code
+it ships a small roster of effort-pinned worker agents (the only mechanism
+that sets per-role effort there). On Codex it documents the native
+`model_reasoning_effort` key. On other harnesses it documents the
+session-level limitation. The role prompts, the dispatch flow, and the model
+choice are all unchanged.
+
+## Relationship to existing work
+
+This sits directly beside the Model Selection section produced by the
+strict-cost SDD work (`2026-06-10-strict-cost-sdd-design.md`, PR #1744) and
+reuses its structure and its guardrails:
+
+- **Effort is the second axis of the model dial.** The task-type boundaries
+  are the same ones Model Selection already validated (transcription vs
+  standard vs judgment). This design does not introduce new task
+  categories; it maps the existing ones to an effort level.
+- **The judgment guardrail applies unchanged: cheapen mechanics, never
+  judgment.** Low effort is used only where the work is mechanical
+  (deterministic, cheaply verifiable, gated by the task review). High
+  effort stays on every judgment point: the final whole-branch review,
+  subtle reviews, BLOCKED diagnosis, and adjudication. Matching effort to
+  task type this way does not trade quality for cost, which is what lets
+  the guidance ship ahead of the full eval campaign (see Validation).
+
+The strict-cost L1 ladder proposed a per-task complexity tag from the
+planner (`mechanical / standard / judgment`). If that ships, the same tag
+can drive both the model tier and the effort level. This design does not
+depend on it and does not implement it.
+
+## Mechanism, per harness
+
+The harnesses expose reasoning depth at different points, which is why the
+mechanism is harness-conditional while the guidance is harness-general.
+
+- **Claude Code.** The Task tool overrides `model` per dispatch but not
+  `effort`. The only per-subagent effort control is agent-definition
+  frontmatter. Subagent calls carry the agent's frontmatter effort on the
+  wire and are sent with thinking disabled, so prompt-level thinking cues
+  are inert for subagents. Therefore effort control requires named agent
+  files. A dispatch-time `model` override takes precedence over an agent's
+  frontmatter model, so an agent file can pin *only* effort and leave the
+  model to the dispatch. The two axes stay independent.
+- **Codex.** `model_reasoning_effort` is a first-class per-custom-agent key
+  that inherits from the session when unset. The knob exists natively; the
+  guidance simply tells SDD to set it.
+- **Other harnesses (Gemini CLI and similar).** Reasoning depth is exposed
+  at session or model-selection level, with no per-role mechanism. No
+  change beyond documenting the session-effort tax.
+
+## Component 1: effort-pinned worker roster
+
+New directory `agents/` at the plugin root (Claude Code auto-discovers it).
+Three files, each a general-purpose worker distinguished only by its effort
+frontmatter:
+
+```
+agents/worker-low-effort.md      effort: low
+agents/worker-medium-effort.md   effort: medium
+agents/worker-high-effort.md     effort: high
+```
+
+**Frontmatter.** `name`, `description`, `effort`. No `model` key, so the
+dispatch-time model override supplies the model (and the agent falls back to
+the session model if a dispatch ever omits it). No `tools` key, so the agent
+inherits the full toolset, which implementers need for edits and reviewers
+use read-only by their prompt. The `description` states that the agent is an
+explicit dispatch target for superpowers dispatch skills and not for
+automatic delegation, so Claude does not auto-select it for unrelated tasks.
+
+**Body.** A short, role-neutral system prompt that fixes only the effort
+posture and defers everything else to the dispatch prompt. It must not
+impose a role, since the same worker serves implementers and reviewers.
+Example for `worker-low-effort.md`:
+
+```markdown
+---
+name: worker-low-effort
+description: Effort-pinned general-purpose worker running at low reasoning
+  effort. Explicit dispatch target for superpowers dispatch skills
+  (subagent-driven-development, dispatching-parallel-agents) when the caller
+  has judged the task transcription-grade or mechanical. The caller supplies
+  the role, task, and model at dispatch; this agent only fixes the reasoning
+  effort the Task tool cannot set per invocation. Not for automatic delegation.
+effort: low
+---
+
+You are a general-purpose worker running at low reasoning effort. Your role,
+task, and instructions come entirely from the dispatch prompt you were given.
+Follow it exactly and do not expand scope. If the task turns out to need more
+reasoning than low effort supports, say so plainly and stop, so the caller can
+re-dispatch you at a higher tier.
+```
+
+`worker-medium-effort.md` and `worker-high-effort.md` are identical except
+for the effort level and a body tuned to it (medium: "take the reasoning the
+task needs without over-investing"; high: "take the time the task needs,
+state your reasoning, and flag uncertainty rather than smoothing it over").
+
+**Naming.** `worker-<level>-effort`, referenceable bare or as
+`superpowers:worker-<level>-effort`. The plugin namespace disambiguates from
+any other effort agents a user has installed. The names are role-agnostic on
+purpose, so `dispatching-parallel-agents` can use them too.
+
+**Effort levels.** Low, medium, high cover the three task-type tiers and are
+supported across the models SDD uses. xhigh and max are deliberately omitted
+from the first roster (YAGNI); adding a file later is trivial if a role
+needs one.
+
+**Haiku caveat.** Haiku has no effort parameter, so `worker-low-effort`
+dispatched on Haiku runs Haiku with no effort change. That is acceptable for
+the cheapest tier, since Haiku is already the reasoning floor. When low
+effort is wanted on a non-floor model, pair `worker-low-effort` with a model
+that honors effort (for example Sonnet). The guidance states this.
+
+## Component 2: Effort Selection section in the SDD skill
+
+A new `## Effort Selection` subsection in
+`skills/subagent-driven-development/SKILL.md`, placed immediately after
+`## Model Selection` and mirroring its shape. Content:
+
+- Effort is the second axis of the same capability match; set it to the
+  least effort the role needs, for the same cost reason model is set.
+- The judgment guardrail, restated: cheapen mechanics, never judgment.
+- Role-to-effort map:
+  - Transcription-grade implementation (the plan carries the complete code)
+    and single-file mechanical fixes: low.
+  - Standard implementation from a prose spec, and integration work: medium.
+  - Design or architecture implementation: high.
+  - The final whole-branch review: high, on the most capable model. It is a
+    judgment task, so do not lower its effort.
+  - Task reviewer: scale effort to the diff exactly as the model is scaled.
+    A small mechanical diff does not need high effort. A subtle change
+    (concurrency, a contract change, shared state) does. Reviewing is
+    judgment, so do not default reviewer effort to the floor.
+  - Fix subagents: match the task's tier, one step up if the fix itself
+    needs judgment the original task did not.
+- The dispatch rule, the analog of "always specify the model explicitly":
+  on Claude Code, always dispatch through the effort-matched worker agent.
+  An omitted effort inherits the session's and defeats this section.
+- The per-harness mechanism note (Claude Code worker agents, Codex
+  `model_reasoning_effort`, other harnesses session-level with the effort
+  tax), and the Haiku caveat.
+
+## Component 3: dispatch template edits
+
+`skills/subagent-driven-development/implementer-prompt.md` and
+`task-reviewer-prompt.md` each change their dispatch header. Today it reads
+`Subagent (general-purpose):` with a required `model:` placeholder. It
+becomes a dispatch target that names the effort-matched worker on Claude
+Code, keeps `general-purpose` as the fallback when the roster is absent or on
+non-Claude-Code harnesses, keeps the `model:` placeholder unchanged, and
+adds an `effort:` note that points at the new Effort Selection section (and,
+for Codex, at `model_reasoning_effort`). The templates stay harness-general.
+
+## Component 4: final review and standalone code review
+
+SDD's final whole-branch review dispatches via `worker-high-effort` on the
+most capable model. This is stated in the Effort Selection section (Component
+2), since SDD's final review reuses the `requesting-code-review` template
+rather than owning one. One line is added to
+`skills/requesting-code-review/code-reviewer.md` noting effort selection, so
+the standalone use of that skill is not left without the dimension. The
+substantive guidance stays in SDD.
+
+## Component 5: tests
+
+A shell test under `tests/claude-code/`, following the existing convention
+(bash, sourced `test-helpers.sh`), doing static validation with no CLI
+invocation:
+
+- Every `agents/worker-*-effort.md` parses, has a `name`, a `description`,
+  and an `effort` value in the supported set (low, medium, high).
+- Every worker name referenced in `SKILL.md` and the two templates has a
+  matching file in `agents/` (a drift guard against renaming one and not the
+  other).
+
+Static and deterministic, so it runs fast and does not depend on a live
+model.
+
+## Validation
+
+The mechanism (Components 1, 3, 4, 5) and the fact that effort is a
+dispatchable second axis are unconditional. They add capability and make no
+cost or quality claim.
+
+The role-to-effort defaults (Component 2) make no *measured* cost claim. The
+repo's standard for behavior-changing cost guidance is the N=5 eval gate
+campaign (`sdd-quality-reviewer-catches-planted-defect`,
+`sdd-rejects-extra-features`, deliverable parity), and this design does not
+run it. The defaults are safe to ship ahead of that campaign for one
+specific reason: the direction respects the judgment guardrail by
+construction. High effort stays on every judgment point, and low effort is
+applied only to task types Model Selection already validated as mechanical,
+where the task review gate catches errors. So the guidance cannot regress
+quality by matching effort to task type, whatever the eventual measured
+magnitude of the cost saving turns out to be.
+
+What remains eval-pending, and is called out as such rather than claimed:
+the magnitude of the cost saving from lowering implementer effort, and
+whether effort-token dynamics differ from the thinking-cap result the
+strict-cost campaign measured backfiring (effort is the model's own
+target-depth control, not a truncation cap, so that result should not
+transfer a priori, but it is not measured here). If the maintainer wants the
+defaults gated, the same harness that gated the model tiers applies
+unchanged, since the task categories are identical.
+
+## Scope boundaries
+
+**Touches:** new `agents/` directory (three worker files),
+`skills/subagent-driven-development/SKILL.md`, its two prompt templates, one
+line in `skills/requesting-code-review/code-reviewer.md`, one new test.
+
+**Does not touch:** the Model Selection section's content (effort sits beside
+it, does not rewrite it), the model-tiering work, other skills, or Codex and
+Gemini config files. Codex is documented, not shipped, because superpowers
+ships no per-role Codex custom-agent TOMLs today; when it does, the effort key
+goes in alongside the model choice.
+
+**Non-goals:** running the eval campaign, implementing the planner complexity
+tag, adding xhigh/max workers, or changing role prompts or the dispatch flow.
+
+## Open decisions
+
+- **RELEASE-NOTES entry.** Whether this PR adds a RELEASE-NOTES stanza and a
+  version bump, or leaves both to the maintainer at release time. Default:
+  leave the bump to the maintainer; add a notes stanza only if the
+  maintainer's PRs conventionally include one.
+- **Worker naming.** `worker-<level>-effort` versus a more explicit prefix
+  (`sp-worker-...`). Default: `worker-<level>-effort`, relying on the
+  `superpowers:` plugin namespace to disambiguate.

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -3,8 +3,9 @@
 Use this template when dispatching a code reviewer subagent.
 
 On Claude Code, dispatch through the effort-matched worker agent, scaled to the
-review's difficulty (see subagent-driven-development's Effort Selection). On
-Codex, set model_reasoning_effort.
+review's difficulty (see subagent-driven-development's Effort Selection). SDD's
+final whole-branch review is a judgment task and stays at high effort regardless
+of the diff size. On Codex, set model_reasoning_effort.
 
 **Purpose:** Review completed work against requirements and code quality standards before it cascades into more work.
 

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -2,6 +2,10 @@
 
 Use this template when dispatching a code reviewer subagent.
 
+On Claude Code, dispatch through the effort-matched worker agent, scaled to the
+review's difficulty (see subagent-driven-development's Effort Selection). On
+Codex, set model_reasoning_effort.
+
 **Purpose:** Review completed work against requirements and code quality standards before it cascades into more work.
 
 ```

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -129,6 +129,59 @@ that implementer. Single-file mechanical fixes also take the cheapest tier.
 - Touches multiple files with integration concerns → standard model
 - Requires design judgment or broad codebase understanding → most capable model
 
+## Effort Selection
+
+Reasoning effort is the second axis of the same capability match as Model
+Selection. Set it to the least effort the role needs, for the same reason you
+set the model: a high-effort session spends high-effort reasoning transcribing
+a plan that already contains the code, and a default-effort session runs the
+final review at default effort.
+
+The judgment guardrail from Model Selection applies unchanged:
+cheapen mechanics, never judgment. Low effort goes only to mechanical work
+(deterministic, cheaply verifiable, gated by the task review). High effort
+stays on every judgment point. Matching effort to task type this way does not
+trade quality for cost, because the task categories are the ones Model
+Selection already draws.
+
+**Effort by role:**
+- Transcription-grade implementation (the plan carries the complete code) and
+  single-file mechanical fixes: low.
+- Standard implementation from a prose spec, and integration work: medium.
+- Design or architecture implementation: high.
+- The final whole-branch review: high, on the most capable model. It is a
+  judgment task, so do not lower its effort.
+- Task reviewer: scale effort to the diff exactly as you scale the model. A
+  small mechanical diff does not need high effort. A subtle change
+  (concurrency, a contract change, shared mutable state) does. Reviewing is
+  judgment, so do not default reviewer effort to the floor.
+- Fix subagents: match the task's tier, one step up if the fix itself needs
+  judgment the original task did not.
+
+**Always dispatch through the effort-matched agent on Claude Code.** An omitted
+effort inherits the session's, which defeats this section, the same way an
+omitted model does for Model Selection.
+
+**Per-harness mechanism.** The harnesses expose reasoning depth at different
+points:
+- **Claude Code:** the Task tool overrides model per dispatch but not effort.
+  The only per-subagent effort control is agent-definition frontmatter, so
+  dispatch through the effort-matched worker agent shipped in this plugin's
+  `agents/` directory: `worker-low-effort`, `worker-medium-effort`,
+  `worker-high-effort`. A dispatch-time model override still takes precedence
+  over the agent's frontmatter, so pick the model per Model Selection and the
+  effort by the worker name. The two axes stay independent.
+- **Codex:** set `model_reasoning_effort` in the role's custom-agent config
+  alongside its model. Unset keys inherit from the session.
+- **Other harnesses:** effort is session-level only. A session pinned high
+  pays an effort tax on every micro-task, with no per-role control until the
+  harness adds one.
+
+Haiku has no effort parameter, so `worker-low-effort` dispatched on Haiku runs
+Haiku with no effort change. That is fine for the cheapest tier, since Haiku is
+already the reasoning floor. When you want low effort on a non-floor model,
+pair `worker-low-effort` with a model that honors effort (for example Sonnet).
+
 ## Handling Implementer Status
 
 Implementer subagents report one of four statuses. Handle each appropriately:

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -3,10 +3,16 @@
 Use this template when dispatching an implementer subagent.
 
 ```
-Subagent (general-purpose):
+Subagent (Claude Code: the effort-matched worker per SKILL.md Effort
+Selection, one of worker-low-effort, worker-medium-effort, or
+worker-high-effort. Other harnesses, or if the roster is absent:
+general-purpose):
   description: "Implement Task N: [task name]"
   model: [MODEL — REQUIRED: choose per SKILL.md Model Selection; an omitted
          model silently inherits the session's most expensive one]
+  effort: [Claude Code carries effort via the worker agent above. Codex: set
+          model_reasoning_effort per SKILL.md Effort Selection. Other
+          harnesses run at session effort.]
   prompt: |
     You are implementing Task N: [task name]
 

--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -8,10 +8,16 @@ code quality.
 more, nothing less) and is well-built (clean, tested, maintainable)
 
 ```
-Subagent (general-purpose):
+Subagent (Claude Code: the effort-matched worker per SKILL.md Effort
+Selection, scaled to the diff, one of worker-low-effort, worker-medium-effort,
+or worker-high-effort. Other harnesses, or if the roster is absent:
+general-purpose):
   description: "Review Task N (spec + quality)"
   model: [MODEL — REQUIRED: choose per SKILL.md Model Selection; an omitted
          model silently inherits the session's most expensive one]
+  effort: [Claude Code carries effort via the worker agent above. Codex: set
+          model_reasoning_effort per SKILL.md Effort Selection. Other
+          harnesses run at session effort.]
   prompt: |
     You are reviewing one task's implementation: first whether it matches its
     requirements, then whether it is well-built. This is a task-scoped gate,
@@ -167,6 +173,10 @@ Subagent (general-purpose):
 
 **Placeholders:**
 - `[MODEL]` — REQUIRED: reviewer model per SKILL.md Model Selection
+- `[EFFORT]` REQUIRED on Claude Code: dispatch through the effort-matched
+  worker agent (worker-low-effort, worker-medium-effort, or worker-high-effort),
+  scaled to the diff, per SKILL.md Effort Selection. On Codex, set
+  model_reasoning_effort instead.
 - `[BRIEF_FILE]` — REQUIRED: the task brief file (`scripts/task-brief PLAN N`
   prints the path; same file the implementer worked from)
 - `[GLOBAL_CONSTRAINTS]` — the binding requirements copied verbatim from

--- a/tests/claude-code/run-skill-tests.sh
+++ b/tests/claude-code/run-skill-tests.sh
@@ -75,6 +75,7 @@ done
 tests=(
     "test-worktree-path-policy.sh"
     "test-sdd-workspace.sh"
+    "test-effort-worker-roster.sh"
     "test-subagent-driven-development.sh"
 )
 

--- a/tests/claude-code/test-effort-worker-roster.sh
+++ b/tests/claude-code/test-effort-worker-roster.sh
@@ -68,10 +68,28 @@ check_drift_guard() {
     done <<< "$refs"
 }
 
+check_effort_section() {
+    echo "--- SDD SKILL.md has Effort Selection section referencing the roster ---"
+    local skill="$SDD_DIR/SKILL.md"
+    grep -q '^## Effort Selection' "$skill" \
+        && pass "SKILL.md has '## Effort Selection'" \
+        || fail "SKILL.md missing '## Effort Selection'"
+    grep -q 'cheapen mechanics, never judgment' "$skill" \
+        && pass "Effort Selection keeps the judgment guardrail" \
+        || fail "Effort Selection missing the judgment guardrail phrase"
+    local level
+    for level in low medium high; do
+        grep -q "worker-${level}-effort" "$skill" \
+            && pass "Effort Selection references worker-${level}-effort" \
+            || fail "Effort Selection missing worker-${level}-effort"
+    done
+}
+
 main() {
     echo "=== Test: effort worker roster ==="
     check_roster
     check_drift_guard
+    check_effort_section
     if [[ "$FAILURES" -gt 0 ]]; then
         echo "FAILED ($FAILURES failure(s))"
         exit 1

--- a/tests/claude-code/test-effort-worker-roster.sh
+++ b/tests/claude-code/test-effort-worker-roster.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Tests for the effort-pinned worker roster: agents/worker-<level>-effort.md
+# exist with valid frontmatter, and every worker name referenced in the SDD
+# skill and its dispatch templates has a matching agent file (drift guard).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AGENTS_DIR="$REPO_ROOT/agents"
+SDD_DIR="$REPO_ROOT/skills/subagent-driven-development"
+CODE_REVIEWER="$REPO_ROOT/skills/requesting-code-review/code-reviewer.md"
+
+FAILURES=0
+pass() { echo "  [PASS] $1"; }
+fail() { echo "  [FAIL] $1"; FAILURES=$((FAILURES + 1)); }
+
+# fm_value <file> <key> : print a single-line YAML frontmatter value
+fm_value() {
+    awk -v key="$2" '
+        /^---$/ { d++; next }
+        d==1 && $1==key":" { sub(/^[^:]*:[[:space:]]*/, ""); print; exit }
+    ' "$1"
+}
+
+check_roster() {
+    echo "--- roster files exist with valid frontmatter ---"
+    local level file name effort
+    for level in low medium high; do
+        file="$AGENTS_DIR/worker-${level}-effort.md"
+        if [[ -f "$file" ]]; then
+            pass "exists: agents/worker-${level}-effort.md"
+        else
+            fail "missing: agents/worker-${level}-effort.md"
+            continue
+        fi
+        name="$(fm_value "$file" name)"
+        [[ "$name" == "worker-${level}-effort" ]] \
+            && pass "name matches for worker-${level}-effort" \
+            || fail "name mismatch for worker-${level}-effort (got '$name')"
+        [[ -n "$(fm_value "$file" description)" ]] \
+            && pass "has description: worker-${level}-effort" \
+            || fail "missing description: worker-${level}-effort"
+        effort="$(fm_value "$file" effort)"
+        [[ "$effort" == "$level" ]] \
+            && pass "effort=$level for worker-${level}-effort" \
+            || fail "effort mismatch for worker-${level}-effort (got '$effort')"
+    done
+}
+
+check_drift_guard() {
+    echo "--- every referenced worker name has a file (drift guard) ---"
+    local refs name
+    refs="$(grep -rhoE 'worker-(low|medium|high)-effort' \
+        "$SDD_DIR/SKILL.md" \
+        "$SDD_DIR/implementer-prompt.md" \
+        "$SDD_DIR/task-reviewer-prompt.md" \
+        "$CODE_REVIEWER" \
+        2>/dev/null | sort -u || true)"
+    if [[ -z "$refs" ]]; then
+        pass "no worker references yet (nothing to drift)"
+        return
+    fi
+    while IFS= read -r name; do
+        [[ -n "$name" ]] || continue
+        [[ -f "$AGENTS_DIR/${name}.md" ]] \
+            && pass "referenced $name has a file" \
+            || fail "referenced $name has NO file in agents/"
+    done <<< "$refs"
+}
+
+main() {
+    echo "=== Test: effort worker roster ==="
+    check_roster
+    check_drift_guard
+    if [[ "$FAILURES" -gt 0 ]]; then
+        echo "FAILED ($FAILURES failure(s))"
+        exit 1
+    fi
+    echo "OK"
+}
+
+main "$@"

--- a/tests/claude-code/test-effort-worker-roster.sh
+++ b/tests/claude-code/test-effort-worker-roster.sh
@@ -85,11 +85,31 @@ check_effort_section() {
     done
 }
 
+check_template_wiring() {
+    echo "--- dispatch templates reference the effort roster / Effort Selection ---"
+    grep -q 'Effort Selection' "$SDD_DIR/implementer-prompt.md" \
+        && pass "implementer-prompt references Effort Selection" \
+        || fail "implementer-prompt missing Effort Selection reference"
+    grep -q 'model_reasoning_effort' "$SDD_DIR/implementer-prompt.md" \
+        && pass "implementer-prompt notes Codex model_reasoning_effort" \
+        || fail "implementer-prompt missing Codex effort note"
+    grep -q 'Effort Selection' "$SDD_DIR/task-reviewer-prompt.md" \
+        && pass "task-reviewer-prompt references Effort Selection" \
+        || fail "task-reviewer-prompt missing Effort Selection reference"
+    grep -q 'model_reasoning_effort' "$SDD_DIR/task-reviewer-prompt.md" \
+        && pass "task-reviewer-prompt notes Codex model_reasoning_effort" \
+        || fail "task-reviewer-prompt missing Codex effort note"
+    grep -qi 'effort' "$CODE_REVIEWER" \
+        && pass "code-reviewer template notes effort" \
+        || fail "code-reviewer template missing effort note"
+}
+
 main() {
     echo "=== Test: effort worker roster ==="
     check_roster
     check_drift_guard
     check_effort_section
+    check_template_wiring
     if [[ "$FAILURES" -gt 0 ]]; then
         echo "FAILED ($FAILURES failure(s))"
         exit 1

--- a/tests/claude-code/test-effort-worker-roster.sh
+++ b/tests/claude-code/test-effort-worker-roster.sh
@@ -99,9 +99,12 @@ check_template_wiring() {
     grep -q 'model_reasoning_effort' "$SDD_DIR/task-reviewer-prompt.md" \
         && pass "task-reviewer-prompt notes Codex model_reasoning_effort" \
         || fail "task-reviewer-prompt missing Codex effort note"
-    grep -qi 'effort' "$CODE_REVIEWER" \
-        && pass "code-reviewer template notes effort" \
-        || fail "code-reviewer template missing effort note"
+    grep -q 'Effort Selection' "$CODE_REVIEWER" \
+        && pass "code-reviewer template references Effort Selection" \
+        || fail "code-reviewer template missing Effort Selection reference"
+    grep -q 'model_reasoning_effort' "$CODE_REVIEWER" \
+        && pass "code-reviewer template notes Codex model_reasoning_effort" \
+        || fail "code-reviewer template missing Codex effort note"
 }
 
 main() {


### PR DESCRIPTION
## Who is submitting this PR?

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (1M-context variant), model id `claude-opus-4-8[1m]` |
| Harness + version | Claude Code 2.1.201 |
| All plugins installed | `superpowers@claude-plugins-official`, `axiom@claude-code-plugins-plus`, `backend-development@claude-code-workflows`, `code-documentation@claude-code-workflows`, `javascript-typescript@claude-code-workflows`, `frontend-design@claude-plugins-official`, `ui-designer@cc-marketplace` |
| Human partner who reviewed this diff | Gabriel Borges (@gborges0727) |

This PR implements issue #1747. The design, plan, and skill wording were produced by the agent above and reviewed line by line by the human partner; the changes were executed with `superpowers:subagent-driven-development` (fresh implementer + two-stage review per task) and the guidance was tested with `superpowers:writing-skills` and a live `quorum` drill.

## What problem are you trying to solve?

SDD dispatches every subagent (implementer, task reviewer, fix, final reviewer) at the session's reasoning effort, because on Claude Code effort cannot be set at dispatch: the Task tool overrides `model` per invocation but not `effort`, and the only per-subagent effort control is agent-definition frontmatter. We hit this first-hand executing this very PR with SDD: dispatching implementers and reviewers, the Agent/Task tool exposed a `model` parameter and no `effort` parameter, so every subagent inherited the session effort regardless of task type.

The misallocation runs both ways, and one direction is a quality risk, not just a cost one. A high-effort session spends high-effort reasoning transcribing plan tasks that already contain the complete code (the effort twin of the "most capable model for transcription-grade tasks" waste that #1744's model fix measured but does not touch). More importantly, a default-effort session runs the final whole-branch review, which SDD deliberately pins to the most capable model, at default effort, and under cost pressure a controller will scale that review's effort down. SDD already matches the model to the task (the Model Selection section from #1744). Effort is the same dial's second axis, and it was welded to the session.

Issue #1747 documents the mechanics per harness, measured at the API request level with a logging proxy (subagent calls carry the agent frontmatter's `output_config.effort` on the wire and are sent with `thinking: disabled`, so prompt-level thinking cues are inert for subagents).

## What does this PR change?

It adds an `## Effort Selection` section to the `subagent-driven-development` skill (mirroring the neighboring Model Selection section and reusing its judgment guardrail), ships three effort-pinned worker agents in a new `agents/` directory (`worker-low-effort`, `worker-medium-effort`, `worker-high-effort`, each carrying only an `effort` value so a dispatch-time model override still wins), wires the effort dimension into the two SDD dispatch templates and the shared code-reviewer template, and adds a static test guarding the roster and its references. No existing guidance is rewritten.

## Is this change appropriate for the core library?

Yes. It is general-purpose SDD guidance that benefits any project, not domain-, team-, or tool-specific, and it adds no third-party dependency. It is the same shape as the existing Model Selection guidance: harness-general reasoning (match effort to task type) with a harness-conditional mechanism (Claude Code needs agent files because the Task tool cannot set effort; Codex has a native `model_reasoning_effort` per-agent key; other harnesses expose effort only at session level, which the section documents). It is not a new skill and does not restructure or reword the project's existing, tuned content.

## What alternatives did you consider?

- **Session-effort guidance only (docs, zero mechanism).** Cannot express "low for transcription implementers, high for the final review" simultaneously in one session, which is the actual win. Rejected.
- **Per-invocation `effort` on Claude Code's Task tool.** Would dissolve the problem cleanly and is requested upstream (anthropics/claude-code#25669, #43083, #14321), but has no movement; agent files work today. This PR is the mechanism that exists now, and it becomes a thin fallback if the Task tool later gains the parameter.
- **Roster shape.** The issue sketched model+effort baked into each agent name (`implementer-sonnet-med`). We rejected that: since the Task tool's model override takes precedence over frontmatter, an agent only needs to carry effort, so three role-agnostic effort workers replace a role x model x effort matrix, avoid stale model names in filenames, and preserve the existing "specify the model per task" philosophy.
- **Thinking-token caps.** #1744 measured these backfiring (E06, output tokens +80%). Effort is a different mechanism (the model's own target-depth control, not a truncation cap), so that result should not transfer a priori, but this PR makes no cost-magnitude claim on that basis; see Evaluation.
- **Do nothing.** Every long autonomous SDD session keeps paying session-effort prices on transcription tasks and risks running the final review below its pinned tier.

## Does this PR contain multiple unrelated changes?

No. One logical change: the effort dimension for SDD dispatch. Every file touched (the roster, the Effort Selection section, the three dispatch templates, the test) serves that single feature.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1744 (MERGED), #1786 (CLOSED), #1852 (CLOSED), #1748 (CLOSED)

No open or closed PR addresses reasoning effort; this is the effort axis, distinct from every model-selection PR. #1744 (the merged cost-tiering stack) is the direct sibling this builds beside, adding the orthogonal effort axis without touching its Model Selection content. #1786 (harness-aware Model Selection) was closed for sitting on a stale base and adding a duplicate section rather than editing existing guidance; this PR is on current `dev` and adds a distinct new dimension adjacent to Model Selection, not a duplicate of it. #1852 was closed as opencode-go-gateway-specific roster guidance kept on a fork; this change is harness-general and vendor-neutral. #1748 ("model selection hard gate") is a different, model-axis proposal.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code | 2.1.201 | Opus (controller) / Sonnet (subagents + eval subject) | claude-opus-4-8[1m] / claude-sonnet-4-6 |

## New harness support

N/A. This PR does not add a new harness.

## Evaluation

**Initial prompt that led to this change:** "i want to try to implement a PR for issue https://github.com/obra/superpowers/issues/1747".

**Static test:** `tests/claude-code/test-effort-worker-roster.sh` validates the roster frontmatter and guards that every worker name referenced in the skill and templates resolves to an agent file. Green.

**Adversarial behavior micro-test (writing-skills methodology), 5 reps per arm, each read manually.** Fresh-context subagents act as the SDD controller and answer a two-dispatch scenario (a transcription task, and the final whole-branch review on a small branch with "minimize cost" pressure). Control arm sees only Model Selection; treatment arm additionally sees Effort Selection.

| Metric | Control (no Effort Selection) | Treatment (+ Effort Selection) |
|---|---|---|
| Transcription dispatch effort | 5/5 low | 5/5 low |
| Transcription dispatch agent (delivers effort on Claude Code?) | 5/5 general-purpose (cannot set effort) | 5/5 worker-low-effort (carries it) |
| Final review effort under cost pressure | 4/5 high, 1/5 slipped to medium | 5/5 high |
| Final review dispatch agent | 5/5 code-reviewer/general-purpose | 5/5 worker-high-effort |

The guidance moves the controller from asserting an effort it cannot deliver to routing through the worker agents that carry it (0/5 to 5/5), and it closes the guardrail slip (the control lowered the final review's effort under cost pressure 1/5; the treatment held it 5/5). Honest caveat: the prompt supplied an effort field, so this measures mechanism-routing and guardrail-holding, not whether an unprompted controller spontaneously considers effort.

**Live drill (`superpowers-evals` quorum, `sdd-rejects-extra-features`, Claude Code, Sonnet).** The same scenario (a full SDD execution of a two-function plan with two-stage review) ran against `dev` (baseline) and against this branch, each via `--plugin-dir` on the respective checkout. Both passed all acceptance criteria and 8/8 deterministic post-checks, so the change is non-regressive. The dispatch pattern is the difference:

| Dispatch | dev baseline (agent / model) | this branch (agent / model) |
|---|---|---|
| Implement Task 1 (add) | general-purpose / haiku | worker-low-effort / haiku |
| Review Task 1 | general-purpose / haiku | worker-medium-effort / sonnet |
| Implement Task 2 (multiply) | general-purpose / haiku | worker-low-effort / haiku |
| Review Task 2 | general-purpose / sonnet | worker-medium-effort / sonnet |
| Final whole-branch review | general-purpose / opus | worker-high-effort / opus |

On `dev`, all five subagents dispatch as `general-purpose` with zero worker references: effort is welded to the session. On this branch, the controller routes each role through the matching effort worker, and the final whole-branch review holds `worker-high-effort` + opus on a two-function diff (the judgment guardrail firing in a real session, not just the micro-test). The run also confirms two things end-to-end that the tool schema only implied: the plugin's `agents/` dir loads via `--plugin-dir` so the workers are dispatchable, and a dispatch-time model override composes with a named effort agent (`worker-low-effort` dispatched with `model: haiku`).

**What this PR does not claim.** It makes no measured cost-magnitude claim. The cost saving from lowering implementer effort remains eval-pending, as the spec states; the change ships the mechanism and the guidance, whose direction is safe by construction because it respects the judgment guardrail (high effort stays on the final review and every judgment point; low effort goes only to task types Model Selection already validated as mechanical, gated by the task review).

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results in Evaluation above)
- [x] This change was tested adversarially, not just on the happy path (cost-pressure temptation on the final-review guardrail; 5 reps per arm read manually)
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language). The Effort Selection section is new and additive; the Model Selection section is untouched.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
