### PR TITLE
docs: add Pi to documented subagent platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .superpowers/
 .DS_Store
 node_modules/
+package-lock.json
 inspo
 triage/
 

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -11,7 +11,7 @@ Load plan, review critically, execute all tasks, report when complete.
 
 **Announce at start:** "I'm using the executing-plans skill to implement this plan."
 
-**Note:** Tell your human partner that Superpowers works much better with access to subagents (Claude Code, Codex CLI, Codex App, Copilot CLI, and Gemini CLI all qualify; see the per-platform tool refs in `../using-superpowers/references/`). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
+**Note:** Tell your human partner that Superpowers works much better with access to subagents (Claude Code, Codex CLI, Codex App, Copilot CLI, Gemini CLI, and Pi all qualify; see the per-platform tool refs in `../using-superpowers/references/`). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
 
 ## The Process
 

--- a/skills/subagent-driven-development/scripts/sdd-workspace
+++ b/skills/subagent-driven-development/scripts/sdd-workspace
@@ -8,11 +8,12 @@
 # artifacts. A stale ledger misread as current progress makes controllers
 # skip whole task sequences — plan-scoping removes that failure structurally.
 #
-# The workspace lives in the working tree (not under .git/) because Claude Code
-# treats .git/ as a protected path and denies agent writes there — which blocks
-# an implementer subagent from writing its report file. A self-ignoring
+# The workspace lives in the working tree (not under .git/) to keep plan
+# artifacts out of the commit graph regardless of platform. A self-ignoring
 # .gitignore at .superpowers/sdd/ keeps every plan's workspace out of
 # `git status` and out of accidental commits without modifying any tracked file.
+# (Originally sited outside .git/ because Claude Code treats .git/ as a
+# protected path; the location is also good hygiene for other platforms.)
 #
 # Single source of truth for the workspace location, so task-brief and
 # review-package cannot drift to different directories.

--- a/skills/using-superpowers/references/pi-tools.md
+++ b/skills/using-superpowers/references/pi-tools.md
@@ -14,3 +14,15 @@ Pi core does not ship a standard subagent tool. The `pi-subagents` package is a 
 ## Task lists
 
 Pi core does not ship a standard task-list tool. If a todo/task extension is installed, use its documented tool. Otherwise use Superpowers plan files, checklists in Markdown, or a repo-local `TODO.md` for task tracking. Older Superpowers docs may refer to `TodoWrite`; treat that as the task-tracking action above.
+
+## When the subagent extension is installed
+
+If `~/.pi/agent/extensions/subagent/` is set up (per Pi's official `examples/extensions/subagent/` plus the user-level `~/.pi/agent/agents/*.md` definitions), the `subagent` tool is loaded automatically. Dispatch with:
+
+- Single: `subagent({ agent: "scout", task: "..." })`
+- Parallel: `subagent({ tasks: [...] })` (max 8 tasks, 4 concurrent)
+- Chain: `subagent({ chain: [{ agent, task: "... {previous} ..." }, ...] })` — `{previous}` carries the previous step's output
+
+Agent definitions are markdown files with YAML frontmatter (`name`, `description`, `tools`, `model`, `systemPrompt`). They live at `~/.pi/agent/agents/*.md` (user-level, always loaded). Project-level agents under `.pi/agents/*.md` require `agentScope: "both"` or `"project"`. Default sample agents shipped with the extension: `scout` (fast recon), `planner` (writes plans), `reviewer` (read-only review), `worker` (full capabilities). To run an agent on a different model than the host session, set its `model:` field.
+
+Workflow prompts (`/implement`, `/scout-and-plan`, `/implement-and-review`) live in `~/.pi/agent/prompts/*.md` and trigger the chain pattern.

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -9,7 +9,7 @@ description: Use when creating new skills, editing existing skills, or verifying
 
 **Writing skills IS Test-Driven Development applied to process documentation.**
 
-**Personal skills live in your runtime's skills directory** (`~/.claude/skills/` on Claude Code) — see [codex-tools.md](../using-superpowers/references/codex-tools.md) or [gemini-tools.md](../using-superpowers/references/gemini-tools.md) for the path on those runtimes. Codex, Copilot CLI, and Gemini CLI all also recognize `~/.agents/skills/` as a cross-runtime alias.
+**Personal skills live in your runtime's skills directory** (`~/.claude/skills/` on Claude Code, `~/.pi/agent/skills/` on Pi) — see [codex-tools.md](../using-superpowers/references/codex-tools.md), [pi-tools.md](../using-superpowers/references/pi-tools.md), or [gemini-tools.md](../using-superpowers/references/gemini-tools.md) for the path on those runtimes. Codex, Copilot CLI, and Gemini CLI all also recognize `~/.agents/skills/` as a cross-runtime alias.
 
 You write test cases (pressure scenarios with subagents), watch them fail (baseline behavior), write the skill (documentation), watch tests pass (agents comply), and refactor (close loopholes).
 


### PR DESCRIPTION
## Summary

Adds Pi to the documented subagent-capable platforms across the skills tree, and documents the Pi subagent extension workflow (`examples/extensions/subagent/`).

Five commits:

1. `docs(skills): add Pi to executing-plans subagent platform list` — `executing-plans/SKILL.md` listed five platforms (Claude Code, Codex CLI, Codex App, Copilot CLI, Gemini CLI) as qualifying for subagent use, omitting Pi. Pi supports subagents via the official `examples/extensions/subagent/` package, so it qualifies for the same `subagent-driven-development` workflow.

2. `docs(references): document Pi subagent extension usage in pi-tools.md` — `pi-tools.md` stopped at 'Pi core does not ship a standard subagent tool. If installed, use it; otherwise do not fabricate Task calls.' This left Pi users who had installed the extension without guidance on dispatch modes, agent definitions, or workflow prompts. Adds a 'When the subagent extension is installed' section.

3. `chore(scripts): make sdd-workspace comment platform-agnostic` — the workspace-location rationale referred specifically to Claude Code's `.git/` protection; other harnesses (Pi, Codex, Gemini) may or may not have similar protection, but the location is good hygiene regardless of platform.

4. `docs(skills): reference pi-tools.md from writing-skills for Pi skill path` — `writing-skills/SKILL.md` documented Claude Code, Codex, and Gemini skill paths but omitted Pi (`~/.pi/agent/skills/`).

5. `chore: ignore package-lock.json in superpowers repo` — Pi's package loader generates a `package-lock.json` when scanning a git package, polluting `git status` for Pi users. superpowers is not an npm project.

## Test plan

- Verified locally: applied in a Pi install with the subagent extension loaded; confirmed `subagent` tool appears in the tool list and a `scout` agent runs end-to-end against Xiaomi MiMo models.
- Documentation: cross-references between `pi-tools.md`, `writing-skills`, and `executing-plans` are consistent after the edits.