### PR TITLE
docs: remove the "We're Hiring" section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 Superpowers is a complete software development methodology for your coding agents, built on top of a set of composable skills and some initial instructions that make sure your agent uses them.
 
 
-## We're Hiring!
-
-We're hiring someone to help out full time with Superpowers community and code work. 
-You can read about the job at https://primeradiant.com/jobs/superpowers-community-engineer/
-If this sounds like someone you know, definitely send them our way.
-
 ## Quickstart
 
 Give your agent Superpowers: [Claude Code](#claude-code), [Antigravity](#antigravity), [Codex App](#codex-app), [Codex CLI](#codex-cli), [Cursor](#cursor), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [GitHub Copilot CLI](#github-copilot-cli), [Kimi Code](#kimi-code), [OpenCode](#opencode), [Pi](#pi).


### PR DESCRIPTION
> **Note on base branch:** this PR deliberately targets `main`, not `dev`.
> It is a maintainer-side docs change to the released README. Opening it as
> a `dev` → `main` PR is not currently possible to rebase-merge: `main..dev`
> carries 64 commits, including the pre-rebase twins of the v6.1.1/v6.2.0
> work (e.g. dev's `d262bc4` vs main's `3dcbd5c`, identical subject,
> different SHA). A local rebase simulation drops commit 1 as already
> upstream and then conflicts at 2/62 on `3bb0a3f Add Codex portal package
> script` (add/add in `scripts/package-codex-plugin.sh` and
> `tests/codex/test-package-codex-plugin.sh`). The same commit is already on
> `dev` as `bb2a34b`, so the branches stay converged.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 5 (`claude-opus-5`) |
| Harness + version | Claude Code 2.1.220 |
| All plugins installed | agent-sdk-dev@claude-plugins-official, claude-code-setup@claude-plugins-official, claude-session-driver@superpowers-marketplace, code-simplifier@claude-plugins-official, context7@claude-plugins-official, elements-of-style@superpowers-marketplace, episodic-memory@superpowers-marketplace, frontend-design@claude-plugins-official, github-triage@github-triage-dev, gopls-lsp@claude-plugins-official, linear@claude-plugins-official, mcp-server-dev@claude-plugins-official, plugin-dev@claude-code-plugins, plugin-dev@claude-plugins-official, primeradiant-ops@primeradiant, release-radar@whats-new-marketplace, summarize-meetings@2389-research-marketplace, superpowers-chrome@superpowers-marketplace, superpowers-developing-for-claude-code@superpowers-marketplace, superpowers-lab@superpowers-marketplace, superpowers@claude-plugins-official, worldview-synthesis@2389-research-marketplace |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — maintainer; requested the change and reviewed the diff in-session |

## What problem are you trying to solve?

The README opened with a "We're Hiring!" section advertising the Superpowers
community engineer role, linking to
https://primeradiant.com/jobs/superpowers-community-engineer/. There is now a
candidate on trial for that role, so the posting no longer belongs at the top
of the project's front page — the first thing a reader sees should be what
Superpowers is, not a job ad for a position that is being filled.

This is a maintainer request, not a discovered defect.

## What does this PR change?

Deletes the six-line "We're Hiring!" section from `README.md`, so the intro
paragraph runs straight into Quickstart. No other content is touched.

## Is this change appropriate for the core library?

Yes — it edits this project's own README. It is not a skill, and it carries no
domain-, tool-, or workflow-specific content.

## What alternatives did you consider?

- **Leave it on `dev` and let it ship with the next release.** Rejected: the
  posting is live on the released README now, and the next release is not
  scheduled.
- **Open the change as a `dev` → `main` PR.** Rejected on mechanics, not
  preference — see the base-branch note at the top. It cannot be rebase-merged
  without hand-resolving 62 replayed commits.
- **Merge `dev` → `main` with a merge commit.** Rejected: `main` is kept
  linear, and a merge commit for a six-line docs edit is not worth the
  exception.
- **Rewrite the section rather than remove it** (e.g. "role filled"). Rejected:
  the maintainer asked for removal, and a filled-role notice ages just as badly.

## Does this PR contain multiple unrelated changes?

No. One file, one six-line deletion.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found — `gh pr list --state all` searches for `hiring` and
  `README hiring` both returned zero results.

## Environment tested

This is a documentation-only change with no executable content, so there is no
runtime behavior to exercise. Verified by inspection: `git diff origin/main`
shows exactly the six removed lines, and a repo-wide grep confirms no remaining
references to the role or the job URL (`grep -rn -i "superpowers-community-engineer\|We're Hiring"` over
`*.md`/`*.json`/`*.txt` returns nothing).

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.220 | Claude Opus 5 | `claude-opus-5` |

## New harness support (required if this PR adds a new harness)

N/A — no harness support added.
