### PR TITLE
fix(codex): bound SDD dispatch and final review

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -158,6 +158,12 @@ conflicts that only emerge from implementation.
 
 Use the least powerful model that can handle each role to conserve cost and increase speed.
 
+When your platform's reference file (using-superpowers → Platform
+Adaptation) defines a dispatch role table, that table IS this section's
+mapping for your harness. Follow it over the tier language below — including
+for the final review and fix-loop escalation — and follow the
+`dispatch:` hint lines the task-brief and review-package scripts print.
+
 **Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.
 
 **Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
@@ -340,7 +346,7 @@ output; dispatch the re-review once all three are present. Name the
 covering test files in the fix message — a one-line fix does not need the
 whole suite.
 
-**The re-review is scoped.** Run `scripts/review-package PLAN_FILE FIX_BASE HEAD`
+**The re-review is scoped.** Run `scripts/review-package --role re-review PLAN_FILE FIX_BASE HEAD`
 where FIX_BASE is the head the previous review saw, and dispatch
 [re-review-prompt.md](re-review-prompt.md) with the findings list, the
 brief, the report file, and the printed diff path. The re-reviewer verdicts
@@ -391,7 +397,7 @@ parked-with-ruling at the cap.
 ## Final Review
 
 The final whole-branch review gets a package too: run
-`scripts/review-package PLAN_FILE MERGE_BASE HEAD` (MERGE_BASE = the commit the
+`scripts/review-package --role final-review PLAN_FILE MERGE_BASE HEAD` (MERGE_BASE = the commit the
 branch started from, e.g. `git merge-base main HEAD`) and include the
 printed path in the final review dispatch, so the final reviewer reads
 one file instead of re-deriving the branch diff with git commands. Dispatch
@@ -406,7 +412,7 @@ with the complete findings list — not one fixer per finding.
 Per-finding fixers each rebuild context and re-run suites; a real
 session's final-review fix wave cost more than all its tasks combined.
 Then run exactly one scoped re-review of the fix wave
-(`scripts/review-package PLAN_FILE FIX_BASE HEAD` over the fix range,
+(`scripts/review-package --role re-review PLAN_FILE FIX_BASE HEAD` over the fix range,
 [re-review-prompt.md](re-review-prompt.md)).
 Adjudicate any residual findings as in the task loop's breaker: park with
 rulings, or stop on load-bearing ones. There is no second fix wave —
@@ -494,7 +500,7 @@ Task reviewer: Spec ❌:
 Implementer: Added progress reporting, extracted PROGRESS_INTERVAL constant.
   Re-ran test/recovery.test.js — 10/10 passing. Fix report appended.
 
-[Run review-package PLAN_FILE FIX_BASE HEAD; dispatch scoped re-review]
+[Run review-package --role re-review PLAN_FILE FIX_BASE HEAD; dispatch scoped re-review]
 Re-reviewer: Missing progress reporting — ADDRESSED (src/recovery.js:41).
   Magic number — ADDRESSED (src/recovery.js:7). New breakage: none.
   Verdict: all findings addressed.
@@ -505,7 +511,7 @@ Re-reviewer: Missing progress reporting — ADDRESSED (src/recovery.js:41).
 ...
 
 [After all tasks]
-[Run review-package PLAN_FILE MERGE_BASE HEAD; dispatch final code-reviewer, most capable model]
+[Run review-package --role final-review PLAN_FILE MERGE_BASE HEAD; dispatch final code-reviewer, most capable model]
 Final reviewer: All requirements met. Deferred minors triaged: none block merge.
 
 [Delete this plan's workspace — the record now lives in git]

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -413,6 +413,15 @@ rulings, or stop on load-bearing ones. There is no second fix wave —
 residual load-bearing findings surface to your human partner when
 finishing-a-development-branch presents the options.
 
+The wave closing is policy, not a verdict. A sufficiently strong reviewer
+finds real defects indefinitely, so "review until one comes back clean"
+never terminates — the completed wave is the exit, not a clean report.
+New Critical/Important breakage in the final fix diff joins the residuals
+for adjudication; it does not start a second wave. And review procedures
+your human partner sets up for one review — competing reviewers, scoring,
+extra seats — apply to that review only. Never adopt them as standing
+procedure for reviews they didn't ask about.
+
 ## Finish
 
 When the final whole-branch review is clean and its fixes are merged,
@@ -434,6 +443,8 @@ Use superpowers:finishing-a-development-branch.
 | "The fix was small, skip the re-review" | Unreviewed fixes are how regressions land. Every round ends with a scoped re-review. |
 | "Reviews slow the loop down" | The loop without reviews is just unverified churn. Reviews are the loop's brakes and steering. |
 | "Ledger bookkeeping is overhead" | The ledger is what survives compaction. Controllers without one have re-dispatched entire completed task sequences. |
+| "This new finding is real — one more wave" | Real findings are infinite under a strong reviewer. The completed wave is the exit; adjudicate and route. |
+| "They liked competing reviewers earlier, I'll run them again" | One-off review procedures apply to the review they were given for. Re-adopting them unasked is scope creep in review clothing. |
 
 ## Example Workflow
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -59,7 +59,7 @@ digraph process {
         "Finding conflicts with plan text?" [shape=diamond];
         "Ask human partner which governs" [shape=box];
         "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" [shape=box];
-        "Dispatch scoped re-review (./re-review-prompt.md)" [shape=box];
+        "Dispatch scoped fix review (./fix-review-prompt.md)" [shape=box];
         "All findings addressed?" [shape=diamond];
         "R = 5?" [shape=diamond];
         "Adjudicate each open finding" [shape=box];
@@ -72,7 +72,7 @@ digraph process {
     "Setup: worktree, ledger check, read plan, pre-flight review" [shape=box];
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" [shape=box];
-    "Final findings? ONE fix dispatch, one scoped re-review, adjudicate residuals" [shape=box];
+    "Final findings? ONE fix dispatch, one scoped fix review, adjudicate residuals" [shape=box];
     "Final review clean: delete this plan's workspace" [shape=box];
     "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
 
@@ -88,8 +88,8 @@ digraph process {
     "Finding conflicts with plan text?" -> "Ask human partner which governs" [label="yes"];
     "Ask human partner which governs" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model";
     "Finding conflicts with plan text?" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" [label="no"];
-    "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" -> "Dispatch scoped re-review (./re-review-prompt.md)";
-    "Dispatch scoped re-review (./re-review-prompt.md)" -> "All findings addressed?";
+    "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" -> "Dispatch scoped fix review (./fix-review-prompt.md)";
+    "Dispatch scoped fix review (./fix-review-prompt.md)" -> "All findings addressed?";
     "All findings addressed?" -> "Append completion to ledger, mark todo complete" [label="yes"];
     "All findings addressed?" -> "R = 5?" [label="no"];
     "R = 5?" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" [label="no - next round"];
@@ -101,8 +101,8 @@ digraph process {
     "Append completion to ledger, mark todo complete" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" [label="no"];
-    "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" -> "Final findings? ONE fix dispatch, one scoped re-review, adjudicate residuals";
-    "Final findings? ONE fix dispatch, one scoped re-review, adjudicate residuals" -> "Final review clean: delete this plan's workspace";
+    "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" -> "Final findings? ONE fix dispatch, one scoped fix review, adjudicate residuals";
+    "Final findings? ONE fix dispatch, one scoped fix review, adjudicate residuals" -> "Final review clean: delete this plan's workspace";
     "Final review clean: delete this plan's workspace" -> "Use superpowers:finishing-a-development-branch";
 }
 ```
@@ -174,7 +174,7 @@ capable available model, not the session default.
 
 **Review tasks**: choose the model with the same judgment, scaled to the
 diff's size, complexity, and risk. A small mechanical diff does not need the
-most capable model; a subtle concurrency change does. Scoped re-reviews of
+most capable model; a subtle concurrency change does. Scoped fix reviews of
 small fix diffs take a cheap-to-mid tier.
 
 **Fix-loop escalation (rounds 4-5)**: use a model at least one tier above
@@ -323,7 +323,8 @@ Before the loop starts, two routes leave it immediately:
   Do not dismiss the finding because the plan mandates it, and do not
   dispatch a fix that contradicts the plan without asking.
 Everything else enters the loop. A fix round is one fix dispatch plus one
-scoped re-review. Five rounds maximum per task:
+scoped fix review — a review of the fix diff, not a fresh review. Five
+rounds maximum per task:
 
 **Rounds 1-3 — resume the original implementer.** Send it the open findings
 verbatim. Its context is intact: it knows the task, the code, and its own
@@ -342,14 +343,14 @@ own problem — fresh eyes and a capability bump in one move.
 covering the amended code, appends its fix report to the same report file,
 and returns the short contract. Before re-dispatching the reviewer, confirm
 the fix report contains the covering tests, the command run, and the
-output; dispatch the re-review once all three are present. Name the
+output; dispatch the fix review once all three are present. Name the
 covering test files in the fix message — a one-line fix does not need the
 whole suite.
 
-**The re-review is scoped.** Run `scripts/review-package --role re-review PLAN_FILE FIX_BASE HEAD`
+**The fix review is scoped.** Run `scripts/review-package --role fix-review PLAN_FILE FIX_BASE HEAD`
 where FIX_BASE is the head the previous review saw, and dispatch
-[re-review-prompt.md](re-review-prompt.md) with the findings list, the
-brief, the report file, and the printed diff path. The re-reviewer verdicts
+[fix-review-prompt.md](fix-review-prompt.md) with the findings list, the
+brief, the report file, and the printed diff path. The fix reviewer verdicts
 each finding ADDRESSED or NOT ADDRESSED and flags new breakage in the fix
 diff only. New Critical/Important breakage in the fix diff joins the open
 findings list. Out-of-scope observations go to the ledger as deferred
@@ -361,7 +362,7 @@ minors — they never extend the loop.
 Never fix findings yourself in the controller session — your context stays
 clean for coordination, and controller fixes skip review.
 
-**The breaker.** When round 5's re-review still leaves findings open, stop
+**The breaker.** When round 5's fix review still leaves findings open, stop
 dispatching. Adjudicate each open finding yourself — you hold the plan and
 the cross-task context the reviewer lacks:
 
@@ -411,9 +412,9 @@ If the final whole-branch review returns findings, dispatch ONE fix subagent
 with the complete findings list — not one fixer per finding.
 Per-finding fixers each rebuild context and re-run suites; a real
 session's final-review fix wave cost more than all its tasks combined.
-Then run exactly one scoped re-review of the fix wave
-(`scripts/review-package --role re-review PLAN_FILE FIX_BASE HEAD` over the fix range,
-[re-review-prompt.md](re-review-prompt.md)).
+Then run exactly one scoped fix review of the fix wave
+(`scripts/review-package --role fix-review PLAN_FILE FIX_BASE HEAD` over the fix range,
+[fix-review-prompt.md](fix-review-prompt.md)).
 Adjudicate any residual findings as in the task loop's breaker: park with
 rulings, or stop on load-bearing ones. There is no second fix wave —
 residual load-bearing findings surface to your human partner when
@@ -444,9 +445,9 @@ Use superpowers:finishing-a-development-branch.
 | "Close enough on spec compliance" | Reviewer found spec gaps = not done. Fix or hit the cap and adjudicate — those are the only exits. |
 | "I'll fix it myself, dispatching is overhead" | Controller fixes pollute your context and skip review. Resume the implementer. |
 | "One more round will converge" | Past the cap, rounds don't converge — the failure is structural. Adjudicate and route. |
-| "The reviewer will just find something new anyway" | Scoped re-reviews verify fixes; they cannot wander. New findings on untouched code go to the ledger, not the loop. |
+| "The reviewer will just find something new anyway" | Scoped fix reviews verify fixes; they cannot wander. New findings on untouched code go to the ledger, not the loop. |
 | "This finding is obviously wrong, I'll drop it" | You adjudicate only at the cap, and every ruling is a ledger entry. Silent discards are forbidden. |
-| "The fix was small, skip the re-review" | Unreviewed fixes are how regressions land. Every round ends with a scoped re-review. |
+| "The fix was small, skip the fix review" | Unreviewed fixes are how regressions land. Every round ends with a scoped fix review. |
 | "Reviews slow the loop down" | The loop without reviews is just unverified churn. Reviews are the loop's brakes and steering. |
 | "Ledger bookkeeping is overhead" | The ledger is what survives compaction. Controllers without one have re-dispatched entire completed task sequences. |
 | "This new finding is real — one more wave" | Real findings are infinite under a strong reviewer. The completed wave is the exit; adjudicate and route. |
@@ -500,8 +501,8 @@ Task reviewer: Spec ❌:
 Implementer: Added progress reporting, extracted PROGRESS_INTERVAL constant.
   Re-ran test/recovery.test.js — 10/10 passing. Fix report appended.
 
-[Run review-package --role re-review PLAN_FILE FIX_BASE HEAD; dispatch scoped re-review]
-Re-reviewer: Missing progress reporting — ADDRESSED (src/recovery.js:41).
+[Run review-package --role fix-review PLAN_FILE FIX_BASE HEAD; dispatch scoped fix review]
+Fix reviewer: Missing progress reporting — ADDRESSED (src/recovery.js:41).
   Magic number — ADDRESSED (src/recovery.js:7). New breakage: none.
   Verdict: all findings addressed.
 

--- a/skills/subagent-driven-development/fix-review-prompt.md
+++ b/skills/subagent-driven-development/fix-review-prompt.md
@@ -1,7 +1,7 @@
-# Scoped Re-Review Prompt Template
+# Scoped Fix Review Prompt Template
 
-Use this template when dispatching a re-review after a fix round. The
-re-reviewer verifies the findings were addressed and checks the fix diff for
+Use this template when dispatching a fix review after a fix round. The
+fix reviewer verifies the findings were addressed and checks the fix diff for
 new breakage. It is not a fresh review — the full review already happened.
 
 **Purpose:** Verify each finding from the previous review was addressed, and
@@ -9,11 +9,11 @@ that the fix itself broke nothing.
 
 ```
 Subagent (general-purpose):
-  description: "Re-review Task N fix round R"
+  description: "Fix review Task N round R"
   model: [MODEL — REQUIRED: choose per SKILL.md Model Selection; an omitted
          model silently inherits the session's most expensive one]
   prompt: |
-    You are re-reviewing one task's fix round. A previous review produced
+    You are reviewing one task's fix round. A previous review produced
     findings; an implementer has attempted to fix them. Your job is to
     verdict each finding and inspect the fix diff — nothing else.
 
@@ -47,7 +47,7 @@ Subagent (general-purpose):
 
     Your scope is the findings list and the fix diff. Verdict every finding.
     Inspect the fix diff for new problems the fix itself introduced. Do NOT
-    re-review code the fix did not touch: if you notice an issue entirely
+    review code the fix did not touch: if you notice an issue entirely
     outside the fix diff, report it under Out-of-Scope Observations — it
     does not block this task and does not extend the loop. A broad
     whole-branch review happens after all tasks are complete.
@@ -93,14 +93,14 @@ Subagent (general-purpose):
 
 **Placeholders:**
 - `[MODEL]` — REQUIRED: reviewer model per SKILL.md Model Selection; scoped
-  re-reviews of small fix diffs take a cheap-to-mid tier
+  fix reviews of small fix diffs take a cheap-to-mid tier
 - `[BRIEF_FILE]` — the task brief file (same file the implementer worked from)
 - `[FINDINGS]` — the Critical/Important findings and spec gaps from the
   previous review, copied verbatim, one per bullet
 - `[REPORT_FILE]` — the implementer's report file (fix reports appended)
 - `[FIX_BASE_SHA]` — the head the previous review saw
 - `[HEAD_SHA]` — current commit
-- `[DIFF_FILE]` — the path `scripts/review-package PLAN_FILE FIX_BASE HEAD` printed
+- `[DIFF_FILE]` — the path `scripts/review-package --role fix-review PLAN_FILE FIX_BASE HEAD` printed
 
-**Re-reviewer returns:** per-finding verdicts (ADDRESSED / NOT ADDRESSED),
+**Fix reviewer returns:** per-finding verdicts (ADDRESSED / NOT ADDRESSED),
 new breakage in the fix diff, out-of-scope observations, and a round verdict.

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -110,14 +110,21 @@ Subagent (general-purpose):
     Fix them, re-run the tests that cover the amended code, and append a fix
     report to your report file: what you changed, the covering tests you
     ran, the command, and the output. Reviewers will not re-run tests for
-    you — your report is the test evidence. Then reply with the same short
-    status contract as your first report.
+    you — your report is the test evidence. If your fix report claims a
+    full-suite pass, that claim needs a fresh run after your last edit —
+    a suite run from before the findings arrived no longer counts. Then
+    reply with the same short status contract as your first report.
 
     ## Report Format
 
     Write your full report to [REPORT_FILE]:
     - What you implemented (or what you attempted, if blocked)
-    - What you tested and test results
+    - What you tested, and for every gate you claim — focused tests, full
+      suite, lint, build — the exact command and the tail of its fresh
+      output. Fresh means run after your final edit: if you edited anything
+      since your last full-suite run, that run is stale — rerun it or
+      report the suite as unverified. A gate claim without pasted fresh
+      output is itself a defect for the reviewer to flag.
     - **TDD Evidence** (if TDD was required for this task):
       - RED: command run, relevant failing output before implementation, and why the failure was expected
       - GREEN: command run and relevant passing output after implementation

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -4,9 +4,9 @@
 # call. Using the recorded per-task BASE (not HEAD~1) keeps multi-commit
 # tasks intact.
 #
-# Usage: review-package [--role task-review|re-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]
+# Usage: review-package [--role task-review|fix-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]
 # Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-basename>/review-<base7>..<head7>.diff
-# (named per range, so a re-review after fixes gets a distinct fresh file).
+# (named per range, so a fix review after fixes gets a distinct fresh file).
 #
 # The trailing dispatch hint rides this output because the controller reads it
 # immediately before spawning the reviewer; skill text loaded at session start
@@ -17,22 +17,18 @@ script_dir=$(cd "$(dirname "$0")" && pwd)
 
 role=task-review
 if [ "${1:-}" = "--role" ]; then
-  [ $# -ge 2 ] || { echo "usage: review-package [--role task-review|re-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]" >&2; exit 2; }
+  [ $# -ge 2 ] || { echo "usage: review-package [--role task-review|fix-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]" >&2; exit 2; }
   role=$2
   shift 2
 fi
 
 case "$role" in
-  task-review)  hint_key=task-review ;;
-  # re-review maps onto the fix-review hints entry; the --role value itself
-  # is renamed in the next commit.
-  re-review)    hint_key=fix-review ;;
-  final-review) hint_key=final-review ;;
-  *) echo "bad --role: ${role} (task-review|re-review|final-review)" >&2; exit 2 ;;
+  task-review|fix-review|final-review) hint_key=$role ;;
+  *) echo "bad --role: ${role} (task-review|fix-review|final-review)" >&2; exit 2 ;;
 esac
 
 if [ $# -lt 3 ] || [ $# -gt 4 ]; then
-  echo "usage: review-package [--role task-review|re-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]" >&2
+  echo "usage: review-package [--role task-review|fix-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]" >&2
   exit 2
 fi
 

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -13,6 +13,8 @@
 # does not survive context compaction, but this line is reprinted every round.
 set -euo pipefail
 
+script_dir=$(cd "$(dirname "$0")" && pwd)
+
 role=task-review
 if [ "${1:-}" = "--role" ]; then
   [ $# -ge 2 ] || { echo "usage: review-package [--role task-review|re-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]" >&2; exit 2; }
@@ -20,12 +22,12 @@ if [ "${1:-}" = "--role" ]; then
   shift 2
 fi
 
-# Model/effort values are mirrored in using-superpowers/references/codex-tools.md
-# (they track Codex's spawn_agent allowlist) — update both together.
 case "$role" in
-  task-review)  hint_role=task-reviewer;      hint_effort=high ;;
-  re-review)    hint_role=scoped-re-reviewer; hint_effort=medium ;;
-  final-review) hint_role=final-reviewer;     hint_effort=high ;;
+  task-review)  hint_key=task-review ;;
+  # re-review maps onto the fix-review hints entry; the --role value itself
+  # is renamed in the next commit.
+  re-review)    hint_key=fix-review ;;
+  final-review) hint_key=final-review ;;
   *) echo "bad --role: ${role} (task-review|re-review|final-review)" >&2; exit 2 ;;
 esac
 
@@ -45,7 +47,7 @@ git rev-parse --verify --quiet "$head" >/dev/null || { echo "bad HEAD: $head" >&
 if [ $# -eq 4 ]; then
   out=$4
 else
-  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace" "$plan")
+  dir=$("$script_dir/sdd-workspace" "$plan")
   out="$dir/review-$(git rev-parse --short "$base")..$(git rev-parse --short "$head").diff"
 fi
 
@@ -64,4 +66,16 @@ fi
 
 commits=$(git rev-list --count "${base}..${head}")
 echo "wrote ${out}: ${commits} commit(s), $(wc -c < "$out" | tr -d ' ') bytes"
-echo "dispatch (codex spawn_agent): role=${hint_role} fork_turns=none model=gpt-5.6-terra reasoning_effort=${hint_effort}"
+
+# Platform dispatch hints ride this output because the controller reads it
+# immediately before spawning; the lines themselves are owned by the platform
+# reference layer (using-superpowers/references/*-dispatch.hints), not this
+# script. Claude Code's dispatch templates carry model selection already, so
+# the relay is suppressed there and on any harness without a hints file.
+hints_file="$script_dir/../../using-superpowers/references/codex-dispatch.hints"
+if [ -z "${CLAUDECODE:-}" ] && [ -f "$hints_file" ]; then
+  hint_line=$(grep "^${hint_key}:" "$hints_file" | head -1 | cut -d: -f2- | sed 's/^ *//') || true
+  if [ -n "$hint_line" ]; then
+    echo "$hint_line"
+  fi
+fi

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -20,6 +20,8 @@ if [ "${1:-}" = "--role" ]; then
   shift 2
 fi
 
+# Model/effort values are mirrored in using-superpowers/references/codex-tools.md
+# (they track Codex's spawn_agent allowlist) — update both together.
 case "$role" in
   task-review)  hint_role=task-reviewer;      hint_effort=high ;;
   re-review)    hint_role=scoped-re-reviewer; hint_effort=medium ;;

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -4,13 +4,31 @@
 # call. Using the recorded per-task BASE (not HEAD~1) keeps multi-commit
 # tasks intact.
 #
-# Usage: review-package PLAN_FILE BASE HEAD [OUTFILE]
+# Usage: review-package [--role task-review|re-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]
 # Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-basename>/review-<base7>..<head7>.diff
 # (named per range, so a re-review after fixes gets a distinct fresh file).
+#
+# The trailing dispatch hint rides this output because the controller reads it
+# immediately before spawning the reviewer; skill text loaded at session start
+# does not survive context compaction, but this line is reprinted every round.
 set -euo pipefail
 
+role=task-review
+if [ "${1:-}" = "--role" ]; then
+  [ $# -ge 2 ] || { echo "usage: review-package [--role task-review|re-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]" >&2; exit 2; }
+  role=$2
+  shift 2
+fi
+
+case "$role" in
+  task-review)  hint_role=task-reviewer;      hint_effort=high ;;
+  re-review)    hint_role=scoped-re-reviewer; hint_effort=medium ;;
+  final-review) hint_role=final-reviewer;     hint_effort=high ;;
+  *) echo "bad --role: ${role} (task-review|re-review|final-review)" >&2; exit 2 ;;
+esac
+
 if [ $# -lt 3 ] || [ $# -gt 4 ]; then
-  echo "usage: review-package PLAN_FILE BASE HEAD [OUTFILE]" >&2
+  echo "usage: review-package [--role task-review|re-review|final-review] PLAN_FILE BASE HEAD [OUTFILE]" >&2
   exit 2
 fi
 
@@ -44,3 +62,4 @@ fi
 
 commits=$(git rev-list --count "${base}..${head}")
 echo "wrote ${out}: ${commits} commit(s), $(wc -c < "$out" | tr -d ' ') bytes"
+echo "dispatch (codex spawn_agent): role=${hint_role} fork_turns=none model=gpt-5.6-terra reasoning_effort=${hint_effort}"

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -39,3 +39,7 @@ if [ ! -s "$out" ]; then
 fi
 
 echo "wrote ${out}: $(wc -l < "$out" | tr -d ' ') lines"
+# The dispatch hint rides this output because the controller reads it
+# immediately before spawning the implementer; skill text loaded at session
+# start does not survive context compaction, but this line reprints per task.
+echo "dispatch (codex spawn_agent): role=implementer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -42,4 +42,6 @@ echo "wrote ${out}: $(wc -l < "$out" | tr -d ' ') lines"
 # The dispatch hint rides this output because the controller reads it
 # immediately before spawning the implementer; skill text loaded at session
 # start does not survive context compaction, but this line reprints per task.
+# Model/effort values are mirrored in using-superpowers/references/codex-tools.md
+# (they track Codex's spawn_agent allowlist) — update both together.
 echo "dispatch (codex spawn_agent): role=implementer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -18,10 +18,12 @@ plan=$1
 n=$2
 [ -f "$plan" ] || { echo "no such plan file: $plan" >&2; exit 2; }
 
+script_dir=$(cd "$(dirname "$0")" && pwd)
+
 if [ $# -eq 3 ]; then
   out=$3
 else
-  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace" "$plan")
+  dir=$("$script_dir/sdd-workspace" "$plan")
   out="$dir/task-${n}-brief.md"
 fi
 
@@ -39,9 +41,16 @@ if [ ! -s "$out" ]; then
 fi
 
 echo "wrote ${out}: $(wc -l < "$out" | tr -d ' ') lines"
-# The dispatch hint rides this output because the controller reads it
-# immediately before spawning the implementer; skill text loaded at session
-# start does not survive context compaction, but this line reprints per task.
-# Model/effort values are mirrored in using-superpowers/references/codex-tools.md
-# (they track Codex's spawn_agent allowlist) — update both together.
-echo "dispatch (codex spawn_agent): role=implementer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"
+
+# Platform dispatch hints ride this output because the controller reads it
+# immediately before spawning; the lines themselves are owned by the platform
+# reference layer (using-superpowers/references/*-dispatch.hints), not this
+# script. Claude Code's dispatch templates carry model selection already, so
+# the relay is suppressed there and on any harness without a hints file.
+hints_file="$script_dir/../../using-superpowers/references/codex-dispatch.hints"
+if [ -z "${CLAUDECODE:-}" ] && [ -f "$hints_file" ]; then
+  hint_line=$(grep "^implementer:" "$hints_file" | head -1 | cut -d: -f2- | sed 's/^ *//') || true
+  if [ -n "$hint_line" ]; then
+    echo "$hint_line"
+  fi
+fi

--- a/skills/using-superpowers/references/codex-dispatch.hints
+++ b/skills/using-superpowers/references/codex-dispatch.hints
@@ -1,0 +1,11 @@
+# Per-role dispatch lines for Codex spawn_agent, relayed by the
+# subagent-driven-development task-brief and review-package scripts at the
+# moment of dispatch (skill text loaded at session start does not survive
+# context compaction; these lines reprint every round).
+# Model names track Codex's spawn_agent allowlist (currently gpt-5.6-sol
+# and gpt-5.6-terra) — update this file when the allowlist changes.
+# Format: <role>: <line printed verbatim>
+implementer: dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high
+task-review: dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high
+fix-review: dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=medium
+final-review: dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -9,48 +9,30 @@ multi_agent = true
 
 This enables `spawn_agent`, `wait_agent`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`. When using subagent-driven-development, close reviewer subagents when their review returns. Keep each implementer subagent open until its task's review passes — the fix loop resumes the implementer — then close it. If your harness cannot send another message to a spawned agent, dispatch each fix round as a fresh implementer carrying the brief, the report file, and the findings.
 
-## SDD dispatch: pin fork_turns and the model on every spawn
+## SDD dispatch on Codex
 
-Every `spawn_agent` call in subagent-driven-development sets
-`fork_turns: "none"`. The parameter defaults to `"all"`, which forks your
-entire session transcript into the child — the opposite of the fresh,
-constructed context SDD requires — and a full-history fork also refuses
-model and effort overrides. Never omit the parameter, and never pass
-`"all"` or a turn count for an SDD dispatch.
+Every SDD `spawn_agent` call sets `fork_turns: "none"` — the default
+`"all"` forks your whole transcript into the child and refuses model
+and effort overrides.
 
-Before Task 1, check your `spawn_agent` tool schema for `model` and
-`reasoning_effort` parameters (present on Codex 0.145+).
+If your `spawn_agent` schema has `model` and `reasoning_effort`
+parameters (Codex 0.145+), set both on every dispatch: task-brief and
+review-package print a `dispatch:` hint line with the exact values —
+copy it onto the call verbatim, every time, even late in a long
+session. Those hints are the Model Selection mapping on Codex:
+reviewer tier never exceeds implementer tier, no fix round gets an
+effort bump, and rounds 4-5's "more capable model" means a fresh
+implementer at the same tier — needing more is a BLOCKED escalation
+to your human partner. Inherited frontier-tier subagents are a
+measured cause of runs spinning out for hours. (Values live in
+`codex-dispatch.hints` beside this file; they track the spawn_agent
+model allowlist.)
 
-**If the parameters exist**, set both explicitly on every dispatch. The
-task-brief and review-package scripts print the exact values for each
-dispatch as a `dispatch (codex spawn_agent):` line with their output —
-copy that line's values onto the spawn_agent call verbatim, every time,
-even late in a long session. The mapping they print: every SDD seat runs
-`gpt-5.6-terra` — implementers and reviewers at `reasoning_effort: high`,
-scoped re-reviews at `medium`. On Codex this mapping IS the Model
-Selection section — including the final review, which stays on
-terra/high rather than "most capable available." Never give a subagent
-your session's model when you run a frontier config (sol at xhigh or
-max): reviewer tier never exceeds implementer tier, and a fix round
-never gets an effort bump. Rounds 4-5's "more capable model" means a
-fresh implementer at the same tier; a task that genuinely needs more
-than terra/high is a BLOCKED escalation to your human partner, not a
-quiet tier climb. Inherited frontier-tier subagents are a measured cause
-of SDD runs spinning out for hours: review seats that inherit a frontier
-model at maximum effort find real-but-endless defects every round, and
-fix diffs balloon instead of converging.
-
-The model names here track Codex's `spawn_agent` allowlist (currently
-`gpt-5.6-sol` and `gpt-5.6-terra`). When the allowlist changes, update
-this file and the hint lines in task-brief and review-package together.
-
-**If the parameters do not exist** (Codex 0.144 and earlier), every child
-inherits your session's model and effort and no override is possible —
-role files in `~/.codex/agents/` do not attach to spawns either. Say so
-to your human partner before starting a plan of more than a few tasks,
-and offer the choice: proceed with inheritance, or restart the session
-at a lower effort so the whole run — controller and children — pays the
-lower rate.
+Without those parameters (Codex 0.144 and earlier), children inherit
+your model and effort with no override — role files in
+`~/.codex/agents/` do not attach to spawns either. Tell your human
+partner before starting a plan of more than a few tasks, and offer a
+lower-effort session instead.
 
 ## Environment Detection
 

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -32,6 +32,9 @@ Before Task 1, check your `spawn_agent` tool schema for `model` and
 
 On Codex this table IS the Model Selection mapping — including the final
 review, which stays on terra/high rather than "most capable available."
+The task-brief and review-package scripts reprint the applicable row as a
+`dispatch (codex spawn_agent):` line with their output — copy those values
+onto the spawn_agent call verbatim, every time, even late in a long session.
 Never give a subagent your session's model when you run a frontier config
 (sol at xhigh or max): reviewer tier never exceeds implementer tier, and
 a fix round never gets an effort bump. Rounds 4-5's "more capable model"

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -9,6 +9,47 @@ multi_agent = true
 
 This enables `spawn_agent`, `wait_agent`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`. When using subagent-driven-development, close reviewer subagents when their review returns. Keep each implementer subagent open until its task's review passes — the fix loop resumes the implementer — then close it. If your harness cannot send another message to a spawned agent, dispatch each fix round as a fresh implementer carrying the brief, the report file, and the findings.
 
+## SDD dispatch: pin fork_turns and the model on every spawn
+
+Every `spawn_agent` call in subagent-driven-development sets
+`fork_turns: "none"`. The parameter defaults to `"all"`, which forks your
+entire session transcript into the child — the opposite of the fresh,
+constructed context SDD requires — and a full-history fork also refuses
+model and effort overrides. Never omit the parameter, and never pass
+`"all"` or a turn count for an SDD dispatch.
+
+Before Task 1, check your `spawn_agent` tool schema for `model` and
+`reasoning_effort` parameters (present on Codex 0.145+).
+
+**If the parameters exist**, set both explicitly on every dispatch:
+
+| Role | model | reasoning_effort |
+|------|-------|------------------|
+| Implementer (all rounds) | `gpt-5.6-terra` | `high` |
+| Task reviewer | `gpt-5.6-terra` | `high` |
+| Scoped re-review | `gpt-5.6-terra` | `medium` |
+| Final whole-branch review | `gpt-5.6-terra` | `high` |
+
+On Codex this table IS the Model Selection mapping — including the final
+review, which stays on terra/high rather than "most capable available."
+Never give a subagent your session's model when you run a frontier config
+(sol at xhigh or max): reviewer tier never exceeds implementer tier, and
+a fix round never gets an effort bump. Rounds 4-5's "more capable model"
+means a fresh implementer at the same tier; a task that genuinely needs
+more than terra/high is a BLOCKED escalation to your human partner, not
+a quiet tier climb. Frontier-tier subagents at inherited effort are the
+measured top driver of Codex SDD runs spinning out to 8+ hours
+(PRI-2672): review seats that inherited sol found real-but-endless
+defects every round, and fix diffs ballooned instead of converging.
+
+**If the parameters do not exist** (Codex 0.144 and earlier), every child
+inherits your session's model and effort and no override is possible —
+role files in `~/.codex/agents/` do not attach to spawns either. Say so
+to your human partner before starting a plan of more than a few tasks,
+and offer the choice: proceed with inheritance, or restart the session
+at a lower effort so the whole run — controller and children — pays the
+lower rate.
+
 ## Environment Detection
 
 Skills that create worktrees or finish branches should detect their

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -21,29 +21,28 @@ model and effort overrides. Never omit the parameter, and never pass
 Before Task 1, check your `spawn_agent` tool schema for `model` and
 `reasoning_effort` parameters (present on Codex 0.145+).
 
-**If the parameters exist**, set both explicitly on every dispatch:
+**If the parameters exist**, set both explicitly on every dispatch. The
+task-brief and review-package scripts print the exact values for each
+dispatch as a `dispatch (codex spawn_agent):` line with their output —
+copy that line's values onto the spawn_agent call verbatim, every time,
+even late in a long session. The mapping they print: every SDD seat runs
+`gpt-5.6-terra` — implementers and reviewers at `reasoning_effort: high`,
+scoped re-reviews at `medium`. On Codex this mapping IS the Model
+Selection section — including the final review, which stays on
+terra/high rather than "most capable available." Never give a subagent
+your session's model when you run a frontier config (sol at xhigh or
+max): reviewer tier never exceeds implementer tier, and a fix round
+never gets an effort bump. Rounds 4-5's "more capable model" means a
+fresh implementer at the same tier; a task that genuinely needs more
+than terra/high is a BLOCKED escalation to your human partner, not a
+quiet tier climb. Inherited frontier-tier subagents are a measured cause
+of SDD runs spinning out for hours: review seats that inherit a frontier
+model at maximum effort find real-but-endless defects every round, and
+fix diffs balloon instead of converging.
 
-| Role | model | reasoning_effort |
-|------|-------|------------------|
-| Implementer (all rounds) | `gpt-5.6-terra` | `high` |
-| Task reviewer | `gpt-5.6-terra` | `high` |
-| Scoped re-review | `gpt-5.6-terra` | `medium` |
-| Final whole-branch review | `gpt-5.6-terra` | `high` |
-
-On Codex this table IS the Model Selection mapping — including the final
-review, which stays on terra/high rather than "most capable available."
-The task-brief and review-package scripts reprint the applicable row as a
-`dispatch (codex spawn_agent):` line with their output — copy those values
-onto the spawn_agent call verbatim, every time, even late in a long session.
-Never give a subagent your session's model when you run a frontier config
-(sol at xhigh or max): reviewer tier never exceeds implementer tier, and
-a fix round never gets an effort bump. Rounds 4-5's "more capable model"
-means a fresh implementer at the same tier; a task that genuinely needs
-more than terra/high is a BLOCKED escalation to your human partner, not
-a quiet tier climb. Frontier-tier subagents at inherited effort are the
-measured top driver of Codex SDD runs spinning out to 8+ hours
-(PRI-2672): review seats that inherited sol found real-but-endless
-defects every round, and fix diffs ballooned instead of converging.
+The model names here track Codex's `spawn_agent` allowlist (currently
+`gpt-5.6-sol` and `gpt-5.6-terra`). When the allowlist changes, update
+this file and the hint lines in task-brief and review-package together.
 
 **If the parameters do not exist** (Codex 0.144 and earlier), every child
 inherits your session's model and effort and no override is possible —

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -165,37 +165,52 @@ PLAN
         echo "    got: $rp_explicit"
     fi
 
-    # --- dispatch hints ride the script output ---
-    if [[ "$brief_out" == *"dispatch (codex spawn_agent): role=implementer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
-        pass "task-brief prints the implementer dispatch hint"
+    # --- platform dispatch hints ride the script output (suppressed on CC) ---
+    local brief_hint
+    brief_hint="$(cd "$repo" && env -u CLAUDECODE "$SDD_SCRIPTS/task-brief" plan-a.md 1)"
+    if [[ "$brief_hint" == *"dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
+        pass "task-brief relays the implementer dispatch hint off Claude Code"
     else
-        fail "task-brief prints the implementer dispatch hint"
-        echo "    got: $brief_out"
+        fail "task-brief relays the implementer dispatch hint off Claude Code"
+        echo "    got: $brief_hint"
     fi
 
-    if [[ "$rp_out" == *"dispatch (codex spawn_agent): role=task-reviewer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
-        pass "review-package defaults to the task-reviewer dispatch hint"
+    local rp_hint
+    rp_hint="$(cd "$repo" && env -u CLAUDECODE "$SDD_SCRIPTS/review-package" plan-a.md HEAD~1 HEAD)"
+    if [[ "$rp_hint" == *"dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
+        pass "review-package relays the default-role hint off Claude Code"
     else
-        fail "review-package defaults to the task-reviewer dispatch hint"
-        echo "    got: $rp_out"
+        fail "review-package relays the default-role hint off Claude Code"
+        echo "    got: $rp_hint"
     fi
 
     local rp_rereview
-    rp_rereview="$(cd "$repo" && "$SDD_SCRIPTS/review-package" --role re-review plan-a.md HEAD~1 HEAD)"
-    if [[ "$rp_rereview" == *"role=scoped-re-reviewer fork_turns=none model=gpt-5.6-terra reasoning_effort=medium"* ]]; then
-        pass "review-package --role re-review prints the medium-effort hint"
+    rp_rereview="$(cd "$repo" && env -u CLAUDECODE "$SDD_SCRIPTS/review-package" --role re-review plan-a.md HEAD~1 HEAD)"
+    if [[ "$rp_rereview" == *"dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=medium"* ]]; then
+        pass "review-package --role re-review relays the medium-effort hint"
     else
-        fail "review-package --role re-review prints the medium-effort hint"
+        fail "review-package --role re-review relays the medium-effort hint"
         echo "    got: $rp_rereview"
     fi
 
     local rp_final
-    rp_final="$(cd "$repo" && "$SDD_SCRIPTS/review-package" --role final-review plan-a.md HEAD~1 HEAD)"
-    if [[ "$rp_final" == *"role=final-reviewer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
-        pass "review-package --role final-review prints the final-reviewer hint"
+    rp_final="$(cd "$repo" && env -u CLAUDECODE "$SDD_SCRIPTS/review-package" --role final-review plan-a.md HEAD~1 HEAD)"
+    if [[ "$rp_final" == *"dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
+        pass "review-package --role final-review relays the high-effort hint"
     else
-        fail "review-package --role final-review prints the final-reviewer hint"
+        fail "review-package --role final-review relays the high-effort hint"
         echo "    got: $rp_final"
+    fi
+
+    local brief_cc rp_cc
+    brief_cc="$(cd "$repo" && CLAUDECODE=1 "$SDD_SCRIPTS/task-brief" plan-a.md 1)"
+    rp_cc="$(cd "$repo" && CLAUDECODE=1 "$SDD_SCRIPTS/review-package" plan-a.md HEAD~1 HEAD)"
+    if [[ "$brief_cc" != *"dispatch (spawn_agent)"* && "$rp_cc" != *"dispatch (spawn_agent)"* ]]; then
+        pass "dispatch hints are suppressed under Claude Code (CLAUDECODE set)"
+    else
+        fail "dispatch hints are suppressed under Claude Code (CLAUDECODE set)"
+        echo "    brief: $brief_cc"
+        echo "    rp:    $rp_cc"
     fi
 
     rc=0

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -165,6 +165,48 @@ PLAN
         echo "    got: $rp_explicit"
     fi
 
+    # --- dispatch hints ride the script output ---
+    if [[ "$brief_out" == *"dispatch (codex spawn_agent): role=implementer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
+        pass "task-brief prints the implementer dispatch hint"
+    else
+        fail "task-brief prints the implementer dispatch hint"
+        echo "    got: $brief_out"
+    fi
+
+    if [[ "$rp_out" == *"dispatch (codex spawn_agent): role=task-reviewer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
+        pass "review-package defaults to the task-reviewer dispatch hint"
+    else
+        fail "review-package defaults to the task-reviewer dispatch hint"
+        echo "    got: $rp_out"
+    fi
+
+    local rp_rereview
+    rp_rereview="$(cd "$repo" && "$SDD_SCRIPTS/review-package" --role re-review plan-a.md HEAD~1 HEAD)"
+    if [[ "$rp_rereview" == *"role=scoped-re-reviewer fork_turns=none model=gpt-5.6-terra reasoning_effort=medium"* ]]; then
+        pass "review-package --role re-review prints the medium-effort hint"
+    else
+        fail "review-package --role re-review prints the medium-effort hint"
+        echo "    got: $rp_rereview"
+    fi
+
+    local rp_final
+    rp_final="$(cd "$repo" && "$SDD_SCRIPTS/review-package" --role final-review plan-a.md HEAD~1 HEAD)"
+    if [[ "$rp_final" == *"role=final-reviewer fork_turns=none model=gpt-5.6-terra reasoning_effort=high"* ]]; then
+        pass "review-package --role final-review prints the final-reviewer hint"
+    else
+        fail "review-package --role final-review prints the final-reviewer hint"
+        echo "    got: $rp_final"
+    fi
+
+    rc=0
+    (cd "$repo" && "$SDD_SCRIPTS/review-package" --role bogus plan-a.md HEAD~1 HEAD >/dev/null 2>&1) || rc=$?
+    if [[ "$rc" -eq 2 ]]; then
+        pass "review-package rejects an unknown --role with exit 2"
+    else
+        fail "review-package rejects an unknown --role with exit 2"
+        echo "    exit: $rc"
+    fi
+
     # --- Worktree isolation: a linked worktree resolves its own workspace ---
     local wt="$TEST_ROOT/wt"
     ( cd "$repo" && git worktree add -q "$wt" -b wt-feature )

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -184,13 +184,13 @@ PLAN
         echo "    got: $rp_hint"
     fi
 
-    local rp_rereview
-    rp_rereview="$(cd "$repo" && env -u CLAUDECODE "$SDD_SCRIPTS/review-package" --role re-review plan-a.md HEAD~1 HEAD)"
-    if [[ "$rp_rereview" == *"dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=medium"* ]]; then
-        pass "review-package --role re-review relays the medium-effort hint"
+    local rp_fixreview
+    rp_fixreview="$(cd "$repo" && env -u CLAUDECODE "$SDD_SCRIPTS/review-package" --role fix-review plan-a.md HEAD~1 HEAD)"
+    if [[ "$rp_fixreview" == *"dispatch (spawn_agent): fork_turns=none model=gpt-5.6-terra reasoning_effort=medium"* ]]; then
+        pass "review-package --role fix-review relays the medium-effort hint"
     else
-        fail "review-package --role re-review relays the medium-effort hint"
-        echo "    got: $rp_rereview"
+        fail "review-package --role fix-review relays the medium-effort hint"
+        echo "    got: $rp_fixreview"
     fi
 
     local rp_final


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Branch authoring: Anthropic Claude Fable 5 (`claude-fable-5`). Stack preparation/submission: OpenAI `gpt-5.6-sol` at max effort. |
| Harness + version | Branch authoring: Claude Code 2.1.216–2.1.218. Stack preparation/submission: Codex Desktop 0.146.0-alpha.3.1. |
| All plugins installed | Claude Code authoring environment: cloud-build, decision-log, elements-of-style, episodic-memory, greenfield, iterative-development, linear, primeradiant-ops, superpowers-chrome, superpowers (local dev), unifi-network. Codex submission environment: documents, pdf, spreadsheets, presentations, template-creator, sites, browser, computer-use, visualize, primeradiant-ops, linear, slack, github, codex-security, superpowers (local dev), cloud-build. |
| Human partner who reviewed this diff | Drew Ritter — reviewed and approved the complete combined diff on 2026-07-24, then explicitly directed this exact split. This PR is the lower, self-contained subset of that reviewed diff. |

The commits identify Claude Fable 5 as co-author. Codex performed the current-`dev` rebase, deterministic verification, duplicate search, stack split, and PR submission.

This is PR 1 of 2. The Codex compaction-hook work follows in #2035.

## What problem are you trying to solve?

Drew reported a real Codex/Superpowers reliability failure: SDD implementations that normally finished in 1–2 hours in Claude Code were taking 8+ hours in Codex, often without finishing. Agents looped through review and minor test fixes, expanded beyond the approved plan, or turned a bounded final review into repeated competing review waves.

The deduplicated session corpus showed 8/22 GPT-5.6-era runs spinning out versus 2/36 GPT-5.5-era runs. One 14-task run spent eight hours completing only six tasks; another reached a terminal final-review loop that continued for more than three hours without a reachable stop state.

This layer addresses three measured causes:

1. Codex `spawn_agent` defaults to full-history forks, and full-history forks refuse per-call model/effort overrides.
2. Omitted routing makes children inherit the frontier parent, accumulating expensive review/fix seats instead of explicit role routing.
3. Final review lacked an enforceable wave-closing policy, while implementer reports could claim a full-suite gate using stale output from before later edits.

The post-compaction bootstrap loss that can reintroduce this drift is handled separately in the stacked follow-up, #2035.

## What does this PR change?

This PR pins Codex SDD dispatches to `fork_turns: "none"` with platform-owned per-role model/effort hints, bounds final review to one fix dispatch plus one scoped fix review, and renames “re-review” to “fix review” so the target is the fix diff. It also requires exact commands and fresh output tails for implementer gate claims, with deterministic coverage for hint routing, role validation, Claude Code suppression, and the bounded review workflow.

## Is this change appropriate for the core library?

Yes. Codex is an existing first-class Superpowers harness, and SDD is a general-purpose core workflow. The failure occurs across projects and customers; the changes are not Prime Radiant-specific, add no dependency, and keep Codex-specific routing values in the existing platform reference rather than hard-coding them into shared scripts.

## What alternatives did you consider?

- **Keep full-history forks and only request lower tiers.** Rejected because full-history forks refuse model/effort overrides and copy the largest possible context into every child.
- **Hard-code Codex model names in shared SDD scripts.** Rejected because shared scripts also run under other harnesses. The role table remains platform-owned and is suppressed under Claude Code.
- **Run progressively stronger reviewers until one returns clean.** Rejected because the reviewer matrix showed strong reviewers continue finding real but progressively narrower defects. Convergence needs a controller-owned wave policy.
- **Add a broad wall-clock or suite governor first.** Deferred because a generic timeout would cut off legitimate work without fixing the measured dispatch and termination mechanisms.
- **Rely on prose without boundary hints.** Rejected because the controller repeatedly consulted `task-brief` and `review-package` immediately before dispatch; those are the durable chokepoints for the routing tuple.

## Does this PR contain multiple unrelated changes?

No. Dispatch routing, bounded final review, the scoped fix-review contract, and evidence-locked completion claims all address the same SDD spinout loop. The separable post-compaction hook and packaging work is intentionally isolated in stacked PR #2035.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1496, #1982, #2035

No duplicate PR was found for Codex SDD spinout, `fork_turns` pinning, role-bound review dispatch, or bounded final-review termination.

- #1496 proposed a new cross-provider model-reconciliation skill and closed without completed evals. This PR keeps model values platform-owned, preserves the existing SDD workflow, and is grounded in measured Codex failure and eval evidence.
- #1982 concerns releasing completed agents to free concurrency slots. It is adjacent capacity hygiene, not dispatch tier/fork routing or final-wave termination.
- #2035 is the deliberate upper layer of this stack: it restores these instructions after Codex compaction and packages that hook with the plugin.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex App manual failure/fix runs | Codex 0.145.0 family | GPT-5.6 Sol parent with explicit Terra child routing | `gpt-5.6-sol`; `gpt-5.6-terra` |
| `superpowers-evals` RED/GREEN campaign | `codex-spinout-scenarios` @ `3c0a2f7`, Codex 0.145.0 | GPT-5.6 Sol parent at max; role-pinned children | `gpt-5.6-sol`; `gpt-5.6-terra` |
| `superpowers-evals` regression guards | campaign @ `3c0a2f7` | Claude Opus 4.8 | `claude-opus-4-8` |
| Fresh lower-layer deterministic check | macOS, bash/zsh | n/a | `tests/claude-code/test-sdd-workspace.sh` |

## New harness support (required if this PR adds a new harness)

Not applicable. Codex is already supported; this changes SDD routing and review-loop behavior in that existing harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```text
Not applicable: this PR does not add a new harness or change Codex's clean-session startup path.
```

</details>

## Evaluation

- **Initial prompt:** Drew reported that roughly half of his recent Codex SDD implementations were spinning out from expected 1–2 hour executions to 8+ hours, with review loops, minor-test churn, scope expansion, and unfinished plans. He supplied three recent session IDs and requested a multi-session diagnosis before any fix.
- **Eval sessions after the change:** two manual Codex App validation runs, followed by a RED/GREEN campaign of approximately 43 cells: three reps per RED/GREEN cell and two reps per regression guard.
- **Before/after:** the previously spun-out final-review continuation completed in 81 minutes with a single bounded review cycle. The formerly spun-out 14-task plan then completed its remaining tasks and final review; after the v2 boundary hints, roughly 20 consecutive dispatches stayed correctly routed across two compactions.

Recorded campaign results in `prime-radiant-inc/superpowers-evals` branch `codex-spinout-scenarios`:

- `sdd-codex-dispatch-pinning`: RED was bimodal/unpinned; GREEN 3/3 gauntlet passes.
- `sdd-codex-no-tier-escalation`: RED 3/3 inherited or escalated; GREEN 3/3 passes.
- `sdd-final-review-contaminated-resume`: RED met the planned probabilistic threshold; GREEN 3/3 passes.
- Across those three structural scenarios, GREEN was 18/18 gauntlet plus deterministic checks.
- `sdd-implementer-evidence-locked-report`: improved from 1/3 to 2/3 judge passes, so this remains an explicit **partial GREEN**, not a claim of full binding.
- The critical Claude Code guard `sdd-round4-escalates-model` was 2/2 clean. No regression-guard failure was attributable to this branch; unrelated anomalies and infrastructure/judge failures remain documented in the campaign record.

No new behavioral eval was run merely to split the already-reviewed branch. Fresh split verification was deterministic:

```bash
git diff --check origin/dev...codex/sdd-review-loop-fix
bash tests/claude-code/test-sdd-workspace.sh
# 19/19 checks passed
```

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

The pressure cases combine frontier-parent inheritance, round-four escalation pressure, contaminated final-review history, stale evidence claims, and a Claude Code regression column. The branch adds final-wave rationalization counters because those exact rationalizations appeared in the failed field sessions; it does not broadly rewrite the skill's voice or philosophy.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed the complete combined GitHub compare, explicitly approved submission on 2026-07-24, and then requested this exact two-PR split. This lower PR is an unchanged subset of that reviewed diff.