### PR TITLE
fix(codex): restore Superpowers after compaction

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
     "workflow"
   ],
   "skills": "./skills/",
-  "hooks": {},
+  "hooks": "./hooks/hooks-codex.json",
   "interface": {
     "displayName": "Superpowers",
     "shortDescription": "Planning, TDD, debugging, and delivery workflows for coding agents",

--- a/README.md
+++ b/README.md
@@ -98,37 +98,18 @@ Superpowers is available via the [official Codex plugin marketplace](https://git
 
 - Select `Install Plugin`.
 
-#### Codex: compaction re-injection hook (recommended)
+#### Codex: compaction re-injection hook
 
 Codex compacts long sessions, replacing the transcript with a summary that
 drops Superpowers' skill instructions mid-run — long autonomous workflows
 (like subagent-driven-development) then drift back to harness defaults.
-Claude Code re-injects the bootstrap after every compaction; this hook
-restores the same behavior on Codex (0.145+).
+Claude Code re-injects the bootstrap after every compaction; the plugin ships
+a SessionStart hook (`hooks/hooks-codex.json`) that restores the same
+behavior on Codex (0.145+). It fires only on post-compaction re-starts
+(`source: "compact"`) and is silent at normal session start.
 
-Merge `hooks/hooks-codex.json.example` from your Superpowers install into
-`~/.codex/hooks.json`, replacing the placeholder with the absolute path to
-your install:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"/path/to/superpowers/hooks/session-start-codex\"",
-            "timeout": 30
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Codex asks you to trust the hook once, the first time it runs in the app.
+The hook installs with the plugin — no configuration needed. Codex asks you
+to review and trust it once, the first time it loads after install or update.
 Headless automation (CI, eval harnesses) must pass
 `--dangerously-bypass-hook-trust` instead, because untrusted hooks are
 skipped silently.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,41 @@ Superpowers is available via the [official Codex plugin marketplace](https://git
 
 - Select `Install Plugin`.
 
+#### Codex: compaction re-injection hook (recommended)
+
+Codex compacts long sessions, replacing the transcript with a summary that
+drops Superpowers' skill instructions mid-run — long autonomous workflows
+(like subagent-driven-development) then drift back to harness defaults.
+Claude Code re-injects the bootstrap after every compaction; this hook
+restores the same behavior on Codex (0.145+).
+
+Merge `hooks/hooks-codex.json.example` from your Superpowers install into
+`~/.codex/hooks.json`, replacing the placeholder with the absolute path to
+your install:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"/path/to/superpowers/hooks/session-start-codex\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Codex asks you to trust the hook once, the first time it runs in the app.
+Headless automation (CI, eval harnesses) must pass
+`--dangerously-bypass-hook-trust` instead, because untrusted hooks are
+skipped silently.
+
 ### Cursor
 
 - In Cursor Agent chat, install from marketplace:

--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -237,10 +237,12 @@ nesting differ per harness**.
 - Manifests: `.cursor-plugin/plugin.json` is the Shape A manifest example that
   points the harness at `./skills/` and the right `hooks-*.json`. Claude Code's
   `.claude-plugin/plugin.json` sets neither field — it auto-discovers `skills/`
-  and `hooks/hooks.json` by convention. Do **not** copy Codex's
-  `.codex-plugin/plugin.json` for Shape A: it declares an empty `hooks` object
-  specifically to suppress Codex's `hooks/hooks.json` auto-discovery, because
-  Codex surfaces skills natively and runs no session-start hook.
+  and `hooks/hooks.json` by convention. Codex's `.codex-plugin/plugin.json`
+  points `hooks` at `./hooks/hooks-codex.json` — a compaction-only hook, not a
+  bootstrap injector: Codex surfaces skills natively at session start, so its
+  hook fires only on post-compaction re-starts. The explicit pointer also
+  suppresses Codex's `hooks/hooks.json` auto-discovery fallback, which would
+  otherwise run the Claude Code hook.
 
 > **A hook *system* is not a session-start *event*.** A harness can have a
 > `hooks.json` mechanism — and even contain the literal string `SessionStart` in
@@ -785,7 +787,7 @@ Use this as the live index; when in doubt, read the files, not this table.
 | Harness | Entry point | Bootstrap mechanism | Tool mapping | Tests | Distribution |
 |---|---|---|---|---|---|
 | Claude Code | `.claude-plugin/plugin.json` + `hooks/hooks.json` | shell hook → `hooks/session-start` (`hookSpecificOutput.additionalContext`) | native `Skill` tool; no adapter file needed | `tests/hooks/` | marketplace |
-| Codex | `.codex-plugin/plugin.json` (declares empty `hooks`) | native skill discovery (no session-start hook) | `references/codex-tools.md` | `tests/codex/`, `tests/codex-plugin-sync/` | fork sync (`scripts/sync-to-codex-plugin.sh`) |
+| Codex | `.codex-plugin/plugin.json` + `hooks/hooks-codex.json` | native skill discovery at startup; shell hook → `hooks/session-start-codex` re-injects after compaction only | `references/codex-tools.md` | `tests/codex/`, `tests/codex-plugin-sync/` | fork sync (`scripts/sync-to-codex-plugin.sh`) |
 | Cursor | `.cursor-plugin/plugin.json` + `hooks/hooks-cursor.json` | shell hook → `hooks/session-start` (`additional_context`) | none needed (Claude Code–compatible tool surface) | `tests/hooks/` | hand-authored |
 | Copilot CLI | (shares Claude Code hook path; `COPILOT_CLI` env) | shell hook → `hooks/session-start` (`additionalContext`) | none needed (Claude Code–compatible tool surface) | `tests/hooks/` | — |
 | Gemini CLI | `gemini-extension.json` + `GEMINI.md` | instructions file `@`-includes bootstrap + mapping | `references/gemini-tools.md` | — | `gemini extensions install` |

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -2,10 +2,12 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "compact",
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/ABSOLUTE/PATH/TO/superpowers/hooks/session-start-codex\"",
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start-codex",
+            "async": false,
             "timeout": 30
           }
         ]

--- a/hooks/hooks-codex.json.example
+++ b/hooks/hooks-codex.json.example
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"/ABSOLUTE/PATH/TO/superpowers/hooks/session-start-codex\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-start-codex
+++ b/hooks/session-start-codex
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Codex SessionStart hook for the superpowers plugin.
+#
+# Codex re-fires SessionStart with source:"compact" after every context
+# compaction (verified on codex-cli 0.145.0). Compaction replaces the live
+# context with a summary, which sheds the using-superpowers bootstrap and any
+# active skill's instructions — the measured cause of mid-session dispatch
+# drift in long multi-agent runs. This hook re-injects the bootstrap at
+# exactly that moment, restoring the same re-injection Claude Code performs
+# via its "startup|clear|compact" SessionStart matcher.
+#
+# On source:"startup" it emits nothing: the native Codex plugin path owns
+# session-start injection, and duplicating it here would recreate the
+# redundancy that led to the original session-start-codex hook's removal.
+#
+# Codex injects raw hook stdout into the model's context (verified with
+# sentinel probes), so output is plain text — not the JSON envelopes other
+# harnesses require of hooks/session-start.
+#
+# A hook failure must never break a session: every path fails open to empty
+# output and exit 0.
+
+set -u
+
+payload="$(cat 2>/dev/null || true)"
+
+# Act only on post-compaction re-fires. Tolerate arbitrary whitespace around
+# the JSON colon; anything unparseable falls through to a silent no-op.
+if ! printf '%s' "$payload" | grep -qE '"source"[[:space:]]*:[[:space:]]*"compact"'; then
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+using_superpowers_content="$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>/dev/null)" || using_superpowers_content=""
+if [ -z "$using_superpowers_content" ]; then
+    exit 0
+fi
+
+# printf instead of heredocs throughout: heredocs hang on bash 5.3+.
+# See: https://github.com/obra/superpowers/issues/571
+printf '%s\n' "<EXTREMELY_IMPORTANT>"
+printf '%s\n\n' "You have superpowers."
+printf '%s\n\n' "**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**"
+printf '%s\n' "$using_superpowers_content"
+printf '%s\n\n' "</EXTREMELY_IMPORTANT>"
+printf '%s\n' "<CONTEXT_RESTORED>"
+printf '%s\n' "Your context was just summarized (compacted). The summary preserves your progress but not your working instructions — the files are authoritative."
+printf '%s\n' ""
+printf '%s\n' "Before your next tool call:"
+printf '%s\n' "- Re-read the SKILL.md of any skill you are mid-way through executing. If you are executing subagent-driven-development, re-read skills/subagent-driven-development/SKILL.md."
+printf '%s\n' "- On Codex, also re-read skills/using-superpowers/references/codex-tools.md and follow its dispatch rules on every spawn_agent call."
+printf '%s\n' "</CONTEXT_RESTORED>"
+
+exit 0

--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -40,8 +40,9 @@ Options:
   -h, --help               Show this help.
 
 The archive is rootless: .codex-plugin/, assets/, skills/, README.md, LICENSE,
-and CODE_OF_CONDUCT.md sit at the archive root. Source-only repo files, hooks, tests,
-docs, and other harness manifests are intentionally not shipped.
+CODE_OF_CONDUCT.md, and the Codex SessionStart hook (hooks/hooks-codex.json plus
+its two scripts) sit at the archive root. Source-only repo files, other-harness
+hooks, tests, docs, and other harness manifests are intentionally not shipped.
 EOF
 }
 
@@ -238,6 +239,9 @@ git -C "$REPO_ROOT" -c tar.umask=0022 archive --format=tar "$REF" -- \
   LICENSE \
   README.md \
   assets \
+  hooks/hooks-codex.json \
+  hooks/run-hook.cmd \
+  hooks/session-start-codex \
   skills \
   | tar -xpf - -C "$STAGE"
 
@@ -333,7 +337,7 @@ esac
 
 unexpected_paths="$(
   printf '%s\n' "$archive_paths" |
-    grep -E '(^superpowers/|^\.agents/|^hooks/|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)' || true
+    grep -E '(^superpowers/|^\.agents/|^hooks/hooks\.json$|^hooks/hooks-cursor\.json$|^hooks/session-start$|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)' || true
 )"
 if [[ -n "$unexpected_paths" ]]; then
   printf '%s\n' "$unexpected_paths" | sed 's/^/  /' >&2

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -73,5 +73,9 @@ if [ -z "${CLAUDECODE:-}" ] && [ -f "$hints_file" ]; then
   hint_line=$(grep "^${hint_key}:" "$hints_file" | head -1 | cut -d: -f2- | sed 's/^ *//') || true
   if [ -n "$hint_line" ]; then
     echo "$hint_line"
+    footer_line=$(grep "^footer:" "$hints_file" | head -1 | cut -d: -f2- | sed 's/^ *//') || true
+    if [ -n "$footer_line" ]; then
+      echo "$footer_line"
+    fi
   fi
 fi

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -52,5 +52,9 @@ if [ -z "${CLAUDECODE:-}" ] && [ -f "$hints_file" ]; then
   hint_line=$(grep "^implementer:" "$hints_file" | head -1 | cut -d: -f2- | sed 's/^ *//') || true
   if [ -n "$hint_line" ]; then
     echo "$hint_line"
+    footer_line=$(grep "^footer:" "$hints_file" | head -1 | cut -d: -f2- | sed 's/^ *//') || true
+    if [ -n "$footer_line" ]; then
+      echo "$footer_line"
+    fi
   fi
 fi

--- a/skills/using-superpowers/references/codex-dispatch.hints
+++ b/skills/using-superpowers/references/codex-dispatch.hints
@@ -5,6 +5,10 @@
 # Model names track Codex's spawn_agent allowlist (currently gpt-5.6-sol
 # and gpt-5.6-terra) — update this file when the allowlist changes.
 # Format: <role>: <line printed verbatim>
+# The footer line prints after every role line: prevention alone does not
+# cure drift — in instrumented runs, reprinted hints did not heal an
+# already-broken dispatch pattern until the text named the drift directly.
+footer: If any spawn this session omitted these params or used fork_turns "all", you have drifted — re-read references/codex-tools.md before dispatching again.
 implementer: dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high
 task-review: dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high
 fix-review: dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=medium

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -19,7 +19,9 @@ If your `spawn_agent` schema has `model` and `reasoning_effort`
 parameters (Codex 0.145+), set both on every dispatch: task-brief and
 review-package print a `dispatch:` hint line with the exact values —
 copy it onto the call verbatim, every time, even late in a long
-session. Those hints are the Model Selection mapping on Codex:
+session. The hints print at those scripts' boundaries; every other
+spawn — ad-hoc fan-outs included — follows the same table without a
+printed reminder. Those hints are the Model Selection mapping on Codex:
 reviewer tier never exceeds implementer tier, no fix round gets an
 effort bump, and rounds 4-5's "more capable model" means a fresh
 implementer at the same tier — needing more is a BLOCKED escalation
@@ -33,6 +35,19 @@ your model and effort with no override — role files in
 `~/.codex/agents/` do not attach to spawns either. Tell your human
 partner before starting a plan of more than a few tasks, and offer a
 lower-effort session instead.
+
+## Compaction sheds these instructions
+
+Context compaction replaces your transcript with a summary that keeps
+your progress but not your working instructions — the first
+post-compaction dispatch is where routing drift starts, and once one
+bare spawn lands, the broken pattern becomes its own precedent. The
+compaction re-injection hook (README, "Codex: compaction re-injection
+hook") restores the bootstrap after every compaction; recommend it to
+your human partner if it is not installed. Without it, the printed
+`dispatch:` hints are your only re-grounding — treat every one you see
+as authoritative, especially right after a summary appears in your
+context.
 
 ## Environment Detection
 

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -42,12 +42,14 @@ Context compaction replaces your transcript with a summary that keeps
 your progress but not your working instructions — the first
 post-compaction dispatch is where routing drift starts, and once one
 bare spawn lands, the broken pattern becomes its own precedent. The
-compaction re-injection hook (README, "Codex: compaction re-injection
-hook") restores the bootstrap after every compaction; recommend it to
-your human partner if it is not installed. Without it, the printed
-`dispatch:` hints are your only re-grounding — treat every one you see
-as authoritative, especially right after a summary appears in your
-context.
+plugin ships a compaction re-injection hook (`hooks/hooks-codex.json`,
+Codex 0.145+) that restores the bootstrap after every compaction; it
+needs one-time trust approval, so if you never see a
+`<CONTEXT_RESTORED>` block after a compaction, tell your human partner
+the hook may be untrusted or unsupported on this version. Without it,
+the printed `dispatch:` hints are your only re-grounding — treat every
+one you see as authoritative, especially right after a summary appears
+in your context.
 
 ## Environment Detection
 

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -175,9 +175,16 @@ PLAN
         echo "    got: $brief_hint"
     fi
 
+    if [[ "$brief_hint" == *"you have drifted"* ]]; then
+        pass "task-brief prints the drift-cure footer after the hint"
+    else
+        fail "task-brief prints the drift-cure footer after the hint"
+        echo "    got: $brief_hint"
+    fi
+
     local rp_hint
     rp_hint="$(cd "$repo" && env -u CLAUDECODE "$SDD_SCRIPTS/review-package" plan-a.md HEAD~1 HEAD)"
-    if [[ "$rp_hint" == *"dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
+    if [[ "$rp_hint" == *"dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* && "$rp_hint" == *"you have drifted"* ]]; then
         pass "review-package relays the default-role hint off Claude Code"
     else
         fail "review-package relays the default-role hint off Claude Code"

--- a/tests/codex/test-marketplace-manifest.sh
+++ b/tests/codex/test-marketplace-manifest.sh
@@ -52,25 +52,37 @@ if not plugin_manifest.exists():
 manifest = json.loads(plugin_manifest.read_text(encoding="utf-8"))
 assert_equal(manifest.get("name"), plugin.get("name"), "plugin manifest name")
 
-# Codex auto-discovers a plugin's hooks/hooks.json whenever the Codex manifest
-# has no `hooks` field: load_plugin_hooks falls back to a hardcoded
-# DEFAULT_HOOKS_CONFIG_FILE = "hooks/hooks.json" and registers it. That file is
-# the Claude Code SessionStart hook, it is tracked in this repo, and this
-# marketplace installs the whole repo root (source url "./"), so on Codex the
-# fallback re-registers the SessionStart hook and its install-time trust prompt.
-# Declaring an empty inline hooks object ({}) parses as an empty inline hook set
-# and suppresses the auto-discovery. An absent field, an empty array ([]), and
-# an empty inline list all collapse back to the fallback, so the value must be
-# exactly an empty object.
+# The Codex manifest must declare its hooks explicitly. An absent field makes
+# load_plugin_hooks fall back to a hardcoded DEFAULT_HOOKS_CONFIG_FILE =
+# "hooks/hooks.json" — the Claude Code SessionStart hook, which injects the
+# bootstrap at startup and must not run on Codex. The explicit pointer both
+# registers the Codex compaction re-injection hook and overrides that fallback.
 hooks_config = repo_root / "hooks" / "hooks.json"
 if not hooks_config.exists():
     raise AssertionError("hooks/hooks.json must exist (Claude Code SessionStart hook)")
 
 assert_equal(
     manifest.get("hooks"),
-    {},
-    "Codex manifest must declare empty hooks {} to suppress hooks/hooks.json auto-discovery",
+    "./hooks/hooks-codex.json",
+    "Codex manifest must point hooks at the Codex hook config (an absent field "
+    "falls back to auto-discovering the Claude Code hooks/hooks.json)",
 )
+
+codex_hooks_path = repo_root / "hooks" / "hooks-codex.json"
+if not codex_hooks_path.exists():
+    raise AssertionError("hooks/hooks-codex.json must exist (Codex manifest points at it)")
+
+codex_hooks = json.loads(codex_hooks_path.read_text(encoding="utf-8"))
+session_start = codex_hooks["hooks"]["SessionStart"]
+assert_equal(len(session_start), 1, "Codex SessionStart hook group count")
+assert_equal(session_start[0].get("matcher"), "compact", "Codex hook matcher")
+entry = session_start[0]["hooks"][0]
+assert_equal(entry.get("type"), "command", "Codex hook type")
+command = entry.get("command", "")
+if "${PLUGIN_ROOT}" not in command or not command.endswith("session-start-codex"):
+    raise AssertionError(
+        f"Codex hook command must run session-start-codex via ${{PLUGIN_ROOT}}: {command!r}"
+    )
 
 print("Codex marketplace manifest looks good")
 PY

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -141,7 +141,7 @@ tar_extracted="$TEST_ROOT/tar-extracted"
 write_metadata_fixture "$metadata_source"
 
 source_hooks="$(python3 -c 'import json; print(json.load(open("'"$REPO_ROOT"'/.codex-plugin/plugin.json")).get("hooks"))')"
-assert_equals "$source_hooks" "{}" "source Codex manifest suppresses local hook auto-discovery"
+assert_equals "$source_hooks" "./hooks/hooks-codex.json" "source Codex manifest declares the Codex hook config"
 
 if output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_source" --output "$archive" 2>&1)"; then
   pass "package script exits successfully"
@@ -163,10 +163,13 @@ assert_contains "$output" "SHA-256:" "reports archive checksum"
 extract_archive "$archive" "$extracted"
 
 archive_paths="$(list_archive "$archive" | normalize_archive_paths)"
-unexpected_pattern='(^superpowers/|^\.agents/|^hooks/|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)'
+unexpected_pattern='(^superpowers/|^\.agents/|^hooks/hooks\.json$|^hooks/hooks-cursor\.json$|^hooks/session-start$|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)'
 assert_not_matches "$archive_paths" "$unexpected_pattern" "archive excludes source-only paths"
 assert_contains "$archive_paths" ".codex-plugin/plugin.json" "archive includes Codex manifest"
 assert_contains "$archive_paths" "skills/brainstorming/SKILL.md" "archive includes skills"
+assert_contains "$archive_paths" "hooks/hooks-codex.json" "archive includes Codex hook config"
+assert_contains "$archive_paths" "hooks/session-start-codex" "archive includes Codex hook script"
+assert_contains "$archive_paths" "hooks/run-hook.cmd" "archive includes hook runner"
 assert_contains "$archive_paths" "skills/brainstorming/agents/openai.yaml" "archive includes OpenAI skill metadata"
 assert_contains "$archive_paths" "assets/app-icon.png" "archive includes app icon"
 assert_contains "$archive_paths" "assets/superpowers-small.svg" "archive includes composer icon"

--- a/tests/hooks/test-session-start-codex.sh
+++ b/tests/hooks/test-session-start-codex.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOOK_UNDER_TEST="$REPO_ROOT/hooks/session-start-codex"
-EXAMPLE_UNDER_TEST="$REPO_ROOT/hooks/hooks-codex.json.example"
+CONFIG_UNDER_TEST="$REPO_ROOT/hooks/hooks-codex.json"
 
 FAILURES=0
 
@@ -86,20 +86,25 @@ else
 fi
 
 if node -e '
-const example = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
-const entry = example.hooks.SessionStart[0].hooks[0];
+const config = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const group = config.hooks.SessionStart[0];
+if (group.matcher !== "compact") {
+  console.error(`hook matcher is ${JSON.stringify(group.matcher)}, expected "compact"`);
+  process.exit(1);
+}
+const entry = group.hooks[0];
 if (entry.type !== "command") {
-  console.error(`example hook type is ${JSON.stringify(entry.type)}, expected "command"`);
+  console.error(`hook type is ${JSON.stringify(entry.type)}, expected "command"`);
   process.exit(1);
 }
-if (!/session-start-codex"$/.test(entry.command)) {
-  console.error(`unexpected example command shape: ${entry.command}`);
+if (!entry.command.includes("${PLUGIN_ROOT}") || !/run-hook\.cmd" session-start-codex$/.test(entry.command)) {
+  console.error(`unexpected command shape: ${entry.command}`);
   process.exit(1);
 }
-' "$EXAMPLE_UNDER_TEST"; then
-    pass "hooks-codex.json.example parses and invokes session-start-codex"
+' "$CONFIG_UNDER_TEST"; then
+    pass "hooks-codex.json runs session-start-codex via \${PLUGIN_ROOT} on compact"
 else
-    fail "hooks-codex.json.example parses and invokes session-start-codex"
+    fail "hooks-codex.json runs session-start-codex via \${PLUGIN_ROOT} on compact"
 fi
 
 if [[ "$FAILURES" -gt 0 ]]; then

--- a/tests/hooks/test-session-start-codex.sh
+++ b/tests/hooks/test-session-start-codex.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK_UNDER_TEST="$REPO_ROOT/hooks/session-start-codex"
+EXAMPLE_UNDER_TEST="$REPO_ROOT/hooks/hooks-codex.json.example"
+
+FAILURES=0
+
+pass() {
+    echo "  [PASS] $1"
+}
+
+fail() {
+    echo "  [FAIL] $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+# run_hook <stdin-payload> — echoes hook stdout; fails the calling test on
+# non-zero exit. env -i mirrors the codex hook executor's clean environment.
+run_hook() {
+    printf '%s' "$1" | env -i PATH="${PATH:-}" bash "$HOOK_UNDER_TEST"
+}
+
+echo "Codex SessionStart hook tests"
+
+startup_payload='{"session_id":"s","hook_event_name":"SessionStart","model":"gpt-5.6-terra","source":"startup"}'
+if output="$(run_hook "$startup_payload")" && [ -z "$output" ]; then
+    pass "source=startup emits nothing and exits 0"
+else
+    fail "source=startup emits nothing and exits 0"
+    printf '%s\n' "$output" | head -3 | sed 's/^/    /'
+fi
+
+compact_payload='{"session_id":"s","hook_event_name":"SessionStart","model":"gpt-5.6-terra","source":"compact"}'
+if output="$(run_hook "$compact_payload")"; then
+    ok=1
+    for needle in \
+        "<EXTREMELY_IMPORTANT>" \
+        "You have superpowers." \
+        "name: using-superpowers" \
+        "<CONTEXT_RESTORED>" \
+        "subagent-driven-development/SKILL.md" \
+        "references/codex-tools.md"; do
+        if [[ "$output" != *"$needle"* ]]; then
+            ok=0
+            echo "    missing: $needle"
+        fi
+    done
+    if [ "$ok" -eq 1 ]; then
+        pass "source=compact emits bootstrap plus re-read addendum"
+    else
+        fail "source=compact emits bootstrap plus re-read addendum"
+    fi
+else
+    fail "source=compact emits bootstrap plus re-read addendum (hook exited non-zero)"
+fi
+
+# Whitespace-tolerant source matching (serializers vary).
+spaced_payload='{"hook_event_name":"SessionStart", "source" : "compact"}'
+if output="$(run_hook "$spaced_payload")" && [[ "$output" == *"<CONTEXT_RESTORED>"* ]]; then
+    pass "whitespace around the source key still triggers injection"
+else
+    fail "whitespace around the source key still triggers injection"
+fi
+
+if output="$(printf '' | env -i PATH="${PATH:-}" bash "$HOOK_UNDER_TEST")" && [ -z "$output" ]; then
+    pass "empty stdin fails open to no output, exit 0"
+else
+    fail "empty stdin fails open to no output, exit 0"
+fi
+
+if output="$(run_hook 'not json at all {{{')" && [ -z "$output" ]; then
+    pass "garbage stdin fails open to no output, exit 0"
+else
+    fail "garbage stdin fails open to no output, exit 0"
+fi
+
+# A compact mention inside some other field must not trigger injection.
+decoy_payload='{"hook_event_name":"SessionStart","source":"startup","cwd":"/tmp/compact"}'
+if output="$(run_hook "$decoy_payload")" && [ -z "$output" ]; then
+    pass "compact appearing outside the source field does not trigger"
+else
+    fail "compact appearing outside the source field does not trigger"
+fi
+
+if node -e '
+const example = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const entry = example.hooks.SessionStart[0].hooks[0];
+if (entry.type !== "command") {
+  console.error(`example hook type is ${JSON.stringify(entry.type)}, expected "command"`);
+  process.exit(1);
+}
+if (!/session-start-codex"$/.test(entry.command)) {
+  console.error(`unexpected example command shape: ${entry.command}`);
+  process.exit(1);
+}
+' "$EXAMPLE_UNDER_TEST"; then
+    pass "hooks-codex.json.example parses and invokes session-start-codex"
+else
+    fail "hooks-codex.json.example parses and invokes session-start-codex"
+fi
+
+if [[ "$FAILURES" -gt 0 ]]; then
+    echo "STATUS: FAILED ($FAILURES failure(s))"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Branch authoring: Anthropic Claude Fable 5 (`claude-fable-5`). Stack preparation/submission: OpenAI `gpt-5.6-sol` at max effort. |
| Harness + version | Branch authoring: Claude Code 2.1.216–2.1.218. Stack preparation/submission: Codex Desktop 0.146.0-alpha.3.1. |
| All plugins installed | Claude Code authoring environment: cloud-build, decision-log, elements-of-style, episodic-memory, greenfield, iterative-development, linear, primeradiant-ops, superpowers-chrome, superpowers (local dev), unifi-network. Codex submission environment: documents, pdf, spreadsheets, presentations, template-creator, sites, browser, computer-use, visualize, primeradiant-ops, linear, slack, github, codex-security, superpowers (local dev), cloud-build. |
| Human partner who reviewed this diff | Drew Ritter — reviewed and approved the complete combined diff on 2026-07-24, then explicitly directed this exact split. This PR is the upper hook/package subset of that reviewed diff. |

The commits identify Claude Fable 5 as co-author. Codex performed the current-`dev` rebase, deterministic verification, duplicate search, stack split, and PR update.

This is PR 2 of 2 and depends on #2036.

## What problem are you trying to solve?

Long Codex SDD sessions lost the Superpowers bootstrap and active skill instructions after context compaction. The first post-compaction dispatch then reverted to harness defaults, and once one child was spawned with inherited full-history frontier settings, that broken pattern became its own precedent for later dispatches.

Codex already discovers skills natively at normal startup, so restoring the old unconditional startup injector would duplicate instructions and recreate a previously removed behavior. The missing lifecycle point is specifically `SessionStart` with `source: "compact"`.

This upper layer preserves the SDD routing and bounded-review policy introduced by #2036 across compaction. Without it, the lower PR's printed boundary hints remain a fallback, but the global bootstrap and platform instructions are still absent from the compacted context.

## What does this PR change?

This PR adds a plugin-provided Codex `SessionStart` hook that is silent at startup, re-injects the bootstrap and a focused re-read addendum after compaction, and fails open on malformed input or missing files. It wires that hook into the Codex manifest and portal package, documents its trust/install behavior, adds a drift-cure footer to SDD boundary hints, and tests the hook lifecycle, manifest, archive contents, and cross-harness non-regression behavior.

## Is this change appropriate for the core library?

Yes. Codex is an existing first-class Superpowers harness, and preserving active Superpowers instructions across the harness's compaction lifecycle is core integration infrastructure. The hook adds no third-party dependency, is limited to Codex's existing plugin path, and remains silent during normal startup so native skill discovery continues to own that path.

## What alternatives did you consider?

- **Skill prose and boundary hints only.** Rejected as the sole mechanism because compaction removes the global bootstrap and platform instructions from active context. The hints remain a fallback at scripted boundaries but cannot restore the whole instruction set.
- **A user-level `~/.codex/hooks.json` entry.** Tested, but it is manual, anonymous in the hooks UI, and not delivered with the plugin. The plugin-provided hook has correct provenance and installation behavior.
- **Restore an unconditional startup hook.** Rejected because modern Codex discovers skills natively at startup; duplicating the bootstrap there recreates the redundancy that caused the previous hook to be removed.
- **Inject on every SessionStart source.** Rejected because the measured gap is post-compaction. The manifest and script both gate on `compact`, while startup and malformed payloads are silent no-ops.
- **Create a standalone plugin.** Rejected because this repairs lifecycle behavior for an already-supported core harness rather than adding a project-specific workflow or dependency.

## Does this PR contain multiple unrelated changes?

No. The hook, manifest wiring, package inclusion, trust documentation, drift-cure footer, and tests are one delivery path for post-compaction instruction restoration. The separable SDD routing/review-loop changes are isolated in the lower PR, #2036.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1540, #1838, #1845, #1879, #1880, #2036

No duplicate PR was found for a Codex compaction-only bootstrap re-injection hook packaged with the plugin.

- #1540 added native Codex plugin hooks for startup bootstrap. This PR reuses that supported packaging path but source-gates output to compaction only.
- #1838 aligned the old matcher with `compact`, but the old startup hook was later removed. This implementation restores only the needed compact behavior and emits nothing at startup.
- #1845 and #1880 removed the Codex startup hook because modern Codex discovers skills natively. This PR agrees with that decision: native startup remains untouched; only post-compaction re-grounding returns.
- #1879 used an explicit empty `hooks` object to suppress fallback auto-discovery. This PR replaces it with an explicit Codex hook manifest, which still avoids accidental `hooks/hooks.json` discovery.
- #2036 is the deliberate lower layer of this stack: it defines the SDD routing, bounded final-review, scoped fix-review, and evidence-locking behavior that this hook preserves across compaction.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex App manual compact/resume probes | Codex 0.145.0 family | GPT-5.6 Sol parent with explicit Terra child routing | `gpt-5.6-sol`; `gpt-5.6-terra` |
| Codex hook discovery/compact probes | Codex app-server 0.146.0-alpha.3 | n/a | hook lifecycle and injected-context inspection |
| Fresh upper-layer deterministic checks | macOS, bash/zsh | n/a | hook, manifest, package, shell-lint, and cross-harness SessionStart tests |

## New harness support (required if this PR adds a new harness)

Not applicable. Codex is already supported; this restores instructions at a missing lifecycle event in that existing harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```text
Not applicable: this PR does not add a new harness and intentionally leaves Codex's native clean-session startup path unchanged.
```

</details>

## Evaluation

- **Initial prompt:** Drew reported that long Codex SDD runs drifted after compaction and could continue for 8+ hours without finishing, even when the same work completed in 1–2 hours in Claude Code.
- **Eval sessions after the change:** two manual Codex App validation runs plus focused sentinel/app-server hook probes. The broader SDD RED/GREEN campaign is documented in the lower PR, #2036.
- **Before/after:** before the hook, compaction replaced the active instructions with a summary and the next dispatch could omit the required routing tuple. After installation and trust, startup emitted nothing while post-compaction `SessionStart` injected exactly one bootstrap/restoration record; a resumed live session retained correctly routed dispatches across two compactions.

The hook was tested with startup, compact, whitespace-varied, empty, malformed, and decoy payloads. Packaging tests verify that the manifest points at the Codex hook and that the portal archive contains the config, script, and cross-platform runner while excluding other harness hooks.

No new behavioral eval was run merely to split the already-reviewed branch. Fresh split verification was deterministic:

```bash
git diff --check codex/sdd-review-loop-fix...codex-spinout-fixes
bash tests/claude-code/test-sdd-workspace.sh
bash tests/hooks/test-session-start-codex.sh
bash tests/codex/test-marketplace-manifest.sh
bash tests/codex/test-package-codex-plugin.sh
bash tests/shell-lint/test-lint-shell.sh
bash tests/hooks/test-session-start.sh
```

All six test commands and the diff check passed on the upper branch.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results in #2036 and hook probes above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

The pressure cases included startup-versus-compact source discrimination, malformed and misleading input, missing-file fail-open behavior, post-compaction dispatch drift, and Claude Code/Cursor/Copilot hook-output regression coverage. The drift-cure footer reflects the observed failure mode where reprinted hints alone did not heal an already-broken dispatch pattern.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed the complete combined GitHub compare, explicitly approved submission on 2026-07-24, and then requested this exact two-PR split. This upper PR is an unchanged subset of that reviewed diff.