### PR TITLE
Make reviewers grep for incomplete sweeps and missed call sites

### DIFF
--- a/skills/subagent-driven-development/re-review-prompt.md
+++ b/skills/subagent-driven-development/re-review-prompt.md
@@ -52,6 +52,14 @@ Subagent (general-purpose):
     does not block this task and does not extend the loop. A broad
     whole-branch review happens after all tasks are complete.
 
+    One check does reach outside the fix diff, because a diff cannot show an
+    absence: if a finding was "this value/string/call site is wrong" and the
+    fix changed it, grep the source tree for the OLD value and confirm no
+    other instance survives. A fix that corrected three of four occurrences
+    verdicts as ADDRESSED on the diff alone and is still broken in the
+    product. This is verifying the finding, not re-reviewing — report the
+    grep and its hits alongside that finding's verdict.
+
     ## Tests
 
     The implementer re-ran the tests covering the amended code and appended

--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -49,6 +49,19 @@ Subagent (general-purpose):
     lock ordering, a function or API contract, or shared mutable state,
     checking the call sites is the right method.
 
+    A diff cannot show an absence, so these two are always named risks worth
+    one grep each:
+    - **Incomplete sweeps.** If the diff changes a user-facing string, a
+      label, an icon, a colour, a constant, or a magic value that plausibly
+      appears elsewhere, grep the source tree for the OLD value. A sweep
+      that fixed three of four call sites looks complete in the diff and is
+      wrong in the product. Report the grep and its hits.
+    - **Missed call sites.** If the diff changes a signature, adds a
+      required parameter, or adds a case to something built per-surface or
+      per-variant, grep for the callers and confirm each was updated.
+      Sibling implementations that no longer share a builder have no
+      compiler or test to reveal the one you missed.
+
     Your review is read-only on this checkout. Do not mutate the working
     tree, the index, HEAD, or branch state in any way.
 


### PR DESCRIPTION
A diff cannot show an absence. Two failure modes get through a diff-only task review looking complete:

- **Incomplete sweeps.** A string, label, icon, colour or constant changed in three of four places. Every hunk in the diff is correct; the product is wrong.
- **Missed call sites.** A signature change, a new required parameter, or a new case in something built per-surface — where a sibling implementation was missed. When those siblings no longer share a builder, there is no compiler error and no failing test to reveal it.

Both are arguably already covered by the template's *"inspect code outside the diff only to evaluate a concrete risk you can name"*. In practice they weren't getting named, because spotting them requires already suspecting them. This adds them to the list of what counts as a named risk, so each gets one grep.

I deliberately kept the existing scoping rather than replacing it with a blanket "always grep" — the *"do not crawl the broader codebase … one focused check per named risk"* constraint is what keeps reviews cheap, and it's still intact.

`re-review-prompt.md` gets the narrower half only. It's deliberately scoped to the fix diff, but a "this value is wrong" finding is exactly where a partial fix verdicts as ADDRESSED — so verifying *that finding* means grepping for the old value. Framed as verifying the finding, not as re-reviewing.

Docs only; no scripts or behaviour touched.