### PR TITLE
fix(cursor): resolve session hook from plugin root

### DIFF
--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -387,15 +387,15 @@ own event-matcher strings (Claude Code uses `startup|clear|compact`, Cursor
 The **hook-config schema itself varies per harness** — don't assume the
 Claude Code shape is universal. Compare `hooks/hooks.json` and
 `hooks/hooks-cursor.json`: Cursor's uses
-`"version": 1`, a lowercase `sessionStart` key, a relative
-`./hooks/run-hook.cmd` command, and omits the `matcher`/`type`/`async` fields
+`"version": 1`, a lowercase `sessionStart` key, a
+`"${CURSOR_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start` command, and omits the `matcher`/`type`/`async` fields
 Claude Code uses. Match your `hooks-<harness>.json` to whichever existing file is
 closest, not to a single canonical template.
 
 The hook **command string references a harness-provided plugin-root variable**,
-and its name differs per harness: `hooks.json` uses `${CLAUDE_PLUGIN_ROOT}`,
-`hooks-cursor.json` uses a relative path. Use
-whatever your harness exports. (The `session-start` script re-derives the root
+and its name differs per harness: `hooks.json` uses `${CLAUDE_PLUGIN_ROOT}` and
+`hooks-cursor.json` uses `${CURSOR_PLUGIN_ROOT}`. Use whatever your harness
+exports. (The `session-start` script re-derives the root
 itself via `dirname`, so the script body doesn't depend on this — but the
 command in the manifest does.)
 

--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -3,7 +3,7 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "./hooks/run-hook.cmd session-start"
+        "command": "\"${CURSOR_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start"
       }
     ]
   }

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -164,6 +164,20 @@ else
     fail "hooks.json registers SessionStart with shell:bash dispatch"
 fi
 
+if node -e '
+const hooks = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const entry = hooks.hooks.sessionStart[0];
+const expected = "\"${CURSOR_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start";
+if (entry.command !== expected) {
+  console.error(`unexpected Cursor sessionStart command: ${entry.command}`);
+  process.exit(1);
+}
+' "$REPO_ROOT/hooks/hooks-cursor.json"; then
+    pass "Cursor resolves the SessionStart dispatcher from CURSOR_PLUGIN_ROOT"
+else
+    fail "Cursor resolves the SessionStart dispatcher from CURSOR_PLUGIN_ROOT"
+fi
+
 claude_home="$(make_home claude-code)"
 assert_command_output \
     "Claude Code emits nested SessionStart additionalContext" \


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 (exact build ID is not exposed by the active harness) |
| Harness + version | Codex Desktop 26.715.72359 |
| All plugins installed | openai-bundled: browser 26.715.72359, sites 0.1.30, visualize 1.0.14; openai-curated-remote: codex-security 0.1.14, figma 2.0.16, github 0.1.8-2841cf9749ae, openai-templates 0.1.0; openai-primary-runtime: documents, pdf, presentations, spreadsheets, template-creator 26.727.11326 |
| Human partner who reviewed this diff | ShiroKSH — approved the complete diff in the task |

## What problem are you trying to solve?

Cursor marketplace plugin hooks run with the opened workspace as their working directory. The relative command in `hooks/hooks-cursor.json` therefore looks for `./hooks/run-hook.cmd` in the workspace instead of the installed plugin, so SessionStart cannot inject the Superpowers bootstrap. [Cursor support confirms](https://forum.cursor.com/t/inconsistent-working-directory-for-plugin-hook-commands/153236) that `${CURSOR_PLUGIN_ROOT}` is the supported way to address the plugin directory from a hook command. This regressed after `2b25774`, which replaced the root-qualified command introduced for the Cursor hook integration.

## What does this PR change?

Restore the root-qualified Cursor dispatcher command, update the porting guide to describe the same contract, and add a regression test that rejects a relative Cursor hook command.

## Is this change appropriate for the core library?

Yes. This is the shipped Cursor plugin bootstrap path and affects every Superpowers user running Cursor marketplace hooks.

## What alternatives did you consider?

- Keep a relative command: it depends on Cursor using the plugin cache as its working directory, which it does not for marketplace hooks.
- Invoke `session-start` directly: that reintroduces the Windows extensionless-script failure addressed by the existing `run-hook.cmd` wrapper.

## Does this PR contain multiple unrelated changes?

No. The config, documentation, and regression test all enforce the same Cursor hook-path contract.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #709, #1054, #1280. #709 introduced the root-qualified Cursor command; #1054 and #1280 changed the dispatcher for Windows but retained a relative path. This PR repairs the later path regression rather than duplicating either fix.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex Desktop | 26.715.72359 | GPT-5 | Exact build ID not exposed by the harness |

## New harness support (required if this PR adds a new harness)

N/A — this does not add a harness.

## Evaluation

- Initial prompt: review `obra/superpowers` for a proven bug, preserve business logic, and choose a real contribution rather than cosmetic refactoring.
- Skill-behavior eval sessions after the change: 0; this modifies hook wiring only and no `SKILL.md` content.
- Before / after: the prior configuration resolved the dispatcher from the workspace; the new configuration resolves it from Cursor's supplied plugin root. `tests/hooks/test-session-start.sh` now asserts the exact command and verifies the wrapper's Cursor JSON output.

## Rigor

- [x] N/A — this change does not modify behavior-shaping skill content.
- [x] The regression test checks the reported failure mode: any return to a relative dispatcher path or removal of the wrapper fails the suite.
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language).

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission.
