### PR TITLE
fix(codex): make package timestamps timezone-independent

### DIFF
--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -294,7 +294,7 @@ case "$FORMAT" in
     (
       cd "$STAGE"
       rm -f "$OUTPUT"
-      COPYFILE_DISABLE=1 zip -X -q - -@ <"$ARCHIVE_LIST" >"$OUTPUT"
+      COPYFILE_DISABLE=1 TZ=UTC zip -X -q - -@ <"$ARCHIVE_LIST" >"$OUTPUT"
     )
     ;;
   tar.gz)

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -135,6 +135,8 @@ echo "Codex package archive tests"
 
 metadata_source="$TEST_ROOT/metadata-source"
 archive="$TEST_ROOT/superpowers"
+utc_archive="$TEST_ROOT/superpowers-utc.zip"
+seoul_archive="$TEST_ROOT/superpowers-seoul.zip"
 tar_archive="$TEST_ROOT/superpowers.tar.gz"
 extracted="$TEST_ROOT/extracted"
 tar_extracted="$TEST_ROOT/tar-extracted"
@@ -159,6 +161,26 @@ fi
 assert_contains "$output" "Archive:" "reports archive path"
 assert_contains "$output" "Format:  zip" "reports default zip format"
 assert_contains "$output" "SHA-256:" "reports archive checksum"
+
+if output="$(TZ=UTC "$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_source" --output "$utc_archive" 2>&1)"; then
+  pass "package script writes ZIP archive under UTC"
+else
+  fail "package script writes ZIP archive under UTC"
+  printf '%s\n' "$output" | sed 's/^/      /'
+fi
+
+if output="$(TZ=Asia/Seoul "$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_source" --output "$seoul_archive" 2>&1)"; then
+  pass "package script writes ZIP archive under Asia/Seoul"
+else
+  fail "package script writes ZIP archive under Asia/Seoul"
+  printf '%s\n' "$output" | sed 's/^/      /'
+fi
+
+if cmp -s "$utc_archive" "$seoul_archive"; then
+  pass "ZIP archives are byte-identical across time zones"
+else
+  fail "ZIP archives are byte-identical across time zones"
+fi
 
 extract_archive "$archive" "$extracted"
 
@@ -210,8 +232,15 @@ assert_equals "$tar_archive_paths" "$archive_paths" "zip and tar.gz archives con
 tar_task_brief_mode="$(tar -tzvf "$tar_archive" skills/subagent-driven-development/scripts/task-brief | awk '{print $1}')"
 assert_equals "$tar_task_brief_mode" "-rwxr-xr-x" "tar.gz archive preserves executable script mode"
 
-tar_metadata_times="$(tar -tzvf "$tar_archive" | awk '{print $6, $7, $8}' | sort -u)"
-assert_equals "$tar_metadata_times" "Dec 31 1969" "tar.gz archive normalizes entry timestamps"
+tar_metadata_times="$(python3 - "$tar_archive" <<'PY'
+import sys
+import tarfile
+
+with tarfile.open(sys.argv[1]) as archive:
+    print("\n".join(sorted({str(member.mtime) for member in archive.getmembers()})))
+PY
+)"
+assert_equals "$tar_metadata_times" "0" "tar.gz archive normalizes entry timestamps"
 
 metadata_archive="$TEST_ROOT/metadata-source.tar.gz"
 metadata_zip="$TEST_ROOT/metadata-source.zip"


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | OpenAI GPT-5.6-sol (primary and final review); GPT-5.6-terra (implementation and task review) |
| Harness + version | ChatGPT/Codex desktop 26.715.31925 (build 5551), embedded Codex CLI 0.145.0-alpha.18; local Codex CLI 0.144.4 |
| All plugins installed | documents, pdf, spreadsheets, presentations, template-creator 26.715.12143; sites 0.1.30; browser and chrome 26.715.31925; computer-use 1.0.1000451; visualize 1.0.12; slack, game-studio, github, codex-security 2f1a8948; active Superpowers skill bundle 6.1.1 |
| Human partner who reviewed this diff | @SeuPut0705 |

## What problem are you trying to solve?

Running `tests/codex/test-package-codex-plugin.sh` on macOS in Asia/Seoul produced two timestamp failures. ZIP entries were stored as `(1980, 1, 1, 9, 0, 0)` instead of midnight, and the tar assertion compared a localized date string (`Dec 31 1969`) with macOS bsdtar's `Jan 1 1970` display.

Direct reproduction showed that UTC and Asia/Seoul ZIP packages had different SHA-256 values and stored `00:00` versus `09:00`, while both tar packages were byte-identical and had raw member `mtime` values of `0`. The ZIP command inherited the host timezone even though the preceding `touch` ran under UTC; the tar test was inspecting presentation text rather than archive metadata.

## What does this PR change?

Run Info-ZIP with `TZ=UTC`, add a regression test that compares real ZIP bytes produced under UTC and Asia/Seoul, and inspect tar member mtimes through Python's `tarfile` API instead of localized `tar -tvf` output.

## Is this change appropriate for the core library?

Yes. This fixes the repository's Codex packaging script and its integration test without adding dependencies or changing skill behavior. Deterministic portal packages benefit every maintainer producing the official Codex archive.

## What alternatives did you consider?

- Keeping UTC only on `touch`: this is the current behavior and leaves Info-ZIP's DOS timestamp conversion timezone-dependent.
- Relaxing the ZIP timestamp assertion: this would hide non-reproducible package bytes.
- Rebuilding ZIP output with Python: this would replace the existing production archive path for a one-environment-variable fix.
- Comparing `tar -tvf` under a forced locale/timezone: the rendered date remains tool-specific; raw `member.mtime` is the portable archive contract.

## Does this PR contain multiple unrelated changes?

No. The one-line packaging fix and both test changes address the same archive timestamp determinism defect.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art.
- Related PRs: none found for `package-codex-plugin timestamp`, `archive timezone deterministic`, or `Codex package zip` in open/closed PRs and issues.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| ChatGPT/Codex desktop on macOS 26.5.2, Asia/Seoul | 26.715.31925 (build 5551), embedded Codex CLI 0.145.0-alpha.18 | OpenAI | GPT-5.6-sol / GPT-5.6-terra |
| Shell integration test: bsdtar 3.5.3, Info-ZIP 3.0, Python 3.14.6 | local Codex CLI 0.144.4 | N/A | N/A |

## New harness support

Not applicable. This PR does not add or change harness support.

## Evaluation

- Initial prompt: the human partner approved proceeding with a PR after the KST packaging test failure was reproduced during Codex package verification.
- Before: explicit UTC and Asia/Seoul ZIP builds had different SHA-256 values and timestamps; the focused test reported two failures.
- After: the focused packaging integration test passes, including byte-identical UTC/Asia/Seoul ZIP output and raw tar `mtime == 0`; the marketplace manifest test and `git diff --check` also pass.
- Model eval sessions after the change: 0. This is packaging infrastructure, not behavior-shaping skill content.

## Rigor

- [x] This is not a skills change; `superpowers:writing-skills` is not applicable.
- [x] The change was tested adversarially with explicit UTC and Asia/Seoul environments.
- [x] No carefully tuned behavior-shaping content was modified.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission.
