### PR TITLE
fix(codex): correct multi-agent guidance against the Codex source (V2)

### DIFF
--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -7,7 +7,34 @@ Add to your Codex config (`~/.codex/config.toml`):
 multi_agent = true
 ```
 
-This enables `spawn_agent`, `wait_agent`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`. When using subagent-driven-development, close reviewer subagents when their review returns. Keep each implementer subagent open until its task's review passes — the fix loop resumes the implementer — then close it. If your harness cannot send another message to a spawned agent, dispatch each fix round as a fresh implementer carrying the brief, the report file, and the findings.
+This enables the multi-agent tools that skills like
+`dispatching-parallel-agents` and `subagent-driven-development` use.
+Which tools you get depends on the multi-agent version your model
+preset selects (current presets run V2; older ones run V1). Trust your
+actual tool list over any table — including this one — when they
+disagree.
+
+- **Spawning:** give children a clean context with
+  `spawn_agent {fork_turns: "none"}`; the default `"all"` copies your
+  entire transcript into the child. On Codex 0.145+, role files under
+  `~/.codex/agents/` attach to isolated forks via `agent_type`.
+  Full-history forks accept `model` and `reasoning_effort` overrides
+  (only `agent_type` is refused there) — isolated forks are the SDD
+  default for context hygiene, not because overrides require them.
+- **Fix rounds:** resume the implementer with `followup_task` — it
+  delivers your message, triggers a turn, and transparently reloads a
+  child the harness evicted. Never dispatch a fresh implementer on the
+  theory that a spawned agent cannot be messaged again; on V2 it
+  always can.
+- **Lifecycle:** V2 has no `close_agent`. Finished children are
+  evicted automatically when slots are needed; leaving them unclosed
+  costs nothing. Only V1 sessions have `close_agent` — there, close
+  reviewers when their review returns, and close each implementer
+  after its task's review passes.
+- **Model names:** never copy a model name from a skill, table, or old
+  session into `spawn_agent` without checking it against your current
+  spawn allowlist — V2 accepts only V2-capable presets and hard-errors
+  on the rest.
 
 ## Environment Detection
 


### PR DESCRIPTION
> **This PR targets `dev`.** Branch: `fix/t3-codex-tools-corrections`.
>
> **Merge order — this is the bottom of a three-PR stack.** Two other PRs in
> this set edit the same file and are stacked on this one:
> `fix/t3-codex-tools-corrections` → `fix/t2-codex-event-waits` →
> `fix/t5-codex-spawn-routing`. This PR is independent and can merge first on
> its own; the other two will show this PR's commit in their diffs until it
> lands.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code CLI 2.1.220 (controller session), driving the work through `superpowers:subagent-driven-development` — per-task implementer and reviewer subagents, plus the eval batteries described below |
| All plugins installed | superpowers 6.2.0 (official marketplace), episodic-memory, superpowers-chrome, linear, context7, agent-sdk-dev, code-simplifier, github-triage, plugin-dev, elements-of-style, cloud-build |
| Human partner who reviewed this diff | Jesse Vincent. He directed these PRs opened on 2026-07-31 after reviewing the fix-cycle's comprehensive change report and verdict evidence; as maintainer he performs the complete diff review on this PR. |

## What problem are you trying to solve?

**The Codex multi-agent paragraph in `dev` tells agents to use a tool that does
not exist on the Codex version they are running, and gives them four other
instructions the Codex source contradicts.** Agents follow it, the tool call
hard-errors or the branch is dead, and the guidance costs turns instead of
saving them.

This surfaced from a real census, not from reading docs. Across a ten-experiment
eval campaign we measured `close_agent` compliance and got a result that was
*perfectly binary* and never graded: one older-model controller family closed
**18/18** of its children, and every other population closed **zero** —
0/19, 0/84, 0/123, 0/16, and 0/48 and 0/67 on our own two battery arms. Nobody
is 40% disciplined. A binary like that is a schema difference, not a behavior
difference, so we stopped scoring and read the Codex CLI source.

The read (recon doc:
`superpowers-autoresearch/docs/2026-07-29-codex-multiagent-v2-capabilities.md`,
every claim file:line-cited against a Codex CLI Rust checkout, 2026-07-29)
found five claims in the shipped guidance contradicted by the source:

1. **`close_agent` does not exist in multi-agent V2.** The V2 "collaboration"
   namespace has exactly six tools — `spawn_agent`, `send_message`,
   `followup_task`, `wait_agent`, `interrupt_agent`, `list_agents`
   (`core/src/tools/spec_plan.rs:833-883`). `close_agent`, `resume_agent` and
   `send_input` are **V1-only** (`spec_plan.rs:900-908`). V2 LRU-evicts
   finished children automatically when slots are needed
   (`agent/control/residency.rs:81-151`), so leaving them unclosed costs
   nothing. The current guidance's close-your-children checklist is
   *unexecutable* on the presets most sessions run, which is exactly why the
   census reads 0/N — not indiscipline.
2. **Fix rounds can always resume the implementer.** `dev` says "If your harness
   cannot send another message to a spawned agent, dispatch each fix round as a
   fresh implementer." On V2 that branch is dead: `followup_task {target,
   message}` delivers, triggers a turn on an idle target, and transparently
   reloads an LRU-evicted child. Taking the dead branch means paying for a fresh
   full-context implementer per fix round.
3. **Role files do attach to spawns.** `~/.codex/agents/**.toml` roles are
   auto-discovered and attach via `agent_type` on isolated forks (Codex 0.145+).
4. **Full-history forks accept `model` and `reasoning_effort` overrides.** Only
   `agent_type` is refused there (test `multi_agents_tests.rs:855`) — contrary
   to the harness's own shipped hint text as well as ours. Isolated forks remain
   the SDD default, but for context hygiene, not because overrides require them.
5. **Model-tier tables naming non-V2 presets hard-error.** V2's spawn allowlist
   is V2-capable presets only; anything else is a hard error at the tool call.

One more thing the live probe found that the doc now carries: a host
`~/.codex/config.toml` setting `features.multi_agent_v2.enabled=true`
**overrides the model-preset default**, so even a V1-preset controller can be
running V2. Any static table is therefore untrustworthy against a live session,
which is why the new text tells the reader to trust their actual tool list over
any table — including ours.

## What does this PR change?

Rewrites the multi-agent paragraph of
`skills/using-superpowers/references/codex-tools.md` to be version-honest: it
labels which behaviors are V1 and which are V2, keeps the `close_agent`
guidance for V1 sessions where it is still correct, states that V2 has no
`close_agent` and that unclosed children cost nothing, points fix rounds at
`followup_task`, corrects the fork/override and role-file claims, and tells the
reader to check any model name against their live spawn allowlist.

## Is this change appropriate for the core library?

Yes. `references/codex-tools.md` is core's own per-harness reference for an
existing first-class harness — this is a factual correction to a file the repo
already ships, not a new integration. It adds no dependency and no third-party
service. It is not project-specific: every Superpowers user running Codex
subagent workflows reads this paragraph.

## What alternatives did you consider?

- **Delete the `close_agent` guidance entirely.** Rejected: V1 sessions are
  real and the advice is correct there — our own census has a controller family
  at 18/18. Version-labelling is honest and costs three lines; deleting it would
  trade one wrong doc for another.
- **Leave the paragraph and append a caveat.** Rejected: four of the five claims
  are affirmatively wrong on the version most sessions run, and a caveat below
  a wrong instruction still leaves the wrong instruction as the thing an agent
  acts on first.
- **Ship a `close_agent` hygiene checklist** — which is where the census result
  was originally pointing before the source read. Explicitly killed by the
  evidence and recorded as **do-not-ship** in the campaign closeout. The
  campaign's `score_e8.py` survives as a V1/V2 *schema detector*, not a hygiene
  grader.
- **Adopt the `codex-tools.md` rewrite in #2036.** Not adopted — see Existing
  PRs.

## Does this PR contain multiple unrelated changes?

No — one paragraph in one file. The five corrections are not five changes: they
are the set of claims in that single paragraph that the source contradicts, and
they interlock (the `close_agent` correction is what makes the `followup_task`
fix-round correction load-bearing, since both describe the same V2 lifecycle).

Two sibling PRs stack on this one and edit the same file in later sections
(waiting semantics; spawn model routing). They are separate PRs precisely so
each carries its own problem statement and evidence.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1982, #1980, #2036, #1662, #963, #900

Searched `gh pr list --state all` for codex-tools, multi-agent, `wait_agent`,
`close_agent` and subagent-lifecycle terms, plus the 25 most recent PRs of any
state, on 2026-07-31.

- **#1982 (open)** is the direct collision and the reason this correction
  matters. It tells controllers to release finished subagents, quoting Codex's
  own tool description ("Completed agents remain open and count toward the
  concurrency limit until closed") from `multi_agents_spec.rs` at
  `rust-v0.142.5`. That quote is real — for **V1**. Our 2026-07-29 source read
  finds `close_agent` absent from the V2 tool set and finished children
  LRU-evicted, and our census independently shows the binary 18/18-or-0/N split
  a schema difference predicts and a discipline problem does not. **This PR does
  not contradict #1982 so much as version-scope it**: it keeps the close
  guidance for V1 and states plainly that V2 has no such tool. If #1982's author
  disagrees on the version boundary, the file:line citations in our recon doc
  are the thing to argue with.
- **#1980 (closed)** documented `wait_agent`/`send_message`/`followup_task`
  liveness semantics in the same file — the closest prior art on
  `followup_task`. Our correction #2 overlaps its `followup_task` point and was
  reached independently from source; ours differs in framing (the fix-round
  branch in the SDD guidance is dead on V2) and in not adding a
  liveness-inference rule to SDD.
- **#2036 (open)** also edits `codex-tools.md`, as part of a Codex SDD dispatch
  stack. **Deliberately not adopted** — Jesse's design spec for this cycle names
  #2036/#2035 as evidence, not adopted text. Our version-honesty rewrite is
  independently derived from a source recon with file:line citations, and does
  not introduce that stack's per-role model-hint file.
- **#1662 (open)** clarifies deferred subagent tool discovery; **#963 (merged)**
  corrected the wait-tool name to `wait_agent`; **#900 (merged)** added the
  named-agent dispatch mapping. All are adjacent edits to this file's tool
  vocabulary; none of them makes any of the five claims this PR corrects.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI (containerized quorum eval lanes, ×2) | `codex-cli 0.146.0` | subscription-driven (`codex_sub` pins no model) | Root `gpt-5.6-sol`; children `gpt-5.6-terra` / `gpt-5.6-sol` |
| Codex CLI source checkout (read-only recon, no execution) | Rust `codex-rs/` tree, read 2026-07-29 | n/a | n/a — every claim carries a file:line citation |

## New harness support (required if this PR adds a new harness)

Not applicable — Codex is already a supported harness. This PR corrects the
existing Codex reference and adds nothing to session startup or the bootstrap.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable: this PR adds no harness and does not touch session startup,
the bootstrap, or any skill's triggering description.
```

</details>

## Evaluation

**Initial prompt.** Jesse asked for an audit of his own two-week Codex window
after repeatedly watching SDD runs balloon. The literal first message is not
preserved in any committed artifact and is not quoted here; what is preserved is
the 728-line audit
(`docs/superpowers/research/2026-07-28-codex-efficiency-audit.md`, branch
`codex/codex-efficiency-audit`, commit `54f5392`), the eval campaign that tested
it, and this fix cycle's approved spec and plan
(`docs/superpowers/specs/2026-07-30-codex-efficiency-fixes-design.md`,
`docs/superpowers/plans/2026-07-30-codex-efficiency-fixes.md`).

**How this treatment is graded, stated up front.** This is a documentation
correction, and its pre-registered grading line says so:
*"Graded by: source citation (already verified); no scorer regressions on the
shared battery."* We did not invent a behavioral scorer for "the doc is now
true." Claiming an eval win for a factual fix would be the dishonest move here.
What we can show is three things:

1. **Source verification (the actual grade).** All five corrections carry
   file:line citations against the Codex CLI source, listed in the recon doc and
   reproduced in the problem statement above. A task reviewer flagged the
   factual-claims basis during the fix cycle; the controller resolved it by
   confirming every claim is the recon doc's own, file:line-verified and
   live-probed, not paraphrased.
2. **Census corroboration, from before the source read.** The `close_agent`
   census (18/18 vs 0/19, 0/84, 0/123, 0/16, 0/48, 0/67) is a real prediction
   of the schema explanation and is what motivated reading the source. The
   campaign registered all three of its pre-registered clauses as confirmed —
   its cleanest single result — and then root-caused the finding away from
   hygiene entirely.
3. **No regression, over 22 graded reps.** This corrected text was live on the
   eval arm for **all three rounds of the shared SDD battery** (n=6, 8, 8 on
   `cx-sdd-small`) and both rounds of the Codex ceremony battery (n=9, n=7). No
   scorer regression is attributable to it: spawn isolation stayed
   `fork_turns:"none"` on 100% of 118 spawns across rounds 2–3, explicit-model
   held 100%, task completion held 67/67 in round 3, and Gauntlet-Agent verdicts
   were 8/8 pass in round 3.

**Eval sessions run AFTER the change: 38 reps carried this text** (22
`cx-sdd-small` + 16 ceremony), none of which regressed. Zero were run *for* this
text, because the criterion for a doc correction is truth, not behavior.

**How outcomes changed compared to before.** The measurable before/after is the
guidance's own executability, not an agent score: before, the paragraph directed
V2 sessions to a tool that does not exist for them (a hard error or a silent
no-op, depending on how the model handles the missing tool) and offered a
fresh-implementer-per-fix-round branch that is dead on V2. After, every
instruction in the paragraph is executable on the version the reader is actually
running, and the reader is told to trust their live tool list over the table.

**Cost:** $0 of dedicated battery spend. The corroborating census was MINE-tier
scoring over corpora already paid for; the regression evidence rides on the
$85.18 shared SDD battery and the $32.10 ceremony batteries reported in the
sibling PRs.

**Honest caveat.** The recon was a read of one Codex CLI source checkout on
2026-07-29. Codex moves; the paragraph is deliberately written to degrade well
if it does (it names the version boundary explicitly and tells the reader to
trust their actual tool list over any table, including ours), but a future Codex
release could still change one of the five facts. The live probe finding that a
host config flag can override the preset's V2 default is in the doc for the same
reason.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

**On the first box, stated plainly rather than checked loosely:**
`superpowers:writing-skills` was not invoked by name in the session that wrote
this text — no record of it appears in the task reports or the hypothesis log,
and we will not claim it. This is also the treatment where it applies least:
this is a platform reference, not behavior-shaping content, and its correctness
bar is source citation.

**Adversarial, not happy-path.** The adversarial move here was against our own
conclusion, not against the model: we had a clean, perfectly binary census
result that would have shipped as a hygiene checklist, and we went and read the
source instead — which killed the checklist. The live probe then attacked the
source read itself and found the config-override wrinkle that makes any static
table untrustworthy, and that wrinkle is now in the shipped text.

No Red Flags table, rationalization list, or "human partner" phrasing is touched
by this diff.

## Human review

- [ ] A human has reviewed the COMPLETE proposed diff before submission
  (opened at Jesse's direction; the maintainer's PR review on this PR is the complete-diff review)

**Do not open this PR until the box above is checked.** Jesse Vincent reviews
the complete diff (`git diff origin/dev...fix/t3-codex-tools-corrections`, 1
file, +28/−1) first; this body is the draft prepared for that review.
