### PR TITLE
fix(planning): the spec travels with the plan

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -140,7 +140,10 @@ a ledger file, not only in todos.
   that happens, recover from `git log`.
 
 Read the plan once, note its context and Global Constraints, and create a
-todo per task.
+todo per task. If the plan names a Spec, read that too: the spec is the
+authority the plan argues from, and conflicts inside the plan resolve
+against it. A plan with no reachable spec gets a ledger note saying so —
+rulings made without one are provisional.
 
 Before dispatching Task 1, scan the plan once for conflicts:
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -66,6 +66,9 @@ independently testable deliverable.
 
 **Tech Stack:** [Key technologies/libraries]
 
+**Spec:** [path to the spec/design doc this plan implements — the plan
+argues from the spec, so the spec travels with it; executors read both]
+
 ## Global Constraints
 
 [The spec's project-wide requirements — version floors, dependency limits,


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code 2.1.220 |
| All plugins installed | superpowers 6.2.0, episodic-memory, linear, context7, superpowers-chrome, agent-sdk-dev, code-simplifier, github-triage, plugin-dev |
| Human partner who reviewed this diff | Jesse Vincent (@obra) — directed the eval program and this submission; reviewing the diff here (opened as DRAFT pending that review) |

## What problem are you trying to solve?

Plans executed without the spec they were derived from are unauditable for cross-task coherence. In our eval program this failure recurred at every layer we instrumented: whole-branch reviewers detected 0/45 seeded cross-module inconsistencies (praising drift as design), a mechanical consistency scanner's findings were 100% dismissed at adjudication ("the plan explicitly requires both values"), and a preflight value-table with amendment authority enumerated the exact seeded conflicts and ruled them "internally explained." The root cause is structural: each side of a plan-internal contradiction is individually plan-mandated, so once the plan is the only authority in scope, incoherence is unfalsifiable — every instrument reaches the same "intentional per-module policy" conclusion.

## What does this PR change?

Two navigational additions (+7/−1 across two files):
- `skills/writing-plans/SKILL.md`: the plan header template gains a `**Spec:**` line pointing at the spec/design doc the plan implements — the spec travels with the plan.
- `skills/subagent-driven-development/SKILL.md`: the setup step reads the plan's named spec ("the spec is the authority the plan argues from; conflicts inside the plan resolve against it"), and a plan with no reachable spec gets a ledger note that rulings are provisional.

## Is this change appropriate for the core library?

Yes — core planning/execution plumbing, project-agnostic, no dependencies. The superpowers flow already produces specs (brainstorming → spec → plan); this closes the loop so execution can see them.

## What alternatives did you consider?

- **Stronger gate text instead of spec plumbing**: tested — a preflight value-table with plan-amendment authority (an arm building on #2080's evidence-bearing preflight) scored 0-1/5 on a seeded-incoherence plan when no spec was in scope. Text cannot substitute for ground truth.
- **Mechanical consistency scanning at final review**: built and tested — the scanner surfaced 14/14 candidates with file:line and adjudication dismissed 100% under plan authority. Same root cause.
- **Anti-rationalization wording alone** (naming the dismissal pattern in the skill text): under test in a running battery; interrogation of the dismissing sessions suggests the operative driver is "tests are green so the divergences must be fine," which ground-truth availability addresses directly.

## Does this PR contain multiple unrelated changes?

No — one mechanism (the spec travels with the plan), two files that each carry half of it.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related: #2077/#2078/#2080 (same eval program, disjoint sections — no textual overlap with this diff; all apply independently). No open or closed PR carries spec context into plan execution.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (authoring) | 2.1.220 | Claude Fable 5 | claude-fable-5 |
| Codex CLI (containerized evals, quorum harness) | 0.46 lineage | GPT-5.6-Codex | gpt-5.6-codex |

## New harness support (required if this PR adds a new harness)

N/A.

## Evaluation

- **Method:** containerized quorum evals; one seeded-incoherence fixture (a 6-task plan whose task briefs pin 5 deliberately incompatible shared values), run in two scenario variants: specless, and with the product spec the plan derives from present and named in the kickoff message. Pre-registered criteria; mechanical spec-resolution scoring + controller hand-reads; raw records public.
- **Results:** specless execution: 0-1/5 conflicts resolved correctly, with controllers ruling the divergences "deliberate module-local differences... internally explained" (3/3 reps). Spec present, **unmodified stock skills (the exact configuration this PR ships): 4/5, 5/5, 4/5** — detection came free; controllers enumerated all five plan/spec conflicts immediately. Gate-text arms on the same spec'd scenario reached uniform 5/5 and resolved autonomously (no human ask), which is why the SDD half of this change also anchors preflight rulings to the spec.
- **Cross-model (2026-08-05):** the mechanism replicates on claude-sonnet-5 via the quorum claude adapter, stock skills: spec present 5/5 ×2, specless 0/5 ×2 (hand-verified divergent values in fully built trees). With the gpt-5.6 batteries this covers the two largest user segments; kimi/glm cells deferred with triggers.
- **Disclosure/update:** the SDD sentence in this diff has now ALSO run verbatim as a composed battery arm (with the reviewer-template paragraph from #2089 co-present): 3/3 reps resolved 5/5 seeded plan/spec conflicts (hand-verified), post-checks 19/19, no regression from the stock-with-spec baseline. The specless ablation also completed after this PR was opened: three further specless text arms (including a counter elicited from the dismissing sessions themselves) all scored 0/5 — the spec's presence, not any wording, is the active ingredient.
- **Full records (public):** https://github.com/prime-radiant-inc/superpowers-autoresearch — `logs/2026-08-03-plan-decomposition-campaign.md` (P2-on-cp-x10 FAIL verdict, P2' three-arm battery pre-registration + verdict, dismisser-interrogation entry) and the cp-x10-spec scenario + answer key under `campaigns/cost-pathologies/scenarios/`.

https://claude.ai/code/session_0185AJr98gHx5EmwqNeft4Sy
