### PR TITLE
feat: add Command Code harness (disk-loaded Shape B, install from this repo)

### DIFF
--- a/.commandcode/mods/superpowers.ts
+++ b/.commandcode/mods/superpowers.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { CommandCodeAPI } from "@commandcode/harness";
+
+const EXTREMELY_IMPORTANT_MARKER = "<EXTREMELY_IMPORTANT>";
+const BOOTSTRAP_MARKER = "superpowers:using-superpowers bootstrap for commandcode";
+
+const modDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(modDir, "../..");
+const skillsDir = resolve(packageRoot, "skills");
+const bootstrapSkillPath = resolve(skillsDir, "using-superpowers", "SKILL.md");
+const toolMappingPath = resolve(
+	skillsDir,
+	"using-superpowers",
+	"references",
+	"commandcode-tools.md",
+);
+
+let cachedBootstrap: string | null | undefined;
+
+export default function superpowersCommandCodeMod(cmd: CommandCodeAPI) {
+	cmd.hooks({
+		appendSystemPrompt: () => getBootstrapContent() ?? "",
+	});
+}
+
+function getBootstrapContent(): string | null {
+	if (cachedBootstrap !== undefined) return cachedBootstrap;
+
+	try {
+		const skillContent = readFileSync(bootstrapSkillPath, "utf8");
+		const mappingContent = readFileSync(toolMappingPath, "utf8");
+		const body = stripFrontmatter(skillContent);
+		cachedBootstrap = `${EXTREMELY_IMPORTANT_MARKER}
+${BOOTSTRAP_MARKER}
+
+You have superpowers.
+
+The using-superpowers skill content is included below and is already loaded for this Command Code session. Follow it now. Do not try to load using-superpowers again.
+
+Skills live at ${skillsDir}. To invoke a skill, read its SKILL.md with read_file (or use /skill-name if already discovered). Reading SKILL.md is the blessed invoke path.
+
+${body}
+
+${mappingContent.trim()}
+</EXTREMELY_IMPORTANT>`;
+		return cachedBootstrap;
+	} catch {
+		cachedBootstrap = null;
+		return null;
+	}
+}
+
+function stripFrontmatter(content: string): string {
+	const match = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+	return (match ? match[1] : content).trim();
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Superpowers is a complete software development methodology for your coding agent
 
 - [How it works](#how-it-works)
 - [Commercial Services](#commercial-services)
-  - [Getting Started](#installation)
+- [Getting Started](#installation)
   - [Claude Code](#claude-code)
   - [Command Code](#command-code)
   - [Antigravity](#antigravity)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Superpowers is a complete software development methodology for your coding agent
 
 - [How it works](#how-it-works)
 - [Commercial Services](#commercial-services)
-- [Getting Started](#installation)
+  - [Getting Started](#installation)
   - [Claude Code](#claude-code)
+  - [Command Code](#command-code)
   - [Antigravity](#antigravity)
   - [Codex App](#codex-app)
   - [Codex CLI](#codex-cli)
@@ -77,6 +78,22 @@ The Superpowers marketplace provides Superpowers and some other related plugins 
   ```bash
   /plugin install superpowers@superpowers-marketplace
   ```
+
+### Command Code
+
+Install Superpowers as a global Command Code mod from this repository:
+
+```bash
+cmd mods add -g obra/superpowers
+```
+
+Update later with:
+
+```bash
+cmd mods update
+```
+
+Detailed docs: [docs/README.commandcode.md](docs/README.commandcode.md)
 
 ### Antigravity
 

--- a/docs/README.commandcode.md
+++ b/docs/README.commandcode.md
@@ -1,0 +1,70 @@
+# Superpowers for Command Code
+
+Complete guide for using Superpowers with Command Code.
+
+## Installation
+
+Install Superpowers as a global Command Code mod from this repository:
+
+```bash
+cmd mods add -g obra/superpowers
+```
+
+Start a fresh Command Code session after installing.
+
+## Updating
+
+Update installed mods with:
+
+```bash
+cmd mods update
+```
+
+Start a fresh session after updating so the new checkout is loaded.
+
+## How It Works
+
+`package.json` declares the Command Code mod:
+
+```json
+{
+  "commandcode": {
+    "mods": ["./.commandcode/mods/superpowers.ts"]
+  }
+}
+```
+
+That mod does two things:
+
+1. Injects the `using-superpowers` bootstrap at session start through `appendSystemPrompt`.
+2. Loads Command Code tool mapping from `skills/using-superpowers/references/commandcode-tools.md` on disk.
+
+Skills stay in this repository's `skills/` directory. There are no copied skills, no `cmd skills add`, and no extra slash commands.
+
+## Tool Mapping
+
+Skills describe actions instead of hard-coding one runtime's tool names. On Command Code these resolve to the mapping in:
+
+[skills/using-superpowers/references/commandcode-tools.md](../skills/using-superpowers/references/commandcode-tools.md)
+
+**Blessed skill invoke path:** read `skills/<name>/SKILL.md` with `read_file` (or use `/skill-name` if already discovered).
+
+## Troubleshooting
+
+### Mod not loading
+
+1. Confirm install with `cmd mods list`.
+2. Re-run `cmd mods add -g obra/superpowers` if the package is missing.
+3. Start a fresh session after install or update.
+
+### Skills not triggering
+
+1. Confirm the mod is installed and enabled.
+2. Start a fresh session.
+3. Try the acceptance prompt: `Let's make a react todo list`. A working install should load `brainstorming` before writing code.
+
+### Bootstrap text missing
+
+1. Confirm `package.json` still declares `"commandcode": { "mods": ["./.commandcode/mods/superpowers.ts"] }`.
+2. Confirm `.commandcode/mods/superpowers.ts` is present in the installed package checkout.
+3. Update with `cmd mods update` and start a fresh session.

--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
     "skills": [
       "./skills"
     ]
+  },
+  "commandcode": {
+    "mods": [
+      "./.commandcode/mods/superpowers.ts"
+    ]
   }
 }

--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -47,6 +47,7 @@ EXCLUDES=(
   "/.claude/"
   "/.claude-plugin/"
   "/.codex/"
+  "/.commandcode/"
   "/.cursor-plugin/"
   "/.devin-plugin/"
   "/.git/"

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -57,6 +57,7 @@ If your harness appears here, read its reference file for special instructions:
 - Pi: `references/pi-tools.md`
 - Antigravity: `references/antigravity-tools.md`
 - Hermes Agent: `references/hermes-tools.md`
+- Command Code: `references/commandcode-tools.md`
 
 ## User Instructions
 

--- a/skills/using-superpowers/references/commandcode-tools.md
+++ b/skills/using-superpowers/references/commandcode-tools.md
@@ -1,0 +1,50 @@
+# Command Code Tool Mapping
+
+Skills speak in actions ("dispatch a subagent", "create a todo", "read a file"). On Command Code these resolve to the tools below.
+
+**Blessed skill invoke path:** read `skills/<name>/SKILL.md` with `read_file` (or use `/skill-name` if already discovered). That is the platform mechanism — do not invent a separate skill tool.
+
+## Tools
+
+| Action skills request | Command Code tool |
+|---|---|
+| Read a file | `read_file` / `read_multiple_files` |
+| Create a new file | `write_file` |
+| Edit a file (targeted patch) | `edit_file` |
+| List a directory | `read_directory` |
+| Find files by name | `glob` |
+| Search file contents | `grep` |
+| Run a shell command | `shell_command` |
+| Fetch a URL / read a webpage | `web_fetch` |
+| Search the web | `web_search` |
+| Invoke a skill | `read_file` on `skills/<name>/SKILL.md` (or `/skill-name` if already discovered) |
+| Dispatch a subagent | `agent` with `subagent_type`: `"general"` \| `"explore"` \| `"plan"` |
+| Task tracking | `todo_write` (or `task_create` / `task_update` / `task_list`) |
+| Ask the user a question | `ask_user_question` |
+| Enter / exit a worktree | `enter_worktree` / `exit_worktree` |
+
+## Invoking a skill
+
+Command Code has no separate Skill tool. Reading `SKILL.md` is the blessed invoke path:
+
+```
+read_file(path="skills/brainstorming/SKILL.md")
+```
+
+If the skill is already discovered, `/skill-name` is also fine. Prefer the path under the package `skills/` directory when resolving files.
+
+## Subagent dispatch
+
+Use `agent` with an explicit `subagent_type`:
+
+```
+agent(subagent_type="general", prompt="...")
+agent(subagent_type="explore", prompt="...")
+agent(subagent_type="plan", prompt="...")
+```
+
+If `agent` is unavailable, do the work inline rather than inventing tool calls.
+
+## Task tracking
+
+Use `todo_write` for session task tracking. If task board tools are available, use `task_create` / `task_update` / `task_list`. Treat older `TodoWrite` references as the task-tracking action.

--- a/tests/commandcode/test-commandcode-mod.mjs
+++ b/tests/commandcode/test-commandcode-mod.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+const packageJsonPath = resolve(repoRoot, 'package.json');
+const modPath = resolve(repoRoot, '.commandcode/mods/superpowers.ts');
+const mappingPath = resolve(
+  repoRoot,
+  'skills/using-superpowers/references/commandcode-tools.md',
+);
+
+async function readPackageJson() {
+  return JSON.parse(await readFile(packageJsonPath, 'utf8'));
+}
+
+async function loadMod() {
+  const hooksCalls = [];
+  let addCommandCalls = 0;
+  const cmd = {
+    hooks(spec) {
+      hooksCalls.push(spec);
+    },
+    addCommand() {
+      addCommandCalls += 1;
+    },
+  };
+  const mod = await import(
+    pathToFileURL(modPath).href + `?cachebust=${Date.now()}-${Math.random()}`
+  );
+  mod.default(cmd);
+  return { hooksCalls, addCommandCalls };
+}
+
+test('package.json declares commandcode.mods for the superpowers mod', async () => {
+  const pkg = await readPackageJson();
+
+  assert.equal(pkg.name, 'superpowers');
+  assert.deepEqual(pkg.commandcode.mods, ['./.commandcode/mods/superpowers.ts']);
+});
+
+test('mod registers exactly one appendSystemPrompt hook and never addCommand', async () => {
+  const { hooksCalls, addCommandCalls } = await loadMod();
+
+  assert.equal(hooksCalls.length, 1, 'expected one hooks() registration');
+  assert.equal(typeof hooksCalls[0].appendSystemPrompt, 'function');
+  assert.equal(addCommandCalls, 0, 'must never call addCommand');
+});
+
+test('appendSystemPrompt injects disk-loaded bootstrap with marker, skills path, and mapping', async () => {
+  const { hooksCalls } = await loadMod();
+  const appendSystemPrompt = hooksCalls[0].appendSystemPrompt;
+
+  const text = await appendSystemPrompt();
+  assert.equal(typeof text, 'string');
+  assert.match(text, /You have superpowers/);
+  assert.match(
+    text,
+    /superpowers:using-superpowers bootstrap for commandcode/,
+  );
+  assert.match(text, new RegExp(resolve(repoRoot, 'skills').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(text, /read_file/);
+
+  const second = await appendSystemPrompt();
+  assert.equal(second, text, 'bootstrap content should be cached');
+});
+
+test('commandcode tools reference documents mapping-table rows', async () => {
+  assert.equal(existsSync(mappingPath), true, 'commandcode-tools.md should exist');
+  const text = await readFile(mappingPath, 'utf8');
+
+  // Assert against the mapping-table rows only. The surrounding prose mentions
+  // these same tokens, so matching the whole file would still pass if the table
+  // were deleted — the exact regression this test exists to catch.
+  const rows = text.split('\n').filter((line) => line.startsWith('|'));
+  assert.ok(
+    rows.some((row) => /subagent/i.test(row)),
+    'mapping table documents subagent dispatch',
+  );
+  assert.ok(
+    rows.some((row) => /todo|task/i.test(row)),
+    'mapping table documents task tracking',
+  );
+});


### PR DESCRIPTION
## What problem are you trying to solve?

Command Code had no Superpowers harness, so skills never auto-triggered. #2099's first version was the right Shape B idea, but obra rejected it before review: hardcoded prose in TypeScript, a manual `cp` of skills into `~/.commandcode/skills/`, install via `yansigit/superpowers-commandcode`, an extra `superpowers-status` command, a missing identification table, and an acceptance transcript that did not show `brainstorming` loading.

This resubmission is that rewrite on current `dev`.

## What does this PR change?

Adds Command Code as a Shape B harness in this repo: `.commandcode/mods/superpowers.ts` loads `using-superpowers/SKILL.md` and `references/commandcode-tools.md` from disk and injects them via `appendSystemPrompt`; `package.json` declares the mod so `cmd mods add -g obra/superpowers` is the install path; README + `docs/README.commandcode.md` + a one-line Platform Adaptation pointer + a Codex sync exclude + unit tests.

## Is this change appropriate for the core library?

Yes. Command Code is a general-purpose coding agent. This is the thin delivery layer (bootstrap + tool mapping + install docs) from `docs/porting-to-a-new-harness.md`. Skills themselves are untouched except the one-line platform pointer the porting guide allows.

## What alternatives did you consider?

- Keep distributing via `yansigit/superpowers-commandcode` and `cp` skills into `~/.commandcode/skills/`. Rejected — obra's #2099 review, and it never upgrades.
- `cmd skills add obra/superpowers`. Rejected — that copies skills and has no update command.
- Shell-hook (Shape A). Not applicable — Command Code has no session-start shell hook.
- Extra `/superpowers-status` command. Rejected — one problem per PR.

## Does this PR contain multiple unrelated changes?

No. One harness. Eight related files (mod, package manifest, mapping, tests, README, install doc, platform pointer, Codex sync exclude).

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: this is the rewrite of **#2099** (still this PR). `gh search prs "commandcode repo:obra/superpowers"` found no other Command Code harness prior art.

This should succeed where the first #2099 push did not because it answers the five owner comments: disk-loaded markdown, no skill copy, install from this repo, no extra command, identification table filled. The acceptance transcript below is honest about what we could and could not prove in this session.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Command Code | 1.21.0 (later auto-updated to 1.26.0 during `cmd --list-models`) | poolside/laguna-s-2.1-free | poolside/laguna-s-2.1-free |
| Node unit tests | — | — | `node --experimental-strip-types --test tests/commandcode/test-commandcode-mod.mjs` (4/4) |

Paid default Command Code models were blocked by insufficient credits (`EXIT:10`). Smoke used session-only `cmd --mod .commandcode/mods/superpowers.ts` so we would not write `~/.commandcode/settings.json`. `cmd mods list` already shows `superpowers · project · .commandcode/mods/superpowers.ts` from the package declaration. Documented `cmd mods add -g obra/superpowers` was not live-run in this session.

## New harness support (required if this PR adds a new harness)

<details>
<summary>Bootstrap marker probe (session-only --mod, free model)</summary>

```
cmd --mod /path/to/superpowers/.commandcode/mods/superpowers.ts \
  --model poolside/laguna-s-2.1-free \
  -p "Reply with exactly three lines: (1) whether you see EXTREMELY_IMPORTANT (2) whether you see superpowers:using-superpowers bootstrap for commandcode (3) the skills directory path from your system prompt if present. Do not call tools." \
  --output-format text --skip-onboarding --no-session --max-turns 3

1. Yes, I see EXTREMELY_IMPORTANT
2. Yes, I see "superpowers:using-superpowers bootstrap for commandcode"
3. Skills directory path: `/Users/user/.local/share/mise/installs/node/26.7.0/lib/node_modules/command-code/dist/bundled/` (skills listed in `<available_skills>`)
EXIT:0
```

Markers (1) and (2) confirm the bootstrap injected. Line (3) is the free model mixing Command Code's bundled skills path with the Superpowers `skills/` path the unit tests prove is in the injected text.

</details>

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
cmd --mod /path/to/superpowers/.commandcode/mods/superpowers.ts \
  --model poolside/laguna-s-2.1-free \
  -p "Let's make a react todo list" \
  --output-format text --skip-onboarding --no-session --max-turns 8 --trust

The tools need permissions. Let me check the config skill to see how to handle this.
Warning: Reached maximum conversation turns (8). The response may be incomplete.
EXIT:8
```

This is **not** a passing acceptance transcript. The free model did not announce `brainstorming` or ask design questions; it stalled on a permissions/config loop. Default/paid models could not be used (insufficient credits). Do not treat this block as proof that brainstorming auto-triggers on Command Code. The proof we do have is: unit tests for disk-loaded injection, `cmd mods list` discovering the project mod, and the marker probe above.

</details>

## Evaluation

- Initial prompt that surfaced the gap: human asked to inspect obra's #2099 comment and make a mergeable Command Code port. First #2099 version failed the five owner points above.
- Eval sessions after the rewrite: unit tests (4/4); `cmd mods list`; two free-model `cmd -p` runs (marker probe passed; todo-list acceptance did not on this model).
- Before vs after this rewrite: before = hardcoded mapping table, fork install, skill `cp`, extra status command. After = Pi-shaped disk load, `cmd mods add -g obra/superpowers`, no copy, no extra command, bootstrap markers visible to the model.

## Rigor

- [x] If this is a skills change: N/A beyond the one-line Platform Adaptation pointer allowed by the porting guide.
- [x] This change was tested adversarially, not just on the happy path (missing-file cache-as-null, no `addCommand`, mapping-table-row assertions, live --mod load, refused to fake a passing todo-list transcript).
- [x] I did not modify carefully-tuned skill bodies (Red Flags table, rationalizations, "human partner" language).

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
