### PR TITLE
fix(using-superpowers): re-check skills mid-workflow, not only at turn start

### DIFF
--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -19,6 +19,8 @@ This is not negotiable. You cannot rationalize your way out of this.
 
 **Invoke relevant or requested skills BEFORE any response or action** — including clarifying questions, exploring the codebase, or checking files. If it turns out wrong for the situation, you don't have to use it.
 
+**Check continuously — not only at turn start.** New decisions, facts, or rejected alternatives mid-conversation can make other skills relevant. Being inside one skill's workflow does not suspend checking for others. When a second skill's trigger is met, invoke it (respecting Skill Priority); do not wait until the active skill fully finishes if the new trigger already applies.
+
 **Before entering plan mode:** if you haven't already brainstormed, invoke the brainstorming skill first.
 
 Then announce "Using [skill] to [purpose]" and follow the skill exactly. If it has a checklist, create a todo per item.
@@ -48,6 +50,8 @@ These thoughts mean STOP—you're rationalizing:
 | "I'll just do this one thing first" | Check BEFORE doing anything. |
 | "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
 | "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+| "I already checked skills this turn" | New content creates new triggers. Re-check. |
+| "I'm mid-workflow — skill check is done" | Active skill ≠ exclusive. Other skills still apply. |
 
 ## Platform Adaptation
 


### PR DESCRIPTION
> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Grok 4.5 |
| Harness + version | Grok Build / Cursor |
| All plugins installed | Superpowers skill pack in use for contribution workflow; no third-party skill plugins installed for authoring this change. Skill text edits hand-written against issue #2051 (not auto-generated skill rewrite). |
| Human partner who reviewed this diff | arimu1 |

## What problem are you trying to solve?

Real session reported in #2051 (Claude Code + Superpowers 6.2.0, Claude Sonnet 5).

`using-superpowers` states that a relevant skill should be checked before any action, with even a 1% chance of relevance enough to invoke it. In the reported session:

1. `brainstorming` engaged correctly for a rate-limiting design.
2. Mid-conversation, design settled with an explicit **rejected alternative** and a second non-obvious decision — content that matched a second skill's trigger description.
3. Implementation proceeded; the second skill never activated.

When asked why, the agent explained (verbatim from the issue):

> "Once brainstorming's design questions wrapped up, I was tracking the brainstorming skill's own terminal state... not scanning for *other* skills that might apply to what had just been decided. The using-superpowers rule says to invoke a skill if there's even a 1% chance it's relevant — I applied that at the start of the turn but not again after the design conversation produced exactly the kind of rejected-alternative/rationale content [the other skill] exists to capture."

Root instruction gap: the bootstrap forbids skipping skill checks before action, but does not say the check is **continuous**. Agents rationalize "I already checked this turn" / "I'm mid-workflow so skill check is done."

A third-party skill cannot fix this from its own body: trigger decisions run against short frontmatter descriptions; body text only loads after the skill is already chosen. Only `using-superpowers` can restate continuous re-check.

Issue author noted prompt-based enforcement may not hard-guarantee compliance; this PR closes the documented wording gap and the exact rationalizations observed.

## What does this PR change?

Skill-content only in `skills/using-superpowers/SKILL.md`:

1. **The Rule:** state that skill check is continuous (not only at turn start); mid-workflow does not suspend checking other skills; when a second skill's trigger is met, invoke it (respecting Skill Priority).
2. **Red Flags:** two rows closing the observed rationalizations ("already checked this turn"; "mid-workflow — skill check is done").

No harness/hook/code changes. No third-party skill content.

## Is this change appropriate for the core library?

Yes. Continuous skill discovery is core bootstrap behavior for every Superpowers user on every project. It is not domain-specific, not a third-party integration, and not a project-local workflow. Third-party skills cannot fix this from their own files (as #2051 demonstrated).

## What alternatives did you consider?

1. **Only add Red Flags rows** — Leaves The Rule readable as once-per-turn-start. Rejected: the positive rule must state continuity; Red Flags alone are the rationalization counter.
2. **Only strengthen The Rule without Red Flags** — Rejected: #2051's agent produced exact mid-workflow rationalizations; project pattern is to table those (see prior "I know what that means" row for explicit-request skips).
3. **Change skill `description` frontmatter** — Rejected: description is discovery/when-to-load; this skill is session bootstrap. Body is where continuous behavior is enforced. Description already says "before ANY response."
4. **Hook/runtime enforcement of re-scan** — Out of scope for skill-content fix; no portable hard guarantee across harnesses; issue asked about the stated policy gap.
5. **Larger rewrite of bootstrap / flowcharts** — Rejected: bootstrap was deliberately compressed (token cost on every session); keep the minimal wording that blocks the observed failure mode.

## Does this PR contain multiple unrelated changes?

No. Single file, single failure mode: skill check treated as turn-start only while mid-workflow.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for issue #2051 or for "mid-workflow skill re-check / continuous skill check while one skill is active"

Searched open and closed PRs for: `2051`, `using-superpowers`, `mid-workflow`, `check continuously`, `before every action`. Nearby using-superpowers PRs (#2010 dangling anchor, #1894 Claude Code platform adaptation, harness PRs) do not address continuous re-check. Related issues cited by #2051 (#1007 composition, #1812 memory) are different problems.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Grok Build / Cursor | Cursor IDE (current) | Grok 4.5 | Grok 4.5 |

Skill-content-only change; no runtime harness integration. Grounding session is the #2051 transcript (Claude Code / Claude Sonnet 5).

## New harness support (required if this PR adds a new harness)

N/A — this PR does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
N/A — not a new harness PR
```

</details>

## Evaluation

- **Initial prompt / source of truth:** Issue #2051 session (Claude Code + Superpowers; brainstorming active; second skill trigger met mid-design via rejected alternative + non-obvious decision; second skill never self-triggered).
- **Before (bootstrap wording + observed agent behavior):**
  - Rule: invoke before any response/action — read as once at turn start
  - No continuous / mid-workflow re-check language
  - Agent tracked active skill's terminal state only; did not re-scan other skill descriptions when new trigger content appeared
- **After (this PR wording):**
  - Explicit: check continuously, not only at turn start
  - Mid-workflow does not suspend other-skill checks
  - Second skill with met trigger: invoke (Skill Priority still applies)
  - Red Flags name the two rationalizations from #2051
- **Adversarial / pressure checks (reasoning + diff review against issue transcript; skill text change only):**
  1. **Exact #2051 case:** After brainstorming produces rejected-alternative content matching another skill's description → continuous re-check + "mid-workflow" red flag forbid treating skill check as done.
  2. **True single-skill turn:** No new triggers mid-turn → no extra invocation required; rule is "when trigger is met," not "invoke everything every message."
  3. **Skill Priority still holds:** Process skills first; continuous check does not invert priority or force parallel exclusive workflows.
  4. **SUBAGENT-STOP unchanged:** Subagents still ignore this skill; no change to that gate.
  5. **Token budget:** +~90 words on a deliberately compressed bootstrap; no flowchart restore; no section restructuring.
  6. **Carefully-tuned content:** Existing Red Flags rows left as-is; two additive rows only. No "human partner" rewording. EXTREMELY-IMPORTANT / 1% block unchanged.
- **Multi-session live harness evals:** Not run in this contribution environment (skill markdown only). Prompt-based enforcement remains soft (as #2051 author noted); this closes the documented gap. Before/after multi-session evals remain welcome as follow-up if maintainers want quantified behavior rates.

## Rigor

- [x] If this is a skills change: I used judgment aligned with superpowers skill philosophy (precise labels, forbid the observed rationalization, keep carefully-tuned sections intact). Full writing-skills multi-subagent campaign was not run in this harness; adversarial cases above map the #2051 failure and adjacent loopholes.
- [x] This change was tested adversarially, not just on the happy path (exact #2051 mid-brainstorming miss, single-skill no-op, Skill Priority, SUBAGENT-STOP)
- [x] I did not modify carefully-tuned content (existing Red Flags rows, rationalizations, "human partner" language) without extensive evals — existing rows left unchanged; only additive continuous-check rule + two new rows matching #2051 rationalizations

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Fixes #2051