### PR TITLE
fix(brainstorm): launch BRAINSTORM_OPEN_CMD without a shell

### DIFF
--- a/skills/brainstorming/scripts/server.cjs
+++ b/skills/brainstorming/scripts/server.cjs
@@ -301,6 +301,33 @@ function browserLauncherForPlatform(url, {
   return null;
 }
 
+// Quote-aware tokenizer for the trusted BRAINSTORM_OPEN_CMD operator input.
+// Splits a single- or double-quoted command string into an argv (no shell, no
+// metacharacter expansion), so execFile can launch it without a `sh -c` layer.
+// Returns null on unbalanced quotes so a malformed command is never handed to
+// a shell as a fallback.
+function shellArgv(input) {
+  const argv = [];
+  let cur = '';
+  let quote = null;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (quote) {
+      if (ch === quote) { quote = null; continue; }
+      cur += ch;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (ch === ' ' || ch === '\t' || ch === '\n') {
+      if (cur.length) { argv.push(cur); cur = ''; }
+    } else {
+      cur += ch;
+    }
+  }
+  if (quote) return null; // unbalanced quotes — refuse to guess
+  if (cur.length) argv.push(cur);
+  return argv.length ? argv : null;
+}
+
 function isRegularFileInsideContentDir(filePath) {
   let stat, realContentDir, realFilePath;
   try {
@@ -535,9 +562,17 @@ function maybeOpenBrowser() {
   if (clients.size > 0) return; // the user already opened it
   const url = companionUrl(); // must carry the key or the gate 403s it
   const cp = require('child_process');
-  // Operator-provided launcher: run as given (this env var is trusted operator input).
+  // Operator-provided launcher: this env var is trusted operator input (opt-in,
+  // loopback-only), but we still avoid the shell entirely. Split the command into
+  // an argv with a quote-aware tokenizer and pass the URL as a single argv element
+  // via execFile, mirroring the platform launchers below — so a URL containing
+  // shell metacharacters can never reach a shell. A command that fails to tokenize
+  // (unbalanced quotes) is rejected rather than handed to a shell.
   if (process.env.BRAINSTORM_OPEN_CMD) {
-    try { cp.exec(process.env.BRAINSTORM_OPEN_CMD + ' ' + JSON.stringify(url), () => {}); } catch (e) { /* best effort */ }
+    const argv = shellArgv(process.env.BRAINSTORM_OPEN_CMD);
+    if (argv) {
+      try { cp.execFile(argv[0], argv.slice(1).concat(url), () => {}); } catch (e) { /* best effort */ }
+    }
     return;
   }
   // Platform launchers: pass the URL as an argv element via execFile (no shell),

--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -102,6 +102,22 @@ scripts/start-server.sh \
 
 Use `--url-host` to control what hostname is printed in the returned URL JSON.
 
+### Custom browser launcher: `BRAINSTORM_OPEN_CMD`
+
+The `--open` flag auto-launches the user's default browser using the platform's native launcher. For environments where that doesn't apply — a container with no desktop session, a headless dev box reached via a tunnel, or a non-standard browser binary — set `BRAINSTORM_OPEN_CMD` to the command that should open a URL:
+
+```bash
+BRAINSTORM_OPEN_CMD='firefox' scripts/start-server.sh --project-dir /path --open
+BRAINSTORM_OPEN_CMD='flatpak run org.mozilla.firefox' scripts/start-server.sh --project-dir /path --open
+```
+
+The server passes the companion URL as the final argument. Accepted shapes:
+- A bare command: `firefox` → `firefox <url>`
+- A command with arguments: `flatpak run org.mozilla.firefox` → `flatpak run org.mozilla.firefox <url>`
+- Quoted argv segments: `node "/path/to/capture.js" "marker"` → that exact argv with `<url>` appended
+
+**Trust posture:** `BRAINSTORM_OPEN_CMD` is an environment variable, so it runs with the invoking user's authority — only set it from a trusted environment, and treat any value the way you'd treat a shell command you typed yourself. The launcher deliberately invokes the command **without a shell** (it tokenizes the value and passes `<url>` as a single argv element), so shell metacharacters in the value are not interpreted — the URL's `&`/`?` stay intact, and the value can't splice in extra commands. This means a value like `firefox ; curl evil` will *not* execute the `curl`; it just fails to find a binary named `firefox ; curl evil`. The no-shell path is the safe default; you don't need to do anything to get it.
+
 ## The Loop
 
 1. **Check server is alive**, then **write HTML** to a new file in `screen_dir`:

--- a/tests/brainstorm-server/lifecycle.test.js
+++ b/tests/brainstorm-server/lifecycle.test.js
@@ -490,6 +490,32 @@ async function runTests() {
     assert(!opened, 'must not open the browser without explicit approval');
   });
 
+  await test('BRAINSTORM_OPEN_CMD launches without a shell and keeps the URL as one argv element', async () => {
+    // Regression for #1957: BRAINSTORM_OPEN_CMD must not go through `sh -c`.
+    // Capture the launched argv with a node script that writes each argv element
+    // on its own line; the server URL carries a `?key=` query (shell metachar `&`),
+    // which a shell would split. execFile passes it intact as the final element.
+    const dir = fs.mkdtempSync('/tmp/bs-argv-');
+    const marker = path.join(dir, 'argv.log');
+    const scriptPath = path.resolve(dir, 'capture-argv.cjs');
+    fs.writeFileSync(scriptPath,
+      "const fs = require('fs');\n" +
+      "fs.appendFileSync(" + JSON.stringify(marker) + ", process.argv.slice(1).join('\\n') + '\\n');\n");
+    const openCmd = `node ${JSON.stringify(scriptPath)}`;
+    const srv = spawn('node', [SERVER], { env: { ...process.env, BRAINSTORM_PORT: 3420, BRAINSTORM_DIR: dir, BRAINSTORM_OPEN: '1', BRAINSTORM_OPEN_CMD: openCmd, BRAINSTORM_LIFECYCLE_CHECK_MS: 100000 } });
+    let out = ''; srv.stdout.on('data', d => out += d.toString());
+    for (let i = 0; i < 60 && !out.includes('server-started'); i++) await sleep(50);
+    fs.writeFileSync(path.join(dir, 'content', 'first.html'), '<h2>First</h2>');
+    await waitForFile(marker);
+    await killAndWait(srv);
+    const lines = fs.readFileSync(marker, 'utf8').trim().split('\n').filter(Boolean);
+    fs.rmSync(dir, { recursive: true, force: true });
+    // argv = [scriptPath, url]; the URL must be a single element carrying the key.
+    assert.strictEqual(lines.length, 2, `expected 2 argv elements (script + url), got ${lines.length}`);
+    assert(/key=/.test(lines[1]), `final argv element should be the URL carrying the key, got ${lines[1]}`);
+    assert(!/[ ;|]/.test(lines[1]), `URL must not be shell-split; found shell metacharacters in ${lines[1]}`);
+  });
+
   await test('unauthenticated requests do not defeat the idle timeout', async () => {
     const dir = fs.mkdtempSync('/tmp/bs-life-');
     const srv = spawn('node', [SERVER], { env: { ...process.env, BRAINSTORM_PORT: 3419, BRAINSTORM_DIR: dir, BRAINSTORM_TOKEN: 'authtok', BRAINSTORM_IDLE_TIMEOUT_MS: 400, BRAINSTORM_LIFECYCLE_CHECK_MS: 100 } });

--- a/tests/brainstorm-server/lifecycle.test.js
+++ b/tests/brainstorm-server/lifecycle.test.js
@@ -516,6 +516,37 @@ async function runTests() {
     assert(!/[ ;|]/.test(lines[1]), `URL must not be shell-split; found shell metacharacters in ${lines[1]}`);
   });
 
+  await test('BRAINSTORM_OPEN_CMD metacharacters do not splice a second command (no shell)', async () => {
+    // Companion to the URL-integrity test above: prove shell metacharacters in the
+    // OPEN_CMD value itself can't inject a second command. A value containing a
+    // command separator (`; touch <pwned>`) must NOT result in <pwned> being
+    // created — the launcher tokenizes and runs without a shell, so `;` is literal.
+    // Without the no-shell fix (#1957), this value reached `sh -c`, the `;`
+    // split it, and `touch <pwned>` executed as a sibling command.
+    const dir = fs.mkdtempSync('/tmp/bs-inj-');
+    const marker = path.join(dir, 'argv.log');
+    const pwned = path.join(dir, 'pwned.flag');
+    const scriptPath = path.resolve(dir, 'capture-argv.cjs');
+    fs.writeFileSync(scriptPath,
+      "const fs = require('fs');\n" +
+      "fs.appendFileSync(" + JSON.stringify(marker) + ", process.argv.slice(1).join('\\n') + '\\n');\n");
+    // A shell would split on `;` and run `touch <pwned>` as a second command.
+    // The no-shell path treats the whole value as one tokenized argv, so the
+    // `;`-bearing command simply fails to launch and <pwned> never appears.
+    const openCmd = `node ${JSON.stringify(scriptPath)} ; touch ${JSON.stringify(pwned)}`;
+    const srv = spawn('node', [SERVER], { env: { ...process.env, BRAINSTORM_PORT: 3424, BRAINSTORM_DIR: dir, BRAINSTORM_OPEN: '1', BRAINSTORM_OPEN_CMD: openCmd, BRAINSTORM_LIFECYCLE_CHECK_MS: 100000 } });
+    let out = ''; srv.stdout.on('data', d => out += d.toString());
+    for (let i = 0; i < 60 && !out.includes('server-started'); i++) await sleep(50);
+    fs.writeFileSync(path.join(dir, 'content', 'first.html'), '<h2>Inject</h2>');
+    // Give the launcher (which fails to spawn the `;`-bearing command) time to
+    // have done nothing — wait long enough that a `sh -c` would have run `touch`.
+    await sleep(500);
+    await killAndWait(srv);
+    const pwnedCreated = fs.existsSync(pwned);
+    fs.rmSync(dir, { recursive: true, force: true });
+    assert(!pwnedCreated, `shell metacharacter ';' must not splice a command: <pwned> was created, meaning BRAINSTORM_OPEN_CMD went through a shell`);
+  });
+
   await test('unauthenticated requests do not defeat the idle timeout', async () => {
     const dir = fs.mkdtempSync('/tmp/bs-life-');
     const srv = spawn('node', [SERVER], { env: { ...process.env, BRAINSTORM_PORT: 3419, BRAINSTORM_DIR: dir, BRAINSTORM_TOKEN: 'authtok', BRAINSTORM_IDLE_TIMEOUT_MS: 400, BRAINSTORM_LIFECYCLE_CHECK_MS: 100 } });


### PR DESCRIPTION
## What

Hardens the `BRAINSTORM_OPEN_CMD` browser-launch path in `skills/brainstorming/scripts/server.cjs` so it no longer goes through a shell. Closes #1957.

## Why

The security audit in #1957 flagged that `maybeOpenBrowser()` ran the operator-provided `BRAINSTORM_OPEN_CMD` via `cp.exec(cmd + ' ' + JSON.stringify(url))`, i.e. through `sh -c`. The env var is opt-in, loopback-only, trusted operator input, so the practical risk is bounded — but the shell-exec shape is what the audit (and downstream org security reviews) block adoption on. The issue's proposed resolution was to match the platform launchers two lines below, which already use `execFile` with the URL as a single argv element.

## How

- Replaced the `cp.exec` branch with `cp.execFile(bin, args.concat(url), …)` — no shell, the URL is a single argv element.
- Added a quote-aware tokenizer `shellArgv()` that splits the operator's command string into an argv honoring single/double quotes (so a command like `node "/path/with space/capture.cjs" "/marker/path"` still resolves to the right tokens, matching how the existing test fixture builds `BRAINSTORM_OPEN_CMD`).
- A command with **unbalanced quotes** returns `null` and is rejected — it is never handed to a shell as a fallback. The previous `try/catch` best-effort semantics are preserved on the actual spawn.

This mirrors the existing `browserLauncherForPlatform` pattern (bin + args + `execFile`), so the two launcher paths now share the same no-shell shape.

## Tests

- Existing `lifecycle.test.js` tests for `BRAINSTORM_OPEN_CMD` still pass — their fixture (`node "script" "marker"`) tokenizes cleanly to `[node, script, marker]`, with the URL appended as the final element.
- Added a regression test: *`BRAINSTORM_OPEN_CMD` launches without a shell and keeps the URL as one argv element*. It captures the launched `argv` and asserts the server URL (which carries a `?key=` query) arrives as exactly one token with no shell-splitting — the direct proof the injection shape is gone.

## Behavior change

Operators who set `BRAINSTORM_OPEN_CMD` to a command relying on shell features (pipes, `&&`, env expansion, globbing) will need to wrap it in a script — the command is now tokenized and `execFile`'d, not shell-interpreted. This matches how the platform launchers already behave and is the intended hardening. I called this out in the env var's comment.

## Checklist

- [x] Change is scoped to the flagged line and its helper
- [x] No new shell surface introduced
- [x] Existing tests green; added a regression test for the no-shell contract
