### PR TITLE
fix(finishing): check in with human partner when worktree removal hits untracked files

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -174,6 +174,29 @@ git worktree remove "$WORKTREE_PATH"
 git worktree prune  # Self-healing: clean up any stale registrations
 ```
 
+**If removal is refused** (`contains modified or untracked files`): the
+worktree holds files that exist nowhere else — uncommitted plans, notes,
+or scratch work. Never `--force` on your own initiative. Show your human
+partner what is at stake and ask:
+
+```bash
+git -C "$WORKTREE_PATH" status --porcelain
+```
+
+```
+Worktree removal refused — these files were never committed:
+
+<file list>
+
+1. Commit them to <branch> before cleanup
+2. Move them into <main repo root>
+3. Delete them (unrecoverable)
+
+Which?
+```
+
+Carry out the choice, then remove the worktree.
+
 **Otherwise:** The host environment owns this workspace — leave it in
 place. If your platform provides a workspace-exit tool, use it.
 
@@ -196,6 +219,7 @@ place. If your platform provides a workspace-exit tool, use it.
 | "'Yeah, get rid of it' counts as confirmation" | Only the typed word `discard` authorizes deletion. |
 | "The PR is up, so the worktree is clutter now" | PR feedback gets fixed in that worktree. It stays until the work lands. |
 | "This other worktree looks stale — I'll clean it too" | Clean up only worktrees under `.worktrees/` or `worktrees/`. Everything else belongs to the host. |
+| "Removal refused — `--force` is just finishing the cleanup" | The refusal means files exist only in that worktree. `--force` destroys them permanently. Show your human partner and ask. |
 | "The merged-result failure is probably flaky" | A failing merged result stops everything. Branch and worktree stay put while you investigate. |
 | "The base branch is obviously main" | Confirm the fork point or ask. Merging into the wrong base is expensive to undo. |
 | "The push was rejected — force-push will fix it" | A rejected push means the remote moved. Investigate; force-push only on your human partner's explicit request. |

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -180,7 +180,7 @@ or scratch work. Never `--force` on your own initiative. Show your human
 partner what is at stake and ask:
 
 ```bash
-git -C "$WORKTREE_PATH" status --porcelain
+git -C "$WORKTREE_PATH" status --porcelain -uall
 ```
 
 ```


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code 2.1.218 (macOS) |
| All plugins installed | superpowers (dev), superpowers-chrome, superpowers-lab, elements-of-style, episodic-memory, frontend-design, plugin-dev, agent-sdk-dev, mcp-server-dev, code-simplifier, claude-code-setup, context7, linear, github-triage, claude-session-driver, release-radar, summarize-meetings, worldview-synthesis, primeradiant-ops, plus personal skills |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — maintainer; specified this exact design interactively during triage of #2016/#1223 and reviews the final diff on this PR |

## What problem are you trying to solve?

`git worktree remove` refuses when the worktree contains modified or untracked files, and Step 6 of `finishing-a-development-branch` gave no guidance for that refusal. The error message itself suggests `--force`, so the natural agent response destroys files that exist nowhere else. Reported from two independent real sessions:

- **#2016**: a user's plan document under `docs/superpowers/plans/` — untracked for the whole branch lifetime — was permanently deleted at cleanup. Reproduced deterministically during triage: `git worktree remove` refuses, `--force` succeeds, the plan is unrecoverable while committed work survives.
- **#1223**: uncommitted work at finish time produced "what does discard mean for my uncommitted files?" confusion with no answer inside the skill.

Both prior fix attempts baked in a policy: #2016 force-committed plan documents into every user's history (declined — not everyone wants superpowers plans committed), #1223 hard-refused with "commit or stash first, then re-run" (a wall that invites workarounds). Maintainer decision: the destruction point should check in with the human partner instead.

## What does this PR change?

Step 6 now treats a refused `git worktree remove` as a stop-and-ask moment: never `--force` on the skill's own initiative; show `git -C "$WORKTREE_PATH" status --porcelain` output to the human partner and offer commit-to-branch / move-to-main-root / delete, then remove the worktree after the choice. One matching row is added to Common Rationalizations.

## Is this change appropriate for the core library?

Yes — it modifies an existing core skill's cleanup step only. Applies to any project on any harness that uses worktrees; no dependencies, no domain-specific content.

## What alternatives did you consider?

- **Unconditional plan commit in writing-plans** (#2016): fixes only superpowers docs, and forces plan files into repo history for users who don't want them there. Declined by maintainer.
- **Hard clean-tree refusal at Step 1** (#1223): blocks integration of committed work because scratch files exist, and refuse-and-rerun is the interaction pattern that historically pushes agents to workarounds. Also stale/conflicting.
- **Scoping the check to superpowers docs only**: rejected — the failure mode is "cleanup destroys untracked work", full stop; plans are just one instance.

## Does this PR contain multiple unrelated changes?

No. One file; the rationalization row exists solely to reinforce the new Step 6 behavior.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2016 (closed — same loss, declined mechanism; this PR credits its diagnosis and reproduction), #1223 (closed — refusal-based variant, cwd half already fixed by #1933), #1933 (merged — modernized this skill; source of the current Step 6 structure).

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (macOS) | 2.1.218 | Claude Fable 5 | claude-fable-5 |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

- **Initial prompt:** maintainer-directed, during interactive triage of #2016: "not everyone wants to commit their superpowers plans" → "[the finishing-side guard] is not just about untracked superpowers docs, but about untracked files. it should check in with its human partner."
- **Loss path verified:** the destruction this guards against was reproduced deterministically in-session with #2016's pure-git recipe (refusal → `--force` → untracked file unrecoverable, committed file survives).
- **Behavioral micro-tests: not yet run.** Honest scope note: this is an additive refusal-path branch (the omitted-element failure class), not a rewording of tuned content, but RED/GREEN fresh-context micro-tests per `writing-skills` methodology have not been executed for this wording. They can be run before or after merge at the maintainer's discretion.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement — the existing rows are untouched; one new row is added, flagged here for maintainer attention

The first two boxes are honestly unchecked: adversarial pressure testing is pending, as stated in Evaluation. The maintainer directed this change and owns the merge decision with that gap visible.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission — the human partner is the repo maintainer, who commissioned the change and performs that review on this PR