### PR TITLE
Codex/1drop pipeline

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -10,47 +10,86 @@ Help turn ideas into fully formed designs and specs through natural collaborativ
 Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.
 
 <HARD-GATE>
-Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
+Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have classified the workflow, presented a design, and the user has approved it. A compact in-chat design satisfies this gate only when every compact-workflow condition below holds.
 </HARD-GATE>
 
-## Anti-Pattern: "This Is Too Simple To Need A Design"
+## Route the Workflow First
 
-Every project goes through this process. A todo list, a single-function utility, a config change — all of them. "Simple" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+### Context gate
+
+Use direct research when the task is confined to one known module and no more than three targeted files. Use **superpowers:exploring-codebase-context** before detailed questions when any of these are true:
+
+- two or more independent domains are involved;
+- the implementation point is unclear;
+- more than five files are likely needed;
+- direct exploration would consume substantial parent context.
+
+Treat its context brief as the exploration result. Open primary files yourself only for conflicts, missing evidence, or high-impact claims.
+
+### Ceremony gate
+
+Use the compact workflow only when **all** conditions hold:
+
+- one module owns the change;
+- no more than two implementation files are expected;
+- no public API, schema, dependency, or architectural boundary changes;
+- no authentication, payments, security, migrations, or infrastructure impact;
+- the solution is unambiguous and has no competing architectural approaches;
+- verification is local and already understood.
+
+Tests and fixtures do not count as implementation files, but their impact must remain local. If any condition fails—or later exploration invalidates one—use the full workflow.
+
+## Anti-Pattern: "Small Means No Design"
+
+Small tasks still require an approved design. What changes is the ceremony: compact tasks use one concise in-chat design; larger or risk-sensitive tasks retain the complete spec and planning workflow.
 
 ## Checklist
 
 You MUST create a task for each of these items and complete them in order:
 
-1. **Explore project context** — check files, docs, recent commits
-2. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
-3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
-4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+1. **Explore project context** — apply the context gate; use the context skill when it fires
+2. **Classify ceremony** — record which compact conditions pass or fail
+3. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
+4. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
+5. **Run the selected workflow**:
+   - **Compact:** present one concise design and verification strategy, then get approval
+   - **Full:** propose 2-3 approaches, present design sections, write and commit the spec, self-review it, obtain user review, then invoke writing-plans
 
 ## Process Flow
 
 ```dot
 digraph brainstorming {
     "Explore project context" [shape=box];
-    "Ask clarifying questions" [shape=box];
+    "All compact conditions hold?" [shape=diamond];
+    "Ask compact clarifying questions" [shape=box];
+    "Ask full clarifying questions" [shape=box];
+    "Present compact design" [shape=box];
     "Propose 2-3 approaches" [shape=box];
     "Present design sections" [shape=box];
-    "User approves design?" [shape=diamond];
+    "Compact design approved?" [shape=diamond];
+    "Full design approved?" [shape=diamond];
+    "Implementation requested?" [shape=diamond];
+    "Invoke TDD and domain skill" [shape=doublecircle];
+    "Stop with approved design" [shape=doublecircle];
     "Write design doc" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
     "User reviews spec?" [shape=diamond];
     "Invoke writing-plans skill" [shape=doublecircle];
 
-    "Explore project context" -> "Ask clarifying questions";
-    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Explore project context" -> "All compact conditions hold?";
+    "All compact conditions hold?" -> "Ask compact clarifying questions" [label="yes"];
+    "All compact conditions hold?" -> "Ask full clarifying questions" [label="no"];
+    "Ask compact clarifying questions" -> "Present compact design";
+    "Ask full clarifying questions" -> "Propose 2-3 approaches";
+    "Present compact design" -> "Compact design approved?";
     "Propose 2-3 approaches" -> "Present design sections";
-    "Present design sections" -> "User approves design?";
-    "User approves design?" -> "Present design sections" [label="no, revise"];
-    "User approves design?" -> "Write design doc" [label="yes"];
+    "Present design sections" -> "Full design approved?";
+    "Compact design approved?" -> "Ask compact clarifying questions" [label="no, revise"];
+    "Compact design approved?" -> "Implementation requested?" [label="yes"];
+    "Implementation requested?" -> "Invoke TDD and domain skill" [label="yes"];
+    "Implementation requested?" -> "Stop with approved design" [label="no"];
+    "Full design approved?" -> "Ask full clarifying questions" [label="no, revise"];
+    "Full design approved?" -> "Write design doc" [label="yes"];
     "Write design doc" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "User reviews spec?";
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
@@ -58,7 +97,7 @@ digraph brainstorming {
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+**Terminal state depends on the selected workflow.** Full workflow invokes writing-plans. Compact workflow, when implementation was requested, invokes test-driven-development and the applicable domain skill only after design approval.
 
 ## The Process
 
@@ -72,7 +111,7 @@ digraph brainstorming {
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
 - Focus on understanding: purpose, constraints, success criteria
 
-**Exploring approaches:**
+**Exploring approaches (full workflow):**
 
 - Propose 2-3 different approaches with trade-offs
 - Present options conversationally with your recommendation and reasoning
@@ -81,6 +120,8 @@ digraph brainstorming {
 **Presenting the design:**
 
 - Once you believe you understand what you're building, present the design
+- For compact work, present one concise section covering the intended change, preserved behavior, affected boundary, and verification
+- For full work, present sections scaled to their complexity
 - Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
 - Ask after each section whether it looks right so far
 - Cover: architecture, components, data flow, error handling, testing
@@ -100,6 +141,12 @@ digraph brainstorming {
 - Don't propose unrelated refactoring. Stay focused on what serves the current goal.
 
 ## After the Design
+
+### Compact workflow
+
+After approval, do not create a design document or separate implementation plan. If implementation was requested, invoke superpowers:test-driven-development and the applicable domain skill. If the user requested discussion only, stop with the approved design.
+
+### Full workflow
 
 **Documentation:**
 

--- a/skills/exploring-codebase-context/SKILL.md
+++ b/skills/exploring-codebase-context/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: exploring-codebase-context
+description: Use when planning, debugging, security review, or migration work requires understanding unfamiliar or multiple codebase areas and direct exploration would consume substantial parent context
+---
+
+# Exploring Codebase Context
+
+## Overview
+
+Delegate bounded, read-only repository research and return one evidence-backed context brief. The parent agent owns scope, synthesis, and every downstream decision.
+
+## Exploration Contract
+
+Before reading implementation files, define:
+
+- **Objective:** the decision or workflow this research must unblock.
+- **Known facts:** established context that should not be rediscovered.
+- **Unknowns:** concrete questions, not broad topics.
+- **Scope:** allowed packages, directories, or subsystems.
+- **Stop condition:** what evidence makes the next workflow safe to continue.
+
+Exploration never edits files and never expands into implementation, design, diagnosis, or audit conclusions.
+
+## Workflow
+
+### 1. Take a surface snapshot
+
+Read only applicable repository instructions, the top-level structure, primary manifests, working-tree status, recent history, and targeted search results. Do not open every search hit.
+
+Follow the shortest evidence chain: authoritative entry point, direct contract or data edge, then tests or history only when the question requires verification or the implementation is ambiguous. Do not recursively map adjacent callers.
+
+### 2. Apply the delegation gate
+
+| Observed scope | Action |
+|---|---|
+| One known module and no more than three targeted files | Research directly |
+| Two or more independent domains | Delegate by domain |
+| Implementation point is unclear | Delegate discovery |
+| More than five files are likely required | Delegate bounded questions |
+
+When uncertain, delegate one discovery question first; do not fan out speculative tasks.
+
+### 3. Dispatch bounded explorers
+
+Read [references/context-explorer.md](references/context-explorer.md) and instantiate it for each question. Use isolated context where supported. Run independent questions in parallel and dependent questions sequentially.
+
+One explorer owns one domain and one answerable question. Do not give explorers the full conversation when the objective, known facts, and constraints are sufficient.
+
+### 4. Synthesize the context brief
+
+Produce a decision-ready brief, not a subsystem inventory. A finding belongs only when omitting it could change the next workflow's scope, feasible approaches, material risks, or verification strategy.
+
+Return:
+
+1. Direct answers to the defined unknowns.
+2. Decision-affecting findings with inline repository paths.
+3. Unknowns that still block the defined objective.
+
+Do not enumerate every component, invariant, test, or file read. Include a flow or component map only when the caller could choose the wrong boundary without it.
+
+Surface-snapshot facts such as unrelated working-tree changes or recent commits are orientation data, not report findings, unless the objective depends on them.
+
+Verify primary files yourself only when reports conflict, evidence is missing, or a claim controls a high-impact decision.
+
+### 5. Stop
+
+Stop each explorer as soon as its question has primary evidence or a documented evidence gap. Stop the overall exploration as soon as the defined decision is unblocked. Hand the context brief to the calling workflow; do not continue into its work.
+
+## Common Mistakes
+
+- **"Understand this subsystem"** is not a question. Name the decision and unknown.
+- Overlapping explorer scopes duplicate reading. Partition by independent boundary.
+- Raw trees, file dumps, and process narration consume the context the skill exists to protect.
+- A catalog of everything discovered is not a context brief. Filter by effect on the next decision.
+- A report that proposes fixes has crossed into another workflow.
+- More research after the stop condition is met is context waste.

--- a/skills/exploring-codebase-context/agents/openai.yaml
+++ b/skills/exploring-codebase-context/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Exploring Codebase Context"
+  short_description: "Delegate focused repository context research"
+  default_prompt: "Use $exploring-codebase-context to gather the minimum repository context needed for this task."

--- a/skills/exploring-codebase-context/references/context-explorer.md
+++ b/skills/exploring-codebase-context/references/context-explorer.md
@@ -1,0 +1,26 @@
+# Context Explorer Dispatch Template
+
+Use this template to create a fresh, read-only explorer task.
+
+```markdown
+Work read-only. Do not edit files or propose implementation.
+
+Objective: <decision or workflow this research must unblock>
+Known facts: <facts that must not be rediscovered>
+Scope: <allowed packages, directories, or subsystem>
+Question: <one concrete, answerable question>
+Evidence required: <contracts, flows, definitions, tests, or history>
+Exclusions: <adjacent areas and downstream work to avoid>
+Stop condition: <evidence that makes the question answered>
+
+Follow the shortest evidence chain: authoritative entry point, direct contract or data edge, then tests or history only if required by the question or an ambiguity. Do not map adjacent code after the stop condition is met.
+
+Return a minimally sufficient report:
+
+1. Direct answer to the assigned question.
+2. Findings whose omission could change scope, feasible approaches, material risks, or verification; cite a primary repository path inline for each.
+3. Unknowns that still prevent a confident answer.
+
+Omit task restatement, process narration, raw listings, large code excerpts, and catalogs of every component or file read.
+If the scope cannot answer one coherent question, stop and propose independent questions instead of broadening the report.
+```


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)
<!-- Required. PRs that omit this will be closed. We assume an agent wrote
     this PR — tell us which one and where it ran. We weigh contributions by
     what produced them: content reasoned from documentation is held to a
     different bar than work grounded in a real session. -->

| Field | Value |
|-------|-------|
| Your model + version | |
| Harness + version | |
| All plugins installed | |
| Human partner who reviewed this diff | |

## What problem are you trying to solve?
<!-- Describe the specific problem you encountered. If this was a session
     issue, include: what you were doing, what went wrong, the model's
     exact failure mode, and ideally a transcript or session log.

     "Improving" something is not a problem statement. What broke? What
     failed? What was the user experience that motivated this? -->

## What does this PR change?
<!-- 1-3 sentences. What, not why — the "why" belongs above. -->

## Is this change appropriate for the core library?
<!-- Superpowers core contains general-purpose skills and infrastructure
     that benefit all users. Ask yourself:

     - Would this be useful to someone working on a completely different
       kind of project than yours?
     - Is this project-specific, team-specific, or tool-specific?
     - Does this integrate or promote a third-party service?

     If your change is a new skill for a specific domain, workflow tool,
     or third-party integration, it belongs in its own plugin — not here.
     See the plugin development docs for how to publish it separately. -->

## What alternatives did you consider?
<!-- What other approaches did you try or evaluate before landing on this
     one? Why were they worse? If you didn't consider alternatives, say so
     — but know that's a red flag. -->

## Does this PR contain multiple unrelated changes?
<!-- If yes: stop. Split it into separate PRs. Bundled PRs will be closed.
     If you believe the changes are related, explain the dependency. -->

## Existing PRs
- [ ] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: <!-- #number, #number, or "none found" -->

<!-- If a related closed PR exists, explain what's different about your
     approach and why it should succeed where the other didn't. -->

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
|                                     |                 |       |                  |

## New harness support (required if this PR adds a new harness)

<!-- If this PR adds support for a new harness (IDE, CLI tool, agent
     runner), you MUST include a session transcript proving the
     integration actually works.

     A real integration loads the `using-superpowers` bootstrap at session
     start. The bootstrap is what causes skills to auto-trigger. Without
     it, the skills are dead weight — present on disk but never invoked
     at the right moments.

     ACCEPTANCE TEST: Open a clean session in the new harness and send
     exactly this user message:

         Let's make a react todo list

     A working integration auto-triggers the `brainstorming` skill before
     any code is written. Paste the complete transcript below.

     These are NOT real integrations and PRs that ship them will be closed:

     - Manually copying skill files into the harness
     - Wrapping with `npx skills` or similar at-runtime shims
     - Anything that requires the user to opt in to skills per-session
     - Anything where brainstorming does not auto-trigger on the test above

     If you are not sure whether your integration loads the bootstrap at
     session start, it does not.
-->

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
paste the complete transcript here
```

</details>

## Evaluation
- What was the initial prompt you (or your human partner) used to start
  the session that led to this change?
- How many eval sessions did you run AFTER making the change?
- How did outcomes change compared to before the change?

<!-- "It works" is not evaluation. Describe the before/after difference
     you observed across multiple sessions. -->

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [ ] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

<!-- If you changed wording in skills that shape agent behavior, show your
     eval methodology and results. These are not prose — they are code. -->

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->
