### PR TITLE
fix(systematic-debugging): find-polluter.sh find -path never matches (fixes #2008)

### DIFF
--- a/skills/systematic-debugging/find-polluter.sh
+++ b/skills/systematic-debugging/find-polluter.sh
@@ -18,9 +18,13 @@ echo "🔍 Searching for test that creates: $POLLUTION_CHECK"
 echo "Test pattern: $TEST_PATTERN"
 echo ""
 
-# Get list of test files
-TEST_FILES=$(find . -path "$TEST_PATTERN" | sort)
-TOTAL=$(echo "$TEST_FILES" | wc -l | tr -d ' ')
+# Get list of test files (find . emits ./-prefixed paths)
+TEST_FILES=$(find . -path "./$TEST_PATTERN" | sort)
+if [ -z "$TEST_FILES" ]; then
+  TOTAL=0
+else
+  TOTAL=$(printf '%s\n' "$TEST_FILES" | wc -l | tr -d ' ')
+fi
 
 echo "Found $TOTAL test files"
 echo ""


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Composer 2.5 |
| Harness + version | Cursor (desktop IDE, current release) |
| All plugins installed | none beyond Cursor built-in |
| Human partner who reviewed this diff | arimu1 — requested fix for #2008 after reading issue + script |

## What problem are you trying to solve?

`find-polluter.sh` collects test files with:

```bash
find . -path "$TEST_PATTERN"
```

using the documented example `TEST_PATTERN='src/**/*.test.ts'`.

When `find` searches from `.`, every result path is prefixed with `./`, so `-path "src/**/*.test.ts"` matches nothing (paths look like `./src/...`). The script then reports **"Found 1 test files"** — from `wc -l` on an empty string — and exits without testing anything. That is a silent no-op that reads as "all tests clean."

From [#2008](https://github.com/obra/superpowers/issues/2008):

> When `find` searches from `.`, every result path is prefixed with `./`, so `-path "src/**/*.test.ts"` matches nothing (paths look like `./src/...`). The script then reports "Found 1 test files" (from `wc -l` on an empty string) and exits without testing anything — a silent no-op that reads as "all tests clean".

Reporter found this while vendoring the skill into an internal project.

## What does this PR change?

1. Uses `find . -path "./$TEST_PATTERN"` so patterns align with `find .` output.
2. Guards the empty-result case so `TOTAL` is 0 instead of `wc -l` returning 1 on empty stdin.

## Is this change appropriate for the core library?

Yes. This fixes a general-purpose bisection helper shipped with the `systematic-debugging` skill. It is not project-specific, domain-specific, or tied to a third-party service.

## What alternatives did you consider?

- Adding `-o -path "$TEST_PATTERN"` — rejected per issue analysis: non-prefixed patterns still cannot match `find .` output.
- Rewriting to `find . -name '*.test.ts'` — rejected: would change the documented contract that callers pass a full `-path` glob.
- Only fixing the `wc -l` guard — rejected: the script would still find zero files for the documented example pattern.

## Does this PR contain multiple unrelated changes?

No. Single file, two-line behavioral fix in `skills/systematic-debugging/find-polluter.sh`.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: [#1483](https://github.com/obra/superpowers/pull/1483) (closed — different bug: whitespace in test paths split by unquoted `for` loop; not the `./` prefix / empty-count issue)

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Cursor | desktop IDE (current release) | Composer | Composer 2.5 |

## New harness support (required if this PR adds a new harness)

N/A — no new harness support.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
N/A — this PR does not add harness support.
```

</details>

## Evaluation
- **Initial prompt:** Implement and open a PR for obra/superpowers issue #2008 — fix `find-polluter.sh` path prefix and empty-result count.
- **Eval sessions after change:** 2 manual smoke runs of the script in a temp directory with a fake test tree.
- **Before:** `./find-polluter.sh '.pollution' 'src/**/*.test.ts'` with one matching test file reported "Found 1 test files" but ran zero iterations (pattern matched nothing); with no matches, still reported "Found 1 test files".
- **After:** Same setup reports "Found 1 test files" and iterates the one `./src/nested/bar.test.ts` match; non-matching pattern reports "Found 0 test files".

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Adversarial checks run:
- Empty pattern result → "Found 0 test files" (not 1)
- Non-empty result with `./`-prefixed find output → correct count and iteration

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Made with [Cursor](https://cursor.com)