### PR TITLE
docs(using-superpowers): drop dangling subagent-support anchor

### DIFF
--- a/skills/using-superpowers/references/antigravity-tools.md
+++ b/skills/using-superpowers/references/antigravity-tools.md
@@ -4,7 +4,7 @@ Skills speak in actions ("dispatch a subagent", "create a todo", "read a file").
 
 | Action skills request | Antigravity CLI equivalent |
 |----------------------|----------------------|
-| Dispatch a subagent (`Subagent (general-purpose):` template) | `invoke_subagent` with a built-in `TypeName` — `self` for full-capability work, `research` for read-only (see [Subagent support](#subagent-support)) |
+| Dispatch a subagent (`Subagent (general-purpose):` template) | `invoke_subagent` with a built-in `TypeName` — `self` for full-capability work, `research` for read-only |
 | Task tracking ("create a todo", "mark complete") | a **task artifact** — `write_to_file` with `IsArtifact: true` and `ArtifactType: "task"` (see [Task tracking](#task-tracking)). **Not** `manage_task`, which manages background processes. |
 
 ## Task tracking


### PR DESCRIPTION
> **Targets the `dev` branch.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 4.8 (1M context) — model ID `claude-opus-4-8[1m]` |
| Harness + version | Claude Code 2.1.215 |
| All plugins installed | A downstream fork of superpowers (`braze-superpowers`, tracking upstream 6.1.1) plus internal Braze plugins. Not the upstream `superpowers` plugin as-shipped. |
| Human partner who reviewed this diff | Mark Rada (@ferrous26) |

## What problem are you trying to solve?

`skills/using-superpowers/references/antigravity-tools.md` contains a link that resolves to nothing.

The dispatch row tells an agent where to learn the difference between the two built-in Antigravity subagent types:

```
| Dispatch a subagent … | `invoke_subagent` with a built-in `TypeName` — `self` for full-capability
work, `research` for read-only (see [Subagent support](#subagent-support)) |
```

There is no `## Subagent support` heading in the file. The only headings are `# Antigravity CLI (agy) Tool Mapping` and `## Task tracking`. An agent that follows the pointer to decide between `self` and `research` lands nowhere.

This is leftover from the prune in `e7ddc25e` ("Prune per-harness tool-mapping boilerplate"). That commit deliberately deleted the `## Subagent support` section but left the inline cross-reference behind:

| tag | file size | `## Subagent support` | cross-reference |
|-----|-----------|----------------------|-----------------|
| v6.0.3 | 5691 B | present | consistent |
| v6.1.0 | 1539 B | **removed** | **left behind** |
| v6.1.1 | 1539 B | removed | left behind |
| `dev` @ cc69047 | 1539 B | removed | left behind |

Still present on `dev` and `main` today.

**How it was found:** not from an Antigravity session. I was syncing a downstream fork to 6.1.1 and ran a static anchor check over the skill tree — every `[text](#anchor)` link compared against the headings actually present in that file. This was the one mismatch.

## What does this PR change?

Removes the dangling `(see [Subagent support](#subagent-support))` parenthetical from the subagent dispatch row in `antigravity-tools.md`. One line, one file.

## Is this change appropriate for the core library?

Yes — it repairs a file already in core, and does not add anything. It is not project-, team-, or tool-specific, and integrates no third-party service. It finishes a cleanup that core already started in `e7ddc25e`.

## What alternatives did you consider?

**1. Restore the deleted `## Subagent support` section.** Rejected. `e7ddc25e` is titled "Prune per-harness tool-mapping boilerplate" and cut the file from 5691 B to 1539 B across several harnesses — the deletion was the point. Re-adding the section would revert a deliberate decision to fix a symptom of it. It would also be a much larger diff for a broken link.

**2. Repoint the anchor at `#task-tracking` or another surviving heading.** Rejected — actively misleading. The reader is asking about subagent types; `## Task tracking` does not answer that.

**3. Leave it and fix only downstream.** Rejected — it recurs for every consumer on every sync, and the fix belongs where the defect is.

The chosen fix works because the guidance the link pointed at **already survives inline in the same table cell**: "`self` for full-capability work, `research` for read-only". The row answers the reader's question without the pointer, so removing it loses no information.

## Does this PR contain multiple unrelated changes?

No. One line, one file.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: **#1987** (merged), **#1992** (closed), **#1710** (open)

**#1987** — "test: realign antigravity + pi mapping assertions with pruned references" (merged 2026-07-15) is the closest prior art: it is the *test-side* cleanup after the same `e7ddc25e` prune. It fixed assertions that referenced deleted content but did not touch the deleted content's leftover link in the doc itself. This PR is the doc-side counterpart it missed. **#1992** was a duplicate of #1987 and was closed.

**#1710** — "docs: update Antigravity porting guidance" (open) touches this file, but its version predates the prune and reintroduces the full pre-`e7ddc25e` text including the `## Subagent support` section. It is a broad PR (adds a Kimi plugin, a pi extension, pre-commit config, and more). If #1710 lands first this fix becomes unnecessary; if this lands first, #1710 needs a rebase on that file regardless of this change. No overlap in intent.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.215 | Claude Opus 4.8 (1M context) | `claude-opus-4-8[1m]` |

**I have not run this in the Antigravity CLI.** I do not have `agy` installed. This is a documentation link repair with no runtime surface — the change removes prose from a reference table and touches no code, hook, or bootstrap path. Verification was the repo's own test suite (below), static analysis, and an agent-based adversarial pressure test of the change (see Rigor) — fresh subagents reading the reference, not the agy harness itself. Flagging plainly rather than implying agy-session coverage I do not have.

## New harness support (required if this PR adds a new harness)

Not applicable — no new harness.

## Evaluation

I ran an adversarial before/after agent evaluation of this change (full methodology and results table under Rigor, below). Headline: across 10 fresh subagents (5 given the pre-fix reference, 5 given the fixed reference), the `self`/`research` dispatch guidance was selected correctly 10/10 in both arms -- the fix loses nothing -- while the dead `#subagent-support` pointer was flagged as a defect by 5/5 subagents before the fix and 0/5 after. In addition:

**Repo test suite, on `dev` @ `cc69047`:**

```
$ bash tests/antigravity/run-tests.sh          # before fix
PASS: Antigravity tool mapping valid (subagent dispatch, task artifact, SKILL.md link)

$ bash tests/antigravity/run-tests.sh          # after fix
PASS: Antigravity tool mapping valid (subagent dispatch, task artifact, SKILL.md link)
=== All Antigravity tests passed ===
```

Green both sides, and not vacuously: `test-antigravity-tools.sh` asserts the mapping documents the built-in `self` and `research` types (lines 33-36). Those assertions pass **because** the fix keeps that guidance inline and removes only the pointer. A fix that deleted the whole table cell would fail this test.

**Static verification:**

- Repo-wide anchor scan across all 38 markdown files under `skills/` — every `[text](#anchor)` checked against headings present in its own file. Before: this one mismatch. After: zero dangling anchors.
- `rg 'subagent-support'` post-fix returns one remaining hit, in `gemini-tools.md`. That file **retains** its `## Subagent support` heading (line 30), so its link is valid and is deliberately left untouched. Worth stating explicitly since a careless sweep of the same string would have broken a working link.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

**Adversarial pressure test (writing-skills discipline).** On reflection this *is* a skills change -- it edits agent-facing instruction content in a skill's reference file -- so I ran the writing-skills reference-skill test methodology (via the `braze-superpowers` fork of `superpowers:writing-skills`, same discipline). Two variants, 5 fresh subagents each, no tools: **BEFORE** = the row as `dev`/`main` ship it (dead `#subagent-support` pointer present), **AFTER** = this PR's fix. Each subagent, given only the reference, had to (a) choose the `invoke_subagent` TypeName for a read-only dispatch and a code-writing dispatch -- the exact decision the pointer used to elaborate -- and (b) report any reference target it could not locate.

| Metric (n=10) | BEFORE (dead pointer) | AFTER (this PR) |
|---|---|---|
| Read-only dispatch -> `research` | 5/5 correct | 5/5 correct |
| Code-writing dispatch -> `self` | 5/5 correct | 5/5 correct |
| Flagged a dangling `#subagent-support` reference | 5/5 | 0/5 |
| Decision impaired by the missing section | 0/5 | 0/5 |
| Invented a `define_subagent` / phantom TypeName | 0/5 | 0/5 |

Reading: the `self`/`research` guidance survives the edit intact (10/10 in both arms -- it is stated inline in the same table cell, so the fix removes nothing operative). But the pointer was not inert: every BEFORE subagent detected the dead `#subagent-support` link, flagged it as a documentation defect, and several said they would escalate it to the reference's maintainer, noting the section's detail was "unavailable/unverified." AFTER, that noise is gone (0/5), with no regression and no hallucinated section. So the change removes a real, agent-visible defect without altering the instruction an agent acts on.

The adversarial box reflects the two checks that could have shown this fix to be wrong: whether any test depended on the removed text (no — the surviving assertions are what constrain the fix), and whether the same string appears elsewhere where removal would cause damage (yes, in `gemini-tools.md`, where the heading still exists and the link was therefore left alone).

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Mark Rada (@ferrous26) reviewed the complete one-line diff and approved submission.

---
<sub>Tracked internally at Braze as [SKILL-345](https://braze.atlassian.net/browse/SKILL-345).</sub>

