### PR TITLE
feat(writing-plans): conditional Flow Diagrams slot in the plan header template

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -73,6 +73,16 @@ naming and copy rules, platform requirements — one line each, with exact
 values copied verbatim from the spec. Every task's requirements implicitly
 include this section.]
 
+## Flow Diagrams
+
+[REQUIRED when the plan spans 3+ interacting components or crosses an async
+boundary (webhooks, queues, background jobs, callbacks); omit the section
+for single-component work. Mermaid fenced blocks: `sequenceDiagram` for
+request/response and handshake flows, `flowchart` for data forking across
+paths. Label arrows with the real endpoint/event/function names the tasks
+implement — the diagram doubles as the interface map between tasks, and it
+is how an implementer holding one task sees where their piece sits.]
+
 ---
 ```
 
@@ -144,6 +154,8 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 **2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+**4. Diagram check:** If the plan spans 3+ components or crosses an async boundary, the header has a Flow Diagrams section and every arrow label matches an endpoint/event/function a task implements. An arrow labeled with a name no task defines is the diagram equivalent of a placeholder — fix one or the other.
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 


### PR DESCRIPTION
> **This PR targets the `dev` branch.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | claude-opus-5 (Claude Opus 5) |
| Harness + version | Claude Code CLI 2.1.220 (Windows 11) |
| All plugins installed | superpowers 6.1.0, claude-mem 13.12.4, codspeed, private org plugins (yavendio-magic, vibegroup) |
| Human partner who reviewed this diff | Banner Gonzales (@bannergz) — reviewed the complete diff and PR body before submission |

## What problem are you trying to solve?

Real session, 2026-07-30. I used `writing-plans` to plan a feature spanning a Next.js dashboard, a FastAPI service, and a Rust webhook gateway — an onboarding flow where a signed webhook and a browser redirect race toward one idempotent completion. The plan came out structurally complete (header, file structure, per-task TDD steps, interfaces) but **prose-only**: the multi-actor flow lived in a 3-sentence Architecture paragraph. My human partner had to ask afterwards, explicitly, for a sequence diagram and a dataflow diagram — their words: it's "más entendible a nivel funcional para el developer" (easier to understand functionally for the developer reviewing/implementing the plan).

Baseline eval reproduces the failure deterministically: 3/3 fresh single-shot runs (claude-sonnet-5, no tools, condensed skill excerpt as system context, same spec shape) produced **zero diagrams** — no Mermaid, no ASCII, nothing — despite the spec being an inherently multi-actor async flow.

## What does this PR change?

Adds a conditional `## Flow Diagrams` slot to the Plan Document Header template, and a 4th Self-Review check that ties diagram arrow labels to the endpoints/events/functions the tasks implement. 12 added lines, one file (`skills/writing-plans/SKILL.md`).

## Is this change appropriate for the core library?

Yes. It is domain-agnostic — any plan spanning 3+ components or an async boundary benefits, regardless of stack or project type. It adds no dependency: Mermaid fences render natively on GitHub and degrade to readable text elsewhere. Single-component plans are explicitly told to omit the section (conditional keyed on an observable predicate), so the slot does not bloat trivial plans.

The form follows the project's own doctrine (`writing-skills` → "Match the Form to the Failure"): the baseline failure is an **omission of a required element**, so the fix is a structural slot in the template the agent already fills in — not a prose reminder, not a prohibition.

## What alternatives did you consider?

- **Prose guidance in the Overview** ("include diagrams for complex flows") — rejected: omission failures respond to REQUIRED slots in the template, not to reminders near it (per `writing-skills`).
- **Unconditional requirement** — rejected: a single-file/library plan would grow a scope-creep diagram. The conditional is keyed to an observable predicate (3+ interacting components, or any async boundary).
- **A separate plan-reviewing skill** — rejected as overkill for a 12-line structural gap; also overlaps existing open PRs in the review space (#1062, #1704) without addressing the authoring-time omission.

## Does this PR contain multiple unrelated changes?

No. One file, one concern: the Flow Diagrams slot and its matching self-review check (the check is the enforcement half of the same slot).

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found addressing diagrams in plans (searched `diagram`, `mermaid`, `sequence`, `writing-plans` across open+closed). Same-shape precedents — template-slot additions to writing-plans: #1831 (Invariants block), #1627 (Evaluator section), #1746 (Global Constraints + per-task Interfaces).

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code (Windows 11) | 2.1.220 | Claude Opus 5 (author/eval driver) | claude-opus-5 |
| Claude Code subagents (eval reps) | 2.1.220 | Claude Sonnet 5 | claude-sonnet-5 |

## Eval evidence (before/after)

Method per `writing-skills` micro-testing: identical task + spec in both arms, condensed skill excerpt as the system context, one fresh single-shot subagent per rep, no tools, every output read manually. Spec: a 4-component merchant-onboarding flow (dashboard → API service → provider → webhook gateway) with a webhook/redirect completion race.

| Arm | Reps | Plans with any diagram | Notes |
|-----|------|------------------------|-------|
| Baseline (current SKILL.md) | 3 | **0/3** | Flow described only in the 3-sentence Architecture paragraph |
| With Flow Diagrams slot | 3 | **3/3** | Each produced a `sequenceDiagram` **and** a `flowchart`; all three independently modeled the webhook/redirect race with `par`/`and`; arrow labels matched task interfaces (`finalize_connection()`, `POST /webhooks/kapso`, `verify_signature()`); Self-Review check 4 was exercised and cited in all three outputs |

Variance note: the with-slot arm converged on the same shape across reps (sequence + flowchart pair, labels from task interfaces), which per `writing-skills` is the signal that the wording binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
