### PR TITLE
fix(sdd): protect task briefs against accidental overwrite and empty file creation (#2012)

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -204,7 +204,8 @@ and fix-round diffs need it.
 
 - **Task brief:** before dispatching an implementer, run this skill's
   `scripts/task-brief PLAN_FILE N` — it extracts the task's full text to a
-  uniquely named file and prints the path. Compose the dispatch so the
+  uniquely named file under `<repo-root>/.superpowers/sdd/<plan-basename>/task-N-brief.md`
+  (refusing to overwrite an existing file unless `--force` is passed) and prints the path. Compose the dispatch so the
   brief stays the single source of
   requirements. Your dispatch should contain: (1) one line on where this
   task fits in the project; (2) the brief path, introduced as "read this

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -3,14 +3,20 @@
 # implementer reads in one call, so the task text never has to be pasted
 # through the controller's context.
 #
-# Usage: task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
+# Usage: task-brief [-f|--force] PLAN_FILE TASK_NUMBER [OUTFILE]
 # Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-basename>/task-<N>-brief.md
 # (per plan and per worktree; concurrent runs of the SAME plan in the same
 # working tree share it).
 set -euo pipefail
 
+force=false
+if [ "${1:-}" = "-f" ] || [ "${1:-}" = "--force" ]; then
+  force=true
+  shift
+fi
+
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then
-  echo "usage: task-brief PLAN_FILE TASK_NUMBER [OUTFILE]" >&2
+  echo "usage: task-brief [-f|--force] PLAN_FILE TASK_NUMBER [OUTFILE]" >&2
   exit 2
 fi
 
@@ -25,17 +31,28 @@ else
   out="$dir/task-${n}-brief.md"
 fi
 
+if [ -f "$out" ] && [ "$force" = false ]; then
+  echo "outfile ${out} already exists (use --force to overwrite)" >&2
+  exit 4
+fi
+
+tmp_out="${out}.tmp.$$.$RANDOM"
+trap 'rm -f "$tmp_out"' EXIT
+
 awk -v n="$n" '
   /^```/ { infence = !infence }
   !infence && /^#+[ \t]+Task[ \t]+[0-9]+/ {
     intask = ($0 ~ ("^#+[ \t]+Task[ \t]+" n "([^0-9]|$)"))
   }
   intask { print }
-' "$plan" > "$out"
+' "$plan" > "$tmp_out"
 
-if [ ! -s "$out" ]; then
+if [ ! -s "$tmp_out" ]; then
   echo "task ${n} not found in ${plan} (no heading matching 'Task ${n}')" >&2
   exit 3
 fi
+
+mv "$tmp_out" "$out"
+trap - EXIT
 
 echo "wrote ${out}: $(wc -l < "$out" | tr -d ' ') lines"

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -129,6 +129,35 @@ PLAN
         echo "    got: $brief_path"
     fi
 
+    # --- task-brief overwrite protection & --force flag ---
+    local overwrite_rc=0
+    (cd "$repo" && "$SDD_SCRIPTS/task-brief" plan-a.md 1 >/dev/null 2>&1) || overwrite_rc=$?
+    if [[ "$overwrite_rc" -eq 4 ]]; then
+        pass "task-brief refuses to overwrite existing brief without --force"
+    else
+        fail "task-brief refuses to overwrite existing brief without --force"
+        echo "    exit: $overwrite_rc"
+    fi
+
+    local force_out force_rc=0
+    force_out="$(cd "$repo" && "$SDD_SCRIPTS/task-brief" --force plan-a.md 1)" || force_rc=$?
+    if [[ "$force_rc" -eq 0 && "$force_out" == *"wrote"* ]]; then
+        pass "task-brief overwrites existing brief when --force is passed"
+    else
+        fail "task-brief overwrites existing brief when --force is passed"
+        echo "    exit: $force_rc"
+    fi
+
+    # --- task-brief missing task cleanup ---
+    local missing_rc=0
+    (cd "$repo" && "$SDD_SCRIPTS/task-brief" plan-a.md 99 >/dev/null 2>&1) || missing_rc=$?
+    if [[ "$missing_rc" -eq 3 && ! -f "$repo/.superpowers/sdd/plan-a/task-99-brief.md" ]]; then
+        pass "task-brief errors and leaves no file when task is missing"
+    else
+        fail "task-brief errors and leaves no file when task is missing"
+        echo "    exit: $missing_rc"
+    fi
+
     # --- review-package takes the plan first and lands in its directory ---
     local git_id=(-c user.email=t@example.com -c user.name=t -c commit.gpgsign=false)
     ( cd "$repo" \


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Gemini 2.5 Pro / Antigravity |
| Harness + version | Antigravity CLI / Claude Code |
| All plugins installed | superpowers |
| Human partner who reviewed this diff | arimu1 |

## What problem are you trying to solve?

In `subagent-driven-development`, running `scripts/task-brief` previously overwrote `$out` directly (`> "$out"`). If `task-brief` was re-run on an existing brief or if the requested task number was not present in the plan file, it would silently truncate/destroy existing task brief files or leave behind empty 0-byte brief files (#2012).

## What does this PR change?

Updates `skills/subagent-driven-development/scripts/task-brief` to:
1. Write output atomically to a temporary file before moving it into place.
2. Check if the output file already exists, exiting with error code 4 unless `--force` / `-f` is passed.
3. Clean up the temporary file and leave no empty file behind if the requested task heading is missing from the plan file.
4. Update `SKILL.md` documentation and `test-sdd-workspace.sh` tests accordingly.

## Is this change appropriate for the core library?

Yes. `subagent-driven-development` is a core skill in superpowers, and protecting task brief artifacts from accidental truncation or empty file creation improves safety across all harnesses and workflows.

## What alternatives did you consider?

1. Only deleting empty files on missing task: This leaves existing brief files vulnerable to silent overwrite when re-running `task-brief`.
2. Requiring custom OUTFILE paths for every call: This breaks default ergonomics for standard SDD task execution.

## Does this PR contain multiple unrelated changes?

No, all changes are strictly focused on fixing artifact collision and safe file creation in `task-brief`.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1943 (merged, plan-scoped workspace layout), #1905 (closed, alternative task-brief scoping approach).

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code / Antigravity | latest | Gemini 2.5 Pro | gemini-2.5-pro |

## New harness support (required if this PR adds a new harness)

N/A

## Evaluation

- What was the initial prompt you (or your human partner) used to start the session that led to this change?
  "Fix obra/superpowers issue #2012: In `scripts/task-brief`, update `out` file creation or check if file exists, or namespace under `.superpowers/sdd/`. Update `subagent-driven-development` skill instructions accordingly."
- How many eval sessions did you run AFTER making the change?
  Ran `./tests/claude-code/test-sdd-workspace.sh` with 16 automated tests covering workspace resolution, overwrite protection, `--force` flag, and missing task cleanup.
- How did outcomes change compared to before the change?
  `task-brief` now safely fails (exit code 4) when attempting to overwrite an existing task brief unless `--force` is specified, and does not pollute the workspace with empty files when a task is missing.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
