### PR TITLE
feat(tdd): the project's suite defines green, not just your test file

### DIFF
--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -182,6 +182,16 @@ Confirm:
 
 **Other tests fail?** Fix now.
 
+**"Other tests" means the project's suite, not just your file.** A
+green run of the test you wrote is not a green suite. Before you call
+the change done, run the project's test command (bare `pytest`,
+`npm test`, `cargo test` — whatever the repo uses) even when your task
+named only one test file. A scope statement in your task bounds the
+deliverable, not your verification. Any failure that run shows —
+including one you didn't cause — goes in your report by name; a red
+test you watched scroll past and didn't mention is a report falsified
+by omission.
+
 ### REFACTOR - Clean Up
 
 After green only:


### PR DESCRIPTION
> **This PR targets `dev`.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5 (`claude-fable-5`) |
| Harness + version | Claude Code CLI 2.1.223 (authoring); eval sessions ran Claude Code, Kimi Code CLI, and Pi (OpenRouter) inside the containerized quorum/gauntlet eval harness |
| All plugins installed | superpowers 6.2.0, agent-sdk-dev, clangd-lsp, claude-code-setup, code-review, code-simplifier, context7, feature-dev, frontend-design, gopls-lsp, linear, episodic-memory, github-triage, plugin-dev, superpowers-chrome |
| Human partner who reviewed this diff | Jesse Vincent (@obra) |

## What problem are you trying to solve?

When a task names a specific test file ("add the function, here's the test"), sessions verify only that file and call the change done — even when the repo's wider suite has a failure sitting right next to their change. In a controlled probe (tiny repo, a small feature task beside a pre-broken test in a *neighboring* file, test runner genuinely available), control sessions ran anything beyond their own targeted test in **1 of 12 runs** across three model families. The neighboring failure was never seen and never reported. The TDD skill already says "Other tests still pass" in its Verify GREEN checklist — and sessions read it and don't act on it, because nothing tells them what "other tests" means or that their task's scope doesn't shrink their verification.

This came out of a measured research program on verification behavior, including the finding that when sessions *do* see a failure they report it essentially every time (20/20 across our batteries) — looking is the entire bottleneck.

## What does this PR change?

Adds one paragraph to `skills/test-driven-development/SKILL.md`, in the existing "Verify GREEN" section directly under "**Other tests fail?** Fix now.": "other tests" means the project's suite, not your file; a scope statement in your task bounds the deliverable, not your verification; any failure that run shows — including one you didn't cause — goes in your report by name.

## Is this change appropriate for the core library?

Yes. Language- and domain-agnostic (names `pytest`/`npm test`/`cargo test` as examples of "whatever the repo uses"), no dependencies, and it sharpens an existing checklist item rather than adding a new procedure.

## What alternatives did you consider?

- **Same text at session-start (bootstrap) placement:** tested first — inert on claude and glm (0 effect over control), partial on kimi. Placement at the moment the model is already attending (its targeted test just went green, it's deciding "done") is the active ingredient.
- **A separate reporting rule** ("your final reply names any watched failure"): tested as its own arm — no headroom, because sessions that see a failure already report it; the gap is looking, not reporting. The report-duty sentence here rides along for the SDD-scale case where failures scroll past mid-workflow.
- **Doing nothing:** the control behavior is a 1-in-12 look rate with a broken neighbor test present.

## Does this PR contain multiple unrelated changes?

No. One paragraph, one file.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none proposing this. Adjacent but different: #946 (open — smoke check at branch-finish time; different moment, complementary), #711 (open — TDD cycle in plan generation; different area).

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code (containerized quorum harness, real plugin) | 2.1.x container | Claude Sonnet 5 | claude-sonnet-5 (served model verified per rep) |
| Kimi Code CLI (same harness) | container | Kimi | kimi-for-coding (from wire-log records) |
| Pi (same harness, OpenRouter) | container | GLM | z-ai/glm-5.2 |

## New harness support

Not applicable.

## Evaluation

- **Initial prompt:** probe sessions get a single small feature task ("add `low_stock_items` to inventory.py, test in test_inventory.py") in a repo where a *neighboring* file's test is already broken. The task never mentions the neighbor. A ready-to-use venv with pytest is provisioned and documented in the fixture README, so "couldn't run the suite" is eliminated as a confound (an earlier version of this battery was discarded and re-run for exactly that reason).
- **Sessions run:** 24 (12 control, 12 with this text), 4 per model family per arm, pre-registered endpoints, per-rep served model recorded.
- **Outcomes** (strict criteria: a "look" requires a suite invocation that produced output; a "saw" requires the failure block in a tool result; file reads and failed attempts don't count):
  - Control: looked 1/12 (one kimi rep); the neighbor failure was reported in that 1.
  - With this text: looked 8/12 — sonnet 4/4, kimi 3/4, glm 1/4 — and **every session that saw the failure named it in its final reply, and none "fixed" the out-of-scope test** (scope discipline held; they reported it instead).
  - Same text at bootstrap placement (earlier battery): no effect on claude/glm — the placement is what changed behavior, not the words alone.

## Rigor

- [x] Skills-change methodology: the exact diff in this PR ran as a committed arm branch of the real plugin in a pre-registered battery; verdicts, per-rep tables, and correction history are in the research log (available on request). The scoring for this battery was done under an adversarial-audit regime adopted this week: signature-counts-before-narrative, strict event criteria, hand-reads with citations.
- [x] Tested adversarially, not just happy path: the control arm measures the no-text baseline; a confounded first battery (test runner silently unavailable) was caught, quarantined, and re-run rather than scored; instrument false-positives (file reads counted as "saw") were caught by near-miss validation and excluded.
- [x] No carefully-tuned content modified — this adds one paragraph under an existing checklist item; Red Flags tables, rationalization lists, and "human partner" language are untouched.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission — Jesse Vincent reviewed the paragraph and the cross-family battery results and chose to ship it.

https://claude.ai/code/session_0185AJr98gHx5EmwqNeft4Sy
