### PR TITLE
fix: resolve 6 bugs in brainstorming skill

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -22,21 +22,21 @@ Every project goes through this process. A todo list, a single-function utility,
 You MUST create a task for each of these items and complete them in order:
 
 1. **Explore project context** — check files, docs, recent commits
-2. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
-3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
-4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+2. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
+   - **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
+3. **Propose 2-3 approaches** — with trade-offs and your recommendation
+4. **Present design** — in sections scaled to their complexity; ask for approval after all sections are presented
+5. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+7. **User reviews written spec** — ask user to review the spec file before proceeding
+8. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
 ```dot
 digraph brainstorming {
     "Explore project context" [shape=box];
-    "Ask clarifying questions" [shape=box];
+    "Ask clarifying questions\n(+ offer visual companion)" [shape=box];
     "Propose 2-3 approaches" [shape=box];
     "Present design sections" [shape=box];
     "User approves design?" [shape=diamond];
@@ -45,15 +45,16 @@ digraph brainstorming {
     "User reviews spec?" [shape=diamond];
     "Invoke writing-plans skill" [shape=doublecircle];
 
-    "Explore project context" -> "Ask clarifying questions";
-    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Explore project context" -> "Ask clarifying questions\n(+ offer visual companion)";
+    "Ask clarifying questions\n(+ offer visual companion)" -> "Propose 2-3 approaches";
     "Propose 2-3 approaches" -> "Present design sections";
     "Present design sections" -> "User approves design?";
-    "User approves design?" -> "Present design sections" [label="no, revise"];
+    "User approves design?" -> "Present design sections" [label="no, revise presentation"];
+    "User approves design?" -> "Propose 2-3 approaches" [label="no, wrong approach"];
     "User approves design?" -> "Write design doc" [label="yes"];
     "Write design doc" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "User reviews spec?";
-    "User reviews spec?" -> "Write design doc" [label="changes requested"];
+    "User reviews spec?" -> "Spec self-review\n(fix inline)" [label="changes requested"];
     "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
 }
 ```
@@ -82,7 +83,7 @@ digraph brainstorming {
 
 - Once you believe you understand what you're building, present the design
 - Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
-- Ask after each section whether it looks right so far
+- Present all sections first, then ask for approval on the complete design
 - Cover: architecture, components, data flow, error handling, testing
 - Be ready to go back and clarify if something doesn't make sense
 
@@ -123,7 +124,7 @@ After the spec review loop passes, ask the user to review the written spec befor
 
 > "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
 
-Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+Wait for the user's response. If they request changes, make them, re-run the spec self-review, and present again for user review. Only proceed once the user approves.
 
 **Implementation:**
 
@@ -156,4 +157,4 @@ A browser-based companion for showing mockups, diagrams, and visual options duri
 A question about a UI topic is not automatically a visual question. "What does personality mean in this context?" is a conceptual question — use the terminal. "Which wizard layout works better?" is a visual question — use the browser.
 
 If they agree to the companion, read the detailed guide before proceeding:
-`skills/brainstorming/visual-companion.md`
+`visual-companion.md`


### PR DESCRIPTION
## Summary

Found and fixed 6 bugs in the brainstorming skill (`skills/brainstorming/SKILL.md`) through systematic review.

## Issues Fixed

### 🚫 B1 — Checklist ordering: visual companion offered before clarifying questions (step 2 vs 3)
The visual companion offer was listed as checklist step 2, *before* "Ask clarifying questions" (step 3). But the companion trigger is "the first time a question would genuinely be clearer shown than described" — you cannot have a visually-clearer question before asking any. **Fix:** Moved into clarifying questions as a sub-bullet, renumbered 9 steps → 8.

### 🚫 B2 — Process flow diagram missing visual companion
The 9-step checklist includes "Offer the visual companion" but the DOT diagram had no trace of it. **Fix:** Added "(+ offer visual companion)" to the "Ask clarifying questions" node.

### 🚫 B3 — Per-section approval contradicts the diagram and itself
"Presenting the design" said "Ask after each section whether it looks right so far" but the diagram shows a single approval gate after all sections are presented. **Fix:** Changed text to "Present all sections first, then ask for approval on the complete design" — matches the diagram.

### 🚫 B4 — Spec review loop-back skips the self-review step
When "User reviews spec?" returns "changes requested", the diagram routed back to "Write design doc", skipping "Spec self-review". The description said "re-run the spec review loop" but the diagram contradicted it. **Fix:** Arrow now points to "Spec self-review (fix inline)". Description updated to "re-run the spec self-review, and present again for user review."

### 🚫 B5 — No backtrack path for fundamentally wrong approach
When "User approves design?" returned "no", the only path was back to "Present design sections". If the user rejects the whole approach, you need to go back to proposing alternatives. **Fix:** Added second "no" edge: "no, wrong approach" → "Propose 2-3 approaches".

### 🚫 B6 — Broken relative path to visual-companion.md
The line `skills/brainstorming/visual-companion.md` resolves against the skill directory (`skills/brainstorming/`) to a non-existent path. **Fix:** Changed to `visual-companion.md`.

## Verification

Checked all cross-references between the checklist, flow diagram, and prose sections for consistency. All 6 fixes verified inline.