### PR TITLE
Store subagent-driven-development artifacts in a per-branch subdirectory

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -223,8 +223,11 @@ prints back — stays resident in your context for the rest of the session
 and is re-read on every later turn. Hand artifacts over as files:
 
 - **Task brief:** before dispatching an implementer, run this skill's
-  `scripts/task-brief PLAN_FILE N` — it extracts the task's full text to a
-  uniquely named file and prints the path. Compose the dispatch so the
+  `scripts/task-brief PLAN_FILE N` — it extracts the task's full text to
+  `.superpowers/sdd/<branch>/task-N-brief.md` (a per-branch subdirectory, `/`
+  in the branch replaced by `-`, so briefs from different branches never
+  collide) and prints the path. Always use the printed path, not a hand-built
+  name. Compose the dispatch so the
   brief stays the single source of requirements. Your dispatch should
   contain: (1) one line on where this task fits in the project; (2) the
   brief path, introduced as "read this first — it is your requirements,
@@ -234,7 +237,8 @@ and is re-read on every later turn. Hand artifacts over as files:
   report contract. Exact values (numbers, magic strings, signatures, test
   cases) appear only in the brief.
 - **Report file:** name the implementer's report file after the brief
-  (brief `…/task-N-brief.md` → report `…/task-N-report.md`) and put it in
+  (brief `…/<branch>/task-N-brief.md` → report `…/<branch>/task-N-report.md`,
+  in the same per-branch subdirectory) and put it in
   the dispatch prompt. The implementer writes the full report there and
   returns only status, commits, a one-line test summary, and concerns.
 - **Reviewer inputs:** the task reviewer gets three paths — the same brief

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -5,8 +5,9 @@
 # tasks intact.
 #
 # Usage: review-package BASE HEAD [OUTFILE]
-# Default OUTFILE: <repo-root>/.superpowers/sdd/review-<base7>..<head7>.diff
-# (named per range, so a re-review after fixes gets a distinct fresh file).
+# Default OUTFILE: <repo-root>/.superpowers/sdd/<branch>/review-<base7>..<head7>.diff
+# (sdd-workspace puts it in a per-branch subdirectory, so packages from different
+# branches don't collide; named per range, so a re-review after fixes gets a distinct fresh file).
 set -euo pipefail
 
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then

--- a/skills/subagent-driven-development/scripts/sdd-workspace
+++ b/skills/subagent-driven-development/scripts/sdd-workspace
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
-# Resolve and ensure the working-tree directory SDD uses for its short-lived
-# artifacts: task briefs, implementer reports, review packages, and the
-# progress ledger. Print the directory's absolute path.
+# Resolve and ensure the per-branch working-tree directory SDD uses for its
+# short-lived artifacts: task briefs, implementer reports, and review packages.
+# Print the directory's absolute path. The directory is
+# <repo-root>/.superpowers/sdd/<branch> (branch name with '/' -> '-'), so
+# artifacts from different branches never collide; a detached HEAD (or no
+# branch) falls back to the .superpowers/sdd root.
+#
+# NOTE: the cross-branch progress ledger lives at the sdd ROOT
+# (<repo-root>/.superpowers/sdd/progress.md), not in this per-branch dir — it is
+# a single index namespaced by per-branch headers.
 #
 # The workspace lives in the working tree (not under .git/) because Claude Code
 # treats .git/ as a protected path and denies agent writes there — which blocks
-# an implementer subagent from writing its report file. A self-ignoring
-# .gitignore keeps the workspace out of `git status` and out of accidental
-# commits without modifying any tracked file.
+# an implementer subagent from writing its report file. One self-ignoring
+# .gitignore at the sdd root keeps the whole tree — including the per-branch
+# subdirectories — out of `git status` and out of accidental commits without
+# modifying any tracked file.
 #
 # Single source of truth for the workspace location, so task-brief and
 # review-package cannot drift to different directories.
@@ -16,7 +24,15 @@
 set -euo pipefail
 
 root=$(git rev-parse --show-toplevel)
-dir="$root/.superpowers/sdd"
+base="$root/.superpowers/sdd"
+mkdir -p "$base"
+printf '*\n' > "$base/.gitignore"
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+  dir="$base/$branch"
+else
+  dir="$base"
+fi
 mkdir -p "$dir"
-printf '*\n' > "$dir/.gitignore"
 cd "$dir" && pwd

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -4,8 +4,9 @@
 # through the controller's context.
 #
 # Usage: task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
-# Default OUTFILE: <repo-root>/.superpowers/sdd/task-<N>-brief.md
-# (per worktree; concurrent runs in the same working tree share it).
+# Default OUTFILE: <repo-root>/.superpowers/sdd/<branch>/task-<N>-brief.md
+# (sdd-workspace puts it in a per-branch subdirectory, so artifacts from
+# different branches don't collide; concurrent runs on the same branch share it).
 set -euo pipefail
 
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then


### PR DESCRIPTION
## Problem

`subagent-driven-development`'s `task-brief` and `review-package` scripts write their default output under `.superpowers/sdd/` with names keyed only by task number / commit range (`task-<N>-brief.md`, `review-<base7>..<head7>.diff`). Because `.superpowers/sdd/` is a single flat directory in the working tree, running the skill on a second feature that reuses the same task numbers **in the same working tree** silently overwrites the first feature's brief — and, by the SKILL.md report-file convention, its report too. A stale report from a prior feature's "task 2" can then be handed to the current feature's task reviewer.

## Change

Give each branch its own subdirectory. `sdd-workspace` (already the single source of truth for the artifact location) now resolves/creates `.superpowers/sdd/<branch>/` (branch name with `/` → `-`), and `task-brief` / `review-package` write plain filenames inside it:

- `.superpowers/sdd/<branch>/task-N-brief.md`
- `.superpowers/sdd/<branch>/review-<base>..<head>.diff`
- report convention → `.superpowers/sdd/<branch>/task-N-report.md`

Details:
- Detached HEAD falls back to the `.superpowers/sdd` root — no behavior change.
- An explicit `OUTFILE` (3rd arg) is used verbatim, unaffected.
- One self-ignoring `.gitignore` at the `.superpowers/sdd` root covers the whole tree, including per-branch subdirs.
- The cross-branch `progress.md` ledger stays at the `.superpowers/sdd` root (single index, namespaced by per-branch headers).

Keeping the branch dimension in `sdd-workspace` means `task-brief`/`review-package` use simple branch-agnostic filenames — collision-avoidance lives in one place.

## Testing

- `bash -n` on all three scripts.
- On branch `main`: `sdd-workspace` → `.superpowers/sdd/main`; wrote `.../main/task-1-brief.md` and `.../main/review-<base>..<head>.diff`; `git status` clean (tree ignored).
- Verified `feat/x` → `feat-x` subdir, detached HEAD → sdd root.

_(Supersedes the earlier filename-prefix version of this PR — same goal, cleaner: one subdirectory per branch.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
