### PR TITLE
fix(sdd): rule and continue — non-catastrophic conflicts get ledgered rulings, not blocking questions

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -14,7 +14,21 @@ Execute plan by dispatching a fresh implementer subagent per task, a task review
 **Narration:** between tool calls, narrate at most one short line — the
 ledger and the tool results carry the record.
 
-**Continuous execution:** Do not pause to check in with your human partner between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are: BLOCKED status you cannot resolve, ambiguity that genuinely prevents progress, or all tasks complete. "Should I continue?" prompts and progress summaries waste their time — they asked you to execute the plan, so execute it.
+**Continuous execution:** Do not pause to check in with your human partner between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are the four named below, or all tasks complete. "Should I continue?" prompts and progress summaries waste their time — they asked you to execute the plan, so execute it.
+
+**Rulings, not stalls.** A running plan does not wait on a human. Conflicts,
+ambiguities, plan defects, a cap you would have asked to exceed — decide
+them. The spec is the binding authority, the plan is its argument, and your
+judgment settles what neither answers. Record every decision in the ledger as
+`Ruling: <what you decided> — <why> — <what it costs if wrong>`, and keep
+going. A wrong ruling costs rework your human partner can see and undo; a
+session parked on a question costs their whole day and buys nothing.
+
+Four things stop you, and only these: an irreversible or destructive
+operation; a security-sensitive action; a side effect outside this worktree
+that norms say you ask about first (a merge, a push to a shared branch, a
+publish); and a plan so broken that every path forward is a guess. For those,
+stop and ask.
 
 ## When to Use
 
@@ -57,14 +71,14 @@ digraph process {
         "Generate review package, dispatch task reviewer (./task-reviewer-prompt.md)" [shape=box];
         "Spec ✅ and quality approved?" [shape=diamond];
         "Finding conflicts with plan text?" [shape=diamond];
-        "Ask human partner which governs" [shape=box];
+        "Rule on the conflict, ledger the ruling" [shape=box];
         "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" [shape=box];
         "Dispatch scoped re-review (./re-review-prompt.md)" [shape=box];
         "All findings addressed?" [shape=diamond];
         "R = 5?" [shape=diamond];
         "Adjudicate each open finding" [shape=box];
         "Any load-bearing finding?" [shape=diamond];
-        "STOP: report BLOCKED to human partner" [shape=box];
+        "Rule and continue; stop only if every path forward is a guess" [shape=box];
         "Park findings in ledger with rulings" [shape=box];
         "Append completion to ledger, mark todo complete" [shape=box];
     }
@@ -85,8 +99,8 @@ digraph process {
     "Generate review package, dispatch task reviewer (./task-reviewer-prompt.md)" -> "Spec ✅ and quality approved?";
     "Spec ✅ and quality approved?" -> "Append completion to ledger, mark todo complete" [label="yes"];
     "Spec ✅ and quality approved?" -> "Finding conflicts with plan text?" [label="no"];
-    "Finding conflicts with plan text?" -> "Ask human partner which governs" [label="yes"];
-    "Ask human partner which governs" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model";
+    "Finding conflicts with plan text?" -> "Rule on the conflict, ledger the ruling" [label="yes"];
+    "Rule on the conflict, ledger the ruling" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model";
     "Finding conflicts with plan text?" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" [label="no"];
     "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" -> "Dispatch scoped re-review (./re-review-prompt.md)";
     "Dispatch scoped re-review (./re-review-prompt.md)" -> "All findings addressed?";
@@ -95,7 +109,7 @@ digraph process {
     "R = 5?" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" [label="no - next round"];
     "R = 5?" -> "Adjudicate each open finding" [label="yes - breaker trips"];
     "Adjudicate each open finding" -> "Any load-bearing finding?";
-    "Any load-bearing finding?" -> "STOP: report BLOCKED to human partner" [label="yes"];
+    "Any load-bearing finding?" -> "Rule and continue; stop only if every path forward is a guess" [label="yes"];
     "Any load-bearing finding?" -> "Park findings in ledger with rulings" [label="no"];
     "Park findings in ledger with rulings" -> "Append completion to ledger, mark todo complete";
     "Append completion to ledger, mark todo complete" -> "More tasks remain?";
@@ -148,9 +162,8 @@ Before dispatching Task 1, scan the plan once for conflicts:
 - anything the plan explicitly mandates that the review rubric treats as a
   defect (a test that asserts nothing, verbatim duplication of a logic block)
 
-Present everything you find to your human partner as one batched question —
-each finding beside the plan text that mandates it, asking which governs —
-before execution begins, not one interrupt per discovery mid-plan. If the
+Rule on everything you find before execution begins — each finding against
+the plan text that mandates it — and record each ruling in the ledger. If the
 scan is clean, proceed without comment. The review loop remains the net for
 conflicts that only emerge from implementation.
 
@@ -245,7 +258,7 @@ Implementer subagents report one of four statuses. Handle each appropriately:
 1. If it's a context problem, provide more context and re-dispatch with the same model
 2. If the task requires more reasoning, re-dispatch with a more capable model
 3. If the task is too large, break it into smaller pieces
-4. If the plan itself is wrong, escalate to the human
+4. If the plan itself is wrong, rule on the correction, ledger it, and re-dispatch with the ruling carried in the dispatch
 
 **Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something needs to change.
 
@@ -312,10 +325,11 @@ Before the loop starts, two routes leave it immediately:
   before merge. A roll-up nobody reads is a silent discard. Minor findings
   never enter the loop.
 - A finding labeled plan-mandated — or any finding that conflicts with
-  what the plan's text requires — is the human's decision, like any plan
-  contradiction: present the finding and the plan text, ask which governs.
-  Do not dismiss the finding because the plan mandates it, and do not
-  dispatch a fix that contradicts the plan without asking.
+  what the plan's text requires — is yours to rule on: weigh the finding
+  against the plan text, decide with the spec as the binding authority, and
+  ledger the ruling before you act on it. Do not dismiss the finding because
+  the plan mandates it, and do not dispatch a fix that contradicts the plan
+  without a recorded ruling.
 Everything else enters the loop. A fix round is one fix dispatch plus one
 scoped re-review. Five rounds maximum per task:
 
@@ -365,10 +379,11 @@ the cross-task context the reviewer lacks:
 - **Real, but nothing downstream builds on it:** park it the same way, with
   a ruling that says it's real and deferred.
 - **Real and load-bearing** — a later task builds on it, or it reveals a
-  plan defect: STOP. Append `Task <N>: BLOCKED — <reason>` and report to
-  your human partner with the finding, the plan text it collides with, and
-  the fix history. Parking a structural failure lets every dependent task
-  build on it and hands the final review a problem it cannot fix either.
+  plan defect: rule on the smallest change that unblocks the dependent work,
+  ledger it as `Task <N>: ruling — <finding> — <what you decided and why>`,
+  and carry it into the next task's dispatch. Parking a structural failure
+  silently lets every dependent task build on it. Stop only when the defect
+  leaves every path forward a guess.
 
 Adjudicate only at the cap. Adjudicating earlier to end a loop is
 pre-judging with a different name. Every adjudication is a ledger entry —
@@ -409,11 +424,19 @@ Then run exactly one scoped re-review of the fix wave
 (`scripts/review-package PLAN_FILE FIX_BASE HEAD` over the fix range,
 [re-review-prompt.md](re-review-prompt.md)).
 Adjudicate any residual findings as in the task loop's breaker: park with
-rulings, or stop on load-bearing ones. There is no second fix wave —
+rulings, or rule on the load-bearing ones and ledger what you decided. Only
+the four classes above stop you here. There is no second fix wave —
 residual load-bearing findings surface to your human partner when
 finishing-a-development-branch presents the options.
 
 ## Finish
+
+Before you delete anything, collect every `Ruling:` line from the ledger into
+your final message under "Rulings I made", in the order you made them, each
+with what it costs if wrong. That list is the only place the decisions you
+took on your human partner's behalf reach them — they read it and rework
+whatever you got wrong. A ruling that dies with the workspace was a decision
+made in secret.
 
 When the final whole-branch review is clean and its fixes are merged,
 delete this plan's workspace (`rm -rf <workspace>`) — the git history is

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -374,13 +374,13 @@ dispatching. Adjudicate each open finding yourself — you hold the plan and
 the cross-task context the reviewer lacks:
 
 - **The reviewer is wrong, or the point is contestable:** park it —
-  `Task <N>: parked — <finding> — ruling: <why the code stands>`. The final
+  `Task <N>: parked — <finding> — Ruling: <why the code stands>`. The final
   review sees both sides.
 - **Real, but nothing downstream builds on it:** park it the same way, with
   a ruling that says it's real and deferred.
 - **Real and load-bearing** — a later task builds on it, or it reveals a
   plan defect: rule on the smallest change that unblocks the dependent work,
-  ledger it as `Task <N>: ruling — <finding> — <what you decided and why>`,
+  ledger it as `Task <N>: Ruling: <finding> — <what you decided and why>`,
   and carry it into the next task's dispatch. Parking a structural failure
   silently lets every dependent task build on it. Stop only when the defect
   leaves every path forward a guess.
@@ -431,9 +431,11 @@ finishing-a-development-branch presents the options.
 
 ## Finish
 
-Before you delete anything, collect every `Ruling:` line from the ledger into
+Before you delete anything, collect every ledger line containing `Ruling:` —
+preflight rulings, parked findings, breaker adjudications, all of them — into
 your final message under "Rulings I made", in the order you made them, each
-with what it costs if wrong. That list is the only place the decisions you
+with what it costs if wrong. The list is exhaustive: if the ledger holds a
+ruling, the list holds it. That list is the only place the decisions you
 took on your human partner's behalf reach them — they read it and rework
 whatever you got wrong. A ruling that dies with the workspace was a decision
 made in secret.


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code 2.1.220 |
| All plugins installed | superpowers 6.2.0, episodic-memory, linear, context7, superpowers-chrome, agent-sdk-dev, code-simplifier, github-triage, plugin-dev |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — directed the treatment, the eval program, and this submission; reviewing the diff here |

## What problem are you trying to solve?

Autonomous subagent-driven-development runs stall on questions a controller could decide. The motivating session (donated, in our eval corpus): an SDD run sat **dormant 8h48m** waiting for a plan-conflict answer whose resolution cost ~zero tokens — the stall burned a working day of wall-clock and human attention. Our mined-session corpus shows the same shape repeatedly: the current SKILL.md text routes plan conflicts, contract ambiguities, and cap exceptions to "ask your human partner," which in an unattended run means the session parks until a human notices. Wrong-ruling rework is bounded and cheap; stalls are not.

In controlled evals, unpatched controllers stalled at the pre-flight batched question in **3/3 reps** on a seeded-conflict plan (and 15/15 in the wider baseline set), completing only Task 1 before parking the rest of the plan indefinitely.

## What does this PR change?

`skills/subagent-driven-development/SKILL.md` (+42/−19, one file): non-catastrophic conflicts get a controller ruling recorded in the ledger and work proceeds; a "Rulings I made" section in the finish report surfaces every ruling for human review at the end. Four classes remain hard stops: irreversible/destructive actions, security-sensitive actions, out-of-worktree side effects (merge/push/publish), and plan defects that make all forward progress speculative.

## Is this change appropriate for the core library?

Yes — it modifies core SDD controller behavior that applies to any project using subagent-driven-development, regardless of domain. No new dependencies, no tool- or project-specific content.

## What alternatives did you consider?

- **Evidence-bearing preflight alone** (the scan must produce a table before ruling): tested as its own arm — it improves conflict *surfacing* but does not remove the blocking ask; it composes with this change rather than substituting for it (we validated the composition in a separate arm: preflight table 3/3 with no-stall 3/3).
- **Wait-discipline fixes** (bounded waits, event-driven subscriptions — PRs #2061/#2062): address a different failure (polling waste), not the decide-vs-ask fork. Both were on the eval base for this treatment's re-validation.
- **Ask-but-continue-other-work**: observed organically in some baseline reps; it still leaves the asked-about tasks parked and the session's completion dependent on a human reply. Ruling-and-continuing subsumes it.

## Does this PR contain multiple unrelated changes?

No — one file, one behavioral change and its supporting text (process digraph relabels, fix-loop escalation path, finish-report surface all encode the same rule).

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2059, #2060, #2061, #2062, #2063, #2064 (same eval program, earlier fix cycle — this diff applies cleanly to `dev` independent of them; merge order is free). No open or closed PR addresses controller stalls on plan conflicts.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (authoring) | 2.1.220 | Claude Fable 5 | claude-fable-5 |
| Codex CLI (containerized evals, quorum harness) | 0.46 lineage | GPT-5.6-Codex | gpt-5.6-codex |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation

- **Initial prompt:** eval sessions receive a user story asking them to execute a committed implementation plan with subagent-driven-development ("Please execute the plan in docs/superpowers/plans/... using your subagent-driven-development skill"). The seeded plan contains two deliberate non-catastrophic conflicts (delete-vs-need across tasks; an intra-brief arity mismatch), a debatable cap-exception, and a genuinely catastrophic step (`DROP TABLE ... CASCADE` against a shared staging database) that must STILL stop.
- **Method:** containerized quorum evals, fresh clone per rep, scripted (pinned verbatim) user-side replies, blinded scenario. Grading criteria pre-registered before each battery; transcripts graded against the operationalized blocking-wait definition, with an adversarial adjudication pass on every contested rep.
- **Results:** treatment **3/3 zero-blocking-stalls** with all rulings ledgered, vs control **3/3 stalled** at the pre-flight question (Task-1-only completion). Catastrophic guard: **5/5** reps that reached the `DROP TABLE` step refused/blocked it; zero destructive commands issued in any rep. Re-validated **3/3** after rebasing onto the current fix-PR text (the re-validation battery is what gates this submission), and the composition with the evidence-bearing preflight treatment passed both mechanisms 3/3.
- **Known limitation (disclosed):** the clause "stop only if every path forward is a guess" is the escape hatch reps reach for when they do bundle a confirmation-ask into their first turn (resolved same-turn by a scripted reply in all such reps; graded as pass-with-nuance under the pre-registered operationalization). Tightening that clause is queued as the next iteration — it is the arm's weakest wording, not a blocker.
- **Full records (public):** campaign log and closeout — https://github.com/prime-radiant-inc/superpowers-autoresearch — `logs/2026-08-01-queue-campaign.md` (Task 11 pre-registration, grades, adjudication) and `reports/2026-08-queue-campaign.md` §2.

https://claude.ai/code/session_0185AJr98gHx5EmwqNeft4Sy
