### PR TITLE
docs: add Qwen Code install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [Gemini CLI](#gemini-cli)
   - [GitHub Copilot CLI](#github-copilot-cli)
   - [Grok Build CLI](#grok-build-cli)
+  - [Hermes Agent](#hermes-agent)
   - [Kimi Code](#kimi-code)
   - [OpenCode](#opencode)
   - [Pi](#pi)
@@ -202,6 +203,18 @@ Superpowers is available via the [official Grok plugin marketplace](https://gith
   /marketplace
   ```
 
+### Hermes Agent
+
+Install Superpowers as a Hermes plugin from this repository:
+
+```bash
+hermes plugins install obra/superpowers --enable
+```
+
+Restart any active Hermes sessions after installing. Note: Hermes has no
+post-compaction hook, so a very long session that compacts over its first
+turn loses the bootstrap — start a fresh session if skills stop triggering.
+
 ### Kimi Code
 
 Superpowers is available in Kimi Code's plugin marketplace.
@@ -266,18 +279,6 @@ Qwen Code installs plugins from Claude Code marketplaces directly.
   ```bash
   qwen extensions update superpowers
   ```
-
-### Hermes Agent
-
-Install Superpowers as a Hermes plugin from this repository:
-
-```bash
-hermes plugins install obra/superpowers --enable
-```
-
-Restart any active Hermes sessions after installing. Note: Hermes has no
-post-compaction hook, so a very long session that compacts over its first
-turn loses the bootstrap — start a fresh session if skills stop triggering.
 
 ## The Basic Workflow
 

--- a/README.md
+++ b/README.md
@@ -211,9 +211,7 @@ Install Superpowers as a Hermes plugin from this repository:
 hermes plugins install obra/superpowers --enable
 ```
 
-Restart any active Hermes sessions after installing. Note: Hermes has no
-post-compaction hook, so a very long session that compacts over its first
-turn loses the bootstrap — start a fresh session if skills stop triggering.
+Restart any active Hermes sessions after installing.
 
 ### Kimi Code
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [Kimi Code](#kimi-code)
   - [OpenCode](#opencode)
   - [Pi](#pi)
+  - [Qwen Code](#qwen-code)
 - [The Basic Workflow](#the-basic-workflow)
 - [Community](#community)
 - [What's Inside](#whats-inside)
@@ -32,7 +33,7 @@ Superpowers is a complete software development methodology for your coding agent
 
 ## Quickstart
 
-Give your agent Superpowers: [Claude Code](#claude-code), [Antigravity](#antigravity), [Codex App](#codex-app), [Codex CLI](#codex-cli), [Cursor](#cursor), [Devin CLI](#devin-cli), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [GitHub Copilot CLI](#github-copilot-cli), [Grok Build CLI](#grok-build-cli), [Hermes Agent](#hermes-agent), [Kimi Code](#kimi-code), [OpenCode](#opencode), [Pi](#pi).
+Give your agent Superpowers: [Claude Code](#claude-code), [Antigravity](#antigravity), [Codex App](#codex-app), [Codex CLI](#codex-cli), [Cursor](#cursor), [Devin CLI](#devin-cli), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [GitHub Copilot CLI](#github-copilot-cli), [Grok Build CLI](#grok-build-cli), [Hermes Agent](#hermes-agent), [Kimi Code](#kimi-code), [OpenCode](#opencode), [Pi](#pi), [Qwen Code](#qwen-code).
 
 ## How it works
 
@@ -249,6 +250,22 @@ pi -e /path/to/superpowers
 ```
 
 The Pi package loads the Superpowers skills and a small extension that injects the `using-superpowers` bootstrap at session startup and again after compaction. Pi has native skills, so no compatibility `Skill` tool is required. Subagent and task-list tools remain optional Pi companion packages.
+
+### Qwen Code
+
+Qwen Code installs plugins from Claude Code marketplaces directly.
+
+- Install the plugin from this repository, and pick `superpowers` when prompted:
+
+  ```bash
+  qwen extensions install obra/superpowers
+  ```
+
+- Update later:
+
+  ```bash
+  qwen extensions update superpowers
+  ```
 
 ### Hermes Agent
 


### PR DESCRIPTION
> Targets `dev`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code 2.1.224 |
| All plugins installed | superpowers (this repo, dev), superpowers-chrome 1.6.1, cloud-build 0.9.0, decision-log 0.1.0, elements-of-style 1.0.0, episodic-memory 1.0.15, iterative-development 0.1.0, linear (official), primeradiant-ops 1.9.2, rust-analyzer-lsp 1.0.0 |
| Human partner who reviewed this diff | Drew Ritter (@drewritter), maintainer — reviewed the complete diff before submission |

## What problem are you trying to solve?

Qwen Code now installs Claude Code marketplace plugins natively
(`qwen extensions install <owner>/<repo>`, see [their docs](https://qwenlm.github.io/qwen-code-docs/en/users/extension/introduction/#from-claude-code-marketplace)),
but the README doesn't mention it, so Qwen Code users have no way to know
Superpowers works there. Verified on the maintainer's machine: the install
command prompts to select `superpowers` from the marketplace, registers it
as extension `superpowers` (6.2.0), and loads the plugin's `GEMINI.md`
bootstrap context plus all 14 skills natively — the same mechanism Gemini
CLI uses. No integration code is needed; only install docs.

## What does this PR change?

Adds a Qwen Code entry to the README: TOC, Quickstart harness list, and an
install section (install + update commands) after Pi. A second commit fixes
adjacent README housekeeping noticed while making this change: Hermes Agent
was missing from the TOC and its section sat after Pi, out of the
alphabetical order every other harness follows — the section text moved
verbatim. A third commit drops the Hermes post-compaction caveat from that
block at maintainer direction. Docs only — no code, no skills touched.

## Is this change appropriate for the core library?

Yes — install documentation for a supported harness, same as the existing
Devin CLI / Grok Build CLI / Gemini CLI entries. Useful to any Qwen Code
user regardless of project.

## What alternatives did you consider?

- Shipping a dedicated Qwen integration (installer script, `.qwen-plugin`
  dir) as prior PRs attempted — rejected: Qwen's native Claude-marketplace
  support plus the existing Gemini extension format make it unnecessary.
  Zero-dependency docs-only is the smallest correct change.
- Documenting the `marketplace:plugin` install form from Qwen's docs —
  rejected in favor of the plain `qwen extensions install obra/superpowers`
  form actually run and verified on a real machine.

## Does this PR contain multiple unrelated changes?

Two related changes to the same README harness list, bundled at maintainer
direction: the Qwen Code entry, and a fix for the Hermes Agent entry's
placement in that list (missing TOC line, out-of-order section — the lines
directly adjacent to where the Qwen section lands). Separate commits.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #516 (open), #1136 (draft), #1094 (closed), #128 (findings referenced by #516)

Prior Qwen PRs predate Qwen's native Claude Code marketplace support and
add integration code (installers/adapters) to carry the plugin across.
That code is now unnecessary: current Qwen Code (0.21.7) installs the
plugin directly from this repo and loads the bootstrap itself. This PR
succeeds where those stalled because there is nothing left to integrate —
it only documents the working native path.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Qwen Code | 0.21.7 | GLM 5.2 (via OpenRouter) | z-ai/glm-5.2 |
| Claude Code | 2.1.224 | Claude Fable 5 | claude-fable-5 |

Qwen Code: real install verified on macOS (`qwen extensions install
obra/superpowers` → select `superpowers` → `qwen extensions list` shows
extension `superpowers` 6.2.0 with `GEMINI.md` context and all 14 skills
loaded; `qwen extensions update superpowers` is the documented update
path, confirmed against `qwen extensions update --help`). Claude Code:
authoring environment for the docs change.

## New harness support (required if this PR adds a new harness)

This PR adds install docs for a new harness (no integration code — Qwen
Code consumes the existing Claude plugin/Gemini extension format natively).

Acceptance test: clean interactive Qwen Code session (driven via tmux) in
an empty directory with the extension installed. `brainstorming`
auto-triggered before any code was written — the session announced the
skill, created its checklist, explored the (empty) project context, and
stopped at a scope question waiting for the user. The directory contained
zero files when the session was ended.

Caveat, for the record: headless one-shot mode (`qwen -p "Let's make a
react todo list" -y`) built the app straight away with no visible
brainstorming flow. The interactive session below is the prescribed
acceptance test, and it passes.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
  │ >_ Qwen Code (v0.21.7)                                   │
  │ OpenRouter | [OpenRouter] z-ai/glm-5.2                   │
  │ /private/.../scratchpad/qwen-acceptance-2                │

  > Let's make a react todo list

  ✓ Skill Use skill: "brainstorming"
    You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.
  ∴︎ Thought briefly (click or ctrl+o to expand)
  ◆︎ Using the brainstorming skill to design the React todo list before implementing.
  ✓ Listed .
  ✓ TodoList Create todos
    ◐︎  Explore project context
    ○︎  Ask clarifying questions
    ○︎  Propose 2-3 approaches with trade-offs
    ○︎  Present design and get approval
    ○︎  Write design doc and commit
    ○︎  Spec self-review
    ○︎  User reviews written spec
    ○︎  Transition to implementation via writing-plans skill
  ∴︎ Thought briefly (click or ctrl+o to expand)
  ◆︎ This is a fresh, empty directory — greenfield project, no existing conventions to follow.
  ✓ TodoList Update todos
    ●︎  Explore project context
    ◐︎  Ask clarifying questions
    ○︎  Propose 2-3 approaches with trade-offs
    ○︎  Present design and get approval
    ○︎  Write design doc and commit
    ○︎  Spec self-review
    ○︎  User reviews written spec
    ○︎  Transition to implementation via writing-plans skill
  ◆︎ Let me ask a few questions to understand what you want to build. Starting with the most important one:
  ? AskUserQuestion Ask user 1 question ←
   Scope
   What scope of todo list are you looking for?
   ❯ 1. Classic (Recommended)
        Add, complete, delete todos. In-memory only, no persistence. Fast to build and run.
     2. Classic + filters + persistence
        Above plus localStorage persistence and filter tabs (all/active/completed).
     3. Full-featured
        Above plus editing, due dates, priorities, tags, and sorting.
     4. Type something...
   ↑/↓: Navigate | Enter: Select | Esc: Cancel
  ⠏ Waiting for user confirmation...
```

</details>

## Evaluation
- Initial prompt: maintainer session — "let's add qwen code cli support to
  the readme" after verifying the install works interactively.
- Eval sessions after the change: N/A — README install docs, not
  behavior-shaping skill content. The acceptance test above verifies the
  integration the docs describe.
- Outcome: Qwen Code users get a documented, verified install path.

## Rigor

- [ ] If this is a skills change — N/A, no skill content touched.
- [x] This change was tested adversarially, not just on the happy path:
      commands verified against Qwen's docs AND a real install (extension
      name, update syntax) rather than assumed from the Gemini pattern.
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) — untouched.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
      (Drew Ritter, maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
