### PR TITLE
fix(brainstorm): keep visual companion alive under Cursor

### DIFF
--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -15,7 +15,8 @@
 #   --open                Auto-open the browser on the first screen (use only
 #                         after the user approves the visual companion).
 #   --foreground          Run server in the current terminal (no backgrounding).
-#   --background          Force background mode (overrides Codex auto-foreground).
+#   --background          Force background mode (overrides Codex/Cursor/Windows
+#                         auto-foreground).
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -94,8 +95,29 @@ is_windows_like_shell() {
   return 1
 }
 
+is_cursor_agent() {
+  # Cursor sets these in agent Shell tool environments. Detached/nohup children
+  # are reaped when the launching tool call exits — same failure mode as Codex.
+  if [[ -n "${CURSOR_AGENT:-}" ]]; then
+    return 0
+  fi
+  if [[ "${CURSOR_EXTENSION_HOST_ROLE:-}" == "agent-exec" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+foreground_retry_hint() {
+  echo "$SCRIPT_DIR/start-server.sh${PROJECT_DIR:+ --project-dir $PROJECT_DIR} --host $BIND_HOST --url-host $URL_HOST --foreground"
+}
+
 # Some environments reap detached/background processes. Auto-foreground when detected.
 if [[ -n "${CODEX_CI:-}" && "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "true" ]]; then
+  FOREGROUND="true"
+fi
+
+# Cursor reaps nohup children after the Shell tool call completes. Auto-foreground.
+if [[ "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "true" ]] && is_cursor_agent; then
   FOREGROUND="true"
 fi
 
@@ -168,7 +190,16 @@ fi
 
 # Foreground mode for environments that reap detached/background processes.
 if [[ "$FOREGROUND" == "true" ]]; then
-  env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs "--brainstorm-server-id=$SERVER_ID" &
+  if is_cursor_agent; then
+    # Agents must keep this process alive via an async/persistent shell
+    # (Cursor: block_until_ms: 0), then read state/server-info + curl the URL.
+    echo '{"type":"hint","message":"Cursor detected: launch with block_until_ms:0 (async shell), then read state/server-info and curl the url before sharing it"}' >&2
+  fi
+  # Tee into server.log so async harnesses can discover startup via server-info
+  # and the log file even while this shell blocks on wait.
+  touch "$LOG_FILE"
+  env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" \
+    node server.cjs "--brainstorm-server-id=$SERVER_ID" > >(tee "$LOG_FILE") 2>&1 &
   SERVER_PID=$!
   echo "$SERVER_PID" > "$PID_FILE"
   wait "$SERVER_PID"
@@ -181,6 +212,16 @@ nohup env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_
 SERVER_PID=$!
 disown "$SERVER_PID" 2>/dev/null
 echo "$SERVER_PID" > "$PID_FILE"
+
+http_ready() {
+  local url="$1"
+  local code
+  if ! command -v curl >/dev/null 2>&1; then
+    return 0
+  fi
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 1 "$url" 2>/dev/null || true)"
+  [[ "$code" == "200" ]]
+}
 
 # Wait for server-started message (check log file)
 for _ in {1..50}; do
@@ -195,10 +236,32 @@ for _ in {1..50}; do
       sleep 0.1
     done
     if [[ "$alive" != "true" ]]; then
-      echo "{\"error\": \"Server started but was killed. Retry in a persistent terminal with: $SCRIPT_DIR/start-server.sh${PROJECT_DIR:+ --project-dir $PROJECT_DIR} --host $BIND_HOST --url-host $URL_HOST --foreground\"}"
+      echo "{\"error\": \"Server started but was killed. Retry in a persistent terminal with: $(foreground_retry_hint)\"}"
       exit 1
     fi
-    grep "server-started" "$LOG_FILE" | head -1
+
+    started_line="$(grep "server-started" "$LOG_FILE" | head -1)"
+    started_url="$(printf '%s\n' "$started_line" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')"
+    if [[ -n "$started_url" ]]; then
+      ready="false"
+      for _ in {1..30}; do
+        if http_ready "$started_url"; then
+          ready="true"
+          break
+        fi
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+          break
+        fi
+        sleep 0.1
+      done
+      if [[ "$ready" != "true" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        echo "{\"error\": \"Server started but HTTP readiness check failed. Retry in a persistent terminal with: $(foreground_retry_hint)\"}"
+        exit 1
+      fi
+    fi
+
+    printf '%s\n' "$started_line"
     exit 0
   fi
   sleep 0.1

--- a/skills/brainstorming/visual-companion.md
+++ b/skills/brainstorming/visual-companion.md
@@ -74,6 +74,17 @@ On Windows, the script auto-detects and switches to foreground mode (which block
 scripts/start-server.sh --project-dir /path/to/project --open
 ```
 
+**Cursor:**
+```bash
+# Cursor reaps nohup children after the Shell tool call exits. The script
+# auto-detects CURSOR_AGENT (or CURSOR_EXTENSION_HOST_ROLE=agent-exec) and
+# switches to foreground mode. Launch with block_until_ms: 0 so the waiting
+# shell stays alive across turns, then read state/server-info and curl the
+# url (must return HTTP 200) BEFORE telling the user the companion is ready
+# or pushing the first screen.
+scripts/start-server.sh --project-dir /path/to/project --open
+```
+
 **Gemini CLI:**
 ```bash
 # Use --foreground and set is_background: true on your shell tool call
@@ -106,7 +117,7 @@ Use `--url-host` to control what hostname is printed in the returned URL JSON.
 ## The Loop
 
 1. **Check server is alive**, then **write HTML** to a new file in `screen_dir`:
-   - **Required: confirm the server is alive before referring to the URL or pushing a screen.** Check that `$STATE_DIR/server-info` exists and `$STATE_DIR/server-stopped` does not. If it has shut down, restart it with `start-server.sh` using the **same `--project-dir`** — it reuses the same port, so the user's open tab reconnects on its own (it shows a "paused" overlay while the server is down) and you don't need to send a new URL. The server auto-exits after 4 hours idle (configurable with `--idle-timeout-minutes`).
+   - **Required: confirm the server is alive before referring to the URL or pushing a screen.** Check that `$STATE_DIR/server-info` exists and `$STATE_DIR/server-stopped` does not. Then **HTTP readiness gate:** `curl` the full `url` from `server-info` (including `?key=…`) and require HTTP 200 before sharing the link or writing the first screen. Connection refused / non-200 means the process was reaped — restart with `start-server.sh` (on Cursor: async Shell + foreground) using the **same `--project-dir`**; do not ask the user to debug. A healthy restart reuses the same port, so the user's open tab reconnects on its own (it shows a "paused" overlay while the server is down) and you don't need to send a new URL. The server auto-exits after 4 hours idle (configurable with `--idle-timeout-minutes`).
    - Use semantic filenames: `platform.html`, `visual-style.html`, `layout.html`
    - **Never reuse filenames** — each screen gets a fresh file
    - Use your file-creation tool — **never use cat/heredoc** (dumps noise into terminal)

--- a/tests/brainstorm-server/start-server.test.sh
+++ b/tests/brainstorm-server/start-server.test.sh
@@ -109,6 +109,113 @@ else
 fi
 
 echo ""
+echo "--- start-server.sh Cursor auto-detect ---"
+
+rm -rf "$TEST_DIR/project"/*
+mkdir -p "$TEST_DIR/cursor-bin" "$TEST_DIR/project"
+
+cat > "$TEST_DIR/cursor-bin/node" <<'EOF'
+#!/usr/bin/env bash
+echo "FOREGROUND_MODE=true"
+exit 0
+EOF
+chmod +x "$TEST_DIR/cursor-bin/node"
+
+captured=$(
+  PATH="$TEST_DIR/cursor-bin:$PATH" \
+    CURSOR_AGENT=1 \
+    MSYSTEM="" \
+    OSTYPE=darwin23 \
+    bash "$START_SCRIPT" --project-dir "$TEST_DIR/project" 2>/dev/null || true
+)
+
+if echo "$captured" | grep -q "FOREGROUND_MODE=true"; then
+  pass "auto-foregrounds when CURSOR_AGENT is set"
+else
+  fail "auto-foregrounds when CURSOR_AGENT is set" \
+       "expected foreground node path, got: $captured"
+fi
+
+rm -rf "$TEST_DIR/project"/*
+mkdir -p "$TEST_DIR/project"
+
+captured=$(
+  PATH="$TEST_DIR/cursor-bin:$PATH" \
+    CURSOR_EXTENSION_HOST_ROLE=agent-exec \
+    MSYSTEM="" \
+    OSTYPE=darwin23 \
+    bash "$START_SCRIPT" --project-dir "$TEST_DIR/project" 2>/dev/null || true
+)
+
+if echo "$captured" | grep -q "FOREGROUND_MODE=true"; then
+  pass "auto-foregrounds when CURSOR_EXTENSION_HOST_ROLE=agent-exec"
+else
+  fail "auto-foregrounds when CURSOR_EXTENSION_HOST_ROLE=agent-exec" \
+       "expected foreground node path, got: $captured"
+fi
+
+rm -rf "$TEST_DIR/project"/*
+mkdir -p "$TEST_DIR/project"
+
+hint_err=$(
+  PATH="$TEST_DIR/cursor-bin:$PATH" \
+    CURSOR_AGENT=1 \
+    MSYSTEM="" \
+    OSTYPE=darwin23 \
+    bash "$START_SCRIPT" --project-dir "$TEST_DIR/project" 2>&1 >/dev/null || true
+)
+
+if echo "$hint_err" | grep -q '"type":"hint"'; then
+  pass "prints Cursor async-shell hint on stderr"
+else
+  fail "prints Cursor async-shell hint on stderr" \
+       "expected hint JSON on stderr, got: $hint_err"
+fi
+
+rm -rf "$TEST_DIR/project"/*
+mkdir -p "$TEST_DIR/cursor-bg-bin" "$TEST_DIR/project"
+
+cat > "$TEST_DIR/cursor-bg-bin/node" <<'EOF'
+#!/usr/bin/env bash
+echo '{"type":"server-started","port":9,"host":"127.0.0.1","url_host":"localhost","url":"http://127.0.0.1:9/?key=test","screen_dir":"/tmp","state_dir":"/tmp","idle_timeout_ms":1}'
+# Stay alive through the post-start alive window
+sleep 3
+exit 0
+EOF
+chmod +x "$TEST_DIR/cursor-bg-bin/node"
+
+cat > "$TEST_DIR/cursor-bg-bin/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "200"
+exit 0
+EOF
+chmod +x "$TEST_DIR/cursor-bg-bin/curl"
+
+captured=$(
+  PATH="$TEST_DIR/cursor-bg-bin:$PATH" \
+    CURSOR_AGENT=1 \
+    MSYSTEM="" \
+    OSTYPE=darwin23 \
+    bash "$START_SCRIPT" --project-dir "$TEST_DIR/project" --background 2>/dev/null || true
+)
+
+if echo "$captured" | grep -q '"type":"server-started"'; then
+  pass "Cursor --background overrides auto-foreground"
+else
+  fail "Cursor --background overrides auto-foreground" \
+       "expected server-started from background path, got: $captured"
+fi
+
+# Kill any leftover fake node from the background path
+pkill -f "brainstorm-start-test-$$" 2>/dev/null || true
+find "$TEST_DIR/project" -name server.pid -print 2>/dev/null | while read -r pidfile; do
+  pid="$(tr -d ' \n' < "$pidfile" 2>/dev/null || true)"
+  if [[ -n "$pid" ]]; then
+    kill "$pid" 2>/dev/null || true
+  fi
+done
+
+echo ""
 echo "--- Results: $passed passed, $failed failed ---"
 if [[ $failed -gt 0 ]]; then
   exit 1


### PR DESCRIPTION
## Problem
On Cursor, `start-server.sh`’s default `nohup`/`disown` path reports `server-started`, then the detached Node process is reaped when the Shell tool call exits. The user’s browser hits “This site can’t be reached” / connection refused on first open. Codex and Windows already auto-foreground for the same class of reaper; Cursor did not, despite a clear env signal (`CURSOR_AGENT=1`).

## Solution
Auto-detect Cursor agent environments and force foreground mode (same pattern as `CODEX_CI` / Windows). Require agents to keep the waiting shell alive (`block_until_ms: 0`), discover via `server-info`, and gate on HTTP 200 before sharing the URL. Also add an HTTP readiness check on the background path and tee foreground logs into `server.log`.

## Key changes
- Auto-foreground when `CURSOR_AGENT` is set or `CURSOR_EXTENSION_HOST_ROLE=agent-exec` (honors `--background` override)
- Cursor stderr hint pointing at async Shell + `server-info` + curl
- Background-mode HTTP readiness probe against the companion URL before returning success
- Foreground mode tees Node output to `server.log`
- Docs: Cursor launch section + readiness gate in The Loop
- Tests for Cursor auto-detect, role-based detect, hint, and `--background` override

## Risks and rollout
- Cursor agents that launch without an async/persistent shell will block on `wait` (expected; documented). Incorrect launches fail closed rather than handing the user a dead URL.
- HTTP readiness depends on `curl` when present; if `curl` is missing the check is skipped (same as prior “assume up” behavior for that edge case).

## Tests
- Extended `tests/brainstorm-server/start-server.test.sh` (8 passed)
- Manual smoke: foreground start under `CURSOR_AGENT`, `curl` of full `?key=` URL returned HTTP 200

## Stack
- Position: Standalone
- Depends on: none
- Ultimate target: `main` (obra/superpowers)

## Test plan
- [ ] Review Cursor auto-detect + `--background` override tests
- [ ] On Cursor: start companion with async Shell; confirm first browser open works without “can’t be reached”
- [ ] Confirm Claude Code / default background path still returns `server-started` and passes HTTP readiness when `curl` is available