### PR TITLE
docs: streamline README getting-started navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [Kimi Code](#kimi-code)
   - [OpenCode](#opencode)
   - [Pi](#pi)
+  - [Hermes Agent](#hermes-agent)
 - [The Basic Workflow](#the-basic-workflow)
 - [Community](#community)
 - [What's Inside](#whats-inside)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ Superpowers is a complete software development methodology for your coding agent
 
 ## Table of Contents
 
-- [Quickstart](#quickstart)
 - [How it works](#how-it-works)
 - [Commercial Services](#commercial-services)
-- [Installation](#installation)
+- [Getting Started](#installation)
   - [Claude Code](#claude-code)
   - [Antigravity](#antigravity)
   - [Codex App](#codex-app)
@@ -29,10 +28,6 @@ Superpowers is a complete software development methodology for your coding agent
 - [Updating](#updating)
 - [License](#license)
 - [Visual companion telemetry](#visual-companion-telemetry)
-
-## Quickstart
-
-Give your agent Superpowers: [Claude Code](#claude-code), [Antigravity](#antigravity), [Codex App](#codex-app), [Codex CLI](#codex-cli), [Cursor](#cursor), [Devin CLI](#devin-cli), [Factory Droid](#factory-droid), [Gemini CLI](#gemini-cli), [GitHub Copilot CLI](#github-copilot-cli), [Grok Build CLI](#grok-build-cli), [Hermes Agent](#hermes-agent), [Kimi Code](#kimi-code), [OpenCode](#opencode), [Pi](#pi).
 
 ## How it works
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5.6 Sol (`gpt-5.6-sol`) |
| Harness + version | Codex Desktop, runtime `0.147.0-alpha.6.5` |
| All plugins installed | `stream-deck-agents-codex` 1.0.0; `documents`, `pdf`, `spreadsheets`, `presentations`, and `template-creator` 26.805.11740; `sites` 0.1.34; `browser` 26.803.41515; `computer-use` 1.0.1000633; `visualize` 1.0.20; `primeradiant-ops` 2.5.0; `linear`, `slack`, `github`, and `codex-security` 11c74d6b; `superpowers` 6.2.0; `cloud-build` 0.9.0 |
| Human partner who reviewed this diff | Drew Ritter (@arittr) |

## What problem are you trying to solve?

PR #1293 added a Quickstart row of installation links, and PR #2090 later added a full table of contents containing the same installation links. The README now presents two adjacent navigation surfaces for the same destinations, which means readers see two competing starting points and maintainers must keep two lists synchronized.

The lists had already drifted: Hermes Agent was present in Quickstart and had an installation section, but was missing from the table of contents. That concrete mismatch demonstrated the maintenance problem rather than merely suggesting a theoretical one.

## What does this PR change?

Removes the redundant Quickstart entry and section, renames the table-of-contents label from “Installation” to “Getting Started” while preserving its existing anchor, and adds Hermes Agent to the installation links in the table of contents.

## Is this change appropriate for the core library?

Yes. This changes only the project README's general navigation. It adds no dependency, service integration, project-specific configuration, harness behavior, or skill content.

## What alternatives did you consider?

- **Keep both Quickstart and the table of contents:** rejected because the two hand-maintained lists had already drifted on Hermes Agent.
- **Also rename the `## Installation` heading:** rejected because the requested change was to the table-of-contents label; changing the heading would unnecessarily change the public anchor and existing bookmarks.
- **Remove Quickstart without adding Hermes to the table of contents:** rejected during independent review because it would remove the README's only direct link to the existing Hermes Agent installation section.

## Does this PR contain multiple unrelated changes?

No. Removing Quickstart, relabeling the remaining navigation entry, and preserving Hermes navigation are one cohesive change. The Hermes entry is necessary because Quickstart previously carried its only direct link.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1293, #2090, #2108

No duplicate was found. #1293 added the Quickstart links before a full table of contents existed. #2090 added the table of contents and deliberately retained Quickstart; this follow-up differs because the post-merge README now provides concrete evidence of duplicated-list drift through the missing Hermes entry. #2108 is an open Qwen Code documentation PR that touches the same navigation area but adds a harness rather than consolidating navigation.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex Desktop | Runtime `0.147.0-alpha.6.5` | GPT-5.6 Sol | `gpt-5.6-sol` |

Validation was structural because this is a README-only change: `git diff --check` passed; the Getting Started link resolves to the unchanged Installation heading; the Hermes link resolves to the existing Hermes Agent heading; no Quickstart references remain; and an independent read-only re-review found no remaining issues.

## New harness support (required if this PR adds a new harness)

Not applicable. This PR adds no harness support and changes no integration code.

## Evaluation

- **Initial prompt:** Drew asked, “we should remove the 'quick start' section now that we have the ToC. But rename 'Installation' in the ToC to 'Getting Started'”.
- **Eval sessions run after the change:** 0. README navigation is not loaded into agent context and does not affect skill behavior, so agent-behavior evals would not measure this change.
- **Outcome change:** Before the change, the README had two adjacent navigation surfaces and the table of contents omitted Hermes Agent. After the change, one table of contents provides the navigation, labels the installation group as Getting Started, and includes Hermes Agent.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing — **not applicable; no skill content changed.**
- [x] This change was tested adversarially, not just on the happy path — an independent reviewer identified the missing Hermes navigation link after Quickstart removal; that regression was corrected and the complete diff was re-reviewed.
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, “human partner” language) — only `README.md` changed.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Drew reviewed and explicitly approved the complete final diff before the branch was pushed and this PR was created.
