### PR TITLE
test: realign antigravity + pi mapping assertions with pruned references

### DIFF
--- a/tests/antigravity/test-antigravity-tools.sh
+++ b/tests/antigravity/test-antigravity-tools.sh
@@ -2,8 +2,9 @@
 # Validate the Antigravity (agy) integration. agy installs the existing plugin
 # directly (`agy plugin install <repo-url>`): it loads the bundled skills and
 # runs the SessionStart hook for bootstrap, so there is no agy-specific scaffold
-# to test. What IS agy-specific is the tool mapping — agy has no `Skill` tool and
-# loads skills by reading SKILL.md with view_file — and SKILL.md pointing at it.
+# to test. What IS agy-specific is the tool mapping — subagent dispatch via
+# invoke_subagent (self/research types) and task tracking via a task artifact —
+# and SKILL.md pointing at it.
 #
 # Mirrors tests/pi/test-pi-extension.mjs's "tools reference documents
 # harness-specific mappings" check. CI-safe: does not require `agy` installed.
@@ -22,16 +23,8 @@ echo "test-antigravity-tools: checking Antigravity tool mapping"
 # --- Mapping exists ---------------------------------------------------------
 [ -f "$MAPPING" ] || fail "tool mapping missing at $MAPPING"
 
-# --- Skill-load mechanism: view_file on SKILL.md (IsSkillFile), no Skill tool -
-grep -qiE "view_file" "$MAPPING" \
-  || fail "mapping does not document view_file as the file/skill-read tool"
-grep -qiE "SKILL\.md" "$MAPPING" \
-  || fail "mapping does not document reading SKILL.md as the skill-load path"
-grep -q "IsSkillFile" "$MAPPING" \
-  || fail "mapping does not document setting IsSkillFile when loading a skill"
-
 # --- Core action→tool mappings are documented -------------------------------
-for tool in write_to_file replace_file_content run_command grep_search invoke_subagent; do
+for tool in write_to_file replace_file_content invoke_subagent; do
   grep -q "$tool" "$MAPPING" \
     || fail "mapping does not document the '$tool' tool"
 done
@@ -50,4 +43,4 @@ grep -qE 'ArtifactType.*task|task. artifact' "$MAPPING" \
 grep -q "antigravity-tools.md" "$SKILL" \
   || fail "SKILL.md Platform Adaptation does not reference antigravity-tools.md"
 
-echo "PASS: Antigravity tool mapping valid (view_file skill-load, agy tools, SKILL.md link)"
+echo "PASS: Antigravity tool mapping valid (subagent dispatch, task artifact, SKILL.md link)"

--- a/tests/pi/test-pi-extension.mjs
+++ b/tests/pi/test-pi-extension.mjs
@@ -122,7 +122,7 @@ test('pi tools reference documents pi-specific mappings', async () => {
   assert.equal(existsSync(piToolsPath), true, 'pi-tools.md should exist');
   const text = await readFile(piToolsPath, 'utf8');
 
-  for (const expected of ['Skill', 'Task', 'TodoWrite', 'read', 'write', 'edit', 'bash']) {
+  for (const expected of ['subagent', 'pi-subagents', 'Task', 'TODO.md']) {
     assert.match(text, new RegExp(expected));
   }
 });

--- a/tests/pi/test-pi-extension.mjs
+++ b/tests/pi/test-pi-extension.mjs
@@ -122,7 +122,16 @@ test('pi tools reference documents pi-specific mappings', async () => {
   assert.equal(existsSync(piToolsPath), true, 'pi-tools.md should exist');
   const text = await readFile(piToolsPath, 'utf8');
 
-  for (const expected of ['subagent', 'pi-subagents', 'Task', 'TODO.md']) {
-    assert.match(text, new RegExp(expected));
-  }
+  // Assert against the mapping-table rows only. The surrounding prose mentions
+  // these same tokens, so matching the whole file would still pass if the table
+  // were deleted — the exact regression this test exists to catch.
+  const rows = text.split('\n').filter((line) => line.startsWith('|'));
+  assert.ok(
+    rows.some((row) => /subagent/i.test(row)),
+    'mapping table documents subagent dispatch',
+  );
+  assert.ok(
+    rows.some((row) => /todo|task/i.test(row)),
+    'mapping table documents task tracking',
+  );
 });


### PR DESCRIPTION
> **Targets the `dev` branch.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (1M context) — model ID `claude-opus-4-8[1m]` |
| Harness + version | Claude Code 2.1.143 |
| All plugins installed |  `superhuman@superhuman`, `superpowers@claude-plugins-official` |
| Human partner who reviewed this diff | Gaurav Dubey (@gaurav0107) |

## What problem are you trying to solve?

The plugin-infrastructure test suite fails on `dev` (and on `main`, 6.1.1). Two per-harness mapping tests assert content that was intentionally deleted:

```
$ git checkout dev
$ bash tests/antigravity/test-antigravity-tools.sh
FAIL: mapping does not document view_file as the file/skill-read tool   # exit 1

$ node tests/pi/test-pi-extension.mjs
✖ pi tools reference documents pi-specific mappings
  AssertionError: The input did not match the regular expression /write/   # exit 1 (1 of 6 cases)
```

Root cause: commit `e7ddc25` ("Prune per-harness tool-mapping boilerplate", 2026-06-24) deliberately removed the skill-loading explainers and the generic action→tool tables from `antigravity-tools.md` and `pi-tools.md`, trimming each file "to the harness-specific notes that still carry weight (subagent dispatch, task tracking…)". That commit did **not** touch `tests/`, so the two content-assertion tests still grep for tokens the prune removed — `view_file`, `IsSkillFile`, `run_command`, `grep_search` (antigravity) and `read`/`write`/`edit`/`bash` (pi). With no CI in the repo, the breakage went unnoticed.

## What does this PR change?

Updates the two orphaned tests to assert only the harness-specific mappings `e7ddc25` kept (subagent dispatch and task tracking) instead of the boilerplate it removed. No reference, skill, or product content is touched — only the stale test assertions (and their now-inaccurate header comment / PASS string).

## Is this change appropriate for the core library?

Yes. These are the repo's own plugin-infrastructure tests under `tests/`. No new dependency, no skill-behavior change, no third-party integration — it makes the existing suite green again on `dev`.

## What alternatives did you consider?

1. **Restore the pruned content to the reference files** so the tests pass unchanged — rejected: it directly contradicts `e7ddc25`'s stated intent, and the restore-direction attempt **PR #1902** ("Document Antigravity tool mappings for skill loading") was already **closed**. Reintroducing the boilerplate would re-break what the maintainer deliberately trimmed.
2. **Delete the two content-assertion tests entirely** — rejected: the reference files still exist and still document harness-specific mappings worth guarding. Trimming the assertions keeps meaningful coverage (subagent dispatch, task artifact, SKILL.md link) while dropping only the pruned tokens.

## Does this PR contain multiple unrelated changes?

No. One root cause — `e7ddc25` orphaned the per-harness mapping-content tests. Both files fail for the identical reason and are fixed the identical way. One problem.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: **#1902** (closed) attempted the opposite fix — restoring the pruned antigravity skill-load docs; its closure is what confirms the reference should stay lean and the *tests* should adapt instead. **#1969 / #1970** address a different slice of `e7ddc25` fallout (dead markdown links to the fully-deleted `claude-code-tools.md` / `copilot-tools.md`), not these test assertions. No open PR targets these two test files as a focused fix. (Several large, CONFLICTING, stale sweep-PRs incidentally include these files but do not repair the assertions.)

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.143 | Claude Opus 4.8 (1M context) | `claude-opus-4-8[1m]` |

Tests run locally on macOS (`bash` + `node --test`).

## New harness support (required if this PR adds a new harness)

N/A — this PR does not add a harness.

## Evaluation

Not a behavior/skill change, so there is no eval-session delta to report. Verification instead:
- **Before** (on `dev`): `tests/antigravity/test-antigravity-tools.sh` → exit 1; `tests/pi/test-pi-extension.mjs` → 5 pass / 1 fail.
- **After**: antigravity → `PASS`; pi → 6 pass / 0 fail.
- Also ran `tests/antigravity/run-tests.sh` (all passed) and the repo shell-lint tests (pass). Confirmed each surviving asserted token is actually present in the pruned reference file.

## Rigor

- [ ] If this is a skills change: … — **N/A, not a skills change** (tests only).
- [x] This change was tested adversarially, not just the happy path — verified failing-first on both `dev` and `main`, and confirmed the new assertions match the pruned references.
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) — no skill/prose content touched.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission — @gaurav0107 reviewed the full two-file diff and approved it.
