### PR TITLE
fix(codex): restore Superpowers after compaction

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,7 +21,7 @@
     "workflow"
   ],
   "skills": "./skills/",
-  "hooks": {},
+  "hooks": "./hooks/hooks-codex.json",
   "interface": {
     "displayName": "Superpowers",
     "shortDescription": "Planning, TDD, debugging, and delivery workflows for coding agents",

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ Superpowers is available via the [official Codex plugin marketplace](https://git
 
 - Select `Install Plugin`.
 
+#### Codex: compaction re-injection hook
+
+Codex compacts long sessions, replacing the transcript with a summary that
+drops Superpowers' skill instructions mid-run — long autonomous workflows
+(like subagent-driven-development) then drift back to harness defaults.
+Claude Code re-injects the bootstrap after every compaction; the plugin ships
+a SessionStart hook (`hooks/hooks-codex.json`) that restores the same
+behavior on Codex (0.145+). It fires only on post-compaction re-starts
+(`source: "compact"`) and is silent at normal session start.
+
+The hook installs with the plugin — no configuration needed. Codex asks you
+to review and trust it once, the first time it loads after install or update.
+Headless automation (CI, eval harnesses) must pass
+`--dangerously-bypass-hook-trust` instead, because untrusted hooks are
+skipped silently.
+
 ### Cursor
 
 - In Cursor Agent chat, install from marketplace:

--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -237,10 +237,12 @@ nesting differ per harness**.
 - Manifests: `.cursor-plugin/plugin.json` is the Shape A manifest example that
   points the harness at `./skills/` and the right `hooks-*.json`. Claude Code's
   `.claude-plugin/plugin.json` sets neither field — it auto-discovers `skills/`
-  and `hooks/hooks.json` by convention. Do **not** copy Codex's
-  `.codex-plugin/plugin.json` for Shape A: it declares an empty `hooks` object
-  specifically to suppress Codex's `hooks/hooks.json` auto-discovery, because
-  Codex surfaces skills natively and runs no session-start hook.
+  and `hooks/hooks.json` by convention. Codex's `.codex-plugin/plugin.json`
+  points `hooks` at `./hooks/hooks-codex.json` — a compaction-only hook, not a
+  bootstrap injector: Codex surfaces skills natively at session start, so its
+  hook fires only on post-compaction re-starts. The explicit pointer also
+  suppresses Codex's `hooks/hooks.json` auto-discovery fallback, which would
+  otherwise run the Claude Code hook.
 
 > **A hook *system* is not a session-start *event*.** A harness can have a
 > `hooks.json` mechanism — and even contain the literal string `SessionStart` in
@@ -785,7 +787,7 @@ Use this as the live index; when in doubt, read the files, not this table.
 | Harness | Entry point | Bootstrap mechanism | Tool mapping | Tests | Distribution |
 |---|---|---|---|---|---|
 | Claude Code | `.claude-plugin/plugin.json` + `hooks/hooks.json` | shell hook → `hooks/session-start` (`hookSpecificOutput.additionalContext`) | native `Skill` tool; no adapter file needed | `tests/hooks/` | marketplace |
-| Codex | `.codex-plugin/plugin.json` (declares empty `hooks`) | native skill discovery (no session-start hook) | `references/codex-tools.md` | `tests/codex/`, `tests/codex-plugin-sync/` | fork sync (`scripts/sync-to-codex-plugin.sh`) |
+| Codex | `.codex-plugin/plugin.json` + `hooks/hooks-codex.json` | native skill discovery at startup; shell hook → `hooks/session-start-codex` re-injects after compaction only | `references/codex-tools.md` | `tests/codex/`, `tests/codex-plugin-sync/` | fork sync (`scripts/sync-to-codex-plugin.sh`) |
 | Cursor | `.cursor-plugin/plugin.json` + `hooks/hooks-cursor.json` | shell hook → `hooks/session-start` (`additional_context`) | none needed (Claude Code–compatible tool surface) | `tests/hooks/` | hand-authored |
 | Copilot CLI | (shares Claude Code hook path; `COPILOT_CLI` env) | shell hook → `hooks/session-start` (`additionalContext`) | none needed (Claude Code–compatible tool surface) | `tests/hooks/` | — |
 | Gemini CLI | `gemini-extension.json` + `GEMINI.md` | instructions file `@`-includes bootstrap + mapping | `references/gemini-tools.md` | — | `gemini extensions install` |

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start-codex",
+            "async": false,
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-start-codex
+++ b/hooks/session-start-codex
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Codex SessionStart hook for the superpowers plugin.
+#
+# Codex re-fires SessionStart with source:"compact" after every context
+# compaction (verified on codex-cli 0.145.0). Compaction replaces the live
+# context with a summary, which sheds the using-superpowers bootstrap and any
+# active skill's instructions — the measured cause of mid-session dispatch
+# drift in long multi-agent runs. This hook re-injects the bootstrap at
+# exactly that moment, restoring the same re-injection Claude Code performs
+# via its "startup|clear|compact" SessionStart matcher.
+#
+# On source:"startup" it emits nothing: the native Codex plugin path owns
+# session-start injection, and duplicating it here would recreate the
+# redundancy that led to the original session-start-codex hook's removal.
+#
+# Codex injects raw hook stdout into the model's context (verified with
+# sentinel probes), so output is plain text — not the JSON envelopes other
+# harnesses require of hooks/session-start.
+#
+# A hook failure must never break a session: every path fails open to empty
+# output and exit 0.
+
+set -u
+
+payload="$(cat 2>/dev/null || true)"
+
+# Act only on post-compaction re-fires. Tolerate arbitrary whitespace around
+# the JSON colon; anything unparseable falls through to a silent no-op.
+if ! printf '%s' "$payload" | grep -qE '"source"[[:space:]]*:[[:space:]]*"compact"'; then
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+using_superpowers_content="$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>/dev/null)" || using_superpowers_content=""
+if [ -z "$using_superpowers_content" ]; then
+    exit 0
+fi
+
+# printf instead of heredocs throughout: heredocs hang on bash 5.3+.
+# See: https://github.com/obra/superpowers/issues/571
+printf '%s\n' "<EXTREMELY_IMPORTANT>"
+printf '%s\n\n' "You have superpowers."
+printf '%s\n\n' "**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**"
+printf '%s\n' "$using_superpowers_content"
+printf '%s\n\n' "</EXTREMELY_IMPORTANT>"
+printf '%s\n' "<CONTEXT_RESTORED>"
+printf '%s\n' "Your context was just summarized (compacted). The summary preserves your progress but not your working instructions — the files are authoritative."
+printf '%s\n' ""
+printf '%s\n' "Before your next tool call:"
+printf '%s\n' "- Re-read the SKILL.md of any skill you are mid-way through executing. If you are executing subagent-driven-development, re-read skills/subagent-driven-development/SKILL.md."
+printf '%s\n' "- On Codex, also re-read skills/using-superpowers/references/codex-tools.md and follow its dispatch rules on every spawn_agent call."
+printf '%s\n' "</CONTEXT_RESTORED>"
+
+exit 0

--- a/scripts/package-codex-plugin.sh
+++ b/scripts/package-codex-plugin.sh
@@ -40,8 +40,9 @@ Options:
   -h, --help               Show this help.
 
 The archive is rootless: .codex-plugin/, assets/, skills/, README.md, LICENSE,
-and CODE_OF_CONDUCT.md sit at the archive root. Source-only repo files, hooks, tests,
-docs, and other harness manifests are intentionally not shipped.
+CODE_OF_CONDUCT.md, and the Codex SessionStart hook (hooks/hooks-codex.json plus
+its two scripts) sit at the archive root. Source-only repo files, other-harness
+hooks, tests, docs, and other harness manifests are intentionally not shipped.
 EOF
 }
 
@@ -238,6 +239,9 @@ git -C "$REPO_ROOT" -c tar.umask=0022 archive --format=tar "$REF" -- \
   LICENSE \
   README.md \
   assets \
+  hooks/hooks-codex.json \
+  hooks/run-hook.cmd \
+  hooks/session-start-codex \
   skills \
   | tar -xpf - -C "$STAGE"
 
@@ -333,7 +337,7 @@ esac
 
 unexpected_paths="$(
   printf '%s\n' "$archive_paths" |
-    grep -E '(^superpowers/|^\.agents/|^hooks/|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)' || true
+    grep -E '(^superpowers/|^\.agents/|^hooks/hooks\.json$|^hooks/hooks-cursor\.json$|^hooks/session-start$|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)' || true
 )"
 if [[ -n "$unexpected_paths" ]]; then
   printf '%s\n' "$unexpected_paths" | sed 's/^/  /' >&2

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -78,6 +78,22 @@ default_subagent_model = "<a mid-tier model from your spawn allowlist>"
 default_subagent_reasoning_effort = "medium"
 ```
 
+## Compaction sheds these instructions
+
+Context compaction replaces your transcript with a summary that keeps
+your progress but not your working instructions — the first
+post-compaction dispatch is where routing drift starts, and once one
+bare spawn lands, the broken pattern becomes its own precedent. The
+plugin ships a compaction re-injection hook (`hooks/hooks-codex.json`,
+Codex 0.145+) that restores the bootstrap after every compaction; it
+needs one-time trust approval, so if you never see a
+`<CONTEXT_RESTORED>` block after a compaction, tell your human partner
+the hook may be untrusted or unsupported on this version. Without it,
+re-ground yourself: when a summary appears in your context, re-read
+this file and the SKILL.md of the skill you are mid-way through
+executing before your next dispatch, and trust the ledger over your
+summarized memory of what happened.
+
 ## Environment Detection
 
 Skills that create worktrees or finish branches should detect their

--- a/tests/codex/test-marketplace-manifest.sh
+++ b/tests/codex/test-marketplace-manifest.sh
@@ -52,25 +52,37 @@ if not plugin_manifest.exists():
 manifest = json.loads(plugin_manifest.read_text(encoding="utf-8"))
 assert_equal(manifest.get("name"), plugin.get("name"), "plugin manifest name")
 
-# Codex auto-discovers a plugin's hooks/hooks.json whenever the Codex manifest
-# has no `hooks` field: load_plugin_hooks falls back to a hardcoded
-# DEFAULT_HOOKS_CONFIG_FILE = "hooks/hooks.json" and registers it. That file is
-# the Claude Code SessionStart hook, it is tracked in this repo, and this
-# marketplace installs the whole repo root (source url "./"), so on Codex the
-# fallback re-registers the SessionStart hook and its install-time trust prompt.
-# Declaring an empty inline hooks object ({}) parses as an empty inline hook set
-# and suppresses the auto-discovery. An absent field, an empty array ([]), and
-# an empty inline list all collapse back to the fallback, so the value must be
-# exactly an empty object.
+# The Codex manifest must declare its hooks explicitly. An absent field makes
+# load_plugin_hooks fall back to a hardcoded DEFAULT_HOOKS_CONFIG_FILE =
+# "hooks/hooks.json" — the Claude Code SessionStart hook, which injects the
+# bootstrap at startup and must not run on Codex. The explicit pointer both
+# registers the Codex compaction re-injection hook and overrides that fallback.
 hooks_config = repo_root / "hooks" / "hooks.json"
 if not hooks_config.exists():
     raise AssertionError("hooks/hooks.json must exist (Claude Code SessionStart hook)")
 
 assert_equal(
     manifest.get("hooks"),
-    {},
-    "Codex manifest must declare empty hooks {} to suppress hooks/hooks.json auto-discovery",
+    "./hooks/hooks-codex.json",
+    "Codex manifest must point hooks at the Codex hook config (an absent field "
+    "falls back to auto-discovering the Claude Code hooks/hooks.json)",
 )
+
+codex_hooks_path = repo_root / "hooks" / "hooks-codex.json"
+if not codex_hooks_path.exists():
+    raise AssertionError("hooks/hooks-codex.json must exist (Codex manifest points at it)")
+
+codex_hooks = json.loads(codex_hooks_path.read_text(encoding="utf-8"))
+session_start = codex_hooks["hooks"]["SessionStart"]
+assert_equal(len(session_start), 1, "Codex SessionStart hook group count")
+assert_equal(session_start[0].get("matcher"), "compact", "Codex hook matcher")
+entry = session_start[0]["hooks"][0]
+assert_equal(entry.get("type"), "command", "Codex hook type")
+command = entry.get("command", "")
+if "${PLUGIN_ROOT}" not in command or not command.endswith("session-start-codex"):
+    raise AssertionError(
+        f"Codex hook command must run session-start-codex via ${{PLUGIN_ROOT}}: {command!r}"
+    )
 
 print("Codex marketplace manifest looks good")
 PY

--- a/tests/codex/test-package-codex-plugin.sh
+++ b/tests/codex/test-package-codex-plugin.sh
@@ -141,7 +141,7 @@ tar_extracted="$TEST_ROOT/tar-extracted"
 write_metadata_fixture "$metadata_source"
 
 source_hooks="$(python3 -c 'import json; print(json.load(open("'"$REPO_ROOT"'/.codex-plugin/plugin.json")).get("hooks"))')"
-assert_equals "$source_hooks" "{}" "source Codex manifest suppresses local hook auto-discovery"
+assert_equals "$source_hooks" "./hooks/hooks-codex.json" "source Codex manifest declares the Codex hook config"
 
 if output="$("$SCRIPT_UNDER_TEST" --allow-dirty --metadata-source "$metadata_source" --output "$archive" 2>&1)"; then
   pass "package script exits successfully"
@@ -163,10 +163,13 @@ assert_contains "$output" "SHA-256:" "reports archive checksum"
 extract_archive "$archive" "$extracted"
 
 archive_paths="$(list_archive "$archive" | normalize_archive_paths)"
-unexpected_pattern='(^superpowers/|^\.agents/|^hooks/|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)'
+unexpected_pattern='(^superpowers/|^\.agents/|^hooks/hooks\.json$|^hooks/hooks-cursor\.json$|^hooks/session-start$|package\.json$|^\.git|^\.pytest_cache|^\.ruff_cache|^scripts/|^tests/|^docs/|^evals/|^lib/|^\.claude|^\.cursor|^\.kimi|^\.opencode|^\.pi|^AGENTS\.md$|^CLAUDE\.md$|^GEMINI\.md$|^RELEASE-NOTES\.md$|^CHANGELOG\.md$)'
 assert_not_matches "$archive_paths" "$unexpected_pattern" "archive excludes source-only paths"
 assert_contains "$archive_paths" ".codex-plugin/plugin.json" "archive includes Codex manifest"
 assert_contains "$archive_paths" "skills/brainstorming/SKILL.md" "archive includes skills"
+assert_contains "$archive_paths" "hooks/hooks-codex.json" "archive includes Codex hook config"
+assert_contains "$archive_paths" "hooks/session-start-codex" "archive includes Codex hook script"
+assert_contains "$archive_paths" "hooks/run-hook.cmd" "archive includes hook runner"
 assert_contains "$archive_paths" "skills/brainstorming/agents/openai.yaml" "archive includes OpenAI skill metadata"
 assert_contains "$archive_paths" "assets/app-icon.png" "archive includes app icon"
 assert_contains "$archive_paths" "assets/superpowers-small.svg" "archive includes composer icon"

--- a/tests/hooks/test-session-start-codex.sh
+++ b/tests/hooks/test-session-start-codex.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK_UNDER_TEST="$REPO_ROOT/hooks/session-start-codex"
+CONFIG_UNDER_TEST="$REPO_ROOT/hooks/hooks-codex.json"
+
+FAILURES=0
+
+pass() {
+    echo "  [PASS] $1"
+}
+
+fail() {
+    echo "  [FAIL] $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+# run_hook <stdin-payload> — echoes hook stdout; fails the calling test on
+# non-zero exit. env -i mirrors the codex hook executor's clean environment.
+run_hook() {
+    printf '%s' "$1" | env -i PATH="${PATH:-}" bash "$HOOK_UNDER_TEST"
+}
+
+echo "Codex SessionStart hook tests"
+
+startup_payload='{"session_id":"s","hook_event_name":"SessionStart","model":"gpt-5.6-terra","source":"startup"}'
+if output="$(run_hook "$startup_payload")" && [ -z "$output" ]; then
+    pass "source=startup emits nothing and exits 0"
+else
+    fail "source=startup emits nothing and exits 0"
+    printf '%s\n' "$output" | head -3 | sed 's/^/    /'
+fi
+
+compact_payload='{"session_id":"s","hook_event_name":"SessionStart","model":"gpt-5.6-terra","source":"compact"}'
+if output="$(run_hook "$compact_payload")"; then
+    ok=1
+    for needle in \
+        "<EXTREMELY_IMPORTANT>" \
+        "You have superpowers." \
+        "name: using-superpowers" \
+        "<CONTEXT_RESTORED>" \
+        "subagent-driven-development/SKILL.md" \
+        "references/codex-tools.md"; do
+        if [[ "$output" != *"$needle"* ]]; then
+            ok=0
+            echo "    missing: $needle"
+        fi
+    done
+    if [ "$ok" -eq 1 ]; then
+        pass "source=compact emits bootstrap plus re-read addendum"
+    else
+        fail "source=compact emits bootstrap plus re-read addendum"
+    fi
+else
+    fail "source=compact emits bootstrap plus re-read addendum (hook exited non-zero)"
+fi
+
+# Whitespace-tolerant source matching (serializers vary).
+spaced_payload='{"hook_event_name":"SessionStart", "source" : "compact"}'
+if output="$(run_hook "$spaced_payload")" && [[ "$output" == *"<CONTEXT_RESTORED>"* ]]; then
+    pass "whitespace around the source key still triggers injection"
+else
+    fail "whitespace around the source key still triggers injection"
+fi
+
+if output="$(printf '' | env -i PATH="${PATH:-}" bash "$HOOK_UNDER_TEST")" && [ -z "$output" ]; then
+    pass "empty stdin fails open to no output, exit 0"
+else
+    fail "empty stdin fails open to no output, exit 0"
+fi
+
+if output="$(run_hook 'not json at all {{{')" && [ -z "$output" ]; then
+    pass "garbage stdin fails open to no output, exit 0"
+else
+    fail "garbage stdin fails open to no output, exit 0"
+fi
+
+# A compact mention inside some other field must not trigger injection.
+decoy_payload='{"hook_event_name":"SessionStart","source":"startup","cwd":"/tmp/compact"}'
+if output="$(run_hook "$decoy_payload")" && [ -z "$output" ]; then
+    pass "compact appearing outside the source field does not trigger"
+else
+    fail "compact appearing outside the source field does not trigger"
+fi
+
+if node -e '
+const config = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const group = config.hooks.SessionStart[0];
+if (group.matcher !== "compact") {
+  console.error(`hook matcher is ${JSON.stringify(group.matcher)}, expected "compact"`);
+  process.exit(1);
+}
+const entry = group.hooks[0];
+if (entry.type !== "command") {
+  console.error(`hook type is ${JSON.stringify(entry.type)}, expected "command"`);
+  process.exit(1);
+}
+if (!entry.command.includes("${PLUGIN_ROOT}") || !/run-hook\.cmd" session-start-codex$/.test(entry.command)) {
+  console.error(`unexpected command shape: ${entry.command}`);
+  process.exit(1);
+}
+' "$CONFIG_UNDER_TEST"; then
+    pass "hooks-codex.json runs session-start-codex via \${PLUGIN_ROOT} on compact"
+else
+    fail "hooks-codex.json runs session-start-codex via \${PLUGIN_ROOT} on compact"
+fi
+
+if [[ "$FAILURES" -gt 0 ]]; then
+    echo "STATUS: FAILED ($FAILURES failure(s))"
+    exit 1
+fi
+
+echo "STATUS: PASSED"


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Anthropic Claude Fable 5 (`claude-fable-5`) — this rebuild, its validation, and this body. The original July branch was authored by Claude Fable 5 with stack preparation by OpenAI `gpt-5.6-sol` (see #2035). |
| Harness + version | Claude Code 2.1.221 |
| All plugins installed | superpowers (local dev), superpowers-chrome, primeradiant-ops, episodic-memory, decision-log, elements-of-style, iterative-development, cloud-build, linear, roborev, gh-stack, find-skills |
| Human partner who reviewed this diff | Drew Ritter — reviewed the original combined diff on 2026-07-24, and reviewed this pared, dev-rebased diff on 2026-08-04 before push. The pare-to-hook-only scope was his explicit direction. |

## What problem are you trying to solve?

Codex compacts long sessions: the transcript is replaced by a summary that keeps progress but sheds the Superpowers bootstrap and any active skill's instructions. The first post-compaction dispatch is where drift starts, and once one bare spawn lands, the broken pattern becomes its own precedent. This was the measured July failure mode in long SDD runs.

The recently merged stack (#2059–#2062, #2077, #2078, #2080) makes this *more* pressing, not less: the bounded-wait discipline, the rulings contract, the no-subagents contract, and the model-routing rule all live in SKILL.md / codex-tools.md prose — exactly the text compaction erases. The merged stack's mitigation is state-side (the ledger survives compaction); nothing on dev restores the *instructions* side.

Codex discovers skills natively at normal startup, so an unconditional startup injector would duplicate instructions (the reason the old startup hook was removed). The missing lifecycle point is specifically `SessionStart` with `source: "compact"`. Fresh corroboration while validating the merged stack: on codex-cli 0.146.0, `codex exec` sessions receive **no** hook injection at startup at all — skills arrive via the agent's own native reads — so the compact re-fire is genuinely the one unowned lifecycle point.

## What does this PR change?

A plugin-provided Codex `SessionStart` hook that is silent at startup, re-injects the bootstrap plus a focused re-read addendum after compaction, and fails open (malformed payload, missing files, any error → empty output, exit 0):

- `hooks/hooks-codex.json` — compact-only matcher, runs `session-start-codex` via `${PLUGIN_ROOT}`
- `hooks/session-start-codex` — the injector script
- `.codex-plugin/plugin.json` — `hooks: {}` → `"./hooks/hooks-codex.json"`
- `scripts/package-codex-plugin.sh` — ships the hook in the portal archives
- `skills/using-superpowers/references/codex-tools.md` — a "Compaction sheds these instructions" section written against the current (post-#2062) file: hook trust behavior, and the no-hook fallback (re-read this file + the active SKILL.md when a summary appears; trust the ledger)
- `README.md`, `docs/porting-to-a-new-harness.md` — install/trust documentation, incl. `--dangerously-bypass-hook-trust` for headless rigs
- Tests: `tests/hooks/test-session-start-codex.sh` (lifecycle: silent on startup, injects on compact, fails open), plus updated manifest and package-archive assertions

## Is this change appropriate for the core library?

Yes. Codex is an existing first-class harness, and preserving active Superpowers instructions across its compaction lifecycle is core integration infrastructure. Zero dependencies, silent during normal startup so native skill discovery continues to own that path.

## What alternatives did you consider?

- **Ledger/prose discipline only (current dev).** The ledger preserves state, not instructions; the July drift was instruction-side (dispatch tuples degrading post-compaction). Kept as the complementary half, not the whole fix.
- **User-level `~/.codex/hooks.json`.** Tested in July: manual, anonymous in the hooks UI, not delivered with the plugin.
- **Unconditional startup hook.** Rejected — duplicates native startup discovery; recreates the redundancy that got the old hook removed.
- **Inject on every SessionStart source.** Rejected — the measured gap is post-compaction only; both the manifest matcher and the script gate on `compact`.
- **Standalone plugin.** Rejected — repairs lifecycle behavior for an already-supported core harness.

## Does this PR contain multiple unrelated changes?

No. Hook, manifest wiring, packaging, docs, and tests are one delivery path. This is deliberately narrower than the July revision of this work: the dispatch-hints layer it used to ride with (#2036) is superseded by the merged #2059–#2062/#2077/#2078/#2080 stack and has been dropped — 5 files and ~50 lines removed relative to the old #2035 diff.

## Existing PRs / prior art

- **#2035** — this PR's previous incarnation (hook subset, stacked on #2036). Auto-closed when its stacked base branch was deleted; this PR is its continuation, rebuilt on current dev.
- **#2036** — the routing/hints lower half; closed as superseded by the merged stack (see closing comment there for the field evidence).
- **#1863 / #1867** — Windows `run-hook.cmd` bash discovery; related but explicitly out of scope here (one problem per PR). On Windows without bash the hook is a silent no-op, consistent with fail-open.
- No other open or closed PR addresses post-compaction re-injection on Codex.

## Evidence and testing

- **July stress validation** (12.4h Codex SDD run, sol@max, 153KB plan, 67 children, 18 compactions): 18/18 hook fires, 66/66 post-compaction dispatch tuples correct. Without the hook, post-compaction dispatch drift was the reproducible failure mode across the July session corpus.
- **Compact re-fire verified on codex-cli 0.146.0** (2026-08-04, after this PR opened): a live-config exec session forced through two compactions (`model_context_window` override) produced 2/2 `context_compacted` → hook fire → `CONTEXT_RESTORED` + bootstrap re-injection, through the normal trust path. Also previously verified on 0.145.0. The hook fails open, so a future Codex that stops re-firing degrades to a silent no-op, never breakage.
- **Environment note:** on 0.146.0, exec sessions receive no plugin hook injection at startup (native skill reads only) — independently observed during the merged-stack validation (see the validation comments on #2059–#2062/#2077/#2078/#2080).
- **This branch, on current dev:** all four touched test suites pass — `tests/hooks/test-session-start-codex.sh`, `tests/hooks/test-session-start.sh`, `tests/codex/test-marketplace-manifest.sh`, `tests/codex/test-package-codex-plugin.sh`.
