### PR TITLE
fix(sdd): preflight emits its checks as a ledger table and rules on what it surfaces

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -142,17 +142,24 @@ a ledger file, not only in todos.
 Read the plan once, note its context and Global Constraints, and create a
 todo per task.
 
-Before dispatching Task 1, scan the plan once for conflicts:
+Before dispatching Task 1, scan the plan once for conflicts, writing down
+what you checked as you check it:
 
 - tasks that contradict each other or the plan's Global Constraints
 - anything the plan explicitly mandates that the review rubric treats as a
   defect (a test that asserts nothing, verbatim duplication of a logic block)
 
-Present everything you find to your human partner as one batched question —
-each finding beside the plan text that mandates it, asking which governs —
-before execution begins, not one interrupt per discovery mid-plan. If the
-scan is clean, proceed without comment. The review loop remains the net for
-conflicts that only emerge from implementation.
+The scan's output is a table, not a verdict. One row for every pair of tasks
+that share a file or an interface: the two tasks, what one produces against
+what the other consumes, and what you found. One row for every task: whether
+its own text agrees with itself — the tests it specifies against the code it
+specifies, the files it creates against the files it later touches. "The scan
+is clean" without those rows is not a scan you ran.
+
+Write the table to the ledger. Rule on each conflict it surfaces — the spec
+is the binding authority, the plan is its argument — record the ruling beside
+its row, and dispatch Task 1. The review loop remains the net for conflicts
+that only emerge from implementation.
 
 ## Model Selection
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code 2.1.220 |
| All plugins installed | superpowers 6.2.0, episodic-memory, linear, context7, superpowers-chrome, agent-sdk-dev, code-simplifier, github-triage, plugin-dev |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — directed the treatment, the eval program, and this submission; reviewing the diff here (opened as DRAFT pending that review) |

## What problem are you trying to solve?

Subagent-driven-development's pre-Task-1 conflict scan is unfalsifiable as written: a controller can report "the scan is clean" having run nothing, and nothing in the ledger shows otherwise. In our mined-session corpus that is exactly what happens — plan conflicts (delete-vs-modify across tasks, contradictory interface specs) surface mid-execution instead, where they cost a blocked task or a blocking question to the human. In controlled evals on a seeded-conflict plan, unpatched controllers either missed conflicts at preflight or surfaced them without evidence of a systematic pass.

## What does this PR change?

`skills/subagent-driven-development/SKILL.md` (+13/−6, one file): the scan must emit its work as a table — one row per pair of tasks sharing a file or interface (produces vs consumes, what was found), one row per task's self-consistency — written to the ledger, with a ruling recorded beside each surfaced conflict before Task 1 dispatches. "The scan is clean" without rows is defined as not having scanned. The ruling authority line is explicit: the spec is binding, the plan is its argument.

## Is this change appropriate for the core library?

Yes — core SDD controller behavior, project-agnostic, no dependencies.

## What alternatives did you consider?

- **Keep the batched-question form** (current text): tested as control across multiple batteries; conflicts routinely go unsurfaced or unevidenced at preflight.
- **A mechanical plan-conflict scanner instead of a controller table**: we built and tested one; mechanical scanning at *final review* gets its findings dismissed ("the plan mandates it") — evidence that conflict handling must happen at plan time with the controller holding ruling authority, which is what this text does. A scanner may later complement this as tooling; it does not replace the evidence-bearing table.
- **Nothing until execution surfaces conflicts**: the review loop does catch some, but at the cost of mid-plan blocking asks — the failure mode #2077 addresses downstream. This change removes the conflicts before they can become stalls.

## Does this PR contain multiple unrelated changes?

No — one file, one mechanism.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related: #2077 edits the SAME preflight paragraph (its never-stall ruling rule). Either PR applies cleanly to `dev` alone; whichever merges second will conflict in this section. The battle-tested resolution is the composed text (validated 3/3 on both mechanisms in the same eval program), reproduced here for whichever merge needs it:

> Write the table to the ledger. Rule on everything you find before execution begins — each finding against the plan text that mandates it — and record each ruling in the ledger. If the scan is clean, proceed without comment. Rule on each conflict it surfaces — the spec is the binding authority, the plan is its argument — record the ruling beside its row, and dispatch Task 1. The review loop remains the net for conflicts that only emerge from implementation.

- Also related: #2059–#2064, #2078 (same eval program, disjoint sections). No open or closed PR adds an evidence-bearing preflight.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (authoring) | 2.1.220 | Claude Fable 5 | claude-fable-5 |
| Codex CLI (containerized evals, quorum harness) | 0.46 lineage | GPT-5.6 family (unpinned) | recorded served models: gpt-5.6-sol (X7-A battery), gpt-5.6-terra (composed x7x9 battery); subscription-selected, no --model pin |

## New harness support (required if this PR adds a new harness)

N/A.

## Evaluation

- **Method:** containerized quorum evals, fresh clone per rep, pinned scripted user replies, blinded seeded-conflict scenarios, pre-registered criteria, mechanical scoring + adversarial adjudication on contested reps.
- **Results:** original battery (cost-pathologies campaign): preflight table present with conflicts surfaced pre-dispatch in **3/3** treatment reps vs unevidenced/absent scans in control. Composed with #2077's text (the two changes bracket the same section): **3/3 preflight-table + 3/3 no-stall** — the composition is the graded configuration backing the resolution text above.
- **Disclosure:** this branch carries the standalone text rebased onto current `dev`; the rebased standalone text was graded as part of the composed arm rather than in isolation. The supporting negative result (mechanical scan findings dismissed under plan authority at final review — motivating plan-time handling) is published in the same repo.
- **Model disclosure correction (2026-08-05):** the eval lane did not pin a model; per-rep recorded served models are in the public logs (census correction entry, 2026-08-05).
- **Full records (public):** https://github.com/prime-radiant-inc/superpowers-autoresearch — `logs/2026-07-31-cost-pathologies.md` (X7-A battery), `logs/2026-08-01-queue-campaign.md` (Task 11 composed battery + adjudication), `logs/2026-08-02-backlog-campaign.md` (X10 authority-gap verdict), `reports/2026-08-backlog-campaign.md` §2.

https://claude.ai/code/session_0185AJr98gHx5EmwqNeft4Sy

