### PR TITLE
docs(test-driven-development): add guidance for modifying behavior with existing tests

### DIFF
--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -180,7 +180,12 @@ Confirm:
 
 **Test fails?** Fix code, not test.
 
-**Other tests fail?** Fix now.
+**Other tests fail?** They encode existing behavior your change touched. For each,
+answer one question before editing anything: **is the CODE wrong (a regression you
+didn't intend) or is this an intended behavior change?** Code wrong → fix the code,
+leave the test. Intended change → update the test to the new contract, this same
+commit. Never edit a red test green without answering. See [Modifying Existing
+Behavior](#modifying-existing-behavior).
 
 ### REFACTOR - Clean Up
 
@@ -194,6 +199,48 @@ Keep tests green. Don't add behavior.
 ### Repeat
 
 Next failing test for next feature.
+
+## Modifying Existing Behavior
+
+The cycle above starts from a blank test file. **Changing** behavior that already
+has tests is different: some already-passing tests encode the OLD behavior, and
+the failure mode is editing those tests green without asking whether the code is
+what's wrong. That turns the regression net into a rubber stamp.
+
+**1. Inventory the existing tests FIRST.** Before touching code, find every test
+that pins the behavior you're about to change. Don't discover them later when CI
+goes red — that's how stale tests are born.
+
+```bash
+grep -rn "functionYoureChanging" test/    # by symbol, route, field, or fixture shape
+```
+
+Can't find a test for behavior you're about to change? Add coverage before changing
+it (see "Existing code has no tests" in Common Rationalizations).
+
+**2. Change the existing test first, in the same commit.** Same red-green, but you
+edit the *existing* test, not a new one: update it to the NEW contract, watch it
+fail against the current code (proving it pins the behavior), then change the code
+to pass. Test and code move in one commit — a contract change whose test lags into
+a later commit is exactly how stale tests surface days later.
+
+**3. When any OTHER test goes red, answer the fork.** For each unexpectedly-red
+test, decide before editing:
+
+> **Is the CODE wrong, or is this an intended behavior change?**
+
+- **Code wrong (a real regression):** fix the *code*. Leave the test. This is the
+  test doing its job.
+- **Intended change:** update the *test* to the new contract, this same commit.
+  Legitimate maintenance — *because you consciously decided the change was
+  intended*, not because green is convenient.
+
+If you can't say which branch you're on, you don't yet understand your own change.
+
+**Brittleness smell:** a refactor that changed no observable behavior yet reddened
+many tests means those tests were coupled to implementation (exact mock shapes,
+call counts), not behavior. Prefer behavior-level assertions so future refactors
+don't pay this tax.
 
 ## Good Tests
 


### PR DESCRIPTION
## Summary

Adds a "Modifying Existing Behavior" section to the `test-driven-development` skill and clarifies the existing "Other tests fail?" note under Verify GREEN. Documentation only, one file.

## Motivation

The red-green-refactor cycle in this skill is written for new behavior, beginning from an empty test file. It offers little guidance for changing behavior that is already covered by tests, which is a common and time-consuming case in practice. The only sentence that addresses it is:

> **Other tests fail?** Fix now.

Taken literally, "fix now" can be read as license to make a failing test pass without first determining whether the code, rather than the test, is at fault. That inverts the purpose of the test: a test that fails on an unintended change is doing its job, and editing it to pass removes that signal.

## Change

Adds a focused section covering the modification case:

1. Inventory the existing tests before changing code, so a contract change is not discovered later as an unexplained CI failure.
2. Update the existing test to the new contract first, in the same commit: watch it fail against the current code, then change the code to make it pass.
3. For any other failing test, decide before editing whether it represents a genuine regression (fix the code) or an intended behavior change (update the test).

It also notes a brittleness signal: a refactor that changes no observable behavior yet breaks many tests indicates tests coupled to implementation rather than behavior.

The "Other tests fail?" line under Verify GREEN is updated to state this decision inline and link to the new section.

## Notes

The change is intentionally scoped to a single section so it continues the existing red-green narrative rather than introducing a separate skill. If the maintainers would prefer a standalone companion skill to match the library's composition style, I would be glad to restructure it accordingly.