### PR TITLE
fix(release): wire Hermes manifest into version bumps

### DIFF
--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,6 +1,7 @@
 {
   "files": [
     { "path": "package.json", "field": "version" },
+    { "path": ".hermes-plugin/plugin.yaml", "field": "version" },
     { "path": ".claude-plugin/plugin.json", "field": "version" },
     { "path": ".cursor-plugin/plugin.json", "field": "version" },
     { "path": ".codex-plugin/plugin.json", "field": "version" },

--- a/docs/superpowers/plans/2026-08-06-hermes-version-bump-wiring.md
+++ b/docs/superpowers/plans/2026-08-06-hermes-version-bump-wiring.md
@@ -1,0 +1,304 @@
+# Hermes Version-Bump Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Hermes YAML manifest version synchronized with every other declared release manifest.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-hermes-version-bump-wiring-design.md`
+
+**Architecture:** Extend the existing release script with a small extension-based dispatcher: JSON continues through `jq`, while `.yaml` uses Mike Farah `yq` v4. Before the mutating bump loop, read every present manifest through that dispatcher so deterministic format or field failures occur before the first write.
+
+**Tech Stack:** Bash 3.2-compatible shell, `jq`, Mike Farah `yq` v4, existing shell-lint tooling.
+
+## Global Constraints
+
+- Support only `.json` and `.yaml`; `.yml` and other extensions remain unsupported.
+- YAML fields are present top-level strings; nested YAML fields are out of scope.
+- Pass the YAML field and new value through environment data, never interpolate either into a `yq` expression.
+- Keep `yq` confined to maintainer release tooling; do not add a plugin runtime dependency.
+- Preserve the existing missing-file behavior: `--check` reports missing files and a bump skips them.
+- Preflight only the mutating bump path; do not add rollback or transactional writes.
+- Do not change audit status behavior, version validation, or the existing JSON field-expression implementation.
+
+---
+
+## File Map
+
+- Create: `tests/version-bump/test-bump-version.sh`
+  - Exercise the real script in temporary JSON/YAML fixtures and check the real registry.
+- Modify: `scripts/bump-version.sh`
+  - Add YAML read/write helpers, format dispatch, and bump-only read preflight.
+- Modify: `.version-bump.json`
+  - Register `.hermes-plugin/plugin.yaml` at top-level field `version`.
+
+### Task 1: Wire Hermes Into The Existing Version-Bump Script
+
+**Files:**
+- Create: `tests/version-bump/test-bump-version.sh`
+- Modify: `scripts/bump-version.sh`
+- Modify: `.version-bump.json`
+
+**Interfaces:**
+- Consumes: `.version-bump.json` records shaped as `{ "path": string, "field": string }`.
+- Produces: `read_manifest_field FILE FIELD`, `write_manifest_field FILE FIELD VALUE`, and `preflight_manifests` Bash helpers.
+
+- [ ] **Step 1: Fetch the current development base**
+
+Run:
+
+```bash
+git fetch origin dev
+```
+
+Expected: command exits 0 and refreshes `origin/dev`.
+
+- [ ] **Step 2: Rebase the task branch**
+
+Run:
+
+```bash
+git rebase origin/dev
+```
+
+Expected: command exits 0, and `git status --short --branch` no longer reports the branch behind `origin/dev`.
+
+- [ ] **Step 3: Add the initial failing behavioral test**
+
+Create `tests/version-bump/test-bump-version.sh` with the happy-path fixture and real registry assertion:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_SOURCE="$REPO_ROOT/scripts/bump-version.sh"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+make_fixture() {
+  local repo="$1"
+  local yaml_body="$2"
+
+  mkdir -p "$repo/scripts" "$repo/.hermes-plugin"
+  cp "$SCRIPT_SOURCE" "$repo/scripts/bump-version.sh"
+  cat >"$repo/.version-bump.json" <<'JSON'
+{
+  "files": [
+    { "path": "package.json", "field": "version" },
+    { "path": ".hermes-plugin/plugin.yaml", "field": "version" }
+  ],
+  "audit": { "exclude": [] }
+}
+JSON
+  cat >"$repo/package.json" <<'JSON'
+{
+  "name": "fixture",
+  "version": "1.2.3"
+}
+JSON
+  printf '%s\n' "$yaml_body" >"$repo/.hermes-plugin/plugin.yaml"
+}
+
+happy_repo="$TEST_ROOT/happy"
+make_fixture "$happy_repo" $'name: superpowers\nversion: 1.2.3'
+
+/bin/bash "$happy_repo/scripts/bump-version.sh" --check >"$TEST_ROOT/check.out"
+/bin/bash "$happy_repo/scripts/bump-version.sh" --audit >"$TEST_ROOT/audit.out"
+/bin/bash "$happy_repo/scripts/bump-version.sh" 2.3.4 >"$TEST_ROOT/bump.out"
+
+[[ "$(jq -r '.version' "$happy_repo/package.json")" == "2.3.4" ]] \
+  || fail "JSON manifest was not bumped"
+[[ "$(yq -r '.version' "$happy_repo/.hermes-plugin/plugin.yaml")" == "2.3.4" ]] \
+  || fail "YAML manifest was not bumped"
+
+jq -e '
+  any(.files[];
+    .path == ".hermes-plugin/plugin.yaml" and .field == "version")
+' "$REPO_ROOT/.version-bump.json" >/dev/null \
+  || fail "Hermes manifest is not registered"
+
+echo "Version-bump tests passed"
+```
+
+- [ ] **Step 4: Run the test to verify RED**
+
+Run:
+
+```bash
+/bin/bash tests/version-bump/test-bump-version.sh
+```
+
+Expected: FAIL before `Version-bump tests passed`; the current JSON-only reader cannot process the YAML fixture.
+
+- [ ] **Step 5: Add minimal YAML dispatch and register Hermes**
+
+In `scripts/bump-version.sh`, add these helpers after `write_json_field`:
+
+```bash
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required tool '$1' is not on PATH" >&2
+    return 1
+  }
+}
+
+read_yaml_field() {
+  local file="$1" field="$2"
+  require_tool yq || return 1
+  FIELD="$field" yq -er '.[strenv(FIELD)] | select(tag == "!!str")' "$file"
+}
+
+write_yaml_field() {
+  local file="$1" field="$2" value="$3"
+  FIELD="$field" VALUE="$value" \
+    yq -i '.[strenv(FIELD)] = strenv(VALUE)' "$file"
+}
+
+read_manifest_field() {
+  local file="$1"
+
+  case "$file" in
+    *.json) read_json_field "$@" ;;
+    *.yaml) read_yaml_field "$@" ;;
+    *)
+      echo "error: unsupported manifest format: $file" >&2
+      return 1
+      ;;
+  esac
+}
+
+write_manifest_field() {
+  local file="$1"
+
+  case "$file" in
+    *.json) write_json_field "$@" ;;
+    *.yaml) write_yaml_field "$@" ;;
+    *)
+      echo "error: unsupported manifest format: $file" >&2
+      return 1
+      ;;
+  esac
+}
+```
+
+Replace the three command-path calls to `read_json_field` with `read_manifest_field`, and replace the bump-path call to `write_json_field` with `write_manifest_field`.
+
+Add this exact entry to `.version-bump.json` immediately after `package.json`:
+
+```json
+{ "path": ".hermes-plugin/plugin.yaml", "field": "version" },
+```
+
+- [ ] **Step 6: Run the initial test to verify GREEN**
+
+Run:
+
+```bash
+/bin/bash tests/version-bump/test-bump-version.sh
+```
+
+Expected: PASS with `Version-bump tests passed`.
+
+- [ ] **Step 7: Add the failing no-partial-write regression**
+
+Insert this block before the final success message in `tests/version-bump/test-bump-version.sh`:
+
+```bash
+invalid_repo="$TEST_ROOT/invalid"
+make_fixture "$invalid_repo" $'name: superpowers\nversion: 123'
+cp "$invalid_repo/package.json" "$TEST_ROOT/package.before"
+cp "$invalid_repo/.hermes-plugin/plugin.yaml" "$TEST_ROOT/plugin.before"
+
+if /bin/bash "$invalid_repo/scripts/bump-version.sh" 2.3.4 \
+  >"$TEST_ROOT/invalid.out" 2>&1; then
+  fail "bump accepted a non-string YAML version"
+fi
+
+cmp -s "$TEST_ROOT/package.before" "$invalid_repo/package.json" \
+  || fail "JSON manifest changed before YAML validation failed"
+cmp -s "$TEST_ROOT/plugin.before" "$invalid_repo/.hermes-plugin/plugin.yaml" \
+  || fail "invalid YAML manifest changed"
+```
+
+- [ ] **Step 8: Run the regression to verify RED**
+
+Run:
+
+```bash
+/bin/bash tests/version-bump/test-bump-version.sh
+```
+
+Expected: FAIL with `JSON manifest changed before YAML validation failed`; without preflight, the JSON manifest is written before the later YAML reader rejects its non-string version.
+
+- [ ] **Step 9: Add the bump-only preflight**
+
+Add this helper after `declared_files` in `scripts/bump-version.sh`:
+
+```bash
+preflight_manifests() {
+  local path field fullpath
+
+  require_tool jq || return 1
+  while IFS=$'\t' read -r path field; do
+    fullpath="$REPO_ROOT/$path"
+    [[ -f "$fullpath" ]] || continue
+
+    if ! read_manifest_field "$fullpath" "$field" >/dev/null; then
+      echo "error: cannot read declared manifest: $path ($field)" >&2
+      return 1
+    fi
+  done < <(declared_files)
+}
+```
+
+Call it in `cmd_bump` after version-format validation and before the first bump output or write:
+
+```bash
+  preflight_manifests
+
+  echo "Bumping all declared files to $new_version..."
+```
+
+- [ ] **Step 10: Run focused verification**
+
+Run:
+
+```bash
+/bin/bash tests/version-bump/test-bump-version.sh
+scripts/lint-shell.sh scripts/bump-version.sh tests/version-bump/test-bump-version.sh
+scripts/bump-version.sh --check
+git diff --check
+```
+
+Expected:
+
+- The behavioral test prints `Version-bump tests passed`.
+- Shell lint reports both scripts with no errors.
+- `--check` lists eight declared manifests, including `.hermes-plugin/plugin.yaml`, all at `6.2.0`.
+- `git diff --check` prints nothing.
+
+- [ ] **Step 11: Review and commit the implementation**
+
+Run:
+
+```bash
+git status --short
+git diff -- .version-bump.json scripts/bump-version.sh tests/version-bump/test-bump-version.sh
+git add .version-bump.json scripts/bump-version.sh tests/version-bump/test-bump-version.sh
+git commit \
+  -m "fix(release): wire Hermes into version bumps" \
+  -m "Register the Hermes YAML manifest alongside the existing JSON manifests. Route manifest reads and writes by extension through jq or Mike Farah yq v4, with field names and values passed as data." \
+  -m "Preflight every present manifest before the mutating bump loop so a deterministic YAML read failure cannot leave earlier JSON manifests partially updated. Cover check, audit, bump, registry wiring, and byte-for-byte no-partial-write behavior with one focused fixture test."
+```
+
+Expected: the commit succeeds with only the three implementation paths staged.

--- a/docs/superpowers/specs/2026-08-05-hermes-version-bump-wiring-design.md
+++ b/docs/superpowers/specs/2026-08-05-hermes-version-bump-wiring-design.md
@@ -1,0 +1,47 @@
+# Hermes Version-Bump Wiring Design
+
+**Date:** 2026-08-05
+**Status:** Draft for Drew review
+
+## Goal
+
+Keep `.hermes-plugin/plugin.yaml` in lockstep with the repository version by
+registering it in `.version-bump.json` and teaching `scripts/bump-version.sh`
+to process YAML without implementing a YAML parser in Bash.
+
+## Design
+
+- Add `{ "path": ".hermes-plugin/plugin.yaml", "field": "version" }` to
+  `.version-bump.json`.
+- Dispatch manifest reads and writes by extension.
+- Keep the existing `jq` path for JSON manifests.
+- Use Mike Farah `yq` v4 for `.yaml` and `.yml` manifests.
+- Limit YAML entries to one top-level field such as `version`; dotted YAML
+  paths are out of scope.
+- Route `--check`, `--audit`, and version updates through the same dispatcher.
+
+Non-help commands fail with an actionable message when a required tool is
+missing, `yq` is not the Mike Farah v4 implementation, a YAML field is nested
+or missing, or a configured extension is unsupported. Existing JSON behavior
+and unrelated release-script semantics remain unchanged.
+
+## Tests
+
+Behavioral tests run the real script against an isolated temporary fixture and
+prove:
+
+- aligned JSON and YAML manifests pass `--check`;
+- YAML drift fails `--check`;
+- a version bump updates both formats;
+- nested YAML fields and an incompatible `yq` fail clearly; and
+- the real Hermes manifest is registered in `.version-bump.json`.
+
+Verification also runs the existing Hermes tests, shell lint, and
+`scripts/bump-version.sh --check` against the repository.
+
+## Non-Goals
+
+- No hand-written YAML parser.
+- No general nested-YAML support.
+- No Hermes runtime changes.
+- No refactor of unrelated audit, missing-file, or version-validation behavior.

--- a/docs/superpowers/specs/2026-08-05-hermes-version-bump-wiring-design.md
+++ b/docs/superpowers/specs/2026-08-05-hermes-version-bump-wiring-design.md
@@ -1,6 +1,7 @@
 # Hermes Version-Bump Wiring Design
 
 **Date:** 2026-08-05
+**Revised:** 2026-08-06
 **Status:** Draft for Drew review
 
 ## Goal
@@ -13,28 +14,30 @@ to process YAML without implementing a YAML parser in Bash.
 
 - Add `{ "path": ".hermes-plugin/plugin.yaml", "field": "version" }` to
   `.version-bump.json`.
-- Dispatch manifest reads and writes by extension.
-- Keep the existing `jq` path for JSON manifests.
-- Use Mike Farah `yq` v4 for `.yaml` and `.yml` manifests.
-- Limit YAML entries to one top-level field such as `version`; dotted YAML
-  paths are out of scope.
-- Route `--check`, `--audit`, and version updates through the same dispatcher.
+- Route `.json` through the existing `jq` helpers and `.yaml` through Mike
+  Farah `yq` v4. The YAML key and value are passed as data, not interpolated
+  into the expression.
+- Support only a present top-level YAML string field. Nested fields and `.yml`
+  are out of scope.
+- Route `--check`, `--audit`, and version updates through the same small
+  read/write dispatcher.
+- Before any non-help command, run one read-only preflight that validates the
+  required tools and configured extensions, then reads every present declared
+  manifest. This prevents a deterministic YAML failure from occurring after
+  earlier JSON files have already been updated. Missing-file behavior remains
+  unchanged, and `--help` still works without `jq` or `yq`.
 
-Non-help commands fail with an actionable message when a required tool is
-missing, `yq` is not the Mike Farah v4 implementation, a YAML field is nested
-or missing, or a configured extension is unsupported. Existing JSON behavior
-and unrelated release-script semantics remain unchanged.
+The preflight is the only reliability addition. It does not make the script
+transactional or redesign its existing audit and error-status behavior.
 
 ## Tests
 
-Behavioral tests run the real script against an isolated temporary fixture and
-prove:
+Three focused behavioral tests run the real script against an isolated
+temporary fixture and prove:
 
-- aligned JSON and YAML manifests pass `--check`;
-- YAML drift fails `--check`;
-- a version bump updates both formats;
-- nested YAML fields and an incompatible `yq` fail clearly; and
-- the real Hermes manifest is registered in `.version-bump.json`.
+- aligned JSON and YAML pass `--check`, and a bump updates both formats;
+- a preflight failure leaves every manifest unchanged; and
+- the real `.version-bump.json` registers the Hermes manifest.
 
 Verification also runs the existing Hermes tests, shell lint, and
 `scripts/bump-version.sh --check` against the repository.
@@ -42,6 +45,9 @@ Verification also runs the existing Hermes tests, shell lint, and
 ## Non-Goals
 
 - No hand-written YAML parser.
-- No general nested-YAML support.
+- No `.yml` or nested-YAML support.
 - No Hermes runtime changes.
-- No refactor of unrelated audit, missing-file, or version-validation behavior.
+- No rollback framework, general config-schema layer, audit/status refactor, or
+  exhaustive failure matrix.
+- No change to the separate version-validation and JSON-expression issue found
+  during review.

--- a/docs/superpowers/specs/2026-08-05-hermes-version-bump-wiring-design.md
+++ b/docs/superpowers/specs/2026-08-05-hermes-version-bump-wiring-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-05
 **Revised:** 2026-08-06
-**Status:** Draft for Drew review
+**Status:** Approved
 
 ## Goal
 
@@ -21,11 +21,11 @@ to process YAML without implementing a YAML parser in Bash.
   are out of scope.
 - Route `--check`, `--audit`, and version updates through the same small
   read/write dispatcher.
-- Before any non-help command, run one read-only preflight that validates the
-  required tools and configured extensions, then reads every present declared
-  manifest. This prevents a deterministic YAML failure from occurring after
-  earlier JSON files have already been updated. Missing-file behavior remains
-  unchanged, and `--help` still works without `jq` or `yq`.
+- Before a version bump writes any manifest, run one read-only preflight that
+  validates the required tools and reads every present declared manifest
+  through the dispatcher. This prevents a deterministic YAML failure from
+  occurring after earlier JSON files have already been updated. Missing-file
+  behavior remains unchanged, and `--help` still works without `jq` or `yq`.
 
 The preflight is the only reliability addition. It does not make the script
 transactional or redesign its existing audit and error-status behavior.
@@ -35,12 +35,15 @@ transactional or redesign its existing audit and error-status behavior.
 Three focused behavioral tests run the real script against an isolated
 temporary fixture and prove:
 
-- aligned JSON and YAML pass `--check`, and a bump updates both formats;
-- a preflight failure leaves every manifest unchanged; and
+- aligned JSON and YAML pass `--check` and `--audit`, and a bump updates both
+  formats;
+- an actual bump with JSON declared first and a later YAML manifest whose
+  top-level `version` is not a string exits nonzero and leaves every manifest
+  byte-for-byte unchanged; and
 - the real `.version-bump.json` registers the Hermes manifest.
 
-Verification also runs the existing Hermes tests, shell lint, and
-`scripts/bump-version.sh --check` against the repository.
+Verification also runs shell lint and `scripts/bump-version.sh --check` against
+the repository.
 
 ## Non-Goals
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -40,10 +40,70 @@ write_json_field() {
   jq "$jq_path = \"$value\"" "$file" > "$tmp" && mv "$tmp" "$file"
 }
 
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required tool '$1' is not on PATH" >&2
+    return 1
+  }
+}
+
+read_yaml_field() {
+  local file="$1" field="$2"
+  require_tool yq || return 1
+  FIELD="$field" yq -er '.[strenv(FIELD)] | select(tag == "!!str")' "$file"
+}
+
+write_yaml_field() {
+  local file="$1" field="$2" value="$3"
+  FIELD="$field" VALUE="$value" \
+    yq -i '.[strenv(FIELD)] = strenv(VALUE)' "$file"
+}
+
+read_manifest_field() {
+  local file="$1"
+
+  case "$file" in
+    *.json) read_json_field "$@" ;;
+    *.yaml) read_yaml_field "$@" ;;
+    *)
+      echo "error: unsupported manifest format: $file" >&2
+      return 1
+      ;;
+  esac
+}
+
+write_manifest_field() {
+  local file="$1"
+
+  case "$file" in
+    *.json) write_json_field "$@" ;;
+    *.yaml) write_yaml_field "$@" ;;
+    *)
+      echo "error: unsupported manifest format: $file" >&2
+      return 1
+      ;;
+  esac
+}
+
 # Read the list of declared files from config.
 # Outputs lines of "path<TAB>field"
 declared_files() {
   jq -r '.files[] | "\(.path)\t\(.field)"' "$CONFIG"
+}
+
+preflight_manifests() {
+  local path field fullpath
+
+  require_tool jq || return 1
+  while IFS=$'\t' read -r path field; do
+    fullpath="$REPO_ROOT/$path"
+    [[ -f "$fullpath" ]] || continue
+
+    if ! read_manifest_field "$fullpath" "$field" >/dev/null; then
+      echo "error: cannot read declared manifest: $path ($field)" >&2
+      return 1
+    fi
+  done < <(declared_files)
 }
 
 # Read the audit exclude patterns from config.
@@ -68,7 +128,7 @@ cmd_check() {
       continue
     fi
     local ver
-    ver=$(read_json_field "$fullpath" "$field")
+    ver=$(read_manifest_field "$fullpath" "$field")
     printf "  %-45s  %s\n" "$path ($field)" "$ver"
     versions+=("$ver")
   done < <(declared_files)
@@ -101,7 +161,7 @@ cmd_audit() {
   current_version=$(
     while IFS=$'\t' read -r path field; do
       local fullpath="$REPO_ROOT/$path"
-      [[ -f "$fullpath" ]] && read_json_field "$fullpath" "$field"
+      [[ -f "$fullpath" ]] && read_manifest_field "$fullpath" "$field"
     done < <(declared_files) | sort | uniq -c | sort -rn | head -1 | awk '{print $2}'
   )
 
@@ -172,6 +232,8 @@ cmd_bump() {
     exit 1
   fi
 
+  preflight_manifests
+
   echo "Bumping all declared files to $new_version..."
   echo ""
 
@@ -182,8 +244,8 @@ cmd_bump() {
       continue
     fi
     local old_ver
-    old_ver=$(read_json_field "$fullpath" "$field")
-    write_json_field "$fullpath" "$field" "$new_version"
+    old_ver=$(read_manifest_field "$fullpath" "$field")
+    write_manifest_field "$fullpath" "$field" "$new_version"
     printf "  %-45s  %s -> %s\n" "$path ($field)" "$old_ver" "$new_version"
   done < <(declared_files)
 

--- a/tests/version-bump/test-bump-version.sh
+++ b/tests/version-bump/test-bump-version.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_SOURCE="$REPO_ROOT/scripts/bump-version.sh"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+make_fixture() {
+  local repo="$1"
+  local yaml_body="$2"
+
+  mkdir -p "$repo/scripts" "$repo/.hermes-plugin"
+  cp "$SCRIPT_SOURCE" "$repo/scripts/bump-version.sh"
+  cat >"$repo/.version-bump.json" <<'JSON'
+{
+  "files": [
+    { "path": "package.json", "field": "version" },
+    { "path": ".hermes-plugin/plugin.yaml", "field": "version" }
+  ],
+  "audit": { "exclude": [] }
+}
+JSON
+  cat >"$repo/package.json" <<'JSON'
+{
+  "name": "fixture",
+  "version": "1.2.3"
+}
+JSON
+  printf '%s\n' "$yaml_body" >"$repo/.hermes-plugin/plugin.yaml"
+}
+
+happy_repo="$TEST_ROOT/happy"
+make_fixture "$happy_repo" $'name: superpowers\nversion: 1.2.3'
+
+/bin/bash "$happy_repo/scripts/bump-version.sh" --check >"$TEST_ROOT/check.out"
+/bin/bash "$happy_repo/scripts/bump-version.sh" --audit >"$TEST_ROOT/audit.out"
+/bin/bash "$happy_repo/scripts/bump-version.sh" 2.3.4 >"$TEST_ROOT/bump.out"
+
+[[ "$(jq -r '.version' "$happy_repo/package.json")" == "2.3.4" ]] \
+  || fail "JSON manifest was not bumped"
+[[ "$(yq -r '.version' "$happy_repo/.hermes-plugin/plugin.yaml")" == "2.3.4" ]] \
+  || fail "YAML manifest was not bumped"
+
+jq -e '
+  any(.files[];
+    .path == ".hermes-plugin/plugin.yaml" and .field == "version")
+' "$REPO_ROOT/.version-bump.json" >/dev/null \
+  || fail "Hermes manifest is not registered"
+
+invalid_repo="$TEST_ROOT/invalid"
+make_fixture "$invalid_repo" $'name: superpowers\nversion: 123'
+cp "$invalid_repo/package.json" "$TEST_ROOT/package.before"
+cp "$invalid_repo/.hermes-plugin/plugin.yaml" "$TEST_ROOT/plugin.before"
+
+if /bin/bash "$invalid_repo/scripts/bump-version.sh" 2.3.4 \
+  >"$TEST_ROOT/invalid.out" 2>&1; then
+  fail "bump accepted a non-string YAML version"
+fi
+
+cmp -s "$TEST_ROOT/package.before" "$invalid_repo/package.json" \
+  || fail "JSON manifest changed before YAML validation failed"
+cmp -s "$TEST_ROOT/plugin.before" "$invalid_repo/.hermes-plugin/plugin.yaml" \
+  || fail "invalid YAML manifest changed"
+
+echo "Version-bump tests passed"


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5.6 via Codex; exact runtime model ID is not exposed in this session |
| Harness + version | Codex desktop; version not exposed in this session |
| All plugins installed | Superpowers 6.1.1; GitHub 0.1.8; Codex Security 0.1.17; Primeradiant Ops 2.5.0; Superpowers Cloud Build 0.9.0; OpenAI bundled/runtime plugins |
| Human partner who reviewed this diff | Drew Ritter (@arittr), maintainer |

## What problem are you trying to solve?

During the separate Hermes version correction for PR #2025, the repository was left with a real release-tooling gap: `.hermes-plugin/plugin.yaml` was at 6.2.0 but was absent from `.version-bump.json`. The current `scripts/bump-version.sh --audit` therefore reports the Hermes manifest as undeclared, and a future version bump would update the JSON manifests while silently leaving Hermes stale. The script also assumes every configured manifest is JSON, so simply registering the YAML file would fail.

## What does this PR change?

- Registers `.hermes-plugin/plugin.yaml` as a top-level `version` manifest.
- Routes JSON through the existing `jq` helpers and YAML through maintainer-only Mike Farah `yq` v4 helpers, with field names and values passed as data.
- Preflights every present manifest before a mutating bump, preventing deterministic JSON-before-invalid-YAML partial updates.
- Adds a real-script fixture test covering `--check`, `--audit`, bumping both formats, registry wiring, and byte-for-byte immutability on invalid YAML field types.

## Is this change appropriate for the core library?

Yes. This is core release tooling for manifests shipped by this repository, and it prevents a harness manifest from drifting from the core version. `yq` is confined to maintainer release tooling; it is not a plugin runtime dependency and is only needed by the maintainers who run version bumps.

## What alternatives did you consider?

- Continue hand-editing the Hermes manifest for each release: this is the current workaround and is exactly how the registry gap can recur.
- Rewrite the whole release script around YAML tooling: unnecessary churn for one YAML manifest.
- Implement a YAML parser in Bash: fragile and larger than the problem.
- Use a broad transaction/rollback framework: outside the failure mode addressed here; the narrow read-only preflight catches deterministic manifest failures before writes.

## Does this PR contain multiple unrelated changes?

No. The design/spec documents, registry entry, release-script dispatch, preflight, and focused test all support the one problem of keeping Hermes versioned with the repository.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2025 (merged Hermes harness support; this PR only adds its manifest to release wiring), #2026 (merged v6.2.0 release prep; it bumped the seven existing JSON manifests but did not change the registry or script), #1261 and #1165 (prior JSON manifest/version-tooling conventions), and the earlier Hermes attempts #1922, #1892, and #1861 documented by #2025. No duplicate PR for this YAML version-bump wiring was found.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop | not exposed in session | GPT-5.6 | exact runtime ID not exposed |

## New harness support

Not applicable. This PR does not add or alter harness support; the Hermes integration was merged separately in #2025.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Not applicable — no new harness is introduced by this PR.

</details>

## Evaluation

- Initial prompt: Drew asked to handle Hermes manifest version-bump wiring on a new branch, separate from the already-pushed version correction.
- Evaluation after the change: one isolated real-script fixture with TDD red/green cycles, plus the existing 19-test Hermes suite.
- Before: Hermes was absent from the version registry, `--audit` reported it as undeclared, and the JSON-only path could not safely process a configured YAML manifest.
- After: the fixture passes `--check`, `--audit`, and bumping both formats; a non-string YAML version fails before any write; all eight repository manifests report 6.2.0 in sync.

## Rigor

- [ ] If this is a skills change: N/A — no skill content changed.
- [x] This change was tested adversarially, not just on the happy path.
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement.

Adversarial coverage includes a later invalid YAML manifest after a valid JSON manifest, byte-for-byte comparisons of every manifest, the independent `--audit` read path, shell lint, and the full Hermes test suite.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew Ritter reviewed the complete branch diff in Codex and explicitly directed publication to `dev`.