### PR TITLE
docs(brainstorming): correct Copilot CLI backgrounding guidance for Windows

### DIFF
--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -83,10 +83,11 @@ scripts/start-server.sh --project-dir /path/to/project --open --foreground
 
 **Copilot CLI:**
 ```bash
-# Use --foreground and start the server via the bash tool with mode: "async"
-# so the process survives across turns. Capture the returned shellId for
-# read_bash / stop_bash if you need to interact with it later.
-scripts/start-server.sh --project-dir /path/to/project --open --foreground
+# Start it with Copilot CLI's non-blocking/background shell mechanism so the
+# server survives across turns. Keep --foreground so the harness, not the
+# script, owns backgrounding. The launcher is a .sh, so invoke it via bash
+# (on Windows, call Git Bash's bash.exe from the PowerShell tool).
+bash scripts/start-server.sh --project-dir /path/to/project --open --foreground
 ```
 
 **Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Gemini 2.0 Pro |
| Harness + version | Antigravity 2.0 |
| All plugins installed | superpowers, caveman |
| Human partner who reviewed this diff | @arimu1 |

## What problem are you trying to solve?
GitHub Copilot CLI on Windows uses PowerShell as its primary shell environment. This environment does not support bash-specific async tool options (`bash` tool, `read_bash`, `stop_bash`, `mode: "async"`). However, `skills/brainstorming/visual-companion.md` incorrectly advises Windows/Copilot CLI users to use these nonexistent bash-specific options.

This mismatch was originally reported in #1929.

## What does this PR change?
This PR updates the Copilot CLI section in `visual-companion.md` to guide users to use the harness's general background execution mechanism instead of bash-specific options, aligning it with the general "Other environments" instructions in the same file.

## Is this change appropriate for the core library?
Yes, it corrects general documentation for the core brainstorming skill.

## What alternatives did you consider?
We considered adding `.ps1` backgrounding scripts or native PowerShell adapters, but decided a docs-only fix pointing to the platform's general background execution mechanism is much simpler, safer, and follows the existing "Other environments" precedent.

## Does this PR contain multiple unrelated changes?
No.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1973 (closed, unrelated whitespace formatting patch)

## Environment tested
N/A (documentation-only correction).
