### PR TITLE
fix(tests): make the Claude Code skill suite runnable and realign SDD assertions with v6.2.0

### DIFF
--- a/tests/claude-code/test-helpers.sh
+++ b/tests/claude-code/test-helpers.sh
@@ -15,8 +15,13 @@ run_claude() {
         cmd+=(--allowed-tools="$allowed_tools")
     fi
 
-    # Run Claude in headless mode with timeout
-    if timeout "$timeout" "${cmd[@]}" > "$output_file" 2>&1; then
+    # Run Claude in headless mode with timeout.
+    # stdin is redirected from /dev/null: the prompt is passed as an argument,
+    # so these calls never want piped input. Without this, an inherited
+    # non-TTY stdin that never closes (CI, or the suite run under a harness)
+    # makes `claude -p` wait on it and the whole script hits its timeout
+    # instead of reporting assertion results.
+    if timeout "$timeout" "${cmd[@]}" < /dev/null > "$output_file" 2>&1; then
         cat "$output_file"
         rm -f "$output_file"
         return 0
@@ -32,12 +37,17 @@ run_claude() {
 # Usage: assert_contains "output" "pattern" "test name"
 # Matching is case-insensitive: patterns are prose keywords, and models
 # freely capitalize skill terms ("Do Not Trust", "Spec Compliance").
+# Newlines are flattened before matching: patterns link two keywords with
+# `.*` ("implementer.*fix"), but grep is line-based, so an answer that puts
+# those keywords in different paragraphs failed despite being correct. Only
+# assert_contains flattens, and flattening can only turn a FAIL into a PASS,
+# so no currently-passing assertion changes meaning.
 assert_contains() {
     local output="$1"
     local pattern="$2"
     local test_name="${3:-test}"
 
-    if echo "$output" | grep -qi "$pattern"; then
+    if echo "$output" | tr '\n' ' ' | grep -qi "$pattern"; then
         echo "  [PASS] $test_name"
         return 0
     else

--- a/tests/claude-code/test-subagent-driven-development.sh
+++ b/tests/claude-code/test-subagent-driven-development.sh
@@ -4,7 +4,7 @@
 #
 # No drill coverage: this test asks the agent to *describe* SDD (string-
 # matches its verbal explanation against expected keywords like
-# "self-review", "skeptical", "worktree", "Step 1", "loop"). Drill scenarios
+# "self-review", "skeptical", "worktree", "Setup", "loop"). Drill scenarios
 # test behavior (real subagent dispatch, plan-following, review loops),
 # not description-recall. Kept by design.
 set -euo pipefail
@@ -83,7 +83,7 @@ else
     exit 1
 fi
 
-if assert_contains "$output" "Step 1\|beginning\|start\|Load Plan" "Read at beginning"; then
+if assert_contains "$output" "Setup\|Step 1\|beginning\|start\|Load Plan" "Read at beginning"; then
     : # pass
 else
     exit 1
@@ -136,7 +136,7 @@ output=$(run_claude "In subagent-driven-development, how does the controller pro
 Controller provides: <directly or by file>
 Implementer must read plan file: <yes or no>" "$CLAUDE_PROMPT_TIMEOUT")
 
-if assert_contains "$output" "provide.*directly\|full.*text\|paste\|include.*prompt" "Provides text directly"; then
+if assert_contains "$output" "Controller provides:.\{0,24\}file\|brief file\|brief path" "Provides the task via a brief file"; then
     : # pass
 else
     exit 1


### PR DESCRIPTION
`tests/claude-code/run-skill-tests.sh` does not currently produce a usable signal for `test-subagent-driven-development.sh`. Two harness defects and two stale assertions compound: the script blocks on stdin, is reported as a 900s timeout, and when it does run it exits at the first of three failing assertions, hiding the rest.

All four are fixed here. The changes are test-only; no skill content is touched.

## 1. `run_claude` blocks on inherited stdin

The prompt is passed as an argument, so these calls never want piped input. But when stdin is a non-TTY that never closes (CI, or the suite invoked from a script), `claude -p` waits on it. The script then hits the runner's 900s per-test cap and is reported as a timeout rather than reporting its assertions.

Redirecting stdin from `/dev/null` took `test-subagent-driven-development.sh` from a 900s timeout to a 110s complete run locally.

## 2. `assert_contains` matched line by line

Its patterns deliberately link two prose keywords with `.*` (`implementer.*fix`, `read.*plan`), but `grep` is line-based, so a correct answer that puts those keywords in different paragraphs fails.

Sampling *"what happens if a reviewer finds issues? Is it a one-time review or a loop?"* three times, the answer contained `implementer` 3x and `fix` 7-9x **every time**, yet `implementer.*fix|fix.*issues` passed only 1 of 3 runs, purely on how the model happened to wrap lines. In a failing sample, `implementer` sat on lines 7-8 and `fix` on lines 3, 5, 9, 19, 21.

Newlines are now flattened before matching. This is confined to `assert_contains`, and flattening can only turn a FAIL into a PASS, so no currently-passing assertion changes meaning. `assert_not_contains` and `assert_order` keep their line-based semantics, and `assert_count` is line-counting by definition and has no callers.

## 3. "Read at beginning" still looked for the pre-rename vocabulary

The assertion searched `Step 1|beginning|start|Load Plan`. The plan-scoped workspace work renamed that phase to **Setup**, so the model answers "during Setup" and the assertion only passed when the wording happened to also contain "start".

Sampling that prompt 5 times: `Setup` appeared **5/5**, the assertion passed **2/5**. `Setup` is added to the alternation.

## 4. "Provides text directly" asserts behaviour v6.2.0 removed

The assertion searched `provide.*directly|full.*text|paste|include.*prompt`. `SKILL.md` now routes the task through `scripts/task-brief`: the dispatch carries the brief path, exact values "appear only in the brief", and "Never make a subagent read the whole plan file."

The prompt asks for `<directly or by file>` and the answer is now consistently **"by file"** (3/3 samples), so this assertion was testing for the behaviour the rewrite deliberately replaced. It now asserts the brief-file handoff and is renamed to match.

## Verification

Two consecutive clean runs of the full runner, no external stdin redirect, exit code 0:

```
  Passed:  3
  Failed:  0
  Skipped: 0
STATUS: PASSED
```

15/15 assertions in `test-subagent-driven-development.sh`. Environment: macOS 15 (arm64), GNU coreutils 9.11 for `timeout`, Claude Code 2.1.156.

Because assertion 3 and 4 are prose-matching against a model's free-form answer, each was sampled repeatedly rather than trusted on a single green run. Sample counts are given above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)