### PR TITLE
docs: add README table of contents and move Community section higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 Superpowers is a complete software development methodology for your coding agents, built on top of a set of composable skills and some initial instructions that make sure your agent uses them.
 
+## Table of Contents
+
+- [Quickstart](#quickstart)
+- [How it works](#how-it-works)
+- [Commercial Services](#commercial-services)
+- [Installation](#installation)
+  - [Claude Code](#claude-code)
+  - [Antigravity](#antigravity)
+  - [Codex App](#codex-app)
+  - [Codex CLI](#codex-cli)
+  - [Cursor](#cursor)
+  - [Factory Droid](#factory-droid)
+  - [Gemini CLI](#gemini-cli)
+  - [GitHub Copilot CLI](#github-copilot-cli)
+  - [Kimi Code](#kimi-code)
+  - [OpenCode](#opencode)
+  - [Pi](#pi)
+- [The Basic Workflow](#the-basic-workflow)
+- [Community](#community)
+- [What's Inside](#whats-inside)
+- [Philosophy](#philosophy)
+- [Contributing](#contributing)
+- [Updating](#updating)
+- [License](#license)
+- [Visual companion telemetry](#visual-companion-telemetry)
 
 ## Quickstart
 
@@ -211,6 +236,14 @@ The Pi package loads the Superpowers skills and a small extension that injects t
 
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
 
+## Community
+
+Superpowers is built by [Jesse Vincent](https://blog.fsck.com) and the rest of the folks at [Prime Radiant](https://primeradiant.com).
+
+- **Discord**: [Join us](https://discord.gg/35wsABTejz) for community support, questions, and sharing what you're building with Superpowers
+- **Issues**: https://github.com/obra/superpowers/issues
+- **Release announcements**: [Sign up](https://primeradiant.com/superpowers/) to get notified about new versions
+
 ## What's Inside
 
 ### Skills Library
@@ -271,11 +304,3 @@ MIT License - see LICENSE file for details
 ## Visual companion telemetry
 
 Because skills and plugins don't provide any feedback to creators, we have no idea how many of you are using Superpowers. By default, the Prime Radiant logo on brainstorming's optional visual companion feature is loaded from our website. It includes the version of Superpowers in use. It does not include any details about your project, prompt, or coding agent. We don't see your clicks or anything about what you're building. This helps us have a rough idea of how many folks are using Superpowers and which version of Superpowers they're using. It's 100% optional. To disable this, set the environment variable `SUPERPOWERS_DISABLE_TELEMETRY` to any true value. Superpowers also honors Claude Code's `DISABLE_TELEMETRY` and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` opt-outs.
-
-## Community
-
-Superpowers is built by [Jesse Vincent](https://blog.fsck.com) and the rest of the folks at [Prime Radiant](https://primeradiant.com).
-
-- **Discord**: [Join us](https://discord.gg/35wsABTejz) for community support, questions, and sharing what you're building with Superpowers
-- **Issues**: https://github.com/obra/superpowers/issues
-- **Release announcements**: [Sign up](https://primeradiant.com/superpowers/) to get notified about new versions


### PR DESCRIPTION
> This PR targets the `dev` branch.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 5 (`claude-opus-5`) |
| Harness + version | Claude Code 2.1.181 (desktop app) |
| All plugins installed | `superpowers@claude-plugins-official` v6.0.2, `superpowers@superpowers-marketplace` v6.0.2 |
| Human partner who reviewed this diff | @kattni |

## What problem are you trying to solve?

We want to direct community members to Discord for support, and the Community
section — Discord, issue tracker, release announcements — was the last section
in the README, sitting below License and the telemetry note. A user with a
question had to scroll past the entire file to find out that a support channel
exists at all. That is the opposite of prominent, and it means support traffic
that Discord could absorb doesn't get there.

Moving Community higher is what surfaced the second problem. Once we started
reasoning about where in the reading order a section should sit to be findable,
it was clear that no position solves this on its own: the README is ~300 lines
across 13 top-level sections, and a reader still has to scroll the whole file to
learn what is in it. Promoting one section just trades away whatever it
displaces. The Quickstart line already hand-maintains anchor links to the 11
install subsections — evidence that the navigation need was real and had already
been solved once, locally, for the one section where it hurt most. Everything
after Installation had no equivalent.

## What does this PR change?

Moves the existing Community section from the bottom of the file to directly
after The Basic Workflow, and adds a Table of Contents after the intro
paragraph listing every top-level section in document order, with the 11
harness install subsections nested under Installation. No prose is reworded;
the Community section's content is byte-identical to what it was.

## Is this change appropriate for the core library?

Yes. This is the project's own README, not a skill or project-specific
configuration. It adds no dependency, promotes no third-party service, and does
not touch any behavior-shaping content. Every Superpowers user who lands on the
repo page sees this file.

## What alternatives did you consider?

- **A generated/automated ToC** (doctoc, a CI step, an HTML comment marker):
  rejected — Superpowers is zero-dependency by design, and a tool that rewrites
  the README on commit is a new dependency plus a new failure mode for a file
  that changes a few times a release.
- **Top-level sections only, no nesting**: shorter, but drops the 11 harness
  links that are the most-used entry point in the file. The Quickstart line
  would remain the only way to reach them.
- **Replacing the Quickstart anchor line with the ToC**: rejected — Quickstart's
  inline list is a deliberate above-the-fold "pick your harness" prompt with
  different framing than a bare navigation list. Removing it would be a content
  change, not a navigation one.
- **Moving Community without adding a ToC** — the original plan. Rejected once
  we saw it only relocates the problem: any section promoted to the top pushes
  another one down, and the reader still cannot see what the document contains.
- **Adding a ToC without moving Community**: the ToC alone does make Community
  reachable in one click. We moved it anyway because the goal is prominence for
  someone who hasn't yet thought to look for a support channel, and the sections
  it was buried under (License, telemetry) are reference material a reader
  consults deliberately rather than stumbles into.

## Does this PR contain multiple unrelated changes?

No — the two changes are causally linked, not merely adjacent. Making Community
prominent was the goal; attempting it is what revealed that the README had no
navigation at all, and the ToC is what makes the promotion hold up instead of
just displacing a different section. The ToC also has to list Community in its
new position, so landing them separately would mean shipping a ToC that
documents an ordering we were about to change.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1293 (MERGED, "docs: add README quickstart install links" — added
  the Quickstart anchor line this ToC complements; no overlap), #718 (CLOSED,
  "Revise README for improved content and organization")

#718 was closed by @obra for being an unreviewed AI-generated submission:
"enhance clarity and structure" with no statement of what was unclear and every
template section left blank. This PR is different in kind — it names one
concrete navigation problem, changes no prose, and the complete diff was
reviewed by a human before submission. It is also far narrower: 33 added lines,
8 moved, nothing reworded.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code (desktop app) | 2.1.181 | Claude Opus 5 | `claude-opus-5` |

Testing for this change is rendering verification: every anchor in the ToC
resolves to a heading in the same file, and the nested install anchors match
the ones the existing Quickstart line already uses.

## New harness support (required if this PR adds a new harness)

N/A — this PR adds no harness support. It is a documentation-only change to
README.md and touches no skill, hook, or integration code.

## Evaluation

- **Initial prompt**: the session began from the goal of making the Community
  section more prominent to route support questions to Discord. The prompt that
  produced this diff was "Generate a table of contents for the README. Place it
  after the first section, before `## Quickstart`."
- **Eval sessions run after the change**: none. This change contains no skill
  content and cannot affect agent behavior — it modifies README.md only, which
  is not loaded into any agent's context by any hook or bootstrap. Running the
  drill harness against it would measure nothing.
- **Outcome change**: not applicable for the reason above. The verification
  performed was structural: confirming each generated anchor matches a real
  heading.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing — **N/A, not a skills change.**
- [x] This change was tested adversarially, not just on the happy path — anchors
      were checked against the actual heading text, including the two that
      GitHub slugifies non-obviously (`What's Inside` → `#whats-inside`).
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) — no skill file is touched by
      this diff.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
