### PR TITLE
fix(codex): preserve SDD helper executable modes in packaging

### DIFF
--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -140,7 +140,8 @@ if [[ "$FORMAT" == "zip" ]]; then
   command -v unzip >/dev/null || die "unzip not found in PATH"
 fi
 
-[[ -d "$REPO_ROOT/.git" ]] || die "repo root is not a git checkout: $REPO_ROOT"
+# Accept linked worktrees (.git is a file) as well as primary checkouts (.git is a dir).
+[[ -e "$REPO_ROOT/.git" ]] || die "repo root is not a git checkout: $REPO_ROOT"
 git -C "$REPO_ROOT" rev-parse --verify "$REF^{commit}" >/dev/null ||
   die "git ref does not resolve to a commit: $REF"
 
@@ -240,6 +241,25 @@ git -C "$REPO_ROOT" -c tar.umask=0022 archive --format=tar "$REF" -- \
   assets \
   skills \
   | tar -xpf - -C "$STAGE"
+
+# Re-apply +x from the git tree for every staged 100755 path. Zip archives
+# store Unix modes in external attributes only when the staged files are
+# executable; installers that honor those bits (Info-ZIP unzip, tar) need
+# them present. Fail closed if any tracked executable lost its mode.
+missing_exec=0
+while IFS=$'\t' read -r meta path; do
+  mode="${meta%% *}"
+  [[ "$mode" == "100755" ]] || continue
+  staged="$STAGE/$path"
+  [[ -f "$staged" ]] || continue
+  chmod a+x "$staged" || die "failed to mark executable: $path"
+  if [[ ! -x "$staged" ]]; then
+    echo "staged path lost executable bit: $path" >&2
+    missing_exec=1
+  fi
+done < <(git -C "$REPO_ROOT" ls-tree -r "$REF")
+[[ "$missing_exec" -eq 0 ]] ||
+  die "one or more staged 100755 files are not executable after extract"
 
 VERSION="$(jq -r '.version // empty' "$STAGE/.codex-plugin/plugin.json")"
 [[ -n "$VERSION" ]] || die "could not read version from .codex-plugin/plugin.json"

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -25,7 +25,11 @@ git rev-parse --verify --quiet "$head" >/dev/null || { echo "bad HEAD: $head" >&
 if [ $# -eq 4 ]; then
   out=$4
 else
-  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace" "$plan")
+  # Invoke sdd-workspace via bash so default OUTFILE still works when an
+  # installer drops the git-tracked 100755 bit (common with zip extractors
+  # that ignore Unix external attributes, e.g. Python zipfile).
+  scripts_dir=$(cd "$(dirname "$0")" && pwd)
+  dir=$("${BASH:-bash}" "$scripts_dir/sdd-workspace" "$plan")
   out="$dir/review-$(git rev-parse --short "$base")..$(git rev-parse --short "$head").diff"
 fi
 

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -21,7 +21,11 @@ n=$2
 if [ $# -eq 3 ]; then
   out=$3
 else
-  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace" "$plan")
+  # Invoke sdd-workspace via bash so default OUTFILE still works when an
+  # installer drops the git-tracked 100755 bit (common with zip extractors
+  # that ignore Unix external attributes, e.g. Python zipfile).
+  scripts_dir=$(cd "$(dirname "$0")" && pwd)
+  dir=$("${BASH:-bash}" "$scripts_dir/sdd-workspace" "$plan")
   out="$dir/task-${n}-brief.md"
 fi
 

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -189,6 +189,36 @@ PLAN
         echo "    status: $wt_status"
     fi
 
+    # --- Mode-stripped install path (Codex marketplace zip extractors that
+    # ignore Unix external attributes leave helpers at 0644). Invoking via
+    # bash must still resolve the default workspace OUTFILE path.
+    local stripped="$TEST_ROOT/stripped-scripts"
+    mkdir -p "$stripped"
+    cp "$SDD_SCRIPTS/sdd-workspace" "$SDD_SCRIPTS/task-brief" "$SDD_SCRIPTS/review-package" "$stripped/"
+    chmod a-x "$stripped"/*
+    local stripped_brief stripped_rp
+    stripped_brief="$(cd "$repo" && bash "$stripped/task-brief" plan-a.md 1)" || true
+    if [[ "$stripped_brief" == *"wrote $repo/.superpowers/sdd/plan-a/task-1-brief.md"* ]]; then
+        pass "task-brief via bash works when helpers are non-executable"
+    else
+        fail "task-brief via bash works when helpers are non-executable"
+        echo "    got: $stripped_brief"
+    fi
+    stripped_rp="$(cd "$repo" && bash "$stripped/review-package" plan-a.md HEAD~1 HEAD)" || true
+    case "$stripped_rp" in
+        wrote\ "$repo"/.superpowers/sdd/plan-a/review-*.diff:*)
+            pass "review-package via bash works when helpers are non-executable" ;;
+        *)
+            fail "review-package via bash works when helpers are non-executable"
+            echo "    got: $stripped_rp"
+            ;;
+    esac
+    if ! "$stripped/sdd-workspace" plan-a.md >/dev/null 2>&1; then
+        pass "direct exec of mode-stripped sdd-workspace fails as expected"
+    else
+        fail "direct exec of mode-stripped sdd-workspace fails as expected"
+    fi
+
     echo ""
     if [[ "$FAILURES" -ne 0 ]]; then
         echo "FAILED: $FAILURES assertion(s)."

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -179,11 +179,40 @@ skill_count="$(find "$extracted/skills" -mindepth 1 -maxdepth 1 -type d | wc -l 
 metadata_count="$(find "$extracted/skills" -path '*/agents/openai.yaml' -type f | wc -l | tr -d ' ')"
 assert_equals "$metadata_count" "$skill_count" "every packaged skill has OpenAI metadata"
 
-if [[ -x "$extracted/skills/subagent-driven-development/scripts/task-brief" ]]; then
-  pass "archive preserves executable script mode"
-else
-  fail "archive preserves executable script mode"
-fi
+sdd_helpers=(
+  skills/subagent-driven-development/scripts/sdd-workspace
+  skills/subagent-driven-development/scripts/task-brief
+  skills/subagent-driven-development/scripts/review-package
+)
+for helper in "${sdd_helpers[@]}"; do
+  if [[ -x "$extracted/$helper" ]]; then
+    pass "zip extract preserves executable mode: $helper"
+  else
+    fail "zip extract preserves executable mode: $helper"
+  fi
+done
+
+zip_sdd_modes="$(python3 - "$archive" <<'PY'
+import sys
+import zipfile
+
+paths = [
+    "skills/subagent-driven-development/scripts/sdd-workspace",
+    "skills/subagent-driven-development/scripts/task-brief",
+    "skills/subagent-driven-development/scripts/review-package",
+]
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    for path in paths:
+        info = archive.getinfo(path)
+        mode = (info.external_attr >> 16) & 0o7777
+        print(f"{path}\t{oct(mode)}")
+PY
+)"
+expected_zip_sdd_modes="$(printf '%s\n' \
+  $'skills/subagent-driven-development/scripts/sdd-workspace\t0o755' \
+  $'skills/subagent-driven-development/scripts/task-brief\t0o755' \
+  $'skills/subagent-driven-development/scripts/review-package\t0o755')"
+assert_equals "$zip_sdd_modes" "$expected_zip_sdd_modes" "zip stores Unix 0755 for SDD helper scripts"
 
 zip_times="$(python3 - "$archive" <<'PY'
 import sys
@@ -207,8 +236,10 @@ extract_archive "$tar_archive" "$tar_extracted"
 tar_archive_paths="$(list_archive "$tar_archive" | normalize_archive_paths)"
 assert_equals "$tar_archive_paths" "$archive_paths" "zip and tar.gz archives contain the same paths"
 
-tar_task_brief_mode="$(tar -tzvf "$tar_archive" skills/subagent-driven-development/scripts/task-brief | awk '{print $1}')"
-assert_equals "$tar_task_brief_mode" "-rwxr-xr-x" "tar.gz archive preserves executable script mode"
+for helper in "${sdd_helpers[@]}"; do
+  tar_helper_mode="$(tar -tzvf "$tar_archive" "$helper" | awk '{print $1}')"
+  assert_equals "$tar_helper_mode" "-rwxr-xr-x" "tar.gz archive preserves executable mode: $helper"
+done
 
 tar_metadata_times="$(python3 - "$tar_archive" <<'PY'
 import sys, tarfile


### PR DESCRIPTION
> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Grok 4.5 |
| Harness + version | Grok Build (xAI) |
| All plugins installed | none (no Cursor plugins; implementator run under Grok Build only) |
| Human partner who reviewed this diff | arimu1 |

## What problem are you trying to solve?

Real report in #2040 from @michaelholcomb-creator: Superpowers **6.2.0** installed via the **Codex marketplace cache** arrived with these SDD helpers at mode `0644` (non-executable):

- `skills/subagent-driven-development/scripts/sdd-workspace`
- `skills/subagent-driven-development/scripts/task-brief`
- `skills/subagent-driven-development/scripts/review-package`

Direct invocation fails with `Permission denied`. Running only `task-brief` / `review-package` through Bash does **not** fully recover the default-output path, because both scripts previously **directly executed** their sibling `sdd-workspace` (which still needs +x).

Upstream git already records all three as `100755`. The portal packager (`scripts/package-codex-plugin.sh`) already aims to preserve modes, but:

1. Packaging tests only checked **one** helper after Info-ZIP extract, and did not assert the **zip external attributes** that installers read.
2. Zip extractors that ignore Unix external attributes (e.g. Python `zipfile.extractall`) leave helpers at `0644` even when the archive stores `0755` — verified locally: same archive → CLI unzip = `755`, Python extract = `644`.

## What does this PR change?

1. **Packaging:** After `git archive | tar -xpf`, re-apply `chmod a+x` for every staged path that is `100755` in the packaged ref, and fail closed if any remains non-executable. Accept linked worktrees (`.git` file) as valid checkouts.
2. **SDD helpers:** `task-brief` and `review-package` invoke `sdd-workspace` via `"${BASH:-bash}"` so default OUTFILE resolution works when helpers are mode-stripped but invoked with Bash.
3. **Tests:** Assert zip extract +x **and** stored zip external attrs `0o755` for all three SDD helpers; assert tar.gz modes for all three; add mode-stripped install-path coverage in `test-sdd-workspace.sh`.

## Is this change appropriate for the core library?

Yes. This is core Codex packaging infrastructure plus the shared SDD helper scripts every harness uses. It does not add third-party dependencies, domain skills, or project-specific config.

## What alternatives did you consider?

1. **Docs-only / “run via bash” in SKILL.md only** — does not fix packaging modes, and without the sibling-bash change, `bash task-brief` still fails when it directly execs non-executable `sdd-workspace`.
2. **Change default package format to tar.gz** — marketplace/portal consumers expect zip; would not help installers that strip modes on extract.
3. **Post-install chmod hook** — we do not control the Codex marketplace install path; not available in-repo.
4. **Only strengthen packaging / only sibling bash** — either alone is incomplete (archive correctness vs install resilience). Combined approach covers both layers we control.

## Does this PR contain multiple unrelated changes?

No. All changes are for #2040: preserve/assert SDD helper execute bits in Codex packaging, and make sibling helper invocation work when installers drop +x.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs:
  - none found that address #2040 / SDD helper executable bits / zip external attributes for these three scripts
  - Searched open+closed: `2040`, `executable bits SDD`, `sdd-workspace executable`, `marketplace package executable`, `100755`, `Permission denied`
  - Adjacent packaging work (not duplicates): #1876 / #1897 (portal packager + mode preserve intent), #1994 (packaging test portability), open #2007 (zip timestamp timezone — separate; pre-existing local timestamp assertion can still fail off-UTC, unrelated to modes)
  - Adjacent SDD workspace PRs (#1949, #1952, #1938, etc.) are about plan/session scoping of artifact dirs, not file modes

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Grok Build (local shell + git packaging) | current session | Grok 4.5 | Grok 4.5 |
| macOS zsh + bash + Info-ZIP + Python 3.14 zipfile | — | — | — |

## New harness support (required if this PR adds a new harness)

N/A — does not add a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
N/A — not a new harness integration.
```

</details>

## Evaluation

- What was the initial prompt you (or your human partner) used to start the session that led to this change?
  - Implement fix for obra/superpowers#2040: Codex marketplace package drops executable bits on SDD helper scripts; target `dev`; preserve `100755` in packaging and/or fix install-path resilience.
- How many eval sessions did you run AFTER making the change?
  - Focused deterministic suites (not multi-session skill evals): `tests/claude-code/test-sdd-workspace.sh` (16/16 PASS including new mode-stripped cases); `tests/codex/test-package-codex-plugin.sh` (all new/mode assertions PASS; one pre-existing zip timestamp timezone assertion still fails on this host — same class as open #2007, not introduced by this change).
- How did outcomes change compared to before the change?
  - **Before:** package tests only checked one helper after unzip; no zip external-attr assertion for the three SDD scripts; `bash task-brief` with all three at `0644` failed when resolving default OUTFILE because it directly executed `sdd-workspace`.
  - **After:** packaging re-chmods staged `100755` paths and fails closed; tests assert `0o755` in the zip for all three helpers + extract +x + tar modes; with helpers at `0644`, `bash task-brief` / `bash review-package` still write under `.superpowers/sdd/<plan>/`.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Not a behavior-shaping skill prose change: only helper scripts (sibling invocation), packaging script, and tests. Adversarial cases: mode-stripped copies (`chmod a-x`), direct exec of stripped `sdd-workspace` (still fails as expected), Python zip extract vs CLI unzip on the produced archive.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Fixes #2040