### PR TITLE
Fix dead references to pruned claude-code-tools.md/copilot-tools.md (#1969)

### DIFF
--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -784,10 +784,10 @@ Use this as the live index; when in doubt, read the files, not this table.
 
 | Harness | Entry point | Bootstrap mechanism | Tool mapping | Tests | Distribution |
 |---|---|---|---|---|---|
-| Claude Code | `.claude-plugin/plugin.json` + `hooks/hooks.json` | shell hook → `hooks/session-start` (`hookSpecificOutput.additionalContext`) | native `Skill` tool; `references/claude-code-tools.md` | `tests/hooks/` | marketplace |
+| Claude Code | `.claude-plugin/plugin.json` + `hooks/hooks.json` | shell hook → `hooks/session-start` (`hookSpecificOutput.additionalContext`) | native `Skill` tool; no adapter file (`claude-code-tools.md` pruned) | `tests/hooks/` | marketplace |
 | Codex | `.codex-plugin/plugin.json` (declares empty `hooks`) | native skill discovery (no session-start hook) | `references/codex-tools.md` | `tests/codex/`, `tests/codex-plugin-sync/` | fork sync (`scripts/sync-to-codex-plugin.sh`) |
-| Cursor | `.cursor-plugin/plugin.json` + `hooks/hooks-cursor.json` | shell hook → `hooks/session-start` (`additional_context`) | `references/claude-code-tools.md` | `tests/hooks/` | hand-authored |
-| Copilot CLI | (shares Claude Code hook path; `COPILOT_CLI` env) | shell hook → `hooks/session-start` (`additionalContext`) | `references/copilot-tools.md` | `tests/hooks/` | — |
+| Cursor | `.cursor-plugin/plugin.json` + `hooks/hooks-cursor.json` | shell hook → `hooks/session-start` (`additional_context`) | none (Claude Code–compatible tool surface; adapter file pruned) | `tests/hooks/` | hand-authored |
+| Copilot CLI | (shares Claude Code hook path; `COPILOT_CLI` env) | shell hook → `hooks/session-start` (`additionalContext`) | none (`copilot-tools.md` pruned) | `tests/hooks/` | — |
 | Gemini CLI | `gemini-extension.json` + `GEMINI.md` | instructions file `@`-includes bootstrap + mapping | `references/gemini-tools.md` | — | `gemini extensions install` |
 | Kimi Code | `.kimi-plugin/plugin.json` | manifest `sessionStart.skill` loads `using-superpowers` | inline `skillInstructions` in manifest | `tests/kimi/` | marketplace or `/plugins install` GitHub URL |
 | OpenCode | `.opencode/plugins/superpowers.js` (declared via root `package.json` `main`) | in-process: `config` hook registers skills dir; `experimental.chat.messages.transform` injects user message | inline in `superpowers.js` | `tests/opencode/` | `opencode.json` plugin git URL |

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -9,7 +9,7 @@ description: Use when creating new skills, editing existing skills, or verifying
 
 **Writing skills IS Test-Driven Development applied to process documentation.**
 
-**Personal skills live in your runtime's skills directory** — see [claude-code-tools.md](../using-superpowers/references/claude-code-tools.md), [codex-tools.md](../using-superpowers/references/codex-tools.md), [copilot-tools.md](../using-superpowers/references/copilot-tools.md), or [gemini-tools.md](../using-superpowers/references/gemini-tools.md) for the path on your runtime. Codex, Copilot CLI, and Gemini CLI all also recognize `~/.agents/skills/` as a cross-runtime alias.
+**Personal skills live in your runtime's skills directory** (`~/.claude/skills/` on Claude Code) — see [codex-tools.md](../using-superpowers/references/codex-tools.md) or [gemini-tools.md](../using-superpowers/references/gemini-tools.md) for the path on those runtimes. Codex, Copilot CLI, and Gemini CLI all also recognize `~/.agents/skills/` as a cross-runtime alias.
 
 You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
 


### PR DESCRIPTION
> Targets `dev`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code, VS Code extension (Agent SDK) |
| All plugins installed | superpowers 6.1.1 (claude-plugins-official marketplace) |
| Human partner who reviewed this diff | @rasibintang |

## What problem are you trying to solve?

#1969: commit `e7ddc25` deliberately deleted `references/claude-code-tools.md` and `references/copilot-tools.md`, but two places still point at them as live files. `skills/writing-skills/SKILL.md`'s Overview (line 12) links both dead files as where to find your runtime's skills directory — every agent that loads writing-skills reads a pointer to nowhere, and the Claude Code personal-skills path is no longer documented on the path that sentence gives. `docs/porting-to-a-new-harness.md`'s Appendix A ("use this as the live index") lists the deleted files as the tool-mapping entries for Claude Code, Cursor, and Copilot CLI.

Found by a mechanical audit of every relative markdown link target under `skills/` (same defect class as #1962/#1511: deliberate removal, dangling references left behind).

## What does this PR change?

Four lines. The writing-skills sentence now inlines the Claude Code path (`~/.claude/skills/`) and links only the surviving reference files (`codex-tools.md`, `gemini-tools.md`); the porting-guide table marks the three affected harnesses' adapter files as pruned instead of linking them.

## Is this change appropriate for the core library?

Yes — it fixes broken pointers in a core skill and a core contributor doc. No new content, dependencies, or third-party anything.

## What alternatives did you consider?

1. **Restore the two deleted files** — rejected: `e7ddc25` removed them deliberately ("nothing left that wasn't generic"); restoring would revert a maintainer decision.
2. **Delete the sentence entirely** — rejected: its payload (where personal skills live) is real guidance; only the pointers were stale. Kept the sentence, fixed the pointers.
3. Leaving RELEASE-NOTES/spec mentions untouched was deliberate — they are historical records and correct as written.

## Does this PR contain multiple unrelated changes?

No — one defect (dangling references left by `e7ddc25`), fixed at both sites where it appears.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1899 (open — removes a different set of orphaned files; does not touch these references), #1934 (draft — touches writing-skills/SKILL.md but not this line; no diff overlap). No PR addressing these dead references found.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (VS Code extension)      | current stable  | Claude Fable 5 | claude-fable-5 |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

- Initial prompt: my human partner asked me to find and fix defects in existing skills; a mechanical link audit over `skills/` surfaced these two dead references.
- This is a broken-pointer fix, not a behavior-shaping change, so the meaningful verification is mechanical, and I ran it: **before** — the audit flags `../using-superpowers/references/claude-code-tools.md` and `copilot-tools.md` as nonexistent targets (the directory contains only `antigravity-tools.md`, `codex-tools.md`, `gemini-tools.md`, `pi-tools.md`); **after** — re-running the same audit over the changed files reports zero dead references, and both retained link targets exist. No agent-behavior eval sessions were run because no behavioral guidance changed; if maintainers want them anyway I'm happy to run some.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

On the unchecked box, honestly: adversarial pressure testing does not apply to a dead-link fix — no rule, threshold, or behavior-shaping wording changed, only pointers to files that no longer exist. The RED→GREEN evidence for this class of change is the mechanical audit above (targets missing → targets resolve). The writing-skills box is checked in the same spirit: its verification-matched-to-change-type guidance is what was applied.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Refs #1969
