### PR TITLE
New harness support: Junie

### DIFF
--- a/JUNIE.md
+++ b/JUNIE.md
@@ -1,0 +1,2 @@
+@./skills/using-superpowers/SKILL.md
+@./skills/using-superpowers/references/junie-tools.md

--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 Superpowers is a complete software development methodology for your coding agents, built on top of a set of composable skills and some initial instructions that make sure your agent uses them.
 
 
-## We're Hiring!
-
-We're hiring someone to help out full time with Superpowers community and code work. 
-You can read about the job at https://primeradiant.com/jobs/superpowers-community-engineer/
-If this sounds like someone you know, definitely send them our way.
-
 ## Quickstart
 
 Give your agent Superpowers: [Claude Code](#claude-code), [Antigravity](#antigravity), [Codex App](#codex-app), [Codex CLI](#codex-cli), [Cursor](#cursor), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [GitHub Copilot CLI](#github-copilot-cli), [Kimi Code](#kimi-code), [OpenCode](#opencode), [Pi](#pi).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Superpowers is a complete software development methodology for your coding agent
 
 ## Quickstart
 
-Give your agent Superpowers: [Claude Code](#claude-code), [Antigravity](#antigravity), [Codex App](#codex-app), [Codex CLI](#codex-cli), [Cursor](#cursor), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [GitHub Copilot CLI](#github-copilot-cli), [Kimi Code](#kimi-code), [OpenCode](#opencode), [Pi](#pi).
+Give your agent Superpowers: [Claude Code](#claude-code), [Antigravity](#antigravity), [Codex App](#codex-app), [Codex CLI](#codex-cli), [Cursor](#cursor), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [GitHub Copilot CLI](#github-copilot-cli), [Junie](#junie), [Kimi Code](#kimi-code), [OpenCode](#opencode), [Pi](#pi).
 
 ## How it works
 
@@ -143,6 +143,24 @@ Superpowers is available via the [official Codex plugin marketplace](https://git
   ```bash
   copilot plugin install superpowers@superpowers-marketplace
   ```
+
+### Junie
+
+Junie has native support for Superpowers. Just open any repository containing a `skills/` folder, and Junie will automatically discover and offer to use the skills.
+
+To install Superpowers as a global extension (available in all projects):
+- Register the repository as a marketplace:
+  ```bash
+  /extensions marketplace add obra/superpowers
+  ```
+- Install the extension from the registered marketplace:
+  ```bash
+  /extensions install superpowers
+  ```
+
+To ensure the full Superpowers methodology is enforced:
+- Junie loads `AGENTS.md` and `JUNIE.md` as context at the start of every session.
+- The `using-superpowers` bootstrap is automatically suggested when Junie detects the Superpowers environment.
 
 ### Kimi Code
 

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -56,6 +56,7 @@ If your harness appears here, read its reference file for special instructions:
 - Codex: `references/codex-tools.md`
 - Pi: `references/pi-tools.md`
 - Antigravity: `references/antigravity-tools.md`
+- Junie: `references/junie-tools.md`
 
 ## User Instructions
 

--- a/skills/using-superpowers/references/junie-tools.md
+++ b/skills/using-superpowers/references/junie-tools.md
@@ -1,0 +1,35 @@
+# Junie Tool Mapping
+
+Skills speak in actions ("dispatch a subagent", "create a todo", "read a file"). On Junie these resolve to the tools below.
+
+| Action skills request | Junie equivalent |
+|----------------------|------------------|
+| Read a file | `open` / `open_entire_file` |
+| Read multiple files | (Multiple `open` calls) |
+| Create a new file | `create` |
+| Edit a file | `search_replace` (single edit) / `multi_edit` (multiple edits) |
+| Run a shell command | `bash` |
+| Search file contents | `grep_search` |
+| Find files by name | `glob_search` |
+| Fetch a URL | `fetch_url` |
+| Search the web | `web_search` |
+| Invoke a skill | `agent_skill_read_doc` |
+| Dispatch a subagent | `spawn_subagent` |
+| Wait for a subagent | `wait_for_subagent` |
+| Stop a subagent | `stop_subagent` |
+| Ask the user | `ask_user` |
+| Task tracking | `update_status` (maintains the plan and status) |
+| Finish task | `submit` |
+| Answer the user | `answer` |
+
+## Task tracking
+
+Junie has a native `update_status` tool that you MUST use to maintain your plan and track progress. When a skill says "create a todo" or "mark complete", use `update_status` to update the `plan` parameter. The tool also captures your analysis and a message for the user.
+
+## Subagent support
+
+Junie dispatches subagents via `spawn_subagent`. It returns a handle immediately. Use `wait_for_subagent` if you need to block until it finishes. Otherwise, continue working; you will receive the result in a future message as a `<subagents_status>` update.
+
+## Skill Discovery
+
+Junie discovers skills in the `skills/` directory of the project root. Use `agent_skill_read_doc` to read the content of a skill. When reading a skill, always read the main body first (omitting `path`) to understand the skill's capabilities.


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)
<!-- Required. PRs that omit this will be closed. We assume an agent wrote
     this PR — tell us which one and where it ran. We weigh contributions by
     what produced them: content reasoned from documentation is held to a
     different bar than work grounded in a real session. -->

| Field | Value |
|-------|-------|
| Gemini 3 Flash Preview | |
| junie v26.7.27 | |
| Context7 java-engineer redis-engineer springboot-engineer superpowers| |
|  dch-actaport — approved the complete diff in the task| |

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1477
 Junie is now supporting the plugins formt from Claude, so the needed changes are minimal

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
|               junie                      |       v26.7.27          |  Gemini Flash      |  Gemini 3 Flash Preview                 |

## New harness support (required if this PR adds a new harness)

<!-- If this PR adds support for a new harness (IDE, CLI tool, agent
     runner), you MUST include a session transcript proving the
     integration actually works.

     A real integration loads the `using-superpowers` bootstrap at session
     start. The bootstrap is what causes skills to auto-trigger. Without
     it, the skills are dead weight — present on disk but never invoked
     at the right moments.

     ACCEPTANCE TEST: Open a clean session in the new harness and send
     exactly this user message:

         Let's make a react todo list

     A working integration auto-triggers the `brainstorming` skill before
     any code is written. Paste the complete transcript below.

     These are NOT real integrations and PRs that ship them will be closed:

     - Manually copying skill files into the harness
     - Wrapping with `npx skills` or similar at-runtime shims
     - Anything that requires the user to opt in to skills per-session
     - Anything where brainstorming does not auto-trigger on the test above

     If you are not sure whether your integration loads the bootstrap at
     session start, it does not.
-->

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```


            ///////               ///                           ///
            ///////               ///                           ///
            ///////               ///  ///     ///  /////////         ///////
     ///////      ///////         ///  ///     ///  //////////  ///  //////////
     ///////      ///////         ///  ///     ///  ///     /// /// ///     ////
     ///////     ////////         ///  ///     ///  ///     /// /// ////////////
            ///////////           ///  ///    ////  ///     /// /// ///
            /////////        ////////  //////////   ///     /// ///  ///////////
            //////           //////     ////////    ///     /// ///   ////////


     v.26.7.27
     ~

   / available commands
   @ search for a file or a folder
   ! bash command
   ? show help
   ! Running in the home directory. File scanning is disabled.

   § Need to add context mid-run?
     Just send a message while Junie is working — it picks up new details without interrupting the run.

   > Let's make a react todo list

     Now I'm reviewing the brainstorming document to understand the initial ideas and context that will guide how I approach the task. This will help me align my next steps with the project's goals and
     constraints.

   ● Read skill
     brainstorming

   ● Bash:  node -v && npm -v && npx -v
     x v24.16.0
     x 11.12.1
     x 11.12.1

     Node.js, npm, and npx are installed with versions 24.16.0, 11.12.1, and 11.12.1 respectively.

     What are the core features you'd like to have in this React todo list? For example, should it support simple add/delete/complete, or do you need more advanced features like persistence (saving to local
     storage or a database), categories, or deadlines?

     >   Enter an answer…
     qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
     Chat about this

     esc to cancel

```

</details>

## Evaluation
- Read the docs/porting-to-a-new-harness.md and show what need to be adapted tu support the harness Junie
- 3
- Junie is now always using superpowers on it's own, before calling manually use-superpowers was needed


## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

<!-- If you changed wording in skills that shape agent behavior, show your
     eval methodology and results. These are not prose — they are code. -->

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->
