### PR TITLE
fix(codex): explicit model+effort on every spawn, with config backstop

### DIFF
--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -59,6 +59,25 @@ two-thirds of all wait calls were short polls that timed out.
   `wait_agent`'s only job. A stretch that times out with no activity
   is your cue to reconcile, not to shorten the next stretch.
 
+## Model routing on spawns
+
+Every `spawn_agent` you issue — including when you are yourself a
+spawned child running a fan-out — sets `model` AND `reasoning_effort`
+explicitly, per the Model Selection rules of the skill you are
+executing. Setting `model` alone is a trap: the child's effort
+silently resets to that model's default, not to yours.
+
+Ask your human partner to add a machine-level backstop to
+`~/.codex/config.toml` so any spawn that slips through still routes to
+a deliberate tier instead of silently inheriting the session's most
+expensive model:
+
+```toml
+[agents]
+default_subagent_model = "<a mid-tier model from your spawn allowlist>"
+default_subagent_reasoning_effort = "medium"
+```
+
 ## Environment Detection
 
 Skills that create worktrees or finish branches should detect their


### PR DESCRIPTION
> **This PR targets `dev`.** Branch: `fix/t5-codex-spawn-routing`.
>
> **Merge order — this is the top of a three-PR stack.**
> `fix/t3-codex-tools-corrections` → `fix/t2-codex-event-waits` →
> **`fix/t5-codex-spawn-routing`**. All three edit
> `skills/using-superpowers/references/codex-tools.md` in different sections.
> **Until T3 and T2 merge, this PR's diff will show their commits as well.**
> Review T3 and T2 first; this PR's own contribution is the "Model routing on
> spawns" section.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code CLI 2.1.220 (controller session), driving the work through `superpowers:subagent-driven-development` — per-task implementer and reviewer subagents, plus the eval batteries described below |
| All plugins installed | superpowers 6.2.0 (official marketplace), episodic-memory, superpowers-chrome, linear, context7, agent-sdk-dev, code-simplifier, github-triage, plugin-dev, elements-of-style, cloud-build |
| Human partner who reviewed this diff | Jesse Vincent. He directed these PRs opened on 2026-07-31 after reviewing the fix-cycle's comprehensive change report and verdict evidence; as maintainer he performs the complete diff review on this PR. |

## What problem are you trying to solve?

**When a spawned child spawns its own children, it omits the model entirely, and
those grandchildren silently inherit the session's most expensive model.** The
audit found the deepest child of a 129-session review tree still running the
root's top-tier model at top effort — a line-inventory worker, at frontier
prices.

The measurement narrows this precisely, and the narrowing is the point. At the
field Codex CLI (0.146.0), **root-controller dispatch is already clean**: 14/14
root spawns on `dev` carry an explicit model, and 45/45 across both arms of that
re-test. An earlier baseline that showed 0/34 explicit turned out to be a
container pinned to CLI 0.144.4, which predates the `model` spawn parameter —
a version artifact, not a skill defect. So a fix aimed at root controllers would
be shipping guidance for a problem that no longer exists, and the campaign
closeout says so explicitly ("do not ship... any model-explicitness fix aimed at
root controllers").

**What is left is one level down.** The only child-issued spawns observed
anywhere in the campaign's CLI-0.146 re-test — 2 of them — omitted `model`
outright: the raw tool-call arguments had keys `['fork_turns','message',
'task_name']` and nothing else, genuinely absent rather than present-and-null.
The only `fork_turns:"all"` spawn observed anywhere in the campaign was also
child-issued. Our own round-1 battery then reproduced it live: a
controller-dispatched `final_reviewer` spawned two sub-reviewers with **no
`model` and no `reasoning_effort` key at all**.

Reading the Codex source (recon:
`superpowers-autoresearch/docs/2026-07-29-codex-multiagent-v2-capabilities.md`,
file:line-cited) found a second, quieter trap that no amount of "specify the
model" guidance catches:

> Resolution order for a child's model and effort is spawn arg →
> `[agents].default_subagent_model` / `default_subagent_reasoning_effort` →
> inherit from parent (`multi_agents_common.rs:257-313`). **Setting `model`
> without `reasoning_effort` resets effort to the MODEL's default** (sol→low,
> terra→medium), **not the parent's** (`:296-298`).

So an agent that dutifully sets `model` alone gets a child at whatever effort
that model defaults to — which can be *lower* than intended on a reviewer, or
just silently different from what the skill's Model Selection rules asked for.
Both halves have to be set, every time.

## What does this PR change?

Adds a "Model routing on spawns" section to
`skills/using-superpowers/references/codex-tools.md`: every `spawn_agent` — including
when you are yourself a spawned child running a fan-out — sets `model` **and**
`reasoning_effort` explicitly per the executing skill's own Model Selection
rules; the effort-reset trap is named; and the reader is told to ask their human
partner for a machine-level backstop via `[agents] default_subagent_model` /
`default_subagent_reasoning_effort` in `~/.codex/config.toml`.

## Is this change appropriate for the core library?

Yes. `references/codex-tools.md` is core's own reference for an existing
first-class harness, and this is a correctness rule about a harness primitive
that every Superpowers Codex user's subagent workflows hit. It names no specific
model — the config snippet's value is a placeholder (`"<a mid-tier model from
your spawn allowlist>"`) precisely so the file does not carry a rotting model
roster — and it defers tier choice to whichever skill is executing. No
dependency, no third-party service, nothing project-specific.

## What alternatives did you consider?

- **Aim the fix at root controllers** (the obvious reading of the original
  baseline). Rejected on measurement: root spawns are already 100% explicit at
  the field CLI, and the 0/34 baseline that suggested otherwise was a
  container-CLI artifact. Recorded as an explicit do-not-ship in the campaign
  closeout.
- **Ship only the config backstop.** Rejected: it is advisory — it requires the
  human to edit `~/.codex/config.toml` — and it is untested (see disclosures).
  The prose rule is what covers the overwhelmingly common case of no backstop
  present.
- **Ship only the prose rule, without the backstop.** Rejected because round 1
  demonstrated the failure mode the backstop exists for: a role that was never
  told to set the values will not set them, and a machine-level default at least
  routes the slip to a deliberate tier instead of the session's most expensive
  model.
- **A cross-provider model-reconciliation skill (#1496's approach).** Rejected —
  a whole new skill, invoked once per plan run, for what is a two-paragraph
  correctness note about one harness primitive. It was also closed without
  completed evals.
- **A platform-owned per-role model/effort hints file (#2036's approach).** Not
  adopted — see Existing PRs. It embeds a concrete Codex model roster in the SDD
  dispatch chokepoints; our text keeps the roster out and points at the
  executing skill's own Model Selection rules, because the campaign found that
  V2's spawn allowlist rejects presets that dispatch tables name from memory.

## Does this PR contain multiple unrelated changes?

No — one section in one file, stating one rule (set both routing fields on every
spawn, at every depth) plus the machine-level backstop for when it slips. The
backstop is not a separable change: it is the recommended mitigation for the
exact failure the rule addresses, and shipping the rule without it would leave
the reader no answer for spawns issued by roles they do not control.

Two sibling PRs sit below this one in the stack and edit different sections of
the same file.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1496, #2036, #2035, #1948, #1738, #1852, #1982

Searched `gh pr list --state all` for model/effort/dispatch, codex-tools and
subagent terms, plus the 25 most recent PRs of any state, on 2026-07-31.

- **#1496 (closed)** proposed a `subagent-model-reconciliation` skill: detect the
  orchestrator's model, look up the provider's mid-tier at decision time, ask the
  user, cache it, and pin `model:` on every dispatch. Same underlying concern
  (children inheriting a frontier parent), much heavier mechanism, closed without
  completed evals. Different in three ways that matter here: ours is a
  documentation rule in an existing per-harness reference rather than a new
  skill; ours targets the depth-2 gap the field CLI actually leaves open rather
  than the root dispatch that is already clean at 100%; and ours carries the
  `reasoning_effort` trap, which is the half no amount of "pin the model" fixes.
- **#2036 (open) / #2035 (open)** are the closest active prior art and are
  **deliberately not adopted** — Jesse's design spec for this cycle names them
  as evidence, not adopted text. #2036 pins `fork_turns:"none"` with
  platform-owned per-role model/effort hints wired into `task-brief` and
  `review-package`. It diagnoses the same class of problem from the same
  person's sessions; we took the problem evidence and left the text. Ours is
  independently derived (source recon plus a pre-registered campaign), touches
  one file, adds no scripts, and names no models.
- **#1948 (open)** adds a reasoning-effort dimension to SDD dispatch — adjacent
  and complementary: it is about *which* effort a role should get, ours is about
  the harness fact that setting `model` alone silently discards that choice.
- **#1738 (closed)** and **#1852 (closed)** both dealt with SDD naming models
  from recall versus inheriting the session model. Our text takes the third
  position the source supports: name both fields explicitly, and check any model
  name against your live spawn allowlist rather than a table.
- **#1982 (open)** is subagent lifecycle (closing children), not routing; its
  factual basis is version-scoped by the T3 PR in this stack.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI (containerized quorum eval lanes, ×2) | `codex-cli 0.146.0` | subscription-driven (`codex_sub` pins no model) | Root `gpt-5.6-sol`; children `gpt-5.6-terra` / `gpt-5.6-sol` |
| Codex CLI source checkout (read-only recon) | Rust `codex-rs/` tree, read 2026-07-29 | n/a | n/a — the effort-reset trap carries a file:line citation |

Twenty-two graded reps of `cx-sdd-small` across three rounds on 2026-07-30.
Codex-specific by construction — `spawn_agent`'s `model`/`reasoning_effort`
arguments and the `[agents]` config block exist only there.

## New harness support (required if this PR adds a new harness)

Not applicable — no harness is added. Codex is already supported; this PR adds a
section to its existing reference.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
Not applicable: this PR adds no harness and does not touch session startup,
the bootstrap, or any skill's triggering description.
```

</details>

## Evaluation

**Initial prompt.** Jesse asked for an audit of his own two-week Codex window
after repeatedly watching SDD runs balloon. The literal first message is not
preserved in any committed artifact and is not quoted here; what is preserved is
the 728-line audit
(`docs/superpowers/research/2026-07-28-codex-efficiency-audit.md`, branch
`codex/codex-efficiency-audit`, commit `54f5392`), the ten-experiment eval
campaign that tested it, and this cycle's approved spec and plan
(`docs/superpowers/specs/2026-07-30-codex-efficiency-fixes-design.md`,
`docs/superpowers/plans/2026-07-30-codex-efficiency-fixes.md`).

**Eval sessions run AFTER the change: 22 graded reps in 3 rounds**, all
`cx-sdd-small`, fix-branch arm, two independent Docker lanes, each round
**pre-registered** in an append-only hypothesis log
(`superpowers-autoresearch/logs/2026-07-30-codex-efficiency-fixes.md`) with
prediction, scorer and criterion written before the run. Every scorer number was
independently re-derived by hand from the raw `spawn_agent` argument JSON — not
scorer inference.

Pre-registered criterion: **every spawn at every depth carries explicit model +
effort.** With a caveat registered *in advance*, before any round ran: *"if T1
[the worker-review prohibition, a sibling PR in this set] eliminates depth-2
spawns entirely, T5 grades as root-spawn regression (hold 100%) plus doc
correctness and is recorded inconclusive-by-zero at depth-2 — the config
backstop is then the operative mechanism."*

| Round | Spawns | Explicit model+effort | Depth-2 population | `fork_turns:"none"` | Verdict |
|---|---:|---|---|---|---|
| Baseline (CLI 0.146 re-test) | — | root **14/14** clean; **depth-2 0/2** | 2 child-issued spawns | the only `"all"` spawn seen was child-issued | the gap |
| 1 (n=6) | 50 | **48/50 (96.0%)**; depth-1 48/48 (100%) | 2 (both from a reviewer role) | 50/50 | **FAIL** — the 2 misses are real |
| 2 (n=8) | 51 | **51/51 (100%)** | **0** | 51/51 | **inconclusive-by-zero at depth-2; PASS on the backstop** |
| 3 (n=8) | 67 | **67/67 (100%)** | **0** | 67/67 | **inconclusive-by-zero at depth-2; PASS on the backstop** |

**How outcomes changed — and the honest shape of the answer.** Round 1 graded
this treatment at depth 2 for real and it **failed**: 2 of 50 spawns omitted
both routing fields, and both were issued by a controller-dispatched
`final_reviewer` that had never been told to set them (the same coverage gap
that made the sibling T1 treatment fail that round). Fixing T1's gap removed the
depth-2 population entirely, so rounds 2 and 3 have nothing left to grade at
that depth. **T5's own FAIL was contingent on T1's prior failure and resolves
along with it.** We are not going to dress that up as a T5 win.

What this PR can honestly claim, and does:

1. **A regression guard that held.** Depth-1 explicit-model routing is 100%
   across 118 spawns in two independent rounds (51/51, 67/67), and isolation
   (`fork_turns:"none"`) held at 100% on all 168 spawns across all three rounds.
   The depth that was already working did not break.
2. **Documentation correctness against source.** The effort-reset trap is
   file:line-cited, and it is the part of this section that no observed session
   would have discovered on its own.
3. **A named backstop for the failure round 1 actually produced.**

**Cost:** $85.18 measured across the three rounds ($26.82 / $24.89 / $33.47),
read from each rep's own economics block. Shared with the T1 and T2 PRs in this
set — one battery graded all three treatments with orthogonal scorers.

### Disclosures that travel with this result

**1. The config backstop has never been tested by any battery.** We checked the
eval container's `config.toml` in all three rounds — round 1 (rep6's container),
round 2 (rep9's), round 3 (lane A's `/root/.codex/config.toml`) — and there were
**no `[agents]` / `default_subagent_*` keys** in any of them. So when round 1's
reviewer omitted both fields, nothing caught it, and this battery cannot say
whether the backstop would have. It ships as advice grounded in the source's
documented resolution order (`multi_agents_common.rs:257-313`), not as a
measured mechanism. Stating that rather than implying the 100% results validate
it.

**2. Depth-2 is inconclusive-by-zero, which under this campaign's standing rule
is a stop, not a pass.** The rig produced zero instances of the phenomenon in
rounds 2 and 3, so the criterion can be neither confirmed nor refuted at that
depth. The pre-registered caveat anticipated exactly this branch, which is why
it is recorded as inconclusive rather than quietly reported as 100%.

**3. This treatment's value is contingent on the sibling T1 PR.** If T1 does not
merge, depth-2 spawns keep happening and this section is the thing that tells
the spawning child what to set. If T1 does merge, this section is a regression
guard, a source-correctness fix, and a backstop recommendation. Both are worth
shipping; neither is worth overclaiming.

**4. Round 1 ran at n=6, not the pre-registered n=8** — a host Docker Desktop
crash killed both lanes' in-flight reps simultaneously. Not backfilled, reported
as n=6.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

**On the first box, stated plainly rather than checked loosely:**
`superpowers:writing-skills` was not invoked by name in the implementer session
that wrote this text — no record of it appears in the task reports or the
hypothesis log, and we will not claim it. This is a platform reference rather
than behavior-shaping skill content; its correctness bar is source citation plus
the per-spawn census above.

**Adversarial, not happy-path.** The adversarial work here was aimed at our own
baseline: the campaign's original model-omission finding (0/34 explicit) looked
like a clean skill defect until we bumped the eval container's Codex CLI to the
field version and it evaporated — which is what redirected this treatment from
root controllers to depth-2 and produced the do-not-ship ruling on the root-level
version. Round 1 then found a live depth-2 violation the happy path would have
missed. No Red Flags table, rationalization list, or "human partner" phrasing is
touched by this diff.

## Human review

- [ ] A human has reviewed the COMPLETE proposed diff before submission
  (opened at Jesse's direction; the maintainer's PR review on this PR is the complete-diff review)

**Do not open this PR until the box above is checked.** Jesse Vincent reviews the
complete diff first; this body is the draft prepared for that review. This PR's
own contribution against its stack base is
`git diff fix/t2-codex-event-waits...fix/t5-codex-spawn-routing` (1 file, +19
lines); against `dev` it currently also carries T3's and T2's commits until they
merge.
