### PR TITLE
SDD: task reviewer writes its full report to a review file (#1930)

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -191,9 +191,10 @@ final whole-branch review. When you fill a reviewer template:
   later dispatches — a real session's dispatch hit 42k chars of which 99%
   was pasted history. A fresh subagent needs its task, the interfaces it
   touches, and the global constraints. Nothing else.
-- Dispatch fix subagents for Critical and Important findings. Record Minor
-  findings in the progress ledger as you go, and point the final
-  whole-branch review at that list so it can triage which must be fixed
+- Dispatch fix subagents for Critical and Important findings, passing the
+  review file path for the full detail. Record each task's Minor count and
+  review file path in the progress ledger as you go, and point the final
+  whole-branch review at those files so it can triage which must be fixed
   before merge. A roll-up nobody reads is a silent discard.
 - A finding labeled plan-mandated — or any finding that conflicts with
   what the plan's text requires — is the human's decision, like any plan
@@ -237,11 +238,18 @@ and is re-read on every later turn. Hand artifacts over as files:
   (brief `…/task-N-brief.md` → report `…/task-N-report.md`) and put it in
   the dispatch prompt. The implementer writes the full report there and
   returns only status, commits, a one-line test summary, and concerns.
-- **Reviewer inputs:** the task reviewer gets three paths — the same brief
-  file, the report file, and the review package — plus the global
-  constraints that bind the task.
-- Fix dispatches append their fix report (with test results) to the same
-  report file and return a short summary; re-reviews read the updated file.
+- **Reviewer inputs:** the task reviewer gets four paths — the same brief
+  file, the report file, the review package, and a review file to write
+  to (brief `…/task-N-brief.md` → review `…/task-N-review.md`) — plus
+  the global constraints that bind the task.
+- **Review file:** the reviewer writes its full report there and returns
+  only verdicts, ⚠️ items, one line per Critical/Important finding, a
+  Minor count, and the path. Don't read the review file — the final
+  message is your decision surface; the detail is for fix subagents.
+- Fix dispatches get the review file path for the full findings, append
+  their fix report (with test results) to the same report file, and
+  return a short summary; re-reviews read the updated report file and
+  append to the review file.
 
 ## Durable Progress
 
@@ -292,9 +300,9 @@ Implementer: "Got it. Implementing now..."
   - Self-review: Found I missed --force flag, added it
   - Committed
 
-[Run review-package, dispatch task reviewer with the printed path]
-Task reviewer: Spec ✅ - all requirements met, nothing extra.
-  Strengths: Good test coverage, clean. Issues: None. Task quality: Approved.
+[Run review-package, dispatch task reviewer with the printed path + review file]
+Task reviewer: Spec ✅. Quality: Approved. Minor: 0.
+  Full report: task-1-review.md
 
 [Mark Task 1 complete]
 
@@ -309,13 +317,13 @@ Implementer:
   - Self-review: All good
   - Committed
 
-[Run review-package, dispatch task reviewer with the printed path]
+[Run review-package, dispatch task reviewer with the printed path + review file]
 Task reviewer: Spec ❌:
   - Missing: Progress reporting (spec says "report every 100 items")
   - Extra: Added --json flag (not requested)
-  Issues (Important): Magic number (100)
+  Important: Magic number (100). Minor: 0. Full report: task-2-review.md
 
-[Dispatch fix subagent with all findings]
+[Dispatch fix subagent with the review file path]
 Fixer: Removed --json flag, added progress reporting, extracted PROGRESS_INTERVAL constant
 
 [Task reviewer reviews again]

--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -112,13 +112,27 @@ Subagent (general-purpose):
 
     Your report should point at evidence: file:line references for every
     finding and for any check you would otherwise answer with a bare
-    "yes." A tight report that cites lines gives the controller everything
-    it needs.
+    "yes." A tight report that cites lines gives the fix subagent
+    everything it needs.
 
-    Your final message is the report itself: begin directly with the
-    spec-compliance verdict. Every line is a verdict, a finding with
-    file:line, or a check you ran — no preamble, no process narration,
-    no closing summary.
+    ## Report Format
+
+    Write your full report to [REVIEW_FILE] using the Output Format
+    below: verdicts, strengths, every finding with file:line, and any
+    check you ran outside the diff. Fix subagents read this file — it is
+    the only place your detail survives.
+
+    Then report back with ONLY (under 15 lines — the detail lives in the
+    review file):
+    - **Spec:** ✅ | ❌ — if ❌, one line per missing/extra/misunderstood
+      item (file:line + summary)
+    - **⚠️ Cannot verify from diff:** [items the controller must resolve
+      itself — always in this message, never only in the file]
+    - **Quality:** Approved | Needs fixes
+    - One line per Critical/Important finding: file:line + what's wrong,
+      with any plan-mandated finding marked (the human adjudicates those)
+    - Minor findings: count only
+    - The review file path
 
     ## Calibration
 
@@ -136,7 +150,7 @@ Subagent (general-purpose):
     Acknowledge what was done well before listing issues — accurate praise
     helps the implementer trust the rest of the feedback.
 
-    ## Output Format
+    ## Output Format (the review file)
 
     ### Spec Compliance
 
@@ -180,9 +194,14 @@ Subagent (general-purpose):
 - `[DIFF_FILE]` — REQUIRED: the path the controller wrote the review
   package to (`scripts/review-package BASE HEAD` prints the unique path it
   wrote; the package never enters the controller's context)
+- `[REVIEW_FILE]` — REQUIRED: the file the reviewer writes its full report
+  to; name it after the brief (brief `…/task-N-brief.md` → review
+  `…/task-N-review.md`). Re-reviews append to the same file.
 
-**Reviewer returns:** Spec Compliance verdict (✅/❌/⚠️), Strengths, Issues
-(Critical/Important/Minor), Task quality verdict
+**Reviewer returns:** full report in `[REVIEW_FILE]`; final message under
+15 lines — Spec verdict (✅/❌/⚠️), Quality verdict, Critical/Important
+findings one line each, Minor count, review file path
 
-A fix dispatch can address spec gaps and quality findings together;
-re-review after fixes covers both verdicts.
+A fix dispatch can address spec gaps and quality findings together — give
+it the review file path for the full findings; re-review after fixes
+covers both verdicts.


### PR DESCRIPTION
> Targets `dev`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code, VS Code extension (Agent SDK); eval subagents ran on Claude Sonnet 5 (`claude-sonnet-5`) |
| All plugins installed | superpowers 6.1.1 (claude-plugins-official marketplace) |
| Human partner who reviewed this diff | @rasibintang |

## What problem are you trying to solve?

Issue #1930: task-reviewer subagents return their **entire report as the final message**, so every passing check, Strengths section, and fix rationale lands in the controller's context and is re-read on every later turn. The issue reporter's transcript analysis found most of that content is non-actionable at the controller level ("things they checked that were OK").

The skill's own File Handoffs section already names this exact failure mode ("everything a subagent prints back stays resident in your context for the rest of the session") and fixes it for every other role: the implementer writes its full report to `task-N-report.md` and returns under 15 lines; the review package "never enters the controller's context"; fix subagents append to the report file and return a short summary. The task reviewer is the one remaining role whose full output lands in the controller's context — `task-reviewer-prompt.md` explicitly instructs "Your final message is the report itself."

Proposed and discussed on the issue: https://github.com/obra/superpowers/issues/1930#issuecomment-4947098490

## What does this PR change?

Applies the implementer's report-file contract to the task reviewer: the full report (Strengths, passing-check citations, finding detail with fixes) goes to a new `[REVIEW_FILE]` (`task-N-review.md`, following the existing brief/report naming); the final message returns only the two verdicts, any ⚠️ "cannot verify from diff" items, one line per Critical/Important finding, a Minor count, and the file path. `SKILL.md` is updated so fix dispatches pass the review file path, the ledger records Minor counts + review file paths, and the controller is told not to read the review file.

## Is this change appropriate for the core library?

Yes — it modifies an existing core SDD skill, is harness-agnostic (prompt/markdown only, no scripts or infrastructure), and benefits any project type. No third-party integration.

## What alternatives did you consider?

1. **Drop the non-actionable content entirely** (the issue author's own alternative). Rejected: the passing-check citation requirement plausibly exists to force the reviewer to actually perform the checks, and Strengths content calibrates trust for the fix loop. This PR relocates that information instead of deleting it.
2. **Implement all three parts of #1930 at once**, including `requesting-code-review/code-reviewer.md` and a blanket "orchestrator must not read raw findings" rule. Deferred: `code-reviewer.md` is also used standalone, where a human reads the report directly, so it needs a mode split; kept as a follow-up so this PR stays one scoped behavior change.

Deliberately preserved constraints: ⚠️ items and plan-mandated findings stay in the final message because the controller/human must act on them directly, and the controller can still make the fix-vs-approve decision from the message alone.

## Does this PR contain multiple unrelated changes?

No. Two files, one behavior: the reviewer's reporting contract and the controller-side handling of it.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1717 (merged — introduced the unified `task-reviewer-prompt.md` this PR modifies), #1956 (open — relocates SDD artifact paths; adjacent to the `task-N-review.md` naming but not conflicting: this PR follows whatever directory convention the brief/report files use). No PR implementing #1930 found.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (VS Code extension)      | current stable  | Claude Sonnet 5 (reviewer subagents), Claude Fable 5 (controller) | claude-sonnet-5, claude-fable-5 |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

- **Initial prompt:** my human partner asked me to analyze issue #1930 and prepare a contribution implementing it (session conducted in Indonesian; the work was proposed on the issue before this PR was opened).
- **Eval sessions after the change:** 2 A/B pairs (n=2 per arm, 4 reviewer subagent sessions total, all on Sonnet 5 with fresh context). Scenario: a small repo with a seeded-flaw task implementation — a skipped requirement (missing `Done: N items total` log), an explicitly forbidden feature (`options.json` API surface), and an implementer report that falsely claims full compliance — reviewed once with the current `dev` prompt (baseline) and once with this PR's prompt, identical inputs otherwise.
- **Outcomes:**
  - **Detection parity, 4/4 runs:** both arms caught both seeded spec violations, flagged the over-claiming implementer report, and returned Spec ❌ / "Needs fixes".
  - **Controller-context cost:** baseline final messages were 4,200 and 4,557 chars (594/632 words). New-prompt final messages were 1,153 and 1,232 chars (138/129 words) — a ~73% reduction in what enters (and stays in) the controller's context per review, before the re-read multiplier.
  - **Detail preserved, not dropped:** both new-prompt runs wrote the full report to the review file (5,191 and 4,965 chars) with every Output Format section present (Spec Compliance, Strengths, Critical/Important/Minor with file:line + fixes, Assessment).
  - Honest scope note: n=2 per arm on one scenario. The size reduction is structural (the contract itself bounds the message); the detection-parity claim is the part that would benefit from more scenarios, and I'm happy to run more if you want them.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

Per writing-skills' "Match the Form to the Failure": the baseline failure is wrong-shaped output (report bloat in the final message), not rule-skipping, so the change is a positive contract (what the final message IS, part by part — mirroring the implementer's proven under-15-lines contract) rather than a prohibition list. The eval scenario is adversarial for a reviewer: an implementer report that over-claims ("All requirements implemented... No concerns") while the diff skips a requirement and adds a forbidden feature — the reviewer must contradict the report, not just summarize it. Both new-prompt runs did (results above). The Red Flags table, rationalization tables, and "human partner" language were not touched.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Refs #1930
