### PR TITLE
feat(brainstorming): ask about quality tooling in the design presentation for new projects

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -85,6 +85,7 @@ digraph brainstorming {
 - Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
 - Ask after each section whether it looks right so far
 - Cover: architecture, components, data flow, error handling, testing
+- For a new project (or one with no configured tooling), the design presentation includes a short tooling question alongside the architecture: which of these to set up from the start — cheapest before any code exists: aggressive linting + auto-formatting (the stack's standard, e.g. ruff+format / eslint+prettier / clippy+rustfmt); unit-test infrastructure (runner, layout, a first passing fixture); end-to-end test infrastructure; fuzz or mutation testing where the stack supports it. The user's selections land in the spec's Global Constraints so every later plan and task inherits them.
 - Be ready to go back and clarify if something doesn't make sense
 
 **Design for isolation and clarity:**


### PR DESCRIPTION
> **This PR targets `dev`.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code CLI 2.1.223 (authoring session); eval sessions ran Codex CLI 0.144.4 inside the quorum/gauntlet container harness |
| All plugins installed | superpowers 6.2.0, agent-sdk-dev, clangd-lsp, claude-code-setup, code-review, code-simplifier, context7, feature-dev, frontend-design, gopls-lsp, linear, episodic-memory, github-triage, plugin-dev, superpowers-chrome |
| Human partner who reviewed this diff | Jesse Vincent (@obra) |

## What problem are you trying to solve?

When someone starts a brand-new project through superpowers, no skill ever asks about quality tooling — linting/auto-formatting, unit-test infrastructure, e2e tests. The session silently decides (in practice: none), and the project is built without any of it. The user never gets the choice at the one moment it's cheapest to take: before any code exists.

This is measured, not theoretical. In a controlled eval cell (build-a-CLI-from-scratch scenario, fresh repo with no tooling configured, current dev-base superpowers loaded, containerized end-to-end sessions through brainstorming → spec → plan → subagent-driven implementation → merge), **0/3 control sessions ever asked the user about tooling**, and all three shipped implementation plans whose Global Constraints contained zero tooling requirements. No linting or formatting infrastructure was configured in any control run. Hand-reads confirmed the mechanical result: every candidate "tooling mention" in the controls was incidental narration ("formatting" inside TDD prose), never a question to the user.

The problem statement originated from my human partner in a live review session: which quality tooling to set up is an ask-the-user question, never a silent default.

## What does this PR change?

Adds one bullet to `skills/brainstorming/SKILL.md`'s "Presenting the design" section: for a new project (or one with no configured tooling), the design presentation includes a tooling question — aggressive linting + auto-formatting, unit-test infrastructure, e2e test infrastructure, fuzz/mutation testing where supported — and the user's selections land in the spec's Global Constraints so every later plan and task inherits them.

## Is this change appropriate for the core library?

Yes. It's harness-, language-, and domain-agnostic (the text names stack-standard examples — ruff/eslint+prettier/clippy — as illustrations, not dependencies). Anyone starting any kind of project benefits; it integrates no third-party service.

## What alternatives did you consider?

Two placements were drafted and tested head-to-head in the same battery:

- **Draft A (this PR):** the ask batched into brainstorming's design presentation — rides the existing "does this look right?" approval gate.
- **Draft B:** a dedicated "Tooling Check" question in `writing-plans`, after spec approval, before task writing.

Empirically they tied on every endpoint (both fire 3/3, both before any code, both land constraints 6/6 combined, both guard-clean). Draft B costs one extra interaction turn in every new project's flow; Draft A rides an existing gate. My human partner chose Draft A on that trade-off. Also considered and rejected: placing the ask at implementation time (too late — code exists, and the user may no longer be attending), and leaving tooling to agent judgment (contradicts the observed behavior: the judgment silently exercised is "none").

## Does this PR contain multiple unrelated changes?

No. One bullet, one file.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found proposing a tooling ask. Nearest neighbors, both different problems: #855 (closed — TDD treatment of config/tooling *tasks* once they exist in a plan; this PR is about the ask that creates them) and #1831 (open — writing-plans Invariants block; adjacent file, unrelated concern).

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex CLI (containerized quorum/gauntlet eval harness, superpowers loaded as real plugin) | 0.144.4 | GPT-5.6 | gpt-5.6-sol (served model verified per-rep from rollout records; uniform across all 9 reps) |

## New harness support

Not applicable — no new harness.

## Evaluation

- **Initial prompt:** eval sessions open with a naive "Let's build a reading-list CLI" style message against a fresh repo containing only a README; scripted user replies carry the session through brainstorming's question loop. One pinned reply ("Yes — linting, auto-formatting, and unit tests please. Skip fuzz testing.") is used **only if the session asks about tooling**.
- **Sessions run:** 9 end-to-end reps — 3 control (unmodified dev-base superpowers), 3 with this PR's exact text, 3 with the alternative Draft B placement. Each rep is a full brainstorm → spec → plan → subagent-driven implementation → merge session (~13–44 min of agent time each).
- **Outcome change:**
  - Control: **0/3** asked about tooling; **0/3** plans carried any tooling constraint; no lint/format infra configured.
  - This text: **3/3** asked, every ask **before any code was written**, batched into the design presentation exactly as the bullet specifies; **3/3** plans landed the user's answer in Global Constraints — including honoring the exclusion ("Do not add fuzz or mutation testing" appears explicitly).
  - Guard: all 9 sessions completed the full flow with no derailment; LLM-verifier verdicts 9/9 pass (one "investigate" was the verifier's own time budget expiring mid-merge; the rep's final git tree shows the merge completed with the full tested implementation).

Honest scope note: this cell ran on one model family (gpt-5.6-sol via Codex). The mechanism — adding an item to a presentation the agent already makes at an attended moment — is the arm class that has transferred across models in our wider testing, unlike new-procedure-at-unprompted-moment texts, but cross-model cells for this specific text have not been run. Happy to run claude/kimi/glm cells on request; the scenario and instruments are built and reusable.

## Rigor

- [x] If this is a skills change: skill-change methodology followed — the exact shipped text ran as a committed arm branch of the real plugin in a pre-registered eval battery with published verdicts (pre-registration and verdict log available on request; scored with mechanical instruments plus hand-reads of every `unknown`)
- [x] This change was tested adversarially, not just on the happy path — a control arm measured the no-text baseline; the detection instrument was conservative (weak matches resolved by hand-reading, all three control "candidates" resolved to non-asks); the scenario's pinned tooling answer is class-routed so it can never prompt the ask itself
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) — this adds one bullet to an existing list and touches nothing tuned

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission — Jesse Vincent reviewed the full one-line diff and the head-to-head evidence for both placements, and chose this one.

https://claude.ai/code/session_0185AJr98gHx5EmwqNeft4Sy
