### PR TITLE
fix(sdd): dispatched subagents never dispatch subagents

### DIFF
--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -34,6 +34,15 @@ Subagent (general-purpose):
 
     Your review is read-only on this checkout. Do not mutate the working tree, the index, HEAD, or branch state in any way. Use tools like `git show`, `git diff`, and `git log` to inspect history. If you need a working copy of a different revision, check it out into a separate temporary directory (e.g. `git worktree add /tmp/review-[SHA] [SHA]`) — never move HEAD on this checkout.
 
+    ## You Do Not Dispatch Subagents
+
+    Do all of this review yourself. Never spawn a subagent to review part
+    of the diff, and never spawn another reviewer for a second opinion.
+    This process already provides every review seat the work gets; a
+    reviewer you spawn duplicates one of them at full cost, and its
+    verdict counts for nothing. If the diff feels too large for one
+    pass, review it in passes yourself and say so in your report.
+
     ## What to Check
 
     **Plan alignment:**

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -223,6 +223,12 @@ and fix-round diffs need it.
   later dispatches — a real session's dispatch hit 42k chars of which 99%
   was pasted history. A fresh subagent needs its task, the interfaces it
   touches, and the global constraints. Nothing else.
+- The dispatch carries the no-subagents contract (it is in the
+  implementer template): the implementer never dispatches subagents —
+  not helpers, and never a reviewer. Review arrives from you, after the
+  report. In real sessions, every reviewer a worker spawned duplicated
+  the task review the controller dispatched anyway — a full extra
+  review seat per task.
 - If an earlier task parked a finding in the area this task touches, carry
   a pointer to that ledger entry in the dispatch.
 - Record the implementer's agent identity from the dispatch result —
@@ -434,6 +440,7 @@ Use superpowers:finishing-a-development-branch.
 | "The fix was small, skip the re-review" | Unreviewed fixes are how regressions land. Every round ends with a scoped re-review. |
 | "Reviews slow the loop down" | The loop without reviews is just unverified churn. Reviews are the loop's brakes and steering. |
 | "Ledger bookkeeping is overhead" | The ledger is what survives compaction. Controllers without one have re-dispatched entire completed task sequences. |
+| "The implementer spawned its own reviewer — free extra assurance" | It's a duplicate seat reviewing the same diff; the task review is the gate. A worker-spawned reviewer is a defect to flag, not rigor. |
 
 ## Example Workflow
 

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -47,6 +47,18 @@ Subagent (general-purpose):
     While iterating, run the focused test for what you're changing; run the
     full suite once before committing, not after every edit.
 
+    ## You Do Not Dispatch Subagents
+
+    Do all of this task's work yourself. Never spawn a subagent to
+    implement part of the task, and above all never spawn a reviewer to
+    check your work. Self-review (below) means reading your own diff.
+    Review is the controller's job: after you report, it dispatches a
+    fresh reviewer against your diff. A reviewer you spawn duplicates
+    that review at full cost, and its approval counts for nothing in
+    the process. If you catch yourself thinking "an independent review
+    would strengthen my report" — that review is already scheduled.
+    Report instead.
+
     ## Code Organization
 
     You reason best about code you can hold in context at once, and your edits are more

--- a/skills/subagent-driven-development/re-review-prompt.md
+++ b/skills/subagent-driven-development/re-review-prompt.md
@@ -43,6 +43,15 @@ Subagent (general-purpose):
     Your review is read-only on this checkout. Do not mutate the working
     tree, the index, HEAD, or branch state in any way.
 
+    ## You Do Not Dispatch Subagents
+
+    Do all of this review yourself. Never spawn a subagent to review part
+    of the diff, and never spawn another reviewer for a second opinion.
+    This process already provides every review seat the work gets; a
+    reviewer you spawn duplicates one of them at full cost, and its
+    verdict counts for nothing. If the diff feels too large for one
+    pass, review it in passes yourself and say so in your report.
+
     ## Scope
 
     Your scope is the findings list and the fix diff. Verdict every finding.

--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -52,6 +52,15 @@ Subagent (general-purpose):
     Your review is read-only on this checkout. Do not mutate the working
     tree, the index, HEAD, or branch state in any way.
 
+    ## You Do Not Dispatch Subagents
+
+    Do all of this review yourself. Never spawn a subagent to review part
+    of the diff, and never spawn another reviewer for a second opinion.
+    This process already provides every review seat the work gets; a
+    reviewer you spawn duplicates one of them at full cost, and its
+    verdict counts for nothing. If the diff feels too large for one
+    pass, review it in passes yourself and say so in your report.
+
     ## Do Not Trust the Report
 
     Treat the implementer's report as unverified claims about the code. It


### PR DESCRIPTION
> **This PR targets `dev`.** Branch: `fix/t1-sdd-no-worker-reviewers`.
> Independent — not stacked on anything.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code CLI 2.1.220 (controller session), driving the work through `superpowers:subagent-driven-development` — per-task implementer and reviewer subagents, plus the eval batteries described below |
| All plugins installed | superpowers 6.2.0 (official marketplace), episodic-memory, superpowers-chrome, linear, context7, agent-sdk-dev, code-simplifier, github-triage, plugin-dev, elements-of-style, cloud-build |
| Human partner who reviewed this diff | Jesse Vincent. He directed these PRs opened on 2026-07-31 after reviewing the fix-cycle's comprehensive change report and verdict evidence; as maintainer he performs the complete diff review on this PR. |

## What problem are you trying to solve?

**In our own sessions, a dispatched worker spawns its own reviewer, and that
reviewer is always a duplicate of the review the controller dispatches
anyway.** We paid for it twice and got one review's worth of signal.

The concrete failure came out of a two-week audit of one person's real Codex
window — 2,240 session records, 24.21 GB of rollout logs, every rollout parsed
and its collaboration ancestry reconstructed from `thread_spawn_edges`. The
audit is committed at
`docs/superpowers/research/2026-07-28-codex-efficiency-audit.md` on branch
`codex/codex-efficiency-audit` (commit `54f5392`); it is not on `dev`.

Its Finding 2 ("reviewer recursion created runaway trees") describes the worst
case: **one final branch review grew to 129 sessions at depth 12**, the deepest
child still running the root's top-tier model and effort. That tree recorded
310 spawn attempts, 30 thread-limit failures, 44 rollout files that never
reached `task_complete`, 167 full-history forks, 1,299 waits, 52 descendants
re-reading `using-superpowers`, and 110 reads of a memory file across 49
descendants. A second, ordinary single-task review grew to 30 sessions at depth
5. The audit's conclusion is that the prose `<SUBAGENT-STOP>` guard is
insufficient when every descendant also carries general encouragement toward
proactive parallel delegation: **reviewer prompts need a structural
non-delegation contract, not a hint.**

We then measured it rather than trusting the narrative. Across a ten-experiment
eval campaign (closeout:
`superpowers-autoresearch/reports/2026-07-codex-efficiency-campaign.md`),
**every depth-2 spawn observed anywhere — 9 occurrences across 4 independent
corpora — was issued by a worker spawning a reviewer, and all 9 were also
same-task duplicate reviews** (a worker-initiated review of a task alongside a
separate controller-initiated review of the same task). Zero counter-examples:
no reviewer-of-a-reviewer, no controller-issued depth-2, in any corpus scored.
The 9 deduplicate by underlying run into one real desktop session, four in our
`cx-compaction` battery, three in our `cx-sdd-small` re-score (spanning two
different superpowers versions), and one in an external corpus we did not
produce. It reproduces across CLI versions, skill versions, scenario shapes,
model families, and other people's sessions. That is the campaign's
most-reproduced result.

Note what the pathology is *not*: at the field Codex CLI (0.146.0),
root-controller dispatch hygiene is already clean (14/14 isolated and
explicit-model on `dev`). Everything that remains lives one level down, in
child-issued spawns.

## What does this PR change?

Adds a "You Do Not Dispatch Subagents" contract to the four dispatched-role
templates that lacked it (`implementer-prompt.md`, `task-reviewer-prompt.md`,
`re-review-prompt.md`, `code-reviewer.md`), and adds the controller-side half
to `subagent-driven-development/SKILL.md` — one dispatch-contract bullet in the
task loop and one Red Flags row. Implementers are told that self-review means
reading their own diff and that review is already scheduled; reviewers are told
never to spawn a sub-reviewer or a second opinion.

## Is this change appropriate for the core library?

Yes. `subagent-driven-development` and `requesting-code-review` are core
general-purpose workflows, and the contract is harness-agnostic prose: on
harnesses where a dispatched child cannot spawn at all, it is a no-op that
costs five lines of prompt; on harnesses where it can (Codex today, others
later), it closes a measured duplicate-cost leak. Nothing here is
project-specific, tool-specific, or dependent on any third-party service. It
adds no dependency.

## What alternatives did you consider?

- **A hard subtree or depth budget** (the audit's own suggested alternative:
  "a depth or total-session ceiling"). Rejected: there is no harness-portable
  mechanism to enforce a ceiling from prose, and imposing one would also cap
  deliberate top-level parallelism, which the audit explicitly says is not the
  problem. The measured pathology is one shape — worker spawns duplicate
  reviewer — and a targeted contract addresses exactly that shape.
- **Put the prohibition only in `SKILL.md`** (controller-side), on the theory
  that the controller writes the dispatch. Rejected *by measurement*, not by
  argument: round 1 of the battery shipped the contract in
  `implementer-prompt.md` only, and a controller-dispatched `final_reviewer`
  spawned two sub-reviewers because no text in *its own* template forbade it.
  Contract text that never reaches the dispatched role's template does not bind
  that role. That is what commit `c07cf7e` in this PR fixes.
- **Rely on the existing `<SUBAGENT-STOP>` prose guard.** Rejected: the audit's
  Finding 2 documents a tree that grew to 30 sessions and depth 5 *after* its
  root read v6.2.0's subagent stop guard.
- **Adopt the bounded final-review wave from #2036.** Not adopted — see
  Existing PRs.

## Does this PR contain multiple unrelated changes?

No. One contract, expressed in the five places a session actually reads it:
the four dispatched-role templates that must obey it, and the SKILL.md loop
where the controller states it and recognizes its violation. Splitting the
worker half from the reviewer half would ship a known-incomplete fix — round 1
of our battery is the direct evidence that the implementer-only version leaks
through the reviewer role.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2036, #2035, #1982, #1984, #1716, #738, #613

Searched `gh pr list --state all` across the reviewer/subagent/spawn,
codex-tools, and brainstorming term spaces, plus the 25 most recent PRs of any
state, on 2026-07-31. No PR proposes a non-delegation contract for dispatched
SDD roles.

- **#2036 (open) and #2035 (open)** are the closest prior art and are
  **deliberately not adopted**. #2036 diagnoses the same class of problem from
  the same person's sessions (its problem statement cites 8/22 spun-out runs in
  one model era) and touches three of the same files. It fixes it differently:
  it pins `fork_turns:"none"` with a platform-owned per-role model/effort hints
  file, bounds the final review to one fix dispatch plus one scoped fix review,
  and renames "re-review" to "fix review". Our change is independently derived
  from the audit plus a pre-registered eval campaign, and is a single behavioral
  contract with no new files, no model roster, and no workflow rename. The two
  are not textually related — we took the problem evidence and left the text.
  Jesse's standing decision on that stack is that it is evidence, not adopted
  text; his design spec for this cycle says so in the Sources section.
- **#1982 (open)** asks controllers to release finished subagents to free
  concurrency slots. Adjacent capacity hygiene, not delegation shape. Its
  factual basis is also superseded by our Codex source recon — see the T3 PR in
  this set.
- **#1984 (open)** scopes `requesting-code-review` to the final SDD review. It
  resolves who owns which review seat between two skills; it does not address a
  worker creating an unscheduled seat of its own.
- **#1716 (closed)** made SDD review fanout scale with the change. Adjacent —
  it sizes the controller's own fanout; ours forbids fanout the controller
  never asked for.
- **#738 (open)** adds a fresh-eyes reviewer for cross-task issues — a new
  controller-dispatched seat, orthogonal to this contract (a fresh-eyes reviewer
  is still forbidden from spawning under our text).
- **#613 (open)** adds hard gates against *skipping* review. Opposite direction,
  no conflict: our contract removes duplicate seats without removing any
  scheduled one, and our battery gates on exactly that ("review coverage
  preserved").

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI (containerized quorum eval lanes, ×2) | `codex-cli 0.146.0` | Root controller and spawned children, subscription-driven (`codex_sub` pins no model) | Root `gpt-5.6-sol`; spawned children `gpt-5.6-terra` (implementers/task reviewers) and `gpt-5.6-sol` (final reviewer), read from the rollouts |

Twenty-two graded reps of the `cx-sdd-small` scenario across three rounds
(2026-07-30), plus the four independent corpora behind the baseline. This is a
Codex-targeted behavior; on Claude Code the contract is a no-op by construction
(dispatched subagents cannot dispatch), so no Claude cell was run for T1.

## New harness support (required if this PR adds a new harness)

Not applicable — no harness is added or changed. Codex, Claude Code and Gemini
are all already supported; this PR only changes SDD prompt text.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable: this PR adds no harness and does not touch session startup,
the bootstrap, or any skill's triggering description.
```

</details>

## Evaluation

**Initial prompt.** This did not start from a desire to contribute. Jesse asked
for an audit of his own two-week Codex window after repeatedly watching SDD runs
balloon; the literal first message of that session is not preserved in any
committed artifact, so it is not quoted here. What is preserved is its output —
the 728-line audit doc cited above — and everything downstream of it: a
ten-experiment eval campaign that tested the audit's claims against evidence
rather than narrative, and then this fix cycle, whose approved design spec and
implementation plan are committed on the working branch at
`docs/superpowers/specs/2026-07-30-codex-efficiency-fixes-design.md` and
`docs/superpowers/plans/2026-07-30-codex-efficiency-fixes.md`.

**Eval sessions run AFTER the change: 22 graded reps in 3 rounds**, all on the
`cx-sdd-small` scenario, fix-branch arm, in two independent Docker lanes. Every
round was **pre-registered** in an append-only hypothesis log
(`superpowers-autoresearch/logs/2026-07-30-codex-efficiency-fixes.md`):
prediction, scorer and criterion written before the battery ran, verdicts
appended after.

Pre-registered criterion (unchanged across all three rounds): **0 worker-issued
depth-2 spawns AND review coverage preserved** (every task still gets exactly
one controller-dispatched task review).

| Round | Arm | n | Worker-issued depth-2 spawns | Same-task duplicate reviews | Verdict |
|---|---|---|---|---|---|
| Baseline (campaign) | 4 independent corpora | — | 9, all implementer-issued, 0 counter-examples | 9/9 | the pathology |
| 1 | fix @ `62c0180`+ | 6 | **2** (1/6 reps, both from a `final_reviewer`) | 0/6 | **FAIL** |
| 2 | fix @ `c07cf7e`+ | 8 | **0 / 51 spawns** (0/8 reps) | 0/8 | **PASS** |
| 3 | fix @ `43ec25f`+ | 8 | **0 / 67 spawns** (0/8 reps) | 0/8 | **PASS** (regression guard) |

Round 1's failure is the interesting part and it is why this PR contains two
commits. Round 1 shipped the contract in `implementer-prompt.md` alone.
Implementer-issued depth-2 spawns went to 0/6 and the 9/9 same-task-duplicate
signature disappeared — but rep6's controller-dispatched `final_reviewer` spawned
two sub-reviewers of its own (`behavior_tests_review`, `packaging_docs_review`).
Root-caused from source, not inferred: `grep -n 'dispatch\|subagent\|spawn'` on
`task-reviewer-prompt.md` and `re-review-prompt.md` returned **zero** matches —
reviewers had never been told. Commit `c07cf7e` extends the identical contract
into the three review templates, and rounds 2 and 3 are clean.

**How outcomes changed.** From 9/9 worker-issued duplicate reviews across four
corpora to **0 in 118 spawns across 16 reps and two independent battery rounds**
— an exhaustive full-corpus census, not a sample: round 2's check greps every
one of the 59 rollout files in the 8 reps' session trees, and both rounds'
scorer output was independently re-derived by hand from the raw rollout JSONL
(the campaign's standing non-circular-verification rule).

**The other half of the criterion held.** Review coverage is preserved in every
rep of every round: exactly `task{1,2,3}_{implementer,reviewer}` plus
`final_reviewer`, and in 6/8 of round 3's reps an additional genuine
fix-and-re-review wave after the final reviewer found a real issue — always
exactly one fixer plus one re-reviewer, never a duplicate of an already-reviewed
task. No task anywhere got more or fewer than one review pass before merge. The
fix removes duplicate seats without removing a single scheduled one.

**Cost:** $85.18 measured across the three rounds ($26.82 / $24.89 / $33.47),
read from each rep's own economics block. Shared with the T2 and T5 PRs in this
set — one battery graded all three treatments with orthogonal scorers.

**Honest caveats.**
- Round 1 lost 2 of its pre-registered 8 reps to a host Docker Desktop crash
  (both lanes' containers exited simultaneously; host disk was at 95%). The
  round was reported at n=6 rather than silently backfilled. Rounds 2 and 3 both
  completed 8/8.
- On this particular scenario the `dev` arm also shows 0 depth-2 spawns across 6
  reps — the pathology is comparatively rare here even unfixed. That is exactly
  why the criterion is an absolute bar (0 spawns AND coverage preserved) rather
  than a fix-vs-dev comparison, and it is why round 1's 2 real spawns mattered:
  they are the signal that the rig *can* produce the phenomenon.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

**On the first box, stated plainly rather than checked loosely:** the
`superpowers:writing-skills` skill was not invoked by name in the implementer
sessions that wrote this text — no record of it appears in the task reports or
the hypothesis log, and we will not claim it. What the change did get instead is
heavier than writing-skills' own micro-test loop: three pre-registered live
battery rounds against real Codex sessions with an absolute criterion, a
failing round that root-caused and produced a second commit, and non-circular
hand verification of every scorer claim from raw rollout JSONL.

**Adversarial, not happy-path.** The battery scenario runs a real three-task SDD
plan to a merge, including defect-driven fix-and-re-review waves — the exact
situation where a reviewer is most tempted to fan out. Round 1 found a live
violation that the happy path would have missed. The one Red Flags row this PR
adds is an addition, not a rewrite; no existing row, rationalization, or
"human partner" phrasing is touched.

## Human review

- [ ] A human has reviewed the COMPLETE proposed diff before submission
  (opened at Jesse's direction; the maintainer's PR review on this PR is the complete-diff review)

**Do not open this PR until the box above is checked.** Jesse Vincent reviews
the complete diff (`git diff origin/dev...fix/t1-sdd-no-worker-reviewers`, 5
files, +46 lines, no deletions) first; this body is the draft prepared for that
review.
