### PR TITLE
docs(skills): tell controllers to release finished subagents

### DIFF
--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -83,6 +83,7 @@ When agents return:
 - Verify fixes don't conflict
 - Run full test suite
 - Integrate all changes
+- Release each agent unless you intend to send it further input — on some harnesses a finished agent holds its slot until closed (see the per-platform tool refs in `../using-superpowers/references/`)
 
 ## Agent Prompt Structure
 

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -44,6 +44,7 @@ Dispatch a `general-purpose` subagent, filling the template at [code-reviewer.md
 - Fix Important issues before proceeding
 - Note Minor issues for later
 - Push back if reviewer is wrong (with reasoning)
+- Release the reviewer unless you intend to send it further input — on some harnesses a finished agent holds its slot until closed (see the per-platform tool refs in `../using-superpowers/references/`)
 
 ## Example
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -394,10 +394,6 @@ Done!
 - Move to next task while the review has open Critical/Important issues
 - Re-dispatch a task the progress ledger already marks complete — check
   the ledger (and `git log`) after any compaction or resume
-- Leave subagents open once you are finished with them — release a task's
-  implementer, reviewer and fixers at task close-out, and the final
-  whole-branch reviewer once you have acted on its findings; you will send
-  none of them further input
 
 **If subagent asks questions:**
 - Answer clearly and completely

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -215,6 +215,8 @@ final whole-branch review. When you fill a reviewer template:
   subagent with the complete findings list — not one fixer per finding.
   Per-finding fixers each rebuild context and re-run suites; a real
   session's final-review fix wave cost more than all its tasks combined.
+- Release the final whole-branch reviewer, and any fixer it triggered, once
+  you have acted on its findings and will send them no further input.
 
 ## File Handoffs
 
@@ -257,6 +259,11 @@ a ledger file, not only in todos.
 - When a task's review comes back clean, append one line to the ledger in
   the same message as your other bookkeeping:
   `Task N: complete (commits <base7>..<head7>, review clean)`.
+  That bookkeeping includes releasing the subagents the task used —
+  implementer, task reviewer, and any fix subagents — you will send none
+  of them further input. On some harnesses a finished agent holds its slot
+  until closed (see the per-platform tool refs in
+  `../using-superpowers/references/`).
 - The ledger is your recovery map: the commits it names exist in git even
   when your context no longer remembers creating them. After compaction,
   trust the ledger and `git log` over your own recollection.
@@ -387,6 +394,10 @@ Done!
 - Move to next task while the review has open Critical/Important issues
 - Re-dispatch a task the progress ledger already marks complete — check
   the ledger (and `git log`) after any compaction or resume
+- Leave subagents open once you are finished with them — release a task's
+  implementer, reviewer and fixers at task close-out, and the final
+  whole-branch reviewer once you have acted on its findings; you will send
+  none of them further input
 
 **If subagent asks questions:**
 - Answer clearly and completely


### PR DESCRIPTION
Closes #1927.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (`claude-opus-4-8`), 1M context |
| Harness + version | Claude Code 2.1.209 |
| All plugins installed | gitban (muunkky.github.io/gitban-site), frontend-design, skill-creator, claude-patent-creator-standalone. Not `superpowers` itself. |
| Human partner who reviewed this diff | Cameron Rout (@muunkky) |

## What problem are you trying to solve?

`subagent-driven-development`, `dispatching-parallel-agents` and `requesting-code-review` all dispatch subagents, consume their results, and never tell the controller to release them.

On Codex a completed agent keeps its concurrency slot until it's closed. That's from the tool description the model is handed — [`multi_agents_spec.rs#L296`](https://github.com/openai/codex/blob/rust-v0.142.5/codex-rs/core/src/tools/handlers/multi_agents_spec.rs#L296):

> "Close an agent and any open descendants when they are no longer needed… Completed agents remain open and count toward the concurrency limit until closed."

The obligation is documented once, in `references/codex-tools.md` — `git grep -l close_agent -- skills/` on `dev` returns that one file — and a controller has no reason to re-read it mid-loop.

That sentence is yours, and keeping it was deliberate. `e7ddc25` deleted the generic row `| Free up subagent slot when done | close_agent |` and in the same commit replaced it with prose: "When using subagent-driven-development, you should always close implementer and reviewer subagents when they have finished all their work." It survived the prune, but it names only `subagent-driven-development`. `requesting-code-review` appears nowhere in that file, and none of the three workflow bodies say anything about releasing an agent at the point they consume a result.

The objection that raises is `e7ddc25`'s own rationale: the tables it pruned "restated guidance modern agents already follow." If that applies here, these nine lines are noise. They aren't: on `dev`, 0 of 8 agents connect closing a subagent to the slot it holds (below).

I haven't watched slot exhaustion in a live Codex session, and nobody on #1927 has. I'm citing the tool description, not an observation.

## What does this PR change?

Adds a release step to the three bodies, at the point each consumes a result. Nine added lines, nothing deleted. No harness or tool is named in any added line, so it reads correctly on a harness with no such concept.

```
$ git diff --numstat upstream/dev...
1	0	skills/dispatching-parallel-agents/SKILL.md
1	0	skills/requesting-code-review/SKILL.md
7	0	skills/subagent-driven-development/SKILL.md
```

## Is this change appropriate for the core library?

It's a platform-step mapping in three core cross-harness skills. On a harness with no release concept the wording is inert: the controller follows the pointer, finds nothing for its harness, and does nothing.

You might reasonably want this in `codex-tools.md` instead of the workflow bodies. Two things against that. The obligation sentence there is scoped to `subagent-driven-development` by name and never reaches `requesting-code-review`, and #1926 owns the file. If you'd rather have it there anyway, say so.

## What alternatives did you consider?

A neutral rule with no pointer — what I first proposed on #1927. A bare "release it" in `dispatching-parallel-agents` points at a rule scoped to a different skill, and in `requesting-code-review` it points at nothing.

Naming `close_agent` in the bodies. It isn't registered on the shipped v2 multi-agent branch of [`spec_plan.rs`](https://github.com/openai/codex/blob/rust-v0.142.5/codex-rs/core/src/tools/spec_plan.rs), which exposes `SpawnAgent`, `SendMessage`, `FollowupTask`, `WaitAgent`, `InterruptAgent` and `ListAgents`. Naming the tool would be wrong on a real version.

A neutral rule plus a pointer to the per-platform refs — chosen. It reuses the construction `executing-plans/SKILL.md:14` already uses from a cross-harness body. The pointer does work rather than decorate: on v1, `close_agent` is registered `ToolExposure::Deferred` for tool-search models, so the tool name and its obligation-bearing description aren't in the controller's context at the moment the rule fires.

The rule is keyed to intent rather than to SDD's implementer statuses:

> Release each agent unless you intend to send it further input

SDD is ambiguous about whether a turn-back reuses the agent (the digraph says "Dispatch fix subagent"; Red Flags say "Implementer (same subagent) fixes them"). A status-keyed rule inverts under one reading and holds a `BLOCKED` agent open forever.

## Does this PR contain multiple unrelated changes?

No. One problem, three dispatch sites of it.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #362 (closed), #1980, #1926, #1934, #1984 (mine)

#362 (@deinspanjer) is the closest prior art. It proposed this rule across `dispatching-parallel-agents`, `executing-plans` and SDD — "Always `wait` for results, then `close_agent` to release resources", "Do not leave spawned agents unclosed". You closed it as stale rather than on the merits: it targeted the Codex bootstrap CLI and `lib/skills-core.js`, both removed in February, and you added "if you'd like to revisit against the current codebase, we'd welcome a fresh PR." This is that revisit. Nine added lines against the current tree — no bootstrap, no `skills-core.js`, no FD-hygiene sections, no rewrites. The parts of #362 that went stale are the parts that are gone.

#1980 (@Seekers2001) is adjacent and points the other way. It stops a controller inferring `BLOCKED` from a mailbox timeout or an unchanged worktree, so it won't kill an agent that is still alive; this one releases an agent that is finished. Neither implies the other, and a controller wants both. We both add to `subagent-driven-development/SKILL.md`: theirs at the four-statuses block, mine at the final-review and ledger steps. I merged its head into this branch — clean auto-merge, both sets of insertions intact.

#1926 owns `references/codex-tools.md`, which I don't touch.

#1934 (yours) touches all three of my files, but its hunks strip sections and mine land in the workflow steps it keeps, so they're disjoint. Merged against this branch: all three files auto-merge, all four insertions survive. It conflicts in `skills/executing-plans/SKILL.md`, which neither of us touches here — it's stale against `dev` and conflicts there on its own.

#1984 is also mine and also touches `skills/requesting-code-review/SKILL.md` — different hunk (line 15 vs line 47), different problem, different issue (#1481, which you specced on #1572). They don't conflict.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code | 2.1.209 | Claude Opus 4.8 | `claude-opus-4-8[1m]` |

## Evaluation

RED/GREEN pressure test, the method `writing-skills` prescribes. Two trees cut from `upstream/dev`, identical
except this patch (`diff -r` = 9 added lines, 3 files, nothing else). Same prompt, fresh headless agent
(`claude -p … --plugin-dir <tree>`), **8 reps per arm**, graded by reading all 16 transcripts.

The prompt: mid-SDD, Task 3's implementer returned DONE, its reviewer came back clean, both subagents are
alive and idle, Task 4 is next and independent. *"Walk me through exactly what you do next… be specific and
complete about your bookkeeping."* Nothing hints at releasing anything.

| | releases the finished subagents | names the slot as the reason |
|---|---|---|
| `dev` | 3 of 8 | **0 of 8** |
| with this change | 8 of 8 | 7 of 8 |

**The interesting column is the second one.** `dev` is not silent — 3 of its 8 agents do stop the subagents,
and two do it as an explicit numbered step (*"I kill them via TaskStop"*). But every one of them gets there
from context hygiene, not capacity: they stop the implementer because **reusing** it would pollute Task 4
(*"Reusing the Task 3 implementer … imports Task 3's history into Task 4's reasoning"*). **No baseline agent
mentions a slot, capacity, or concurrency at all** — `grep -lic 'slot|concurrency|capacity'` over the 8 `dev`
transcripts returns nothing. The obligation isn't reachable from the workflow bodies, so they reason their way
to the action for an unrelated reason, and only sometimes.

With the change, 7 of 8 name it: *"on this harness a finished agent holds its slot until it's closed."* The
eighth releases too, but on context-hygiene grounds — right action, `dev`'s reason.

**Adversarial arm — the failure this wording exists to avoid.** Same setup, except the reviewer returns two
blocking findings, so the implementer is about to be reused. A status-keyed rule would release it here and
break the fix cycle. 3 of 3 hold it:

> "I do **not** release the Task 3 implementer or reviewer; both are needed again, and I only close a task's
> subagents as part of the same message that marks it complete."

> "Keep both subagents alive. Releasing subagents is part of *task-completion* bookkeeping… the implementer
> is about to do the fix."

All three then release at completion. That is the intent-keyed wording doing its job.

**Correction.** An earlier version of this PR reported 0 of 3 and 3 of 3, from an n=3 run. Re-run at n=8, the
release effect is smaller than that (3 of 8 → 8 of 8) and the earlier numbers were both wrong in my favour.
The case now rests on the second column, which is the thing the nine lines actually teach.

What this does not show: Claude Code has no release concept, so this measures whether the prose teaches the
obligation, not whether a Codex controller then calls `close_agent`. I have no Codex multi-agent access.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals

First box unticked: I didn't open `writing-skills` or work through its process. The before/after above is RED/GREEN, which is the method that skill prescribes, but I'm not ticking a box for a skill I didn't use. The adversarial case is the turn-back above, since the failure mode for this rule is releasing an agent you are about to reuse.

Nothing in the diff touches the Red Flags table or the rationalization lists. A Red Flags entry would back the final reviewer's release, as SDD has no prose step after the final review for it to attach to, but that's tuned content and I left it out. If you'd rather have it, I'll add it with the same before/after.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission


