### PR TITLE
feat(skills): add tracing-acceptance-criteria skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The Pi package loads the Superpowers skills and a small extension that injects t
 **Collaboration** 
 - **brainstorming** - Socratic design refinement
 - **writing-plans** - Detailed implementation plans
+- **tracing-acceptance-criteria** - Give acceptance criteria stable IDs and trace them from spec to the tests that prove them
 - **executing-plans** - Batch execution with checkpoints
 - **dispatching-parallel-agents** - Concurrent subagent workflows
 - **requesting-code-review** - Pre-review checklist

--- a/skills/tracing-acceptance-criteria/SKILL.md
+++ b/skills/tracing-acceptance-criteria/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: tracing-acceptance-criteria
+description: Use when acceptance criteria already exist and need to be traced to code — giving each criterion a stable ID, tagging the tests that prove it with @ac markers, or checking which criteria are covered, orphaned, or duplicated. For authoring the criteria themselves, that is a separate concern; this skill starts once they exist and runs through verification.
+---
+
+# Tracing acceptance criteria
+
+## Overview
+
+Give every acceptance criterion a stable ID, keep it in the spec, and link it to
+the test that proves it with a one-line `@ac` marker. A criterion counts as covered
+only when a test demonstrates it — which is exactly the test-first stance this
+library already takes.
+
+This is the *traceability* half of acceptance criteria: it assumes the criteria are
+already written (however you got there) and gives them IDs, markers, and a coverage
+check. Three stages — **Define IDs**, **Link**, **Check** — layered onto the
+existing flow. Nothing to install: the check is a couple of `rg` commands you run
+and reason about.
+
+## When to use
+
+- After `superpowers:brainstorming` writes the design doc and before
+  `superpowers:writing-plans`, to attach testable, ID'd criteria to the spec.
+- During `superpowers:test-driven-development`, to tag each proving test as you
+  write it.
+- At `superpowers:verification-before-completion`, to report which criteria are
+  proven, which aren't, and which markers are stray.
+
+Not for UI-polish checklists — criteria capture **functional behavior + critical
+constraints**: how the system _should_ behave.
+
+## Conventions
+
+- **Storage: the spec.** Add an `## Acceptance Criteria` section to the design doc
+  `superpowers:brainstorming` saved under
+  `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`. The spec is the source of
+  truth and is committed with the work.
+- **ID scheme:** `COMPONENT-N`, e.g. `AUTH-1`, scoped to one spec. `COMPONENT` is a
+  single uppercase token (`[A-Z]+`) — no digits, underscores, or hyphens inside it,
+  since the scan regex below captures exactly that shape. The same ID in two specs
+  is a collision — the Check step flags it.
+- **Marker:** `@ac <ID>` as a prefix in a normal comment, any language:
+  `// @ac AUTH-1`, `# @ac AUTH-1`. The `@ac` prefix keeps the scan targeted so a
+  bare ID mentioned elsewhere won't match — but it's a text scan, not a parser, so
+  confirm each hit is a real comment and not an ID quoted in a string or doc.
+- **The marker's canonical home is the TEST that proves the criterion.** This
+  library is test-first, so a criterion counts as covered only when a test
+  demonstrates it. A marker on production code is allowed but never sufficient on
+  its own.
+
+## 1. Define IDs
+
+Record the criteria in the spec as a markdown table, each with a stable ID:
+
+```markdown
+## Acceptance Criteria
+
+| ID     | Criterion                                  |
+| ------ | ------------------------------------------ |
+| AUTH-1 | Reject requests with no bearer token (401) |
+| AUTH-2 | Verify bearer token signature              |
+| AUTH-3 | Scope queries to the token's tenant        |
+```
+
+Group related criteria under one `COMPONENT`. Keep each criterion behavioral and
+independently testable.
+
+## 2. Link
+
+During TDD, the failing test that proves a criterion carries its marker:
+
+```ts
+// @ac AUTH-1
+it('rejects requests with no bearer token', () => {
+  expect(handler(noAuthRequest).status).toBe(401);
+});
+```
+
+```python
+# @ac AUTH-2
+def test_verifies_bearer_signature():
+    assert verify_bearer_token(signed) is True
+```
+
+When writing the plan, list the AC IDs each task satisfies so the mapping is
+explicit before code exists. One test may carry several markers; one criterion may
+be proven by several tests.
+
+## 3. Check (ad hoc — no tooling)
+
+Run this at verification time and reason about the output.
+
+1. **Covered IDs** — grep only the test files, since coverage means "a test proves
+   it". Widen the globs to your project's test conventions:
+
+   ```bash
+   rg -o '@ac\s+([A-Z]+-\d+)' -r '$1' --no-filename \
+     -g '*.test.*' -g '*.spec.*' -g '*_test.*' -g 'test_*.*' | sort -u
+   ```
+
+   To locate every marker tree-wide (for reporting orphans — a stray marker in
+   production code is still an orphan), use:
+
+   ```bash
+   rg -n '@ac\s+[A-Z]+-\d+'
+   ```
+
+2. **Defined IDs** — read the `## Acceptance Criteria` table(s) from the relevant
+   spec(s) under `docs/superpowers/specs/`.
+
+3. **Diff and report** (report-only — no build gate):
+   - **Uncovered** — a defined ID absent from the covered-IDs (test-file) scan. A
+     production-code marker alone does not make an ID covered.
+   - **Orphan** — an `@ac` marker whose ID appears in no spec.
+   - **Duplicate** — the same ID defined in more than one spec.
+
+   Example:
+
+   ```
+   auth-redesign: 3 ACs
+     AUTH-1  covered (2 refs)
+     AUTH-2  covered (1 ref)
+     AUTH-3  UNCOVERED
+   orphan: @ac AUTH-9 (auth.test.ts:42) — no matching AC
+   coverage 2/3 (67%)
+   ```
+
+## Where this fits in the flow
+
+| Stage                                                                 | This skill                                    |
+| --------------------------------------------------------------------- | --------------------------------------------- |
+| after `superpowers:brainstorming`, before `superpowers:writing-plans` | **Define IDs** for the AC table in the spec   |
+| `superpowers:writing-plans` / TDD implementation                      | **Link** proving tests with `@ac <ID>`        |
+| `superpowers:verification-before-completion`                          | **Check** with `rg` + spec cross-reference    |
+
+It adds to the flow; it does not replace any skill.


### PR DESCRIPTION
## Who is submitting this PR?

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (1M context), `claude-opus-4-8` |
| Harness + version | Claude Code |
| All plugins installed | superpowers 6.1.1, chrome-devtools-mcp, figma, github, linear |
| Human partner who reviewed this diff | @katspaugh (PR author) |

## What problem are you trying to solve?

The flow produces a spec with acceptance criteria and a plan, but nothing links a
criterion to the test that proves it. At `verification-before-completion` there is
no cheap way to answer "which criteria are actually demonstrated by a test, and are
any of my requirement references stale?" In practice a criterion silently goes
unproven, or a code comment references a requirement ID that no longer exists in any
spec, and nobody notices until review.

## What does this PR change?

Adds a `tracing-acceptance-criteria` skill: give each acceptance criterion a stable
`COMPONENT-N` ID in its `docs/superpowers/specs/` design doc, tag the proving test
with an `@ac <ID>` marker during TDD, and run an ad-hoc `rg` check at verification
that reports **uncovered** (defined ID with no test marker), **orphan** (marker
whose ID is in no spec), and **duplicate** (same ID across specs) IDs. No tooling to
install. Also adds one catalog line to the README.

## Is this change appropriate for the core library?

- Useful on a completely different project? Yes — requirement→test traceability is
  domain-agnostic; the check is a plain ripgrep over any test suite.
- Project/team/tool-specific? No. It stores criteria in the library's own
  `docs/superpowers/specs/` artifact and integrates with the existing
  brainstorming → writing-plans → TDD → verification skills. No third-party service.
- The mechanism (stable IDs + `@ac` markers + coverage scan) is the piece missing
  from the current flow; it's adapted from acai.sh's "specsmaxxing".

## What alternatives did you consider?

1. **Fold it into `#1112` / the AC-authoring step** — rejected as a bundle. #1112 is
   about *writing* good criteria (Given/When/Then, SMART). This is the orthogonal
   *traceability* half. Keeping them separate lets either land on its own; this skill
   is deliberately named `tracing-acceptance-criteria` to avoid colliding with #1112.
2. **A committed executable / CI gate** — rejected (YAGNI). The check is two `rg`
   commands the agent runs and reasons about; a script adds install/maintenance
   surface for no judgment the agent can't do inline. It is report-only, not a gate.
3. **Reference IDs in production code instead of tests** — rejected. This library is
   test-first, so "covered" must mean a test proves it; the coverage scan is scoped
   to test files and a production-only marker never counts as covered.

## Does this PR contain multiple unrelated changes?

No. One skill (`skills/tracing-acceptance-criteria/SKILL.md`) plus its one-line
README catalog entry.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs:
  - **#1112 (open) — complementary, not a duplicate.** #1112 adds an
    `acceptance-criteria` skill for *authoring* criteria (GWT/SMART). This PR is the
    *traceability* half (IDs + `@ac` markers + `rg` coverage scan) and uses a distinct
    name/path to avoid collision. The two compose: author with #1112, trace with this.
  - #966 (open, writing-test-scenario-specs) — about test scenarios for *skills*, not
    feature ACs. Different problem.
  - #1704 (open, verifying-plan-coverage) — proves a *plan* covers a spec before
    execution; this proves *tests* cover criteria after implementation. Adjacent, not
    overlapping.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | current | Claude Opus | `claude-opus-4-8` (1M context) |

## Evaluation

Followed `superpowers:writing-skills`. Three layers of testing, honestly scoped:

**1. Command correctness (dry-run).** Ran the Check commands against a scratch fixture
(a test file with `@ac AUTH-1/AUTH-2/AUTH-9`, a spec defining `AUTH-1/2/3`, a
production-only `@ac AUTH-4`). Confirmed: covered = {AUTH-1, AUTH-2}, UNCOVERED =
AUTH-3, ORPHAN = AUTH-9, production-only AUTH-4 not counted. Also confirmed the ID
regex `[A-Z]+-\d+` rejects malformed IDs (`1AUTH-2`) and that the tree-wide scan does
surface an `@ac` ID quoted inside a string literal — which is why the skill calls the
scan a text match, not a parser.

**2. RED/GREEN behavioral eval (paired subagents, 5 reps per arm).** Built a fixture
where the discriminating case is AUTH-3: marked with `@ac` on *production code only*,
no test (correct answer: UNCOVERED, coverage 2/3). Ten fresh agents got the same
natural-language question ("which acceptance criteria are covered by tests?"); the
skill arm additionally had the SKILL.md available.
- **Baseline (no skill), 5/5:** every rep counted AUTH-3 as **covered** off the
  production marker and reported **3/3** — the exact failure the skill's test-scoping
  rule targets. (Several noted AUTH-3 "has no test" as a caveat, yet still counted it.)
- **With the skill, 5/5:** every rep reported AUTH-3 **UNCOVERED** for the right reason,
  AUTH-9 orphan, no duplicates, **2/3**. Two reps reproduced the skill's example report
  format; one explicitly confirmed the markers weren't string false-positives.

Fully separated distributions, zero variance on the verdict: 3/3 (wrong) → 2/3 (right).

**3. Drill scenario authored (not yet executed).** I wrote a
`applying-tracing-acceptance-criteria` scenario (`story.md` / `setup.sh` /
`checks.sh`) in the superpowers-evals format, encoding the same discriminator as
verifier acceptance criteria. I could not execute the official `evals/` drill harness
in my environment (no `ANTHROPIC_API_KEY`, no `uv`; it runs real multi-minute agent
sessions). The scenario is ready for a follow-up PR to `superpowers-evals` and a
multi-rep run by anyone with a key.

**Still a draft because:** the human diff review below is pending, and the official
multi-backend drill run (Codex/Gemini as well as Claude) hasn't been executed —
the subagent eval above covers the Claude backend only.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills`
- [x] This change was tested adversarially, not just on the happy path — *baseline vs.
      skill on the production-only-marker trap, 5 reps per arm: 5/5 baseline wrong (3/3),
      5/5 skill correct (2/3), fully separated. Edge cases covered (production-only
      marker, malformed ID, string-literal false positive). Caveat: Claude backend only;
      the official multi-backend drill run is pending (scenario authored).*
- [x] I did not modify carefully-tuned content (Red Flags tables, rationalizations,
      "human partner" language, or any existing skill)

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission