### PR TITLE
fix(hooks): run-hook.cmd heredoc deadlocks all hooks on macOS (Homebrew bash >= 5.1)

### DIFF
--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -745,8 +745,10 @@ single file that's valid as both a Windows batch script and a Unix shell script.
 On Windows, `cmd.exe` runs the batch portion, which locates `bash` (Git for
 Windows, then `bash` on PATH) and runs the named hook script; if no bash is
 found it exits cleanly so the harness still works, just without injection. On
-Unix, the leading `:` makes the batch block a no-op and the shell runs the
-script directly.
+Unix, the shell executes the leading `:;` lines and `exec`s the hook script
+before reaching the batch block (cmd.exe skips those lines as labels).
+Heredocs are banned throughout hooks/ — see issue #571 and the fence test
+`tests/hooks/test-no-heredocs-in-hooks.sh`.
 
 Two rules this enforces, which you must respect:
 

--- a/docs/windows/polyglot-hooks.md
+++ b/docs/windows/polyglot-hooks.md
@@ -65,9 +65,9 @@ The path is quoted because `${CLAUDE_PLUGIN_ROOT}` may contain spaces.
 
 ## How `run-hook.cmd` Works at a High Level
 
-`run-hook.cmd` is a polyglot script: Windows treats the first block as batch
-commands, while Unix shells treat that block as a no-op heredoc and continue
-after it.
+`run-hook.cmd` is a polyglot script: its first lines start with `:;`, which
+cmd.exe skips as labels and Unix shells execute — the shell execs the hook
+before ever reaching the batch block that Windows runs.
 
 Do not copy an implementation from this document. Read `hooks/run-hook.cmd`
 directly when changing the dispatcher, and run `tests/hooks/test-session-start.sh`
@@ -89,10 +89,14 @@ afterward.
 
 ### How it works on Unix (bash/sh)
 
-1. `: << 'CMDBLOCK'` opens a heredoc on a no-op command.
-2. The entire CMD batch block is consumed by the heredoc and ignored.
-3. After `CMDBLOCK`, bash resolves the script directory and `exec`s the named
-   extensionless script directly.
+1. Each leading `:;` line is a no-op label to cmd.exe but real commands to a
+   POSIX shell.
+2. The shell checks bash exists (silent exit 0 if not), resolves the script
+   directory CDPATH-proof, and `exec`s the named extensionless script — it
+   never reads the batch block at all.
+3. Heredocs are banned in this file and all hooks/ executables (issue #571:
+   bash >= 5.1 pre-fork pipe writes deadlock on macOS under pipe pressure);
+   `tests/hooks/test-no-heredocs-in-hooks.sh` enforces the ban.
 
 ### Key design decisions
 

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,8 +1,20 @@
-: << 'CMDBLOCK'
+:; command -v bash >/dev/null 2>&1 || exit 0
+:; [ $# -ge 1 ] || exit 0
+:; SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+:; SCRIPT_NAME="$1"; shift; exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"
 @echo off
 REM Cross-platform polyglot wrapper for hook scripts.
-REM On Windows: cmd.exe runs the batch portion, which finds and calls bash.
-REM On Unix: the shell interprets this as a script (: is a no-op in bash).
+REM On Unix: POSIX shells execute the ":;" lines above and exec away before
+REM reaching this batch block (":" is a no-op; cmd.exe treats lines starting
+REM with ":" as labels and skips them). If bash or the script name is
+REM missing, the wrapper exits 0 silently - hooks are optional context, never
+REM a session breaker.
+REM On Windows: cmd.exe runs this batch portion, which finds and calls bash.
+REM
+REM Heredocs are banned in this file and every hooks/ executable: bash 5.1+
+REM delivers them via a pre-fork pipe write that deadlocks on macOS under
+REM pipe pressure (issue #571). tests/hooks/test-no-heredocs-in-hooks.sh is
+REM the fence.
 REM
 REM Hook scripts use extensionless filenames (e.g. "session-start" not
 REM "session-start.sh") so Claude Code's Windows auto-detection -- which
@@ -35,12 +47,4 @@ if %ERRORLEVEL% equ 0 (
 )
 
 REM No bash found - exit silently rather than error
-REM (plugin still works, just without SessionStart context injection)
 exit /b 0
-CMDBLOCK
-
-# Unix: run the named script directly
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SCRIPT_NAME="$1"
-shift
-exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/tests/hooks/test-no-heredocs-in-hooks.sh
+++ b/tests/hooks/test-no-heredocs-in-hooks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Heredocs are banned from the hook delivery chain: bash >= 5.1 delivers
+# them through a pre-fork pipe write that deadlocks on macOS under pipe
+# pressure (issue #571; the #571 class). This fence fails the moment one
+# returns. The operator is spelled out of a variable so this file does not
+# trip its own check.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+OP='<''<'
+FAILURES=0
+for f in "$REPO_ROOT"/hooks/*; do
+    case "$f" in *.json) continue;; esac
+    [ -f "$f" ] || continue
+    if hits="$(grep -nE "$OP" "$f")"; then
+        echo "  [FAIL] heredoc operator in ${f#"$REPO_ROOT"/}:"
+        printf '%s\n' "$hits" | sed 's/^/    /'
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "  [PASS] ${f#"$REPO_ROOT"/} is heredoc-free"
+    fi
+done
+
+if [ "$FAILURES" -gt 0 ]; then
+    echo "STATUS: FAILED ($FAILURES file(s))"
+    exit 1
+fi
+echo "STATUS: PASSED"

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -184,6 +184,15 @@ assert_command_output \
     CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
     bash "$WRAPPER_UNDER_TEST" session-start
 
+# With no bash available, the wrapper must fail open: silent, exit 0.
+if output="$(env -i PATH=/nonexistent /bin/sh "$WRAPPER_UNDER_TEST" session-start 2>&1)" \
+   && [ -z "$output" ]; then
+    pass "wrapper with no bash on PATH is silent and exits 0"
+else
+    fail "wrapper with no bash on PATH is silent and exits 0"
+    printf '%s\n' "$output" | head -3 | sed 's/^/    /'
+fi
+
 cursor_home="$(make_home cursor)"
 assert_command_output \
     "Cursor emits top-level additional_context only" \


### PR DESCRIPTION
> **This PR MUST target the `dev` branch, not `main`.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Anthropic Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code 2.1.221 |
| All plugins installed | superpowers (local dev), superpowers-chrome, primeradiant-ops, episodic-memory, decision-log, elements-of-style, iterative-development, cloud-build, linear, roborev, gh-stack, find-skills |
| Human partner who reviewed this diff | Drew Ritter — reviewed the complete diff and this body on 2026-08-05 before the PR was opened |

## What problem are you trying to solve?

`hooks/run-hook.cmd` — the wrapper every hook runs through — contained a
~1.4KB heredoc (`: << 'CMDBLOCK'`). On macOS, when the shell parsing it is
bash >= 5.1 (e.g. Homebrew bash on PATH), the wrapper could deadlock before
any hook logic ran. #571 fixed this class of bug inside `hooks/session-start`
by switching to `printf`, but the wrapper itself kept its heredoc, so the
same failure chain was still exposed at every compaction/session-start on
affected machines. This PR completes the fix #571 started by removing the
last heredoc from the hook delivery chain.

### Mechanism (verified)

- Since bash 5.1 (CHANGES, 5.1-alpha), heredocs no larger than the
  build-time pipe size (65536 on macOS) are written into a pipe **before**
  the consumer is forked (`redir.c`, `here_document_to_fd`). Linux re-checks
  the live pipe capacity with `F_GETPIPE_SZ`; macOS has no such fcntl.
- Under pipe-memory pressure, macOS xnu hands out fresh pipes with 512-byte
  buffers. Bash's pre-fork write of a larger document then blocks forever.
  For `: << 'X'` the target is a builtin — no reader will ever exist to
  drain the pipe.
- An idle machine never triggers this, which is why #571 looked
  unreproducible at the time; #571's own ~512-byte idle threshold is
  evidence the original reporter's machine was already under pipe pressure.
  Session startup — many concurrent processes and pipes — is exactly when
  it triggers.
- Diagnostic: on bash 5.3 only, `BASH_COMPAT=50` forces the temp-file
  delivery path and sidesteps the hang; bash 5.1 and 5.2 have no escape
  hatch.

### Reproduction

Host: Darwin 25.6.0 (macOS 26.6), arm64-apple-darwin25 (aarch64-apple-darwin25.6.0
for self-built shells). Reproducer is the exact #571 case: a 520-byte
`printf`-generated heredoc body (`s=$(printf "%0.s=" $(seq 520)); cat
<<EOF\n${s}\nEOF`) — the same heredoc-into-a-builtin shape `run-hook.cmd`'s
`: << 'CMDBLOCK'` used — run once idle and once after holding filled pipes
until macOS handed fresh pipes a shrunken 512-byte buffer, then released:

| Shell | Version confirmed (`--version`) | Idle | Under pipe pressure |
|---|---|---|---|
| bash 5.1 (built, 16/16 official patches) | `GNU bash, version 5.1.16(1)-release (aarch64-apple-darwin25.6.0)` | pass (rc=0, 521 bytes) | **HUNG** |
| bash 5.2 (built, 37/37 official patches) | `GNU bash, version 5.2.37(1)-release (aarch64-apple-darwin25.6.0)` | pass (rc=0, 521 bytes) | **HUNG** |
| bash 5.3.9 (built, 9 official patches) | `GNU bash, version 5.3.9(1)-release (aarch64-apple-darwin25.6.0)` | pass (rc=0, 521 bytes) | **HUNG** |
| /bin/bash (system, 3.2) | `GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)` | pass (rc=0, 521 bytes) | pass (rc=0, 521 bytes) |

```
$ python3 pressure-matrix.py bash-5.1/bash bash-5.2/bash bash-5.3/bash /bin/bash
== idle (capacity 65536) ==
  .../bash-5.1/bash: rc=0 bytes=521
  .../bash-5.2/bash: rc=0 bytes=521
  .../bash-5.3/bash: rc=0 bytes=521
  /bin/bash: rc=0 bytes=521
== pressure (capacity 512) ==
  .../bash-5.1/bash: HUNG
  .../bash-5.2/bash: HUNG
  .../bash-5.3/bash: HUNG
  /bin/bash: rc=0 bytes=521
released (capacity 65536)
```

Every shell passes idle and only bash >= 5.1 hangs under pressure; capacity
was confirmed restored to 65536 immediately after release.

The wrapper itself was also driven directly, not just the abstracted case,
using the same pressure harness on the same machine (from-source bash
5.3.9, same build as above). `bash53`/`bash32`/`dash` below are the
from-source GNU bash 5.3.9 build, system `/bin/bash` 3.2.57, and
`/bin/dash`; each invocation is `<shell> run-hook.cmd <hook-name>` with a
compact JSON payload on stdin:

```
pressure reached: 300 pipes held, fresh-pipe capacity 512
== bash 5.3.9 parsing run-hook.cmd (CMDBLOCK heredoc) ==
  bash53 run-hook.cmd: HUNG (timeout)
== isolated: bash 5.3.9, static quoted heredoc 1.4KB ==
  bash53 static-1400: HUNG (timeout)
== control: system bash 3.2 parsing run-hook.cmd ==
  bash32 run-hook.cmd: rc=0 bytes_out=3814
== control: dash parsing run-hook.cmd under same pressure ==
  dash run-hook.cmd: rc=0 bytes_out=3814
released all pipes
```

The shipped wrapper hangs under the same pressure condition that leaves
system bash 3.2 and dash unaffected parsing the identical file — confirming
the mechanism above against the actual `run-hook.cmd`, not just the
isolated reproducer.

### Affected surfaces

- Claude Code: `hooks/hooks.json` runs the wrapper with `"shell": "bash"`
  (PATH-resolved — Homebrew bash wins over `/bin/bash` when installed).
- Codex: hooks run via `$SHELL -lc`; a shebang-less wrapper reaches the
  ENOEXEC fallback of whatever `$SHELL` is. (Known pre-existing edge: a
  `$SHELL` with no sh-fallback, e.g. fish, fails noisily either way — out
  of scope for this PR.)
- Interplay: open PR #2020's 10s SessionStart timeout would degrade this
  from a hang to a silent 10s stall per fire, rather than fixing it.

## What does this PR change?

Replaces the heredoc-based Unix half of `hooks/run-hook.cmd` with `:;`
label lines: cmd.exe treats them as no-op labels and skips straight to the
batch block, while POSIX shells execute them as real commands and `exec`
into the target hook script before ever reaching the batch block — so no
heredoc exists anywhere in the parse path. Adds a repo-wide fence test
(`tests/hooks/test-no-heredocs-in-hooks.sh`) that fails if any `hooks/`
executable contains a heredoc operator, a no-bash-on-PATH regression case
to `tests/hooks/test-session-start.sh`, and updates
`docs/porting-to-a-new-harness.md` and `docs/windows/polyglot-hooks.md` to
describe the new mechanism (they previously described the heredoc).

### Behavior changes

Two silent-behavior changes fall out of the rewrite, both intentional:

- **No bash on PATH (Unix path):** now silent exit 0. Previously the
  shebang-less file would hit the ENOEXEC fallback and fail noisily with
  exit 127 in most shells.
- **Zero-argument invocation (POSIX path):** now silent exit 0. Previously
  this was shell-dependent noisy nonzero (e.g. an unbound-variable error
  under `set -u`, or a bash usage error).
- **cmd.exe paths are unchanged**, including the explicit
  `run-hook.cmd: missing script name` / exit 1 error on zero args.

Rationale: hooks are optional context injection, never a session breaker —
this matches the philosophy the Windows side already used (silent exit 0
when bash can't be found at all). Making the POSIX side consistent with
that philosophy, rather than leaving it to fail noisily depending on the
invoking shell, is a deliberate part of this fix, not a side effect.

## Is this change appropriate for the core library?

Yes. `hooks/run-hook.cmd` is the dispatcher every hook (session-start,
etc.) runs through on every currently supported harness — it is core
infrastructure, not project-specific. Anyone running Superpowers on macOS
with a newer bash ahead of `/bin/bash` on PATH (Homebrew's default
installation location) is exposed to this hang; the fix benefits every
user in that configuration regardless of what they're building.

## What alternatives did you consider?

- **Shrink the heredoc below the pressure-shrunk pipe size.** Rejected:
  the pressure condition can shrink a fresh pipe's buffer to as little as
  512 bytes, which is smaller than the batch block content already needs
  to be; the failure mode is triggered by the runtime environment, not
  something the wrapper's own code size can reliably stay under.
- **Rely on `BASH_COMPAT=50` to force bash onto the temp-file delivery
  path.** Rejected: confirmed as a working escape hatch on bash 5.3 only
  (see Diagnostic above) — bash 5.1 and 5.2 have no equivalent knob, so
  this would leave two of the three affected versions still broken.
- **Detect Homebrew bash and re-exec under `/bin/bash` 3.2.** Rejected:
  fragile (requires locating a specific system binary that may not exist
  or may itself be a newer bash on non-macOS systems), doesn't address
  Linux users with bash >= 5.1 as their default `/bin/bash`, and adds
  re-exec complexity to a wrapper that should stay minimal.
- **Wait for #1175 to land first**, since it also rewrites the Unix half
  of this file. Rejected: #1175 has been open without merging, and this is
  a correctness bug affecting every hook invocation on affected machines —
  not a reason to block on an unrelated open PR. See Existing PRs below for
  the conflict and rebase plan.
- **`:;` label-line polyglot (chosen).** No heredoc exists anywhere in the
  parse path on either platform. Verified across bash 3.2.57, 5.1.16,
  5.2.37, 5.3.9, and dash on the POSIX side, and cmd.exe with Git-for-Windows
  bash on the Windows side (see Evaluation below).

## Does this PR contain multiple unrelated changes?

No. Every file changed is required by this single fix: the wrapper rewrite
itself, the fence test and regression case that prove the heredoc is gone
and stays gone, and the two doc files that describe `run-hook.cmd`'s
mechanism in prose and would otherwise describe the removed heredoc
incorrectly. (`git diff origin/dev...HEAD --stat` — `hooks/run-hook.cmd`,
`tests/hooks/test-no-heredocs-in-hooks.sh`,
`tests/hooks/test-session-start.sh`, `docs/porting-to-a-new-harness.md`,
`docs/windows/polyglot-hooks.md`.) Nothing here touches the Codex hook
revision work being tracked separately.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1175, #1864, #1753, #2020 (history: #571, #1863, #1867)

- **#1175** (open) rewrites the same Unix-half lines of `run-hook.cmd`, and
  also touches `hooks-codex.json`/`codex-tools.md`. This PR conflicts
  textually with #1175 — if #1175 lands first, this PR will need a rebase.
  The conflict is mechanical, not architectural: the `:;` mechanism this PR
  ships is compatible with #1175's `SCRIPT_NAME`-variable approach, which
  this PR's wrapper already adopts (see the `SCRIPT_NAME="$1"` line).
- **#1864** (open) batch-blocks Git-bash discovery in the same file but
  doesn't touch the lines this PR changes — no conflict.
- **#1753** wrapper doc examples — adjacent only, no textual conflict.
- **#2020** (open) adds a 10s SessionStart timeout — complementary, not
  conflicting: absent this PR, #2020 would turn the heredoc hang into a
  silent 10s stall on every affected fire rather than fixing it.
- History: **#571** is the partial fix this PR completes (it fixed the
  heredoc-deadlock class inside `hooks/session-start` but left this
  wrapper's own heredoc in place). **#1863**/**#1867** are the related
  Windows bash-discovery threads; untouched by this PR.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | 2.1.221 | Anthropic Claude Fable 5 | `claude-fable-5` |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add support for a new harness — it fixes
a dispatch bug in the existing cross-platform wrapper (`hooks/run-hook.cmd`)
already used by every currently supported harness.

## Evaluation

**Initial prompt:** This PR originated from a structured investigation
(SDD brief `2026-08-05-heredoc-hardening-and-codex-hook-revision`) into
whether the heredoc-deadlock class fixed in #571 for `hooks/session-start`
was still present anywhere else in the hook dispatch chain. `hooks/run-hook.cmd`'s
own `: << 'CMDBLOCK'` heredoc was identified and confirmed as the same
defect class via the mechanism and reproduction evidence above.

**Eval sessions run after making the change:** four independent
verification passes against the final committed wrapper (commit
`d80fc180`):

1. **POSIX matrix** (dash, system bash 3.2.57, and self-built bash 5.1.16 /
   5.2.37 / 5.3.9 — 5 shells x direct-invocation + `-lc` = 10 cases, plus a
   no-bash-on-PATH case and a zero-arg case):

   ```
   == /bin/dash direct ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == /bin/dash -lc ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == /bin/bash direct ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == /bin/bash -lc ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == .../bash-5.1/bash direct ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == .../bash-5.1/bash -lc ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == .../bash-5.2/bash direct ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == .../bash-5.2/bash -lc ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == .../bash-5.3/bash direct ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == .../bash-5.3/bash -lc ==
   PROBE-OK args=[a1] stdin=[{"source":"compact"}]
   == no bash ==
   rc=0
   == zero args ==
   rc=0
   ```

   (Bash-path lines abbreviated to `.../bash-5.N/bash`, matching the source
   matrix file's own abbreviation.) All 10 direct/`-lc` invocations print
   the expected `PROBE-OK` line; the no-bash and zero-arg cases both print
   nothing and exit 0, as designed.

2. **Pressure A/B — old (heredoc) wrapper vs. new (`:;` label) wrapper**,
   the direct before/after comparison, run once under a single pipe-pressure
   window across bash 5.1.16 / 5.2.37 / 5.3.9 (6 shell x wrapper combos):

   ```
   == idle (capacity 65536) ==
     bash-5.1 x OLD (origin/dev, heredoc): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
     bash-5.1 x NEW (d80fc180, :; labels): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
     bash-5.2 x OLD (origin/dev, heredoc): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
     bash-5.2 x NEW (d80fc180, :; labels): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
     bash-5.3 x OLD (origin/dev, heredoc): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
     bash-5.3 x NEW (d80fc180, :; labels): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
   == pressure (capacity 512) ==
     bash-5.1 x OLD (origin/dev, heredoc): HUNG
     bash-5.1 x NEW (d80fc180, :; labels): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
     bash-5.2 x OLD (origin/dev, heredoc): HUNG
     bash-5.2 x NEW (d80fc180, :; labels): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
     bash-5.3 x OLD (origin/dev, heredoc): HUNG
     bash-5.3 x NEW (d80fc180, :; labels): rc=0 stdout='PROBE-OK args=[] stdin=[{"source":"compact"}]'
   released (capacity 65536)
   ```

3. **Windows 11 cmd.exe matrix** (physical Windows 11 10.0.26200 host,
   Git-for-Windows bash, files transferred LF-only, executed via `cmd /c`):

   ```
   === 1. args+discovery ===
   PROBE-OK args=[hello world] stdin=[]
   exit=0
   === 2. stdin ===
   PROBE-OK args=[] stdin=[{"source":"compact"} ]
   exit=0
   === 3. zero-arg ===
   run-hook.cmd: missing script name
   exit=1
   ```

4. **Repo test suites**, run locally: `tests/hooks/test-no-heredocs-in-hooks.sh`
   (`[PASS] hooks/run-hook.cmd is heredoc-free`, `[PASS] hooks/session-start
   is heredoc-free`, `STATUS: PASSED`) and `tests/hooks/test-session-start.sh`,
   7/7 passing including the new `wrapper with no bash on PATH is silent and
   exits 0` case.

**Outcome change compared to before:** the pressure A/B is the clean
before/after — under identical pipe pressure, the old heredoc-based wrapper
hangs on all 3 tested bash versions (5.1, 5.2, 5.3.9) and the new wrapper
succeeds on all 3, with zero regressions across dash, system bash 3.2.57,
and cmd.exe in every matrix. Every invocation across all four passes
matched its expected outcome exactly; the only deviations from prior
behavior are the two intentional silent-exit-0 changes documented above.

## Rigor

- [ ] If this is a skills change: N/A — this PR does not touch any skill
      content, only `hooks/`, `tests/hooks/`, and two doc files.
- [x] This change was tested adversarially, not just on the happy path —
      pipe-pressure deadlock condition, no-bash-on-PATH, zero-argument
      invocation, and a physical Windows 11 host were all exercised, not
      just the straight-line success case.
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) — this PR does not touch
      any skill files.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission —
      Drew Ritter reviewed the complete diff and this PR body on 2026-08-05
      before the PR was opened.
