### PR TITLE
docs: clarify Codex subagent liveness

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -133,6 +133,13 @@ that implementer. Single-file mechanical fixes also take the cheapest tier.
 
 Implementer subagents report one of four statuses. Handle each appropriately:
 
+These statuses are reports, not controller inferences. Enter the
+`NEEDS_CONTEXT` or `BLOCKED` branch only after the implementer reports that
+status or a runtime error prevents progress. A coordination timeout, silence
+after a queue-only message, or a lack of new files does not establish either
+status. On Codex, use `followup_task` when an immediate answer is required; see
+[Codex coordination semantics](../using-superpowers/references/codex-tools.md#coordination-semantics).
+
 **DONE:** Generate the review package (`scripts/review-package BASE HEAD`, from this skill's directory — it prints the unique file path it wrote; BASE is the commit you recorded before dispatching the implementer — never `HEAD~1`, which silently drops all but the last commit of a multi-commit task), then dispatch the task reviewer with the printed path.
 
 **DONE_WITH_CONCERNS:** The implementer completed the work but flagged doubts. Read the concerns before proceeding. If the concerns are about correctness or scope, address them before review. If they're observations (e.g., "this file is getting large"), note them and proceed to review.

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -9,6 +9,16 @@ multi_agent = true
 
 This enables `spawn_agent`, `wait_agent`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`. When using subagent-driven-development, you should always close implementer and reviewer subagents when they have finished all their work.
 
+## Coordination Semantics
+
+- A `wait_agent` timeout means no mailbox update or final-status notification
+  arrived during that wait. It does not mean the subagent is blocked or idle.
+- `send_message` queues context without requesting a new turn. When an answer
+  is required, use `followup_task`, which triggers a turn if the target is idle.
+- Child tool activity is not necessarily visible as a parent mailbox update,
+  and a lack of new files is not a liveness signal. Do not interrupt or split a
+  task based only on timeouts, queue-only silence, or an unchanged worktree.
+
 ## Environment Detection
 
 Skills that create worktrees or finish branches should detect their


### PR DESCRIPTION
Closes #1979.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5; the exact point version/model ID is not exposed in this session |
| Harness + version | Codex Desktop 26.707.62119, embedded `codex-cli 0.144.2` |
| All plugins installed | documents 26.709.11516; spreadsheets 26.709.11516; presentations 26.709.11516; hyperframes 0.1.2; github 0.1.6; superpowers 5.1.3; canva 1.0.2; outlook-email 0.1.3; xhs-travel-ops (configured, but its local marketplace manifest is currently invalid); remotion 1.0.3; pdf 26.709.11516; template-creator 26.709.11516; chrome 26.707.62119; computer-use 1.0.1000387; sites 0.1.27; visualize 1.0.11; browser 26.707.62119 |
| Human partner who reviewed this diff | @Seekers2001 reviewed the complete 17-line diff in the Codex thread and explicitly replied `go` |

## What problem are you trying to solve?

Issue #1979 documents a real Codex session where the controller treated repeated `wait_agent` timeouts, silence after `send_message`, and an unchanged worktree as proof that a child was stuck. It then interrupted the child and split the task even though those signals do not establish child liveness. The issue's redacted trace records 12 mailbox timeouts, 8 filesystem polls, and 0 child tool calls visible to the parent; those figures are evidence supplied by the reporter, not measurements invented for this PR.

The existing Codex reference names the coordination tools but does not define their liveness semantics, while subagent-driven-development says how to handle reported statuses without saying that controllers must not infer `BLOCKED` or `NEEDS_CONTEXT` from mailbox silence. That gap reproduces the failure mode under deadline and sunk-cost pressure.

## What does this PR change?

It documents the mailbox, queueing, and liveness semantics of `wait_agent`, `send_message`, and `followup_task` in the Codex tool reference. It also makes subagent-driven-development consume that definition when deciding whether an implementer is actually blocked or needs context.

## Is this change appropriate for the core library?

Yes. The decision rule applies to any Codex project using Superpowers' subagent workflows, independent of repository, language, or domain. It clarifies an existing core harness adapter and an existing generic workflow. It adds no service, dependency, personal configuration, or project-specific behavior.

## What alternatives did you consider?

- Waiting longer does not fix the semantic error: a longer mailbox timeout is still not a child-status report.
- Polling the worktree cannot prove liveness because a child may be reading, testing, or reasoning without writing files.
- Repeated `send_message` calls still only queue context; they do not request an immediate turn from an idle target.
- Interrupting or splitting on those signals can discard live work and create duplicate effort.

The chosen change uses the existing `followup_task` primitive when an answer is actually required and otherwise waits for an explicit status or runtime error.

## Does this PR contain multiple unrelated changes?

No. The Codex reference defines the coordination semantics, and subagent-driven-development applies the same semantics at the status-decision point. Neither file is useful as a standalone fix: definition without consumption leaves the failure mode, while consumption without a canonical reference duplicates tool semantics in a workflow skill.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1926, #1662, #963

I searched all PR states immediately before submission for `1979`, `wait_agent`, `mailbox liveness`, and `followup_task`. #1926 documents deferred tool-name mapping, #1662 documents deferred subagent tool discovery, and merged #963 corrects the wait-tool name. None defines mailbox timeout/liveness semantics or the SDD rule for inferring implementer status.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex Desktop | 26.707.62119 (`codex-cli 0.144.2`) | GPT-5 | Exact point version/ID not exposed by the harness |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR clarifies behavior for the existing Codex harness and does not add a harness integration.

## Evaluation

- Initial pressure prompt: a controller had received repeated `wait_agent` timeouts, no response to a queue-only `send_message`, and no new files while a deadline, sunk-cost concern, and manager instruction pushed it to interrupt and split the task. The controller had to decide whether those observations established that the implementer was blocked.
- Before the change: 5 independent fresh sessions; 0/5 made the correct decision. All five inferred stuck/blocked from timeout, silence, or unchanged files and chose interruption or task splitting.
- After the change: 5 independent fresh sessions with the same pressure scenario; 5/5 made the correct decision. They treated the observations as inconclusive, chose `followup_task` when an immediate answer was required, and otherwise continued waiting for an explicit report or runtime failure.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Evaluation methodology: each trial used a fresh subagent session and the same combined pressure factors (deadline, manager authority, sunk cost, and an unchanged worktree). The scoring criterion was behavioral: do not infer `BLOCKED`/`NEEDS_CONTEXT` from those observations; use `followup_task` if a synchronous answer is required. The wording was added only after the 0/5 baseline, then retested independently to 5/5.

Static verification:

- `git diff --check` — pass
- `TZ=UTC bash tests/codex-plugin-sync/test-sync-to-codex-plugin.sh` — pass
- `TZ=UTC bash tests/codex/test-package-codex-plugin.sh` — all content, mode, dirty-worktree, and zip timestamp assertions pass; one pre-existing macOS display mismatch remains for the normalized tar timestamp (`Dec 31 1969` expected, `Jan 1 1970` displayed)

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
