### PR TITLE
test(antigravity): realign mapping assertions with the pruned reference

### DIFF
--- a/tests/antigravity/test-antigravity-tools.sh
+++ b/tests/antigravity/test-antigravity-tools.sh
@@ -2,8 +2,9 @@
 # Validate the Antigravity (agy) integration. agy installs the existing plugin
 # directly (`agy plugin install <repo-url>`): it loads the bundled skills and
 # runs the SessionStart hook for bootstrap, so there is no agy-specific scaffold
-# to test. What IS agy-specific is the tool mapping — agy has no `Skill` tool and
-# loads skills by reading SKILL.md with view_file — and SKILL.md pointing at it.
+# to test. What IS agy-specific is the tool mapping — subagent dispatch via
+# invoke_subagent (self/research types) and task tracking via a task artifact —
+# and SKILL.md pointing at it.
 #
 # Mirrors tests/pi/test-pi-extension.mjs's "tools reference documents
 # harness-specific mappings" check. CI-safe: does not require `agy` installed.
@@ -22,16 +23,8 @@ echo "test-antigravity-tools: checking Antigravity tool mapping"
 # --- Mapping exists ---------------------------------------------------------
 [ -f "$MAPPING" ] || fail "tool mapping missing at $MAPPING"
 
-# --- Skill-load mechanism: view_file on SKILL.md (IsSkillFile), no Skill tool -
-grep -qiE "view_file" "$MAPPING" \
-  || fail "mapping does not document view_file as the file/skill-read tool"
-grep -qiE "SKILL\.md" "$MAPPING" \
-  || fail "mapping does not document reading SKILL.md as the skill-load path"
-grep -q "IsSkillFile" "$MAPPING" \
-  || fail "mapping does not document setting IsSkillFile when loading a skill"
-
 # --- Core action→tool mappings are documented -------------------------------
-for tool in write_to_file replace_file_content run_command grep_search invoke_subagent; do
+for tool in write_to_file replace_file_content invoke_subagent; do
   grep -q "$tool" "$MAPPING" \
     || fail "mapping does not document the '$tool' tool"
 done
@@ -50,4 +43,4 @@ grep -qE 'ArtifactType.*task|task. artifact' "$MAPPING" \
 grep -q "antigravity-tools.md" "$SKILL" \
   || fail "SKILL.md Platform Adaptation does not reference antigravity-tools.md"
 
-echo "PASS: Antigravity tool mapping valid (view_file skill-load, agy tools, SKILL.md link)"
+echo "PASS: Antigravity tool mapping valid (subagent dispatch, task artifact, SKILL.md link)"


### PR DESCRIPTION
> **This PR targets the `dev` branch.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (`claude-opus-4-8`), via Google Vertex AI |
| Harness + version | An internal Google agent harness (not publicly named) |
| All plugins installed | None relevant to this change; the `superpowers` plugin was installed on the real Antigravity CLI (`agy` 1.1.1) for live verification |
| Human partner who reviewed this diff | Casey West (@cwest) — reviewed the complete diff and verified it end-to-end, including a live run on the real `agy` CLI |

## What problem are you trying to solve?

`tests/antigravity/test-antigravity-tools.sh` fails on `dev`:

```
$ bash tests/antigravity/test-antigravity-tools.sh
test-antigravity-tools: checking Antigravity tool mapping
FAIL: mapping does not document view_file as the file/skill-read tool   # exit 1
```

`e7ddc25` (#1847) intentionally trimmed the skill-loading explainer and the generic action→tool table out of `antigravity-tools.md` (pruning to "the harness-specific notes that still carry weight"), but did not update `tests/`. The test still greps for tokens the prune removed — `view_file`, `IsSkillFile`, `SKILL.md`, `run_command`, `grep_search` — so the antigravity suite has been red ever since. The doc is correct as-is; the **test** is stale.

## What does this PR change?

Realigns `tests/antigravity/test-antigravity-tools.sh` with the slimmed reference: it now asserts only what the doc still documents and agents rely on — subagent dispatch (`invoke_subagent`, `self`/`research`), the `write_to_file`/`replace_file_content` tools, and the task-artifact mechanism — plus the `SKILL.md` Platform Adaptation link. Drops the assertions for the intentionally-removed tokens. One file (test only); the reference doc is untouched.

## Is this change appropriate for the core library?

Yes — it repairs an existing core test so the antigravity suite is green again. No new skill, domain, or third-party integration; no product behavior change.

## What alternatives did you consider?

1. **Restore the pruned content to `antigravity-tools.md`** (turn the test green by re-adding `view_file`/`IsSkillFile`/etc.). Rejected: #1847 removed that content deliberately, and a clean `agy` run confirms agents don't need it (skills load and `brainstorming` auto-triggers without it). Re-adding it would reintroduce exactly what the prune set out to remove.
2. **Realign the test with the slimmed doc** (this PR). Chosen — it matches the intent of #1847 and keeps the doc lean.

## Does this PR contain multiple unrelated changes?

No. Single file, single concern: make the stale antigravity test match the intentionally-pruned reference.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1987 (open), #1902 (closed)

**#1987** (open) proposes the same realignment across **two** files (`tests/antigravity` + `tests/pi`). This PR is the **narrower, antigravity-only** version — happy to defer to #1987 if you'd rather take the combined change; flagging it so you can choose.

**#1902** (closed) proposed the opposite fix (restoring the doc). Per the reasoning above, the doc-restore direction re-adds content #1847 intentionally removed, so this PR fixes the test instead.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Antigravity CLI (`agy`) | 1.1.1 | Antigravity default (Gemini) | not surfaced by `agy` |

Repo suite (no model): `bash tests/antigravity/run-tests.sh` → PASS; `bash tests/hooks/test-session-start.sh` → PASS; `git diff --check` → clean.

## New harness support (required if this PR adds a new harness)

N/A — no new harness. As corroboration that the removed details aren't needed at runtime: on a clean, isolated `agy` 1.1.1 profile (`agy plugin install <repo>`) the plugin loaded 14 skills + the SessionStart hook, and a live session auto-triggered `brainstorming` before any code was written — without the pruned mapping lines present.

## Evaluation
- Before: the antigravity suite fails on `dev` with the error above.
- After: `bash tests/antigravity/run-tests.sh` passes; the test still catches real regressions (removing `invoke_subagent`, the `self`/`research` types, or the task-artifact mechanism from the doc still fails it).
- A live `agy` run confirmed skills load/trigger without the removed tokens — i.e. the doc is correct as slimmed.

## Rigor
- [ ] N/A — not a skills change (this is a test-harness assertion realignment)
- [x] This change was tested adversarially, not just on the happy path (full antigravity suite + hooks test + whitespace check + live `agy` run; confirmed the trimmed test still fails when a still-documented token is removed)
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language)

## Human review
- [x] A human (Casey West, @cwest) has reviewed the COMPLETE proposed diff before submission
