### PR TITLE
fix(sdd,codex): event-driven bounded waits — 65-78% wait timeouts to 0%

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -197,6 +197,14 @@ Everything you paste into a dispatch prompt — and everything a subagent
 prints back — stays resident in your context for the rest of the session
 and is re-read on every later turn. Hand artifacts over as files.
 
+**Waiting on dispatched subagents:** never poll a wait interface with
+short timeouts. While you have local work — ledger updates, packaging
+the next review, reading reports — keep working; child results arrive
+on their own. Wait only when you are genuinely idle, and then issue one
+long wait (fifteen minutes or more, where your platform allows it)
+instead of many short ones: a long wait wakes just as fast and costs
+one call instead of dozens.
+
 ### 1. Dispatch the implementer
 
 Record BASE (`git rev-parse HEAD`) before dispatching — the review package

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -198,12 +198,15 @@ prints back — stays resident in your context for the rest of the session
 and is re-read on every later turn. Hand artifacts over as files.
 
 **Waiting on dispatched subagents:** never poll a wait interface with
-short timeouts. While you have local work — ledger updates, packaging
-the next review, reading reports — keep working; child results arrive
-on their own. Wait only when you are genuinely idle, and then issue one
-long wait (fifteen minutes or more, where your platform allows it)
-instead of many short ones: a long wait wakes just as fast and costs
-one call instead of dozens.
+short timeouts, and never sit in one silent, open-ended wait either.
+While you have local work — ledger updates, packaging the next review,
+reading reports — keep working; child results arrive on their own.
+When you are genuinely idle, wait in bounded stretches (five to ten
+minutes, where your platform allows), and between stretches post one
+line of status and reconcile your live children: list them, and chase
+any that finished without reporting. A bounded stretch keeps nearly
+all of a long wait's efficiency while guaranteeing a stuck or lost
+child is noticed within minutes, not at the end of the session.
 
 ### 1. Dispatch the implementer
 

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -36,6 +36,25 @@ disagree.
   spawn allowlist — V2 accepts only V2-capable presets and hard-errors
   on the rest.
 
+## Waiting on children
+
+`wait_agent` is an event subscription, not a poll: a long wait wakes
+the moment a child produces mailbox activity, with the same latency as
+a short one. Short-timeout polling buys nothing and costs a tool call —
+and a context rebill — per poll. In measured sessions, roughly
+two-thirds of all wait calls were short polls that timed out.
+
+- While you still have local work, do not wait at all. A completed
+  child's final answer is pushed into your mailbox and arrives with
+  your next turn.
+- When you are genuinely idle with children outstanding, issue ONE
+  `wait_agent` with a long `timeout_ms` — 900000 (15 minutes) or more —
+  and let the event wake you.
+- Completion mail cannot wake an idle controller (it is delivered
+  without triggering a turn); covering that idle window is
+  `wait_agent`'s only job. If a long wait times out, check
+  `list_agents` for stuck children — do not fall back to short polls.
+
 ## Environment Detection
 
 Skills that create worktrees or finish branches should detect their

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -47,13 +47,17 @@ two-thirds of all wait calls were short polls that timed out.
 - While you still have local work, do not wait at all. A completed
   child's final answer is pushed into your mailbox and arrives with
   your next turn.
-- When you are genuinely idle with children outstanding, issue ONE
-  `wait_agent` with a long `timeout_ms` — 900000 (15 minutes) or more —
-  and let the event wake you.
+- When you are genuinely idle with children outstanding, wait in
+  bounded stretches: `wait_agent` with `timeout_ms` 300000-600000
+  (5-10 minutes). After each stretch — wake or timeout — post one
+  status line, run `list_agents`, and chase any child that finished
+  without reporting. Never stack polls shorter than five minutes; the
+  event subscription wakes a bounded stretch just as fast as a short
+  one.
 - Completion mail cannot wake an idle controller (it is delivered
   without triggering a turn); covering that idle window is
-  `wait_agent`'s only job. If a long wait times out, check
-  `list_agents` for stuck children — do not fall back to short polls.
+  `wait_agent`'s only job. A stretch that times out with no activity
+  is your cue to reconcile, not to shorten the next stretch.
 
 ## Environment Detection
 


### PR DESCRIPTION
> **This PR targets `dev`.** Branch: `fix/t2-codex-event-waits`.
>
> **Merge order — this is the middle of a three-PR stack.**
> `fix/t3-codex-tools-corrections` → **`fix/t2-codex-event-waits`** →
> `fix/t5-codex-spawn-routing`. All three edit
> `skills/using-superpowers/references/codex-tools.md` in different sections.
> **Until T3 merges, this PR's diff will show T3's commit as well.** Review
> T3 first; this PR's own contribution is the "Waiting on children" section in
> `codex-tools.md` plus the "Waiting on dispatched subagents" paragraph in
> `subagent-driven-development/SKILL.md`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code CLI 2.1.220 (controller session), driving the work through `superpowers:subagent-driven-development` — per-task implementer and reviewer subagents, plus the eval batteries described below |
| All plugins installed | superpowers 6.2.0 (official marketplace), episodic-memory, superpowers-chrome, linear, context7, agent-sdk-dev, code-simplifier, github-triage, plugin-dev, elements-of-style, cloud-build |
| Human partner who reviewed this diff | Jesse Vincent. He directed these PRs opened on 2026-07-31 after reviewing the fix-cycle's comprehensive change report and verdict evidence; as maintainer he performs the complete diff review on this PR. |

## What problem are you trying to solve?

**Codex controllers burn roughly two out of every three `wait_agent` calls on
polls that time out, because the poll timeouts they reach for are shorter than
a unit of real subagent work.** Each timed-out poll is a tool call and a context
rebill that buys nothing.

This is not a story about one bad session. It reproduces in **every** corpus we
measured with meaningful `wait_agent` use:

| Corpus | `wait_agent` calls | Timed out |
|---|---:|---:|
| An external stress session (not ours) | 805 | **78.3%** |
| The audit's highest-wait root session | 1,058 | **74.5%** (788) |
| Our own fresh 3-task battery, `dev` arm | — | **67.1%** |
| Our own fresh 3-task battery, comparison arm | — | **60.2%** |

The fresh 3-task battery matters most: it kills the "this is a long-session
problem" story. A brand-new session on a small plan does it too. The mechanism
is a cadence mismatch — the overwhelmingly common `timeout_ms` values in the
wild are 10s / 20s / 30s, and a real unit of subagent work routinely takes
longer than one poll window. The one runaway review tree the audit documents
recorded **1,299 waits** on its own.

Reading the Codex source (recon:
`superpowers-autoresearch/docs/2026-07-29-codex-multiagent-v2-capabilities.md`,
file:line-cited) showed the polling is pure waste rather than a necessary
tradeoff:

- `wait_agent` is an **event subscription over a watch channel, not a poll**
  (`multi_agents_v2/wait.rs:72-96,178-196`). A 15-minute wait has the same wake
  latency as a 10-second poll at roughly 1/90th the tool calls. Its bounds are
  min 10,000 ms, default 30,000 ms, max 3,600,000 ms
  (`config/mod.rs:210-212`).
- A completed child's FINAL_ANSWER is **pushed into the parent's mailbox**
  (`agent/control.rs:501-536`) and drained into the next model request
  (`session/turn.rs:276-282`) — a controller that keeps doing local work
  receives child results with **no wait calls at all**.
- The one real caveat: completion mail carries `trigger_turn=false` and will
  **not** wake an idle controller (`agent/control.rs:520-526`). Covering that
  idle window is the only job `wait_agent` actually has.

## What does this PR change?

Adds a "Waiting on children" section to
`skills/using-superpowers/references/codex-tools.md` (never short-poll; while
local work remains, do not wait at all; when genuinely idle, wait in bounded
5–10 minute stretches and reconcile after each one) and a matching,
harness-agnostic "Waiting on dispatched subagents" paragraph to
`subagent-driven-development/SKILL.md` §1 — the controller loop a session
actually re-reads every turn.

## Is this change appropriate for the core library?

Yes. `subagent-driven-development` is a core general-purpose workflow and
`references/codex-tools.md` is core's own reference for an existing first-class
harness. The SKILL.md paragraph is written harness-agnostically ("wherever your
platform offers it", "where your platform allows") so it degrades to sensible
advice on harnesses without a wait primitive; the numeric `timeout_ms` values
live in the Codex reference where they belong. No dependency, no third-party
service, nothing project-specific.

## What alternatives did you consider?

Three of these are not hypotheticals — we shipped them, measured them, and they
are why this PR has three commits.

- **Docs-only in `codex-tools.md`** (round 1, commit `4a0038b`). Measured:
  **65.1%** timeout rate vs the `dev` baseline's 67.1% — a 2-point shift on a
  criterion of <25%. The platform reference is read at session start and not
  again mid-loop; guidance that never gets re-read at the decision point changes
  nothing. This is why commit `3da65fb` puts the discipline in the SDD
  controller loop.
- **One long wait (900,000 ms+) when idle** (round 2, commit `3da65fb`) — the
  guidance the source recon literally implies, and what this cycle's approved
  spec originally specified. Measured: it **works** on the metric it targets
  (65.1% → **0.0%**, call volume ~25/rep → ~6.9/rep) and **breaks
  observability**. Turning dozens of short visible polls into one long silent
  wait produced **22–38 minute stretches of zero new transcript content** in
  3/8 reps while a review genuinely kept working underneath — long enough to
  exhaust the supervising QA judge's own testing-time budget, and one dispatched
  child of 51 never reported completion. Rejected on evidence, replaced by
  commit `43ec25f`.
- **Keep polling but lengthen the poll.** Rejected from source: it is an event
  subscription, so more calls buy identical wake latency at strictly more tool
  calls and context rebills.
- **Adjust the eval harness's testing budget instead of the guidance.** This was
  a live fork in the road after round 2 — the hypothesis log records it as
  "bounded waits w/ heartbeat vs harness-budget adjustment", explicitly awaiting
  Jesse's call. Rejected: raising a judge's budget fixes our rig, not the
  user-visible property that a controller can go dark for 38 minutes with no way
  for anyone — human or supervisor — to tell working from stuck. Jesse chose the
  bounded-stretch direction.
- **Adopt the wait guidance in #2036/#1980.** Not adopted — see Existing PRs.

## Does this PR contain multiple unrelated changes?

No. One rule — how a controller waits on its children — stated in the two
places a session reads it: the platform reference (with Codex's actual
`timeout_ms` numbers) and the controller loop (harness-agnostic). The three
commits are the iteration history of that single rule, not three changes:
`4a0038b` states it in the reference, `3da65fb` moves it into the loop where it
is re-read, and `43ec25f` replaces the single long wait with bounded stretches
plus reconciliation after round 2's measured side effect.

**Every line in this diff is text that a graded battery actually ran.** A
further tightening of this paragraph — a preference for non-blocking child-result
delivery over any blocking wait — was written during this cycle but landed after
round 3's battery, so it is **deliberately held back** and stays on the working
branch for the next graded round. The whole-branch review raised it as finding
I3 (ungraded text on an otherwise fully-graded branch) and Jesse ruled it out of
this PR. This PR ships exactly the arm that scored the numbers below, and
nothing else.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1980, #1982, #2036, #2035, #1662, #963

Searched `gh pr list --state all` for `wait_agent`, polling, codex-tools,
multi-agent and subagent-lifecycle terms, plus the 25 most recent PRs of any
state, on 2026-07-31.

- **#1980 (closed)** is the closest prior art and touches **the same two files**.
  It added a "Coordination Semantics" block stating that a `wait_agent` timeout
  does not mean the child is blocked, that `send_message` queues without
  triggering a turn, and that a controller must not infer `BLOCKED` from
  silence. **Different claim, no conflict.** #1980 is about how to *interpret* a
  timeout; this PR is about how often to *incur* one. Its "don't infer blocked
  from a timeout" rule is compatible with our "a stretch that times out with no
  activity is your cue to reconcile, not to shorten the next stretch." It was
  closed by the maintainers; we are not re-litigating it, and this PR does not
  add a liveness-inference rule to SDD. Its `followup_task` point is covered in
  the stacked T3 PR, which reached it independently from source.
- **#1982 (open)** is about releasing finished children to free concurrency
  slots — lifecycle, not wait cadence. Its factual basis is version-scoped by
  the T3 PR in this stack.
- **#2036 (open) / #2035 (open)** are the Codex SDD stack. **Deliberately not
  adopted** — Jesse's design spec for this cycle names them as evidence, not
  adopted text. #2036 attacks Codex SDD spinout through dispatch pinning and a
  bounded final-review wave; it does not change wait cadence. Ours is
  independently derived and graded against a pre-registered timeout-rate
  criterion across three battery rounds.
- **#1662 (open)** and **#963 (merged)** are adjacent `codex-tools.md` edits to
  the tool vocabulary; neither addresses poll cadence.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI (containerized quorum eval lanes, ×2) | `codex-cli 0.146.0` | subscription-driven (`codex_sub` pins no model) | Root `gpt-5.6-sol`; children `gpt-5.6-terra` / `gpt-5.6-sol` |
| Codex CLI source checkout (read-only recon) | Rust `codex-rs/` tree, read 2026-07-29 | n/a | n/a — mechanism claims carry file:line citations |

Twenty-two graded reps of `cx-sdd-small` across three rounds on 2026-07-30.
Codex is the only harness with the `wait_agent` primitive this treatment
measures; the SKILL.md paragraph rode the same arm through the cross-harness
ceremony batteries (Claude Code 2.1.209 / `claude-opus-4-8`, Gemini CLI 0.50.0 /
`gemini-3.5-flash`) with no regression, but no wait-cadence number exists for
those harnesses because they have nothing to measure.

## New harness support (required if this PR adds a new harness)

Not applicable — no harness is added. Codex is already supported; this PR
changes wait guidance in an existing reference and an existing skill.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable: this PR adds no harness and does not touch session startup,
the bootstrap, or any skill's triggering description.
```

</details>

## Evaluation

**Initial prompt.** Jesse asked for an audit of his own two-week Codex window
after repeatedly watching SDD runs balloon. The literal first message is not
preserved in any committed artifact and is not quoted here; what is preserved is
the 728-line audit
(`docs/superpowers/research/2026-07-28-codex-efficiency-audit.md`, branch
`codex/codex-efficiency-audit`, commit `54f5392`), the ten-experiment eval
campaign that tested it, and this cycle's approved spec and plan
(`docs/superpowers/specs/2026-07-30-codex-efficiency-fixes-design.md`,
`docs/superpowers/plans/2026-07-30-codex-efficiency-fixes.md`).

**Eval sessions run AFTER the change: 22 graded reps in 3 rounds**, all
`cx-sdd-small`, fix-branch arm, two independent Docker lanes. Every round was
**pre-registered** in an append-only hypothesis log
(`superpowers-autoresearch/logs/2026-07-30-codex-efficiency-fixes.md`) —
prediction, scorer and criterion before the run, verdicts appended after — and
every scorer number was independently re-derived by hand from the raw rollout
JSONL (the campaign's standing non-circular-verification rule).

Pre-registered criterion, rounds 1–2: **timeout rate < 25% with no loss of task
completion.** Round 3 added a third clause after round 2's finding: **no silent
gap over 12 minutes (720 s) in any controller transcript**, measured as the max
paired `wait_agent` call duration per root session from raw rollout timestamps.

| Round | Fix under test | Timeout rate | Completion | Max silent gap | Verdict |
|---|---|---|---|---|---|
| Baseline | `dev` | **67.1%** | — | — | the pathology |
| 1 (n=6) | docs-only (`4a0038b`) | **65.1%** (95/146 paired, 150 calls) | 6/6 pass; 50/50 children | not yet measured | **FAIL** |
| 2 (n=8) | one long wait in the SDD loop (`3da65fb`) | **0.0%** (0/54 paired, 55 calls) | 5/8 pass; **50/51** children | **22–38 min** in 3/8 reps | **FAIL** (completion clause) |
| 3 (n=8) | bounded stretches + reconciliation (`43ec25f`) | **0.0%** (0/73 paired, 73 calls) | **8/8** pass; **67/67** children | **3.91 min** (234.3 s) | **PASS — all three clauses** |

**How outcomes changed, in one line: 67.1% → 0.0% timeout rate, with task
completion and controller observability both intact — and it took three rounds
to get all three at once.**

Round 2's failure is the honest centre of this PR. The mechanism it fixed worked
perfectly and produced a new problem nobody predicted: a controller obeying "one
long wait" goes silent for as long as the underlying work takes. In three reps
that was 30m48s, 22m32s and 37m34s — all resolving `timed_out:false`, i.e. real
work, not hangs. The supervising QA judge, watching a live terminal, cannot
distinguish "working silently per instructions" from "stalled", and its own
testing-time budget ran out first. One of 51 dispatched children was cut off
mid-work and never reported `task_complete`. Round 1's short polls had hidden
this by refreshing the transcript every 10–30 s regardless.

Commit `43ec25f` replaces "one long wait (fifteen minutes or more)" with "wait
in bounded stretches (`timeout_ms` 300000–600000) … after each stretch — wake or
timeout — post one status line, run `list_agents`, and chase any child that
finished without reporting." Round 3's numbers say it kept the whole win and
closed the gap: per-rep maximum silences of 156.9 / 145.6 / 131.9 / 122.1 /
134.9 / **234.3** / 137.5 / 151.8 seconds, every one under four minutes against
a 12-minute bar. A whole-transcript cross-check (max gap between any two
consecutive timestamped records) matched the wait-duration figure exactly in
every rep — no silence anywhere in the transcript was attributable to anything
but a `wait_agent` call.

**Cost:** $85.18 measured across the three rounds ($26.82 / $24.89 / $33.47),
read from each rep's own economics block. Shared with the T1 and T5 PRs in this
set — one battery graded all three treatments with orthogonal scorers.

### Disclosures that travel with this PASS

**1. Nothing in this diff is ungraded.** A further tightening — preferring
non-blocking child-result delivery over any blocking wait — was written this
cycle but landed after round 3's battery, and is held back for the next graded
round rather than shipped here (whole-branch review finding I3).

**2. A correction to our own round-3 record, made by the task reviewer and
recorded append-only.** The round-3 log entries and report claimed all 73
`wait_agent` calls used `timeout_ms:300000`. **That was false** — it was
verified only for the two hand-inspected reps and then wrongly generalized. The
true distribution, re-derived from the committed scorer output: **55/73 at
300000 ms, rep18 all 7 calls at 600000, rep19 all 10 at 360000, rep23 nine at
300000 plus one at 120000** — and that single 120000 ms call is *below* the
5-minute floor the guidance states, an undisclosed compliance deviation the
spot-check could not have caught. The verdict is unaffected: the criterion
measures observed durations from raw timestamps, not requested timeouts, and
rep23's under-floor call resolved in 10.5 s. We are reporting the overclaim
because a reader who checks our work should find it from us first.

**3. The reconciliation step went unused in practice.** Round 3's smoke rep
issued **0 `list_agents` calls** despite the fix's literal "after each stretch …
run `list_agents`". Every stretch resolved via the wake event well inside its
own timeout, so the controller never had a stuck child to chase — the step was
not skipped under pressure, it simply never fired. That means round 3 validates
the bounded-duration half of `43ec25f` strongly and the reconciliation half not
at all. It stays in the text because it is the part that would have caught round
2's one lost child, but it is untested and we are not claiming otherwise.

**4. Round 1 ran at n=6, not the pre-registered n=8** — a host Docker Desktop
crash killed both lanes' in-flight reps simultaneously (host disk at 95%). Not
backfilled, reported as n=6. Rounds 2 and 3 both completed 8/8 with no Docker
loss.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

**On the first box, stated plainly rather than checked loosely:**
`superpowers:writing-skills` was not invoked by name in the implementer sessions
that wrote this text — no record of it appears in the task reports or the
hypothesis log, and we will not claim it. What the change did get is three
pre-registered live battery rounds on real Codex sessions against an absolute
criterion, two of which **failed** and produced the next commit.

**Adversarial, not happy-path.** The adversarial pressure here came from the
measurement, not from a scripted prompt: round 1 falsified "docs are enough",
and round 2 falsified the source-implied ideal fix by surfacing a second-order
harm the criterion did not originally cover. Round 3's pre-registration added
the silent-gap clause specifically to make that harm gradable rather than
narrated. No Red Flags table, rationalization list, or "human partner" phrasing
is touched by this diff — the SKILL.md change is a new paragraph in §1.

## Human review

- [ ] A human has reviewed the COMPLETE proposed diff before submission
  (opened at Jesse's direction; the maintainer's PR review on this PR is the complete-diff review)

**Do not open this PR until the box above is checked.** Jesse Vincent reviews
the complete diff first; this body is the draft prepared for that review. This
PR's own contribution against its stack base is
`git diff fix/t3-codex-tools-corrections...fix/t2-codex-event-waits` (2 files,
+34 lines); against `dev` it currently also carries T3's commit until T3 merges.
