### PR TITLE
feat(brainstorming): three-path router — ceremony scales, approval never does

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -35,8 +35,10 @@ override it:
 - **Bounded** — a well-scoped change to an existing, understood flow: a
   new flag, a small endpoint, a one-file fix. Ask the clarifying
   questions that matter, present a short design IN CHAT (a few
-  sentences to a few short paragraphs), and get approval. No spec
-  file, no implementation plan document.
+  sentences to a few short paragraphs), and STOP. Implementation
+  starts only after your human partner says yes to that design — a
+  bounded task's approval is as hard a gate as an architectural
+  one. No spec file, no implementation plan document.
 - **Architectural** — new projects, new subsystems, changes that
   restructure how components fit together or alter interfaces others
   depend on. Follow the full process: questions, approaches, sectioned
@@ -61,6 +63,7 @@ artifact, never the approval.
 |---------|---------|
 | "This is too simple to need a design" | Simple means a short design, not no design. Two sentences in chat, then approval. |
 | "I'll call it bounded and skip the spec" | Reaching for a label to skip work IS the doubt — take the heavier path. |
+| "It's bounded and the design is obvious — I'll start while they read it" | The gate is the approval, not the design's length. Present, then stop until you hear yes. |
 | "The spike works, so I'll keep the code" | A spike's output is an answer. Keeping the code is a new request — classify it. |
 | "It grew, but I'm almost done — no need to re-classify" | Hidden complexity upgrades the path mid-task. Stop and say so. |
 | "They approved the spike, so the follow-up change is approved too" | Each task gets its own classification and its own approval. |
@@ -81,7 +84,7 @@ your path and complete them in order.
 1. **Explore project context** — check files, docs, recent commits
 2. **Ask clarifying questions** — one at a time, the ones that matter
 3. **Present short design in chat** — approach, files touched, testing
-4. **Get approval** — explicit, before any implementation
+4. **Get approval** — STOP and wait for an explicit yes; presenting the design and starting in the same breath is skipping the gate
 5. **Implement** — proceed with the normal development workflow (TDD applies); no plan document
 
 **Architectural:**

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -7,20 +7,84 @@ description: "You MUST use this before any creative work - creating features, bu
 
 Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
 
-Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.
+Start by classifying how much process the request needs, then work
+through your path: understand the context, refine the idea, present a
+design, and get your human partner's approval.
 
 <HARD-GATE>
-Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
+Do NOT invoke any implementation skill, write any code, scaffold any
+project, or take any implementation action until you have told your
+human partner what you intend and they have approved it. This applies
+to EVERY task on EVERY path below — the ceremony scales with the task;
+the approval gate never does.
 </HARD-GATE>
 
-## Anti-Pattern: "This Is Too Simple To Need A Design"
+## Three Paths
 
-Every project goes through this process. A todo list, a single-function utility, a config change — all of them. "Simple" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+Before your first question, classify the request and say the
+classification out loud — "this looks bounded, so I'll present a short
+design here rather than write a spec" — so your human partner can
+override it:
+
+- **Spike** — a feasibility question ("can we...", "is it possible...",
+  "quick and dirty is fine") whose output is an answer, not code you
+  keep. Present the question and what you'll try in 2-3 sentences, get
+  a nod, then find out as cheaply as correctness allows. No design
+  doc, no spec file. Report findings as a recommendation; anything you
+  built stays labeled throwaway.
+- **Bounded** — a well-scoped change to an existing, understood flow: a
+  new flag, a small endpoint, a one-file fix. Ask the clarifying
+  questions that matter, present a short design IN CHAT (a few
+  sentences to a few short paragraphs), and get approval. No spec
+  file, no implementation plan document.
+- **Architectural** — new projects, new subsystems, changes that
+  restructure how components fit together or alter interfaces others
+  depend on. Follow the full process: questions, approaches, sectioned
+  design, written spec, then the writing-plans skill.
+
+When in doubt between two paths, take the heavier one. The ratchet is
+one-way: hidden complexity discovered mid-task upgrades the path —
+stop, say so, and step up. Nothing downgrades mid-task.
+
+## Anti-Pattern: "Too Simple To Need Approval"
+
+Every path ends with your human partner approving your intent before
+implementation. A todo list, a single-function utility, a config
+change — the design may be two sentences in chat, but you MUST present
+it and get approval. "Simple" tasks are where unexamined assumptions
+cause the most wasted work. What scales with simplicity is the
+artifact, never the approval.
+
+## Red Flags
+
+| Thought | Reality |
+|---------|---------|
+| "This is too simple to need a design" | Simple means a short design, not no design. Two sentences in chat, then approval. |
+| "I'll call it bounded and skip the spec" | Reaching for a label to skip work IS the doubt — take the heavier path. |
+| "The spike works, so I'll keep the code" | A spike's output is an answer. Keeping the code is a new request — classify it. |
+| "It grew, but I'm almost done — no need to re-classify" | Hidden complexity upgrades the path mid-task. Stop and say so. |
+| "They approved the spike, so the follow-up change is approved too" | Each task gets its own classification and its own approval. |
 
 ## Checklist
 
-You MUST create a task for each of these items and complete them in order:
+Classify first, announce the path, then create a task for each item on
+your path and complete them in order.
 
+**Spike:**
+1. **Explore project context** — enough to frame the probe
+2. **Present question + probe plan** — 2-3 sentences
+3. **Get approval** — a nod is enough
+4. **Investigate** — as cheaply as correctness allows
+5. **Report findings** — a recommendation; label anything built as throwaway
+
+**Bounded:**
+1. **Explore project context** — check files, docs, recent commits
+2. **Ask clarifying questions** — one at a time, the ones that matter
+3. **Present short design in chat** — approach, files touched, testing
+4. **Get approval** — explicit, before any implementation
+5. **Implement** — proceed with the normal development workflow (TDD applies); no plan document
+
+**Architectural:**
 1. **Explore project context** — check files, docs, recent commits
 2. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
@@ -35,6 +99,13 @@ You MUST create a task for each of these items and complete them in order:
 
 ```dot
 digraph brainstorming {
+    "Classify: spike / bounded / architectural" [shape=diamond];
+    "Present question + probe (2-3 sentences)" [shape=box];
+    "Ask clarifying questions (bounded)" [shape=box];
+    "Present short design in chat" [shape=box];
+    "Human approves?" [shape=diamond];
+    "Investigate; report recommendation" [shape=doublecircle];
+    "Implement via normal workflow (no plan doc)" [shape=doublecircle];
     "Explore project context" [shape=box];
     "Ask clarifying questions" [shape=box];
     "Propose 2-3 approaches" [shape=box];
@@ -44,7 +115,17 @@ digraph brainstorming {
     "Spec self-review\n(fix inline)" [shape=box];
     "User reviews spec?" [shape=diamond];
     "Invoke writing-plans skill" [shape=doublecircle];
+    "Hidden complexity? Upgrade path" [shape=box];
 
+    "Classify: spike / bounded / architectural" -> "Present question + probe (2-3 sentences)" [label="spike"];
+    "Classify: spike / bounded / architectural" -> "Ask clarifying questions (bounded)" [label="bounded"];
+    "Classify: spike / bounded / architectural" -> "Explore project context" [label="architectural"];
+    "Present question + probe (2-3 sentences)" -> "Human approves?";
+    "Ask clarifying questions (bounded)" -> "Present short design in chat";
+    "Present short design in chat" -> "Human approves?";
+    "Human approves?" -> "Investigate; report recommendation" [label="spike: yes"];
+    "Human approves?" -> "Implement via normal workflow (no plan doc)" [label="bounded: yes"];
+    "Hidden complexity? Upgrade path" -> "Classify: spike / bounded / architectural";
     "Explore project context" -> "Ask clarifying questions";
     "Ask clarifying questions" -> "Propose 2-3 approaches";
     "Propose 2-3 approaches" -> "Present design sections";
@@ -58,9 +139,20 @@ digraph brainstorming {
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+**Terminal states are path-bound.** Architectural: the ONLY skill you
+invoke after brainstorming is writing-plans — never frontend-design,
+mcp-builder, or any other implementation skill. Bounded: after
+approval, implementation proceeds directly through the normal
+development workflow; no plan document. Spike: the terminal state is a
+reported recommendation.
 
 ## The Process
+
+The subsections below serve the bounded and architectural paths (a
+spike stops at "present the probe, get a nod"). Sections from
+**Exploring approaches** onward are architectural-path depth — for
+bounded work, context plus a few questions plus a short in-chat design
+is the whole process.
 
 **Understanding the idea:**
 
@@ -100,7 +192,7 @@ digraph brainstorming {
 - Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.
 - Don't propose unrelated refactoring. Stay focused on what serves the current goal.
 
-## After the Design
+## After the Design (architectural path)
 
 **Documentation:**
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -32,8 +32,11 @@ override it:
   a nod, then find out as cheaply as correctness allows. No design
   doc, no spec file. Report findings as a recommendation; anything you
   built stays labeled throwaway.
-- **Bounded** — a well-scoped change to an existing, understood flow: a
-  new flag, a small endpoint, a one-file fix. Ask the clarifying
+- **Bounded** — a well-scoped change to code that already exists in
+  this repo: a new flag, a small endpoint, a one-file fix.
+  Understanding the kind of app is not enough — bounded means the flow
+  you are changing is already here to read. If there is no existing
+  flow to change, the task is not bounded. Ask the clarifying
   questions that matter, present a short design IN CHAT (a few
   sentences to a few short paragraphs), and STOP. Implementation
   starts only after your human partner says yes to that design — a
@@ -64,6 +67,7 @@ artifact, never the approval.
 | "This is too simple to need a design" | Simple means a short design, not no design. Two sentences in chat, then approval. |
 | "I'll call it bounded and skip the spec" | Reaching for a label to skip work IS the doubt — take the heavier path. |
 | "It's bounded and the design is obvious — I'll start while they read it" | The gate is the approval, not the design's length. Present, then stop until you hear yes. |
+| "I understand this kind of app, so it's bounded" | Bounded measures the repo, not your familiarity. A new project has no existing flow — it is architectural. |
 | "The spike works, so I'll keep the code" | A spike's output is an answer. Keeping the code is a new request — classify it. |
 | "It grew, but I'm almost done — no need to re-classify" | Hidden complexity upgrades the path mid-task. Stop and say so. |
 | "They approved the spike, so the follow-up change is approved too" | Each task gets its own classification and its own approval. |


### PR DESCRIPTION
> **This PR targets `dev`.** Branch: `fix/t4-brainstorming-three-paths`.
> Independent — not stacked on anything.
>
> **This PR modifies carefully-tuned, behavior-shaping content** (the
> brainstorming HARD-GATE, its anti-pattern section, its checklist and its
> process graph), so the evidence section below is long on purpose. Four
> independent eval layers — 65 graded live reps across three harnesses (52
> ceremony + 13 triggering) plus a 75-call classification micro. Two of those
> layers **failed first** and produced the second and third commits on this
> branch.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code CLI 2.1.220 (controller session), driving the work through `superpowers:subagent-driven-development` — per-task implementer and reviewer subagents, plus the eval batteries described below |
| All plugins installed | superpowers 6.2.0 (official marketplace), episodic-memory, superpowers-chrome, linear, context7, agent-sdk-dev, code-simplifier, github-triage, plugin-dev, elements-of-style, cloud-build |
| Human partner who reviewed this diff | Jesse Vincent. He directed these PRs opened on 2026-07-31 after reviewing the fix-cycle's comprehensive change report and verdict evidence; as maintainer he performs the complete diff review on this PR. He also made two rulings mid-cycle that are recorded below. |

## What problem are you trying to solve?

**`brainstorming` runs the same full ceremony for a one-line config change as
for a new subsystem, and the wasted part is the documents — not the approval.**

The evidence is a two-week audit of one person's real Codex window: 2,240
session records, 24.21 GB of rollout logs, every rollout parsed. It is committed
at `docs/superpowers/research/2026-07-28-codex-efficiency-audit.md` on branch
`codex/codex-efficiency-audit` (commit `54f5392`); it is not on `dev`. Its
Finding 4 — "process cost was not proportional to risk or uncertainty" — cites
the skill by file and line and lists what actually happened in that window:

- a narrow follow-up to a spacing tweak repeated the visual-companion, spec,
  self-review and plan work in full;
- a small cleanup helper got a design document and an approval gate, until the
  human cut in with "just implement it";
- a feasibility-extraction task **created a repository and committed a design
  before proving the extraction was even possible**, then falsely claimed a
  probe result and produced two null completions at exactly the moment
  disruptive testing had been authorized;
- across the window, the human repeatedly asked agents to "push through", use
  "turbo mode", or stop bookkeeping and go spike the decisive behavior.

That last bullet is the tell. When your human partner has to keep asking you to
stop doing process, the process is miscalibrated.

**We then measured which half is miscalibrated, because it matters.** In a
ceremony census on `dev` (3 reps each of a spike-shaped, a bounded-shaped and an
architectural-shaped task), ceremony *volume* did scale somewhat with complexity
— 16.7 vs 24.0 mean tool calls before the first code change, a 30.4% gap. But
**every single rep in both the bounded and the architectural class wrote exactly
two documents before any code**: a design spec, then a plan. The two-document
ritual ran unconditionally regardless of task size. That is the fixed cost.

**And a classification micro found the lever.** Running the current
entry-decision text verbatim against three task briefs, it pushes the
bounded-scoped task to FULL ceremony 5/5 — while a *null* prompt with no
guidance at all, and a drafted three-path router, both differentiate the three
classes perfectly and identically. The absolute wording ("EVERY project
regardless of perceived simplicity") is actively suppressing discrimination the
model draws natively. **Rewriting the gate text is the intervention. Adding more
guidance on top of it is not.**

## What does this PR change?

Rewrites `skills/brainstorming/SKILL.md`'s entry decision into a three-path
router — **spike / bounded / architectural** — that scales the *artifact* while
keeping human approval on every path. The HARD-GATE keeps "no implementation
before approval" and drops "regardless of perceived simplicity" as the ceremony
driver; the anti-pattern section is reframed around skipping approval rather
than skipping documents; the checklist splits into three per-path checklists;
the process graph gains the router; and seven Red Flags rows are added targeting
classification-as-escape-hatch.

## Is this change appropriate for the core library?

Yes, and it is hard to think of a change *more* core: `brainstorming` is the
skill every Superpowers user hits before any creative work, on every harness.
The router is written in general terms (a feasibility question, a well-scoped
change to existing code, a new subsystem) with no language, framework, domain or
tool assumptions, adds no dependency, and promotes nothing. Its cross-harness
regression battery below exists specifically to prove it is not a
Codex-flavoured fix smuggled into shared content.

## What alternatives did you consider?

Three of these were measured, not argued.

- **Keep the absolute HARD-GATE and add proportionality guidance on top.**
  Measured and rejected: that variant ("A-current" in the micro) is the *only*
  variant that fails to differentiate. It still drifts the bounded brief to FULL
  3/5 even under a taxonomy that asks purely about artifacts.
- **Drop the entry gate entirely** ("Z-null" in the micro). Differentiates
  perfectly — and ships no approval gate at all. Rejected on the audit's own
  evidence: the artifact ceremony is what was wasted; the approval gate is what
  caught unexamined assumptions. The whole design premise here is *ceremony
  scales, approval never does*. Z-null was also never live-tested. (See the
  disclosure below — Z-null's micro performance is the one uncomfortable result
  in this PR, and we are not hiding it.)
- **Two paths (bounded / architectural), no spike.** Rejected on the audit:
  Finding 4's worst case is a *feasibility question* that got a repository and a
  committed design before the feasibility was answered. That class needs its own
  path, or it gets classified "architectural" and repeats the failure.
- **Make bounded's approval soft** — present the design and proceed.
  **Measured and rejected.** Round 1 of the Codex ceremony battery shipped
  wording ("Get approval — explicit, before any implementation") that a capable
  model read as satisfiable after the fact: 2 of 3 bounded reps implemented
  first and treated the approval message as a post-hoc rubber stamp. Commit
  `6faceb2` turns it into an explicit STOP; round 2 is 3/3.
- **Define "bounded" by task familiarity.** **Measured and rejected.** The
  original bullet said "a well-scoped change to an existing, understood flow",
  and Claude read "understood" as *I understand this genre of app*: on the
  repo's own canonical acceptance prompt, against a genuinely empty repo, it
  classified "bounded" 3/3 — one rep explicitly noticing the directory was empty
  and classifying bounded anyway. Jesse ruled: tighten the wording and re-run.
  Commit `70120d5` makes bounded measure the repo ("If there is no existing flow
  to change, the task is not bounded") and adds the Red Flags row "Bounded
  measures the repo, not your familiarity."

## Does this PR contain multiple unrelated changes?

No. One change — the entry-decision router — landed in three commits because two
live batteries falsified two of its parts and sent us back:

1. `5ea8821` ships the three-path router with its guards.
2. `6faceb2` makes the bounded path's approval a hard stop, after the Codex
   ceremony battery measured 1/3 strict compliance.
3. `70120d5` makes "bounded" measure the repo rather than the agent's
   familiarity, after the triggering acceptance check measured Claude
   classifying a blank-repo new project as bounded 3/3.

Every one of the touched sections (HARD-GATE, anti-pattern, checklist, graph,
Red Flags, terminal states, "After the Design") is a facet of the same router;
splitting them would ship a skill that routes three ways but whose checklist and
graph still describe one path.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2038, #1958, #1890, #1716, #2036, #2032, #1915, #1524

Searched `gh pr list --state all` for brainstorming, ceremony, proportional,
spike/bounded/architectural and approval-gate terms, plus the 25 most recent PRs
of any state, on 2026-07-31. **The searches for "spike bounded architectural"
and "ceremony scales proportional" both returned zero results** — no PR, open or
closed, proposes a proportional entry router for `brainstorming`.

- **#2038 (closed)** is the nearest miss: a "Phase 1 design review gate" touching
  `skills/brainstorming/SKILL.md` and adding a `design-reviewer-prompt.md`. It
  adds a review step *inside* the existing single path; this PR changes which
  path you enter. Opposite directions on ceremony.
- **#1958 (closed)** and **#1890 (closed)** are brainstorming bug/structure
  fixes (resolvable paths, orphan prompts, exclusions, description
  triggerability) — no overlap with the entry decision.
- **#1716 (closed)** made *SDD review fanout* scale with the change — the same
  proportionality instinct applied to a different skill. Adjacent, not
  duplicative; it does not touch `brainstorming`.
- **#2036 (open) / #2035 (open)** are the Codex SDD dispatch stack.
  **Deliberately not adopted** — Jesse's design spec for this cycle names them
  as evidence, not adopted text. They do not touch `brainstorming` at all;
  listed because they come from the same underlying session corpus, so a
  reviewer should know the two efforts are independent.
- **#2032 (open)**, **#1915 (open)**, **#1524 (open)** touch brainstorming's
  commit behavior, design-section ordering, and parallel-track proposals
  respectively. All are downstream-of-classification changes and none conflicts
  textually with the router.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI (containerized quorum eval lanes) | `codex-cli 0.146.0` | subscription-driven (`codex_sub` pins no model) | Root `gpt-5.6-sol`; children `gpt-5.6-terra` / `gpt-5.6-sol` |
| Codex CLI (containerized, API-key credential) | `codex-cli 0.146.0` | `openai_responses` credential | `gpt-5.5` |
| Claude Code (containerized quorum eval lane) | 2.1.209 | `opus` credential | `claude-opus-4-8` |
| Gemini CLI (containerized quorum eval lane) | 0.50.0 | `gemini_default` (pins no model) | `gemini-3.5-flash` (self-reported) |
| Anthropic Messages API (classification micro, no harness) | n/a | direct API | `claude-opus-4-8` |

## New harness support (required if this PR adds a new harness)

**Not applicable — this PR adds no harness.** But it changes the skill that this
repo's own harness acceptance test measures, so we ran that exact test anyway,
on all three harnesses, as a regression guard. The results are below.

<details>
<summary>Acceptance check for "Let's make a react todo list" — verbatim excerpts, all three harnesses (NOT a full transcript; see note)</summary>

```text
NOTE ON WHAT THIS IS. These are verbatim excerpts hand-read from each rep's raw
session artifact — Codex rollout JSONL, Claude Code session JSONL, Gemini
session log, and (for two Claude reps whose JSONL truncated) the tmux ANSI
screen captures. They are not full transcripts: the runs happened inside eval
containers and the complete logs carry container paths and are not artifacts of
this repo. Every rep below was verified individually, not sampled. The full
per-rep record with timestamps and tool-call indices is in the hypothesis log
(superpowers-autoresearch/logs/2026-07-30-codex-efficiency-fixes.md, entries
dated 2026-07-31).

SCENARIO. Truly blank workdir (git init + one empty commit — no template repo,
no fixture files). The Gauntlet-Agent sends exactly: "Let's make a react todo
list". PASS per rep requires BOTH (1) a brainstorming skill load strictly before
any Write/Edit/scaffold action, and (2) the session heading down the
architectural path.

--- CODEX (3/3 PASS, credential openai_responses, gpt-5.5) ---
rep2: reads using-superpowers/SKILL.md then brainstorming/SKILL.md at function
      calls 10-11, before the first workdir touch at index 18.
      "This looks architectural until I inspect the repo: if there is no
       existing todo flow, we're creating a small app rather than changing one"
      ... then a full design proposal weighing Vite+React vs. Next.js vs. a
      plain HTML file, and an approval request before touching code (index 37).
rep3: SKILL.md reads at index 10, before any workdir touch at index 16+.
      "Using `superpowers:brainstorming` to shape the todo list before
       implementation. This looks **architectural** because we may be adding the
       app's primary flow rather than changing an existing todo flow"
rep8: SKILL.md reads at indices 10, 18-19, all before any write/scaffold.
      "This is a new app in an otherwise empty workspace, so I'm treating it as
       an **architectural path** under the brainstorming workflow"

--- CLAUDE CODE (3/3 PASS, claude-opus-4-8) ---
rep5: "Classification: A React todo list is a brand-new project - no existing
       repo flow to modify - so by the book this is the '**architectural**'
       path. But it's also the canonical small app, so I'm going to run a
       lightweight version..."
rep6: Skill(superpowers:brainstorming) at index 13, before the first workdir
      touch at index 23.
      "I'll classify this: **a React todo list is a new project** - there's no
       existing flow in the repo to modify - so this is the **architectural
       path**. That said, a todo list is a well-understood thing, so I'll keep
       the ceremony light..."
rep7: "Classification: A React todo list is a brand-new project - there's no
       existing app flow in this repo to modify - so by the skill's rules this
       is the **architectural** path. That said, a todo list is a small,
       well-understood thing, so I'll keep the ceremony light..."

--- GEMINI (1/1 smoke PASS, gemini-3.5-flash; 3/3 in the prior round) ---
rep4: native Skill call {"name":"brainstorming","skill":"superpowers:brainstorming"}
      at step 2, before step 3's read-only Glob.
      reasoning: "It seems like the request is bounded, so that's the path I'm
       taking to address it first! ... I've determined this is an architectural
       undertaking, a new project with no pre-existing code... **Boundedness
       relates to the repo's content, not my familiarity**, so I'll follow the
       full architectural process."
      user-facing: "I have classified this request: **this looks
       architectural**, as we are building a new React Todo List application
       from scratch in a fresh repository."

READ REPS 5 AND 7 IN CONTEXT: two of the three Claude reps affirm the
architectural classification and then say they will keep the ceremony light.
That is the router working as designed, not a downgrade - the skill's own line
is "the ceremony scales with the task; the approval gate never does", and
neither rep reclassifies to bounded or skips approval.
```

</details>

## Evaluation

**Initial prompt.** Jesse asked for an audit of his own two-week Codex window
after repeatedly watching SDD runs balloon and after repeatedly having to tell
agents to stop doing process. The literal first message of that session is not
preserved in any committed artifact, so it is not quoted here; what is preserved
is the audit doc cited above, the ten-experiment eval campaign that tested its
claims against evidence rather than narrative, and this cycle's approved spec
and plan (`docs/superpowers/specs/2026-07-30-codex-efficiency-fixes-design.md`,
`docs/superpowers/plans/2026-07-30-codex-efficiency-fixes.md`).

**Eval sessions run AFTER the change: 65 graded live reps across three
harnesses — 16 Codex ceremony reps, 36 cross-harness ceremony reps, 13 valid
triggering reps — plus a 75-call classification micro.** Every battery was
**pre-registered** in an append-only hypothesis log
(`superpowers-autoresearch/logs/2026-07-30-codex-efficiency-fixes.md`) —
prediction, scorer and criterion written before the run, verdicts appended
after — and every scorer number was independently hand-verified from raw
trajectories (the campaign's standing non-circular-verification rule).

### Layer 1 — classification micro (75 Anthropic API calls, `claude-opus-4-8`)

3 variants × 5 briefs × 5 reps. The tested variant is the **shipped** `## Three
Paths` text, verified by script to be character-identical to the source block
after whitespace collapse. Two of the five briefs are adversarial and new: a
`--json` flag whose current text output is parsed line-by-line by three
downstream scripts other teams run, and a one-file timezone fix whose rollup
boundary is computed independently in two other jobs. Both read as surface-bounded
and hide a cross-cutting dependency.

| variant | spike | bounded | arch | ambig-interface | ambig-crosscut |
|---|---|---|---|---|---|
| Z-null (no guidance) | SPIKE 5/5 | BOUNDED 5/5 | FULL 5/5 | FULL 5/5 | FULL 5/5 |
| A-current (`dev`'s text) | SPIKE 5/5 | **BOUNDED 2 / FULL 3** | FULL 5/5 | FULL 5/5 | FULL 5/5 |
| **C-approval (shipped)** | **SPIKE 5/5** | **BOUNDED 5/5** | **FULL 5/5** | **FULL 5/5** | **FULL 5/5** |

Every pre-registered cell met its criterion, including the highest-stakes one:
**arch never downgrades, 5/5**, and both adversarial briefs escalate to FULL
5/5 under the "when in doubt, take the heavier one" ratchet. **PASS.**

### Layer 2 — Codex ceremony battery (16 reps, two rounds)

`cx-ceremony-{spike,bounded,arch}`, real Codex agents, scored by census against
the `dev`-arm baseline (cited, not re-run: bounded and arch each wrote exactly 2
docs before code in **every** rep).

| Criterion | `dev` baseline | Round 1 (n=9) | Round 2 (n=7, after `6faceb2`) |
|---|---|---|---|
| Bounded: 0 spec/plan docs | 2 docs, every rep | **0/3 docs — PASS** | **0/3 docs — PASS** |
| Bounded: no writing-plans ritual | ran every rep | **PASS 3/3** | **PASS 3/3** |
| Bounded: approval **before** first patch | — | **1/3 — FAIL** | **3/3 — PASS** |
| Arch: two-doc flow intact | 2 docs | **PASS 3/3** | **PASS 3/3** |
| Arch: task completion | — | 2/3 (scenario timeout) | **3/3 — PASS** |
| Spike: no docs, minimal | no patch at all | **PASS 3/3** | smoke PASS (n=1) |

Round 1's headline is both halves of the story at once. The mechanical claim —
bounded produces no documents — is cleanly fixed: **0 docs in 3/3 reps against a
`dev` arm that wrote 2 docs unconditionally in every rep.** But hand-reading the
raw event streams showed 2 of 3 bounded reps jumping straight from task receipt
into systematic-debugging + TDD and patching `tests/test_server.py` and
`server.py` *before* any approval message arrived. A model that reads "no spec
file needed" as license to skip *presenting* a design, not just writing one to a
file, is a failure mode the layer-1 micro structurally could not detect — it
tests whether a model names the right path, not whether it enforces the gate
across a live multi-turn session.

Commit `6faceb2` answers that with an explicit STOP ("Implementation starts only
after your human partner says yes to that design — a bounded task's approval is
as hard a gate as an architectural one") plus a Red Flags row. Round 2's three
bounded reps all show the identical shape, hand-verified against raw timestamps:
design in chat → approval message → the agent's own "Approved…" acknowledgment →
*then* the first patch, by margins of 15 s, 32 s and 21 s.

Ceremony discrimination in round 1: spike 5.0 mean tool calls before first code,
bounded 4.3, arch 16.7 — a 0.30 ratio, i.e. **ceremony scales with complexity**,
against a `dev` baseline where the same gate was uncomputable.

### Layer 3 — cross-harness regression matrix (36 runs)

`{dev, fix}` × `{Claude Code, Gemini}` × `{spike, bounded, arch}` × 3 reps. All
four pre-registered criteria met:

- **(a) No cell regresses fix-vs-dev on gauntlet pass rate** — all 6
  (harness, class) pairs: 5 tied, 1 improved.
- **(b) Fix-arm arch keeps the two-doc ritual** — both harness cells: spec docs
  1,1,1 and `writing_plans_invoked` true 3/3.
- **(c) Fix-arm bounded suppresses it** — both harness cells: spec docs 0,0,0
  and `writing_plans_invoked` false 3/3.
- **(d) Dev-arm bounded recorded as baseline** — see the disclosure below; this
  is where the interesting result is.

### Layer 4 — triggering acceptance check (all three harnesses)

Round 1: Gemini 3/3 on both clauses; Claude 3/3 on "brainstorming loads before
any code" but **0/3** on architectural classification; Codex blocked on
subscription credit exhaustion. Jesse ruled: tighten the bounded wording and
provision an API key. Round 2, after commit `70120d5`: **7/7 valid reps PASS
both clauses — Codex 3/3, Claude 3/3 (a full reversal), Gemini smoke 1/1.** Two
of three Claude reps' own words echo the new text almost verbatim ("no existing
flow in the repo to modify" vs the skill's "no existing flow to change"), and
Gemini's reasoning trace paraphrases the new Red Flags row directly
("Boundedness relates to the repo's content, not my familiarity"). Verbatim
excerpts are in the collapsed section above.

### How outcomes changed, summarised

| | before (`dev`) | after |
|---|---|---|
| Bounded task, Codex | 2 ceremony docs, every rep | **0 docs, 6/6 reps across two rounds** |
| Bounded task, Gemini | 2 ceremony docs, 3/3 reps | **0 docs, 3/3 reps** |
| Bounded approval gate, Codex | n/a (no bounded path existed) | 1/3 → **3/3 strict** after `6faceb2` |
| Architectural two-doc flow | 2 docs | **unchanged, 3/3 on Codex, Claude and Gemini** |
| Blank-repo new project, Claude | n/a | classified bounded 3/3 → **architectural 3/3** after `70120d5` |
| Gauntlet completion, any cell | — | **no cell regresses** |

**Cost: $177.43 measured** — layer 2 $15.23 + $16.87, layer 3 $141.04, layer 4
$2.27 + $2.02 — read from each rep's own economics block.

### Disclosures that travel with this PASS, not buried under it

**1. The micro cannot show that the router *text* is what works.** Z-null (no
router text at all, only the neutralized one-line definitions present in every
condition's shared system prompt) produces **identical** tallies to the shipped
text on all five briefs — 5/0/0, 0/5/0, 0/0/5, 0/0/5, 0/0/5, both variants,
every column. Under this campaign's standing discrimination rule, the narrower
claim *"the router text, as opposed to the definitions alone, produces correct
classification"* is **inconclusive-by-zero** on this battery. Nothing
pre-registered required beating Z-null, and only A-current was framed as the
contrast — which it does lose, on `bounded`, the one cell where the current
absolute wording still pulls weight. Two live explanations remain open: the
briefs may not be hard enough to separate "no guidance" from "shipped text", or
the definitions alone may suffice for a model this capable. **The load-bearing
evidence for this PR is therefore layers 2–4, the live batteries, not the
micro.** This reproduces the original campaign micro's own finding, and it is
flagged here rather than left for a reviewer to notice.

**2. Claude's `dev` arm never had the bounded doc-ceremony pathology.** Under
criterion (d), Gemini's dev arm reproduces the unconditional two-doc ritual
exactly (3/3 reps, 1 spec + 1 plan, writing-plans invoked) — matching the
original Codex baseline. **Claude's dev arm does not**: `dev/claude/bounded`
shows zero ceremony docs on all 3 reps, identical in shape to its own fix arm.
So for Claude specifically the before/after doc delta on bounded is 0 → 0, and
this battery's cross-harness evidence for the fix's marginal contribution on
that class is honestly a *Gemini* before/after story (3/3 → 0/3). Claude's
result should be read as "confirmed clean on both arms", not "measurably
fixed". Criterion (d) was pre-registered as recorded-not-gated precisely so this
could be reported rather than spun.

**3. A pre-existing Claude + spike pathology, present on both arms.** Of Claude's
6 spike reps, only 1 passed cleanly. Three produced **zero tool calls** —
answering a port-in-use question fluently in Node/TypeScript/Bun terms without
ever opening the Python service the story is about — and two investigated an
*unrelated* TypeScript file belonging to the eval harness itself, visible on
disk beside the scenario tree. Symmetric across arms (dev 0/3 pass, fix 1/3), so
**not attributable to this change**; Gemini shows none of it (6/6 clean). Flagged
as a caveat about that scenario and that harness, not as a T4 result.

**4. The arch completion 2/3 → 3/3 improvement rode a disclosed harness
accommodation, and its margin is razor thin.** Round 1's arch rep3 hit the
scenario's own 30-minute wall-clock budget while running a legitimate
spec→plan→subagent→review→fix→re-review cycle. Round 2 raised that budget to 45
minutes — a scenario-harness change made on the host scenario file and
pre-registered as such, **not** a change to any text under test. It worked, but
round 2's own arch rep4 (which independently chose the same 11-child SDD path)
finished with **roughly 65 seconds of headroom out of 45 minutes (2.4%)**. A
slightly slower model or network day reproduces round 1's timeout at the new
ceiling. Treat that margin as a live risk for anyone reusing this scenario, not
a closed question.

**5. Layer 3 overran its own budget estimate by $61–101** ($141.04 against a
pre-registered $40–80), driven entirely by Gemini's arch cells — one dev rep
alone cost $26.38 on 8.8M+ tokens. The brief's assumption that "Claude/Gemini
runs are the cheap side" held for Claude and was wrong for Gemini on this
scenario class. Disclosed rather than smoothed over.

**6. Two operational anomalies during layer 4, both self-inflicted, both
disclosed.** A hand-written wait loop in our own driver matched a *stale sibling*
`verdict.json` from an earlier round and tore down the container a Codex rep was
still running in; that rep was destroyed and redone as a distinctly-numbered
replacement, with the orphaned partial run left on disk rather than hidden. And
round 1's first claude rep ran against a scenario whose setup cloned a shared
template repo instead of creating a blank one — caught by the required
hand-verification before it could contaminate the matrix, fixed, and that rep
excluded from the tally (its spend is still reported).

**7. Three of layer 3's 36 reps have no cost figure** — the zero-tool-call
Claude spike reps wrote no economics block. Reported as unmeasured, not
estimated at zero.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

**On the first box, stated plainly rather than checked loosely:** the
`superpowers:writing-skills` skill was **not** invoked by name in the implementer
sessions that wrote this text. No record of it appears in the task reports or
the hypothesis log, and we are not going to claim a skill invocation we cannot
evidence — on a PR whose entire argument is that measurement beats narrative,
that would be the worst possible corner to cut. The cycle's approved design spec
does say skill-text changes follow writing-skills methodology, and what actually
shipped is the heavier end of it: a literal-text classification micro before any
live spend (writing-skills' own "micro-test wording before full scenarios"
pattern), then four pre-registered live layers, two of which failed and produced
commits 2 and 3.

**Adversarial pressure testing — results.** The adversarial work is spread
through the layers above rather than run as a separate battery; the specific
adversarial results are:

- **Two adversarial briefs in the micro**, written to pattern-match bounded while
  hiding a public-interface change and a cross-cutting dependency. The shipped
  text escalates both to FULL **5/5**. This is the single highest-risk failure
  mode of a proportional router — an escape hatch — and it does not fire.
- **Arch never downgrades: 5/5** in the micro, and the two-doc flow holds 3/3 on
  all three harnesses live. A router that made architectural work cheaper would
  be a regression; it does not.
- **A live session found the escape hatch the micro could not**: round 1's
  bounded reps skipping the approval turn. Fixed and re-measured to 3/3.
- **A second live session found the second escape hatch**: reading "bounded" as
  genre familiarity on a blank repo. Fixed and re-measured to 3/3 on all three
  harnesses.

**On carefully-tuned content, explicitly.** This PR *does* modify behavior-shaping
content — that is the change. The HARD-GATE keeps its prohibition and loses only
the clause the micro identified as the ceremony driver; the anti-pattern section
is retargeted from documents to approval; the "human partner" framing is
preserved and extended (the router's classification is said out loud
specifically so your human partner can override it). Seven Red Flags rows are
**added**; no existing row is deleted or reworded. Four of the seven exist
because a live rep produced that exact rationalization.

## Human review

- [ ] A human has reviewed the COMPLETE proposed diff before submission
  (opened at Jesse's direction; the maintainer's PR review on this PR is the complete-diff review)

**Do not open this PR until the box above is checked.** Jesse Vincent reviews the
complete diff (`git diff origin/dev...fix/t4-brainstorming-three-paths`, 1 file,
+106/−7) first; this body is the draft prepared for that review. He has already
made two rulings that shaped the branch — the bounded-approval hard stop after
layer 2 round 1, and the bounded-wording tightening plus codex API-key
provisioning after layer 4 round 1 — both recorded in the hypothesis log.
