### PR TITLE
fix(sdd): guard worktree commits in prompts and review-package (#2050)

### DIFF
--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -40,6 +40,19 @@ Subagent (general-purpose):
     6. Report back
 
     Work from: [directory]
+    Expected git toplevel: [WORKTREE_TOP]
+    Expected branch: [EXPECTED_BRANCH]
+
+    ## Git worktree guard (before any git add or git commit)
+
+    Agent-tool subagents do not always inherit the controller's active worktree
+    cwd. Before every `git add` or `git commit`, verify:
+    - `git rev-parse --show-toplevel` equals [WORKTREE_TOP]
+    - `git branch --show-current` equals [EXPECTED_BRANCH]
+
+    If either check fails, STOP with status BLOCKED. Report the paths and branch
+    you see. Never commit from the main repository checkout when this task runs
+    in a worktree.
 
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -22,6 +22,29 @@ head=$3
 git rev-parse --verify --quiet "$base" >/dev/null || { echo "bad BASE: $base" >&2; exit 2; }
 git rev-parse --verify --quiet "$head" >/dev/null || { echo "bad HEAD: $head" >&2; exit 2; }
 
+# The reviewed commits must be on the branch checked out here. A subagent
+# whose cwd resolved to another working tree of this repository commits onto
+# the branch checked out there, and the shared .git makes that commit
+# resolvable from here: without these two checks the package builds, renders
+# this branch's earlier work as deletions, and reads as plausible.
+branch=$(git rev-parse --abbrev-ref HEAD)
+root=$(git rev-parse --show-toplevel)
+
+if ! git merge-base --is-ancestor "$head" HEAD; then
+  echo "HEAD $head is not reachable from $branch in $root." >&2
+  echo "It was committed from a different working tree, so BASE..HEAD would diff two unrelated histories." >&2
+  echo "Run 'git branch --contains $head' to find where the work landed, and move it onto $branch before reviewing." >&2
+  exit 3
+fi
+
+commits=$(git rev-list --count "${base}..${head}")
+if [ "$commits" -eq 0 ]; then
+  echo "no commits in ${base}..${head}: nothing to review on $branch in $root." >&2
+  echo "If the implementer reported commits, they landed on another branch or working tree." >&2
+  echo "Run 'git branch --contains <reported sha>' before treating the task as done." >&2
+  exit 3
+fi
+
 if [ $# -eq 4 ]; then
   out=$4
 else
@@ -42,5 +65,4 @@ fi
   git diff -U10 "${base}..${head}"
 } > "$out"
 
-commits=$(git rev-list --count "${base}..${head}")
 echo "wrote ${out}: ${commits} commit(s), $(wc -c < "$out" | tr -d ' ') bytes"

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -189,6 +189,62 @@ PLAN
         echo "    status: $wt_status"
     fi
 
+    # --- review-package refuses a range whose commits are not on this
+    # checkout's branch: a subagent that committed from the parent checkout
+    # otherwise produces a plausible-looking package (issue #2050) ---
+    local wt_base stray
+    ( cd "$wt" && printf 'feature\n' > feature.txt && git add feature.txt \
+        && git "${git_id[@]}" commit -qm "task 1: feature" )
+    wt_base="$(cd "$wt" && git rev-parse HEAD)"
+
+    ( cd "$repo" && printf 'task 2\n' > task2.txt && git add task2.txt \
+        && git "${git_id[@]}" commit -qm "task 2: committed in the parent checkout" )
+    stray="$(cd "$repo" && git rev-parse HEAD)"
+
+    rc=0
+    (cd "$wt" && "$SDD_SCRIPTS/review-package" plan-a.md "$wt_base" "$stray" >/dev/null 2>&1) || rc=$?
+    if [[ "$rc" -eq 3 ]]; then
+        pass "review-package rejects a HEAD committed in another working tree"
+    else
+        fail "review-package rejects a HEAD committed in another working tree"
+        echo "    exit: $rc"
+    fi
+
+    rc=0
+    (cd "$wt" && "$SDD_SCRIPTS/review-package" plan-a.md "$wt_base" HEAD >/dev/null 2>&1) || rc=$?
+    if [[ "$rc" -eq 3 ]]; then
+        pass "review-package rejects an empty range: nothing landed on this branch"
+    else
+        fail "review-package rejects an empty range: nothing landed on this branch"
+        echo "    exit: $rc"
+    fi
+
+    ( cd "$wt" && printf 'more\n' >> feature.txt && git add feature.txt \
+        && git "${git_id[@]}" commit -qm "task 2: in the worktree" )
+    rc=0
+    (cd "$wt" && "$SDD_SCRIPTS/review-package" plan-a.md "$wt_base" HEAD >/dev/null 2>&1) || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        pass "review-package accepts commits made in this worktree"
+    else
+        fail "review-package accepts commits made in this worktree"
+        echo "    exit: $rc"
+    fi
+
+    # A fix round that amends orphans the recorded FIX_BASE; the re-review
+    # package must still build.
+    local fix_base
+    fix_base="$(cd "$wt" && git rev-parse HEAD)"
+    ( cd "$wt" && printf 'amended\n' >> feature.txt && git add feature.txt \
+        && git "${git_id[@]}" commit -q --amend -m "task 2: in the worktree (amended)" )
+    rc=0
+    (cd "$wt" && "$SDD_SCRIPTS/review-package" plan-a.md "$fix_base" HEAD >/dev/null 2>&1) || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        pass "review-package accepts a FIX_BASE orphaned by an amend"
+    else
+        fail "review-package accepts a FIX_BASE orphaned by an amend"
+        echo "    exit: $rc"
+    fi
+
     echo ""
     if [[ "$FAILURES" -ne 0 ]]; then
         echo "FAILED: $FAILURES assertion(s)."


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Grok (via Cursor Agent) |
| Harness + version | Cursor IDE agent |
| All plugins installed | OSS factory workspace; superpowers skills read from upstream clone |
| Human partner who reviewed this diff | Stan Shih (stantheman0128) reviewed the complete diff before publish |

AI-assisted contribution. Evidence and eval notes below are from a real Windows 11 session.

## What problem are you trying to solve?

Issue #2050: during subagent-driven-development (SDD), a dispatched implementer ran `git add` / `git commit` from the main repository checkout instead of the isolated worktree branch. The worktree was meant to isolate the work, but the subagent cwd was not enforced, so `main` received an out-of-context commit and the review package still looked plausible.

Failure mode: implementer reports a commit SHA; `review-package` builds a diff from BASE..HEAD even when HEAD lives on another branch or working tree, so the controller reviews unrelated history as if it were the task.

## What does this PR change?

1. `implementer-prompt.md`: require verifying `git rev-parse --show-toplevel` and `git branch --show-current` before every `git add` / `git commit`; STOP with BLOCKED if they do not match the dispatched worktree.
2. `review-package`: exit 3 when HEAD is not reachable from the checked-out branch, or when BASE..HEAD is empty (commit landed elsewhere).
3. `test-sdd-workspace.sh`: four regression cases for stray-tree HEAD, empty range, happy path, and amend orphaning FIX_BASE.

Deliberately **not** changing `SKILL.md` prose (#1588 was closed for blast radius on that file; obra asked for the smallest surface, likely `implementer-prompt.md` only). The mechanical guard lives in `review-package`, which every task review already calls.

## Is this change appropriate for the core library?

Yes. Any SDD user with multiple working trees of the same repo hits this; it is not project-specific.

## What alternatives did you consider?

- Broad `SKILL.md` guardrails (rejected: #1588 closed for touching behavior-shaping prose without evals).
- Controller-only cwd checks (insufficient: subagents do not inherit cwd reliably per #2050).
- Only prompt text without `review-package` enforcement (insufficient: prompts alone did not stop the reported failure).

## Does this PR contain multiple unrelated changes?

No. All three files serve the same worktree isolation failure mode.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1588 (closed, SKILL.md blast radius), #1589 (closed, EnterWorktree bare-parent guard)

#1588/#1589 addressed adjacent git-worktree hazards. This PR targets the SDD implementer dispatch path described in #2050: subagent commits on the wrong branch/tree and review-package still packages plausible output.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Cursor Agent | current (2026-08) | Grok | via Cursor |

## Evaluation

- Initial prompt: factory scout on obra/superpowers #2050 after maintainer discussion on worktree isolation.
- Eval sessions after the change: multiple local A/B runs on Git Bash (Windows 11).
- Before: stray-commit scenarios produced exit 0 review packages with unrelated history (2 commits / hundreds of bytes of wrong diff in one repro).
- After: both stray-commit cases exit 3 with `git branch --contains` guidance; in-worktree commits and amend orphan case still exit 0.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

## Verification / Evidence

```text
# Git Bash on Windows 11, from repo root:
bash tests/claude-code/test-sdd-workspace.sh

# #2050-related cases (all PASS):
#   review-package rejects a HEAD committed in another working tree
#   review-package rejects an empty range: nothing landed on this branch
#   review-package accepts commits made in this worktree
#   review-package accepts a FIX_BASE orphaned by an amend

# Four pre-existing workspace-path assertions still fail on this Windows host
# (prints <repo-root>/.superpowers/sdd/<plan-basename>, linked worktree workspace).
# Those failures reproduce on origin/dev without this branch; not introduced here.
```

Linked-worktree live repro: commit on branch A while review runs in worktree B -> exit 3 before writing a misleading package.

## What was not tested

- Full Claude Code `EnterWorktree` dispatch on macOS/Linux (mechanism is plain git ancestry checks; platform-agnostic).
- End-to-end multi-subagent SDD session in Claude Code harness (local script regression + manual linked-worktree repro only).

Fixes #2050
