### PR TITLE
test(pi): trim stale tool-mapping assertions

### DIFF
--- a/tests/pi/test-pi-extension.mjs
+++ b/tests/pi/test-pi-extension.mjs
@@ -122,7 +122,7 @@ test('pi tools reference documents pi-specific mappings', async () => {
   assert.equal(existsSync(piToolsPath), true, 'pi-tools.md should exist');
   const text = await readFile(piToolsPath, 'utf8');
 
-  for (const expected of ['Skill', 'Task', 'TodoWrite', 'read', 'write', 'edit', 'bash']) {
+  for (const expected of ['pi-subagents', 'subagent', 'TODO.md', 'TodoWrite']) {
     assert.match(text, new RegExp(expected));
   }
 });

--- a/tests/pi/test-pi-extension.mjs
+++ b/tests/pi/test-pi-extension.mjs
@@ -122,7 +122,7 @@ test('pi tools reference documents pi-specific mappings', async () => {
   assert.equal(existsSync(piToolsPath), true, 'pi-tools.md should exist');
   const text = await readFile(piToolsPath, 'utf8');
 
-  for (const expected of ['pi-subagents', 'subagent', 'TODO.md', 'TodoWrite']) {
-    assert.match(text, new RegExp(expected));
-  }
+  const rows = text.split('\n').filter((line) => line.startsWith('|'));
+  assert.ok(rows.some((row) => /subagent/i.test(row)), 'mapping table documents subagent dispatch');
+  assert.ok(rows.some((row) => /todo|task/i.test(row)), 'mapping table documents task tracking');
 });


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (`claude-opus-4-8`), 1M context |
| Harness + version | Claude Code 2.1.207 |
| All plugins installed | gitban (muunkky.github.io/gitban-site), frontend-design, skill-creator, claude-patent-creator-standalone. Not `superpowers` itself. |
| Human partner who reviewed this diff | Cameron Rout (@muunkky) |

## What problem are you trying to solve?

`tests/pi/test-pi-extension.mjs` fails on `dev`:

```
$ node --test tests/pi/test-pi-extension.mjs
not ok 6 - pi tools reference documents pi-specific mappings
  name: 'AssertionError'
# pass 5
# fail 1
```

The test loops over `['Skill', 'Task', 'TodoWrite', 'read', 'write', 'edit', 'bash']` and asserts each matches `pi-tools.md`. `write`, `edit` and `bash` are gone — `e7ddc25` ("Prune per-harness tool-mapping boilerplate") removed those generic mapping rows on purpose. The test was never updated, so it fails on `write`.

## What does this PR change?

The assertion in that one test. It now checks the mapping table itself:

```diff
-  for (const expected of ['Skill', 'Task', 'TodoWrite', 'read', 'write', 'edit', 'bash']) {
-    assert.match(text, new RegExp(expected));
-  }
+  const rows = text.split('\n').filter((line) => line.startsWith('|'));
+  assert.ok(rows.some((row) => /subagent/i.test(row)), 'mapping table documents subagent dispatch');
+  assert.ok(rows.some((row) => /todo|task/i.test(row)), 'mapping table documents task tracking');
```

`pi-tools.md` is not touched — the prune stays pruned. `git diff --numstat dev` → `3  3  tests/pi/test-pi-extension.mjs`. Suite goes 5 pass / 1 fail → 6 pass / 0 fail.

## Is this change appropriate for the core library?

Yes — it repairs a core test that is currently red.

## What alternatives did you consider?

**Restoring the deleted rows to `pi-tools.md`** would also turn the test green, and that's what the earlier attempt did. It's the wrong fix: it reverts a deliberate decision to satisfy a stale assertion.

**A straight trim of the token list** — my first attempt, and it was wrong for a reason worth stating. I trimmed the list to `['pi-subagents', 'subagent', 'TODO.md', 'TodoWrite']` and it passed. Then I deleted the entire mapping table from `pi-tools.md` and it *still* passed: all four tokens survive in the prose around the table. The trimmed list guarded nothing — the same defect the original list has. So the assertions here anchor on the table rows instead. I verified it by deleting the table and watching the test fail, then restoring it and watching it pass.

That's three added lines rather than one, which is more than a pure trim. If you'd rather have the one-line version, it's yours, but it doesn't test anything.

## Does this PR contain multiple unrelated changes?

No. One file.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: **#1903** (closed)

#1903 (@tianma-if) found this failure and the credit for spotting it is theirs. It was closed partly as one of a ten-PR batch, but also on the merits: it restored the pruned `Read`/`Write`/`Edit`/`Bash` rows, reversing `e7ddc25`. This does the opposite and leaves `pi-tools.md` alone. I said on that thread I'd stand aside if they wanted to write it; there's been no reply.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code | 2.1.207 | Claude Opus 4.8 | `claude-opus-4-8` (1M context) |

Reproduced the failure on a clean `dev` checkout (Linux, `node --test`) before changing anything; confirmed green after; and confirmed the new assertions fail when the mapping table is removed.

## Evaluation

Not applicable — test-only change, no skill prose touched, so there's no agent behaviour to eval. The verification is the test: red before, green after, and red again if the thing it checks is deleted.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals

First box unticked: this is test-only, no skill content changed, so `writing-skills` doesn't apply.

The adversarial test is the mutation above: I deleted the mapping table and confirmed the assertions fail. That's what caught my first attempt, which passed with the table gone.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission


