### PR TITLE
Require explicit acknowledgement for plaintext remote Brainstorm binds

### DIFF
--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Start the brainstorm server and output connection info
-# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--foreground] [--background]
+# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--insecure-remote] [--foreground] [--background]
 #
 # Starts server on a random high port, outputs JSON with URL.
 # Each session gets its own directory to avoid conflicts.
@@ -9,8 +9,10 @@
 #   --project-dir <path>  Store session files under <path>/.superpowers/brainstorm/
 #                         instead of /tmp. Files persist after server stops.
 #   --host <bind-host>    Host/interface to bind (default: 127.0.0.1).
-#                         Use 0.0.0.0 in remote/containerized environments.
+#                         Non-loopback binds require --insecure-remote.
 #   --url-host <host>     Hostname shown in returned URL JSON.
+#   --insecure-remote     Acknowledge that a non-loopback bind uses plaintext HTTP.
+#                         Prefer an SSH tunnel or a TLS-terminating reverse proxy.
 #   --idle-timeout-minutes <n>  Shut down after n minutes idle (default 240 = 4h).
 #   --open                Auto-open the browser on the first screen (use only
 #                         after the user approves the visual companion).
@@ -23,6 +25,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR=""
 FOREGROUND="false"
 FORCE_BACKGROUND="false"
+INSECURE_REMOTE="false"
 BIND_HOST="127.0.0.1"
 URL_HOST=""
 IDLE_TIMEOUT_MINUTES=""
@@ -39,6 +42,10 @@ while [[ $# -gt 0 ]]; do
     --url-host)
       URL_HOST="$2"
       shift 2
+      ;;
+    --insecure-remote)
+      INSECURE_REMOTE="true"
+      shift
       ;;
     --idle-timeout-minutes)
       IDLE_TIMEOUT_MINUTES="$2"
@@ -62,6 +69,22 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+is_loopback_bind_host() {
+  case "$1" in
+    localhost|127.*|::1|'[::1]') return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# The session key is a bearer credential carried in the companion URL and
+# WebSocket connection. This server intentionally speaks HTTP only, so exposing
+# it beyond loopback is unsafe unless the operator has arranged a secure
+# transport (for example SSH port forwarding or TLS termination).
+if ! is_loopback_bind_host "$BIND_HOST" && [[ "$INSECURE_REMOTE" != "true" ]]; then
+  echo '{"error": "Refusing non-loopback HTTP bind without --insecure-remote. Use SSH port forwarding or a TLS-terminating reverse proxy."}'
+  exit 2
+fi
 
 if [[ -z "$URL_HOST" ]]; then
   if [[ "$BIND_HOST" == "127.0.0.1" || "$BIND_HOST" == "localhost" ]]; then

--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -91,16 +91,24 @@ scripts/start-server.sh --project-dir /path/to/project --open --foreground
 
 **Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.
 
-If the URL is unreachable from your browser (common in remote/containerized setups), bind a non-loopback host:
+If the URL is unreachable from your browser because the agent runs remotely or
+inside a container, keep the companion bound to loopback and forward its port
+through SSH. The session URL contains a bearer key, so the server must not be
+exposed through plaintext HTTP on a LAN or the Internet.
 
 ```bash
+# On the remote machine: start normally and note the returned port and URL.
 scripts/start-server.sh \
-  --project-dir /path/to/project \
-  --host 0.0.0.0 \
-  --url-host localhost
+  --project-dir /path/to/project
+
+# On your local machine: replace both ports with the returned remote port.
+ssh -L <local-port>:127.0.0.1:<remote-port> user@remote-host
 ```
 
-Use `--url-host` to control what hostname is printed in the returned URL JSON.
+Open the returned URL after replacing its host and port with
+`localhost:<local-port>`. If direct non-loopback exposure is unavoidable, pass
+`--insecure-remote` explicitly and place the server behind TLS; this mode is
+not safe over plaintext HTTP.
 
 ## The Loop
 

--- a/tests/brainstorm-server/start-server.test.sh
+++ b/tests/brainstorm-server/start-server.test.sh
@@ -109,6 +109,26 @@ else
 fi
 
 echo ""
+echo "--- start-server.sh remote bind safety ---"
+
+captured=$(bash "$START_SCRIPT" --project-dir "$TEST_DIR/project" --host 0.0.0.0 2>&1 || true)
+if echo "$captured" | grep -q 'Refusing non-loopback HTTP bind without --insecure-remote'; then
+  pass "rejects non-loopback HTTP binds without explicit acknowledgement"
+else
+  fail "rejects non-loopback HTTP binds without explicit acknowledgement" \
+       "expected remote bind safety error, got: $captured"
+fi
+
+captured=$(PATH="$TEST_DIR/fake-bin:$PATH" \
+  bash "$START_SCRIPT" --project-dir "$TEST_DIR/project" --host 0.0.0.0 --insecure-remote --foreground 2>&1 || true)
+if echo "$captured" | grep -q 'FOREGROUND_MODE=true'; then
+  pass "allows explicitly acknowledged non-loopback binds"
+else
+  fail "allows explicitly acknowledged non-loopback binds" \
+       "expected fake node to run after acknowledgement, got: $captured"
+fi
+
+echo ""
 echo "--- Results: $passed passed, $failed failed ---"
 if [[ $failed -gt 0 ]]; then
   exit 1


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Branch authoring: Anthropic Claude Fable 5 (claude-fable-5) |
| Harness + version | Branch authoring: Claude Code 2.1.216–2.1.218. Stack preparation/submission: Codex Desktop 0.146.0-alpha.3.1. |
| All plugins installed | Claude Code authoring environment: cloud-build, decision-log, elements-of-style, episodic-memory, greenfield, iterative-development, linear, primeradiant-ops, superpowers-chrome, superpowers (local dev), unifi-network. Codex submission environment: documents, pdf, spreadsheets, presentations, template-creator, sites, browser, computer-use, visualize, primeradiant-ops, linear, slack, github, codex-security, superpowers (local dev), cloud-build. |
| Human partner who reviewed this diff | Avza |

## What problem are you trying to solve?

In a remote/containerized Brainstorm Companion session, I needed to bind the
server with `--host 0.0.0.0` so that a browser outside the execution
environment could access it.

The companion serves HTTP only and returns a URL containing
`?key=<session-token>`. This token is a bearer credential accepted by both the
HTTP endpoints and WebSocket upgrade path. If a non-loopback listener is
exposed over an untrusted network without encrypted transport, an observer can
capture and replay the token to read companion screens and files or submit
WebSocket events that are persisted to `state/events`.

The previous launcher made a plaintext non-loopback bind easy to select without
requiring the operator to explicitly acknowledge that transport boundary.

## What does this PR change?

- Reject non-loopback HTTP binds unless the operator explicitly passes
  `--insecure-remote`.
- Document SSH local port forwarding as the default remote/container access
  pattern.
- Document that direct non-loopback use requires a TLS-terminating reverse
  proxy or another trusted encrypted transport.
- Add regression coverage for both the default rejection and explicit opt-in
  behavior.

## Is this change appropriate for the core library?

Yes. This changes the shared Brainstorm Companion launch path and protects all
users who run the companion outside a loopback-only environment. It is not
project-, harness-, or vendor-specific.

## What alternatives did you consider?

Adding TLS directly to the zero-dependency companion server would require
certificate and private-key configuration, as well as a broader deployment and
support model. Keeping loopback as the secure default and recommending SSH port
forwarding preserves the existing architecture. The explicit
`--insecure-remote` escape hatch preserves deployments that already provide TLS
termination or an equivalent trusted transport.

## Does this PR contain multiple unrelated changes?

No. The launcher guard, remote-access documentation, and regression tests are
one cohesive security change: preventing accidental plaintext non-loopback
exposure of a bearer-authenticated companion.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Desktop | Not exposed in session | Claude Fable 5 Ultracode | Claude Fable 5 Ultracode  |

Validation run:

```
text
npm test
git diff --check
```


## New harness support

Not applicable. This PR does not add or modify support for any harness.

## Evaluation

| Item | Result |
|---|---|
| Initial prompt | Investigate the security implications of running the Brainstorm Companion remotely with `--host 0.0.0.0`. |
| Post-change eval sessions | Not applicable. This change affects launcher infrastructure, not behavior-shaping skill content. |
| Before | A non-loopback plaintext HTTP bind could start without an explicit operator acknowledgement. |
| After | A non-loopback bind fails closed unless `--insecure-remote` is explicitly supplied. |

## Rigor

| Check | Status |
|---|---|
| Skill-content change | Not applicable — no skill-content behavior was modified. |
| Adversarial coverage | Passed — regression coverage verifies rejection without acknowledgement and success with explicit opt-in. |
| Tuned skill wording | Unchanged. |

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission.

