### PR TITLE
fix(hooks): eliminate subprocess spawns in session-start

### DIFF
--- a/hooks/session-start
+++ b/hooks/session-start
@@ -3,27 +3,50 @@
 
 set -euo pipefail
 
-# Determine plugin root directory
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# Determine plugin root directory without forking dirname/cd/pwd subshells -
+# on Windows each subprocess spawn costs ~250-300ms (fork() is emulated).
+# hooks.json invokes the wrapper as "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd",
+# so the variable is guaranteed set under Claude Code; Cursor sets
+# CURSOR_PLUGIN_ROOT. The ${0%/*} fallback keeps standalone execution
+# working without a subshell (it does not resolve ".." or symlinks the way
+# `cd && pwd` did, but nothing here ever displays SCRIPT_DIR/PLUGIN_ROOT -
+# it is only used to build a path handed to a file read, which resolves
+# ".." itself).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+elif [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+    PLUGIN_ROOT="${CURSOR_PLUGIN_ROOT}"
+else
+    case "$0" in
+        */*) PLUGIN_ROOT="${0%/*}/.." ;;
+        *) PLUGIN_ROOT=".." ;;
+    esac
+fi
 
-# Read using-superpowers content
-using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
+# Read using-superpowers content via a bash builtin instead of forking cat.
+# Note: this changes the failure-path behavior slightly. The original's
+# `2>&1 || echo ...` folded cat's own stderr text into the injected content
+# on a partial failure; this guard instead falls back to a clean fixed
+# string. Flagging this explicitly since it's the one behavior difference
+# in this change - everything else is byte-identical to the original.
+skill_file="${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md"
+if [ -r "$skill_file" ]; then
+    using_superpowers_content=$(<"$skill_file")
+else
+    using_superpowers_content="Error reading using-superpowers skill"
+fi
 
 # Escape string for JSON embedding using bash parameter substitution.
 # Each ${s//old/new} is a single C-level pass - orders of magnitude
-# faster than the character-by-character loop this replaces.
-escape_for_json() {
-    local s="$1"
-    s="${s//\\/\\\\}"
-    s="${s//\"/\\\"}"
-    s="${s//$'\n'/\\n}"
-    s="${s//$'\r'/\\r}"
-    s="${s//$'\t'/\\t}"
-    printf '%s' "$s"
-}
-
-using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
+# faster than the character-by-character loop this replaces. Done in
+# place on the target variable instead of through a captured function
+# call so this doesn't fork a subshell either.
+using_superpowers_escaped="$using_superpowers_content"
+using_superpowers_escaped="${using_superpowers_escaped//\\/\\\\}"
+using_superpowers_escaped="${using_superpowers_escaped//\"/\\\"}"
+using_superpowers_escaped="${using_superpowers_escaped//$'\n'/\\n}"
+using_superpowers_escaped="${using_superpowers_escaped//$'\r'/\\r}"
+using_superpowers_escaped="${using_superpowers_escaped//$'\t'/\\t}"
 session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n</EXTREMELY_IMPORTANT>"
 
 # Output context injection as JSON.
@@ -37,13 +60,13 @@ session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the 
 # See: https://github.com/obra/superpowers/issues/571
 if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
   # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
-  printf '{\n  "additional_context": "%s"\n}\n' "$session_context" | cat
+  printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
 elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
   # Claude Code sets CLAUDE_PLUGIN_ROOT without COPILOT_CLI
-  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context" | cat
+  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context"
 else
   # Copilot CLI (sets COPILOT_CLI=1) or unknown platform — SDK standard format
-  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context" | cat
+  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
 fi
 
 exit 0

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -217,6 +217,38 @@ assert_command_output \
     CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
     bash "$HOOK_UNDER_TEST"
 
+# Missing SKILL.md: falls back to a clean fixed string, without folding a
+# stderr "No such file" / "cat:" message from the failed read into the
+# injected context.
+missing_skill_root="$TEST_ROOT/missing-skill-root"
+mkdir -p "$missing_skill_root"
+missing_skill_home="$(make_home missing-skill)"
+assert_command_output \
+    "SessionStart falls back cleanly when SKILL.md is missing" \
+    "nested" \
+    "Error reading using-superpowers skill" \
+    "No such file"$'\037'"cat:" \
+    "$missing_skill_home" \
+    CLAUDE_PLUGIN_ROOT="$missing_skill_root" \
+    bash "$HOOK_UNDER_TEST"
+
+# CLAUDE_PLUGIN_ROOT must be authoritative for locating the hook's own
+# files, not merely consulted for the output JSON shape. Point it at a
+# second plugin root with distinguishable content and confirm the hook
+# reads from there rather than from $0's real location.
+divergent_root="$TEST_ROOT/divergent-plugin-root"
+mkdir -p "$divergent_root/skills/using-superpowers"
+printf '%s\n' "MARKER-DIVERGENT-PLUGIN-ROOT-CONTENT" >"$divergent_root/skills/using-superpowers/SKILL.md"
+divergent_home="$(make_home divergent-plugin-root)"
+assert_command_output \
+    "SessionStart honors CLAUDE_PLUGIN_ROOT over \$0's real location" \
+    "nested" \
+    "MARKER-DIVERGENT-PLUGIN-ROOT-CONTENT" \
+    "Red Flags" \
+    "$divergent_home" \
+    CLAUDE_PLUGIN_ROOT="$divergent_root" \
+    bash "$HOOK_UNDER_TEST"
+
 if [[ "$FAILURES" -gt 0 ]]; then
     echo "STATUS: FAILED ($FAILURES failure(s))"
     exit 1


### PR DESCRIPTION
> **This PR targets `dev`, not `main`.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Sonnet 5 (`claude-sonnet-5`) |
| Harness + version | Claude Code 2.1.226 |
| All plugins installed | `supabase@claude-plugins-official` v0.1.13 (user-scope; unrelated to this change) |
| Human partner who reviewed this diff | Samed Bilgin (@SamedBilginAlternet) |

## What problem are you trying to solve?

Issue #2081: `hooks/session-start` forks 6 subprocesses on every session
start for work that needs none. It's harmless on Linux/macOS, but on
Windows (where `fork()` is emulated) the reporter measured 2254ms as
shipped vs. 291ms with the spawns removed, roughly 2s of pure overhead on
every session start, every `/clear`, and every auto-compact. They
confirmed byte-identical output (same SHA-256, same length, same exit
code) across 7 runs each.

I'm not the one who hit this in a live session, and I want to be upfront
about that rather than imply otherwise: I found this by reading the issue
tracker, not from a session where the slowdown affected me directly. What
made me pick this one specifically is that the issue isn't a request for
someone else to investigate. The reporter already fully diagnosed it,
wrote a complete patch, and verified it byte-identical to the original
(SHA-256 `69cde947...`, which I independently reproduced myself before
touching any code, same hash). They explicitly said they didn't open a PR
themselves only because of one open question about a minor error-path
behavior change, and invited whoever picked it up to send one. This PR
implements their patch, with one adjustment (see below), plus my own
independent verification of every claim rather than taking the issue at
its word.

## What does this PR change?

Implements the three-part patch from the issue: (1) uses
`CLAUDE_PLUGIN_ROOT`/`CURSOR_PLUGIN_ROOT` directly when the host sets it,
falling back to `${0%/*}` parameter expansion instead of forking
`dirname`+`cd`+`pwd`; (2) reads `SKILL.md` via `$(<file)` instead of
forking `cat`; (3) drops the three `printf ... | cat` pipes, which don't
do anything `printf` alone doesn't already do, and inlines the JSON-escape
substitutions on the target variable instead of capturing them through a
function call, removing that fork too. `strace -f -e trace=clone`: 8
`clone()` calls per invocation down to 0.

Also adds two cases to `tests/hooks/test-session-start.sh` covering the
two disclosed behavior changes below (missing-`SKILL.md` fallback text,
and `CLAUDE_PLUGIN_ROOT` being honored over `$0`), so a future edit that
silently reverts either one fails CI instead of only being caught by
someone re-reading this PR body.

## Is this change appropriate for the core library?

Yes. `hooks/session-start` is core plugin infrastructure that runs for
every user of every harness on every session start. It isn't
project-specific, domain-specific, or a third-party integration.

## What alternatives did you consider?

I want to be honest about the actual sequence here rather than presenting
a clean narrative. I initially wrote my own, more conservative version of
this fix: the `${0%/*}` path-resolution piece and dropping `| cat`, but I
left the `SKILL.md` read as `$(cat ...)` untouched, since removing that
fork changes the error-path semantics and I wasn't sure it was worth the
risk. I also tried converting the JSON-escape function into a nameref
out-parameter to remove its fork, but reverted that because ShellCheck
(SC2154) can't see the nameref assignment and flags the target variable
as unassigned. This repo's shell scripts have zero existing `shellcheck
disable` comments, and I didn't want to be the first PR to add one for a
small gain.

Only after drafting that did I read the rest of the issue body (past the
initial repro/measurement) and find that the reporter had already solved
both problems I was hedging on: `$(<file)` reads the file without forking
`cat` and is still a command substitution, so it still strips trailing
newlines the same way `$(cat ...)` does; and inlining the substitutions
directly onto the target variable removes the escape function's fork
without needing a nameref at all. Their version is strictly better than
what I'd written (it gets to zero forks instead of three, and it doesn't
need a lint suppression), so I adopted it instead of my own draft.

The one place I kept their patch exactly as proposed rather than picking
the alternative they offered: they flagged that `[ -r "$skill_file" ]`
changes the failure path (the original's `cat ... 2>&1 || echo ...` folds
`cat`'s own stderr text into the injected content on a partial failure;
the guard falls back to a clean fixed string instead) and asked
maintainers which behavior they wanted before opening a PR themselves. I
did not see a response to that question anywhere in the issue thread, so
I'm not resolving it unilaterally. I'm submitting their proposed behavior
and flagging it here for a maintainer to weigh in on, same as they did.

## Does this PR contain multiple unrelated changes?

No. All three code changes (path resolution, the file read, removing
`| cat`) are the same fix for the same problem (unnecessary subprocess
spawns in this one script) and were designed together as one patch in the
source issue. The two added test cases cover behavior changes introduced
by that same fix, not a separate concern.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found. Searched open+closed PRs for "session-start",
  "2081", "subprocess spawn", and "fork Windows": no PR references issue
  #2081 or implements this patch. (#2095 and #2053 touch
  session-start/cursor hook resolution but for unrelated bugs: macOS
  heredoc deadlock and Cursor plugin-root resolution, respectively.)

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|------------------|-------|-------------------|
| Claude Code (Linux) | 2.1.226 | Claude Sonnet 5 | claude-sonnet-5 |

I could not test the Windows wall-clock improvement firsthand: no Windows
environment available, and I'm relying on the issue's own measurement for
that number rather than reproducing it. What I verified myself, on Linux:

- `strace -f -e trace=clone`: 8 → 0 `clone()` calls per invocation
- SHA-256-identical output before/after across all 4 output-shape branches
  (Cursor, Claude Code, Copilot CLI, unknown-platform/SDK-standard); the
  Claude Code branch hash (`69cde947...`) matches the one the issue
  reporter posted independently
- The `$0`-has-no-slash edge case (no host env var set, script invoked as
  a bare name on PATH) still resolves correctly
- The missing-`SKILL.md` error path: confirmed the only difference from
  original behavior is the documented stderr-folding change above; built
  a throwaway copy of the hook with no `skills/` directory and diffed
  original vs. patched output directly
- One behavior difference beyond what the issue documented, found while
  testing: the original never actually uses `CLAUDE_PLUGIN_ROOT` to locate
  its own files. It derives the path from `$0` unconditionally and only
  reads `CLAUDE_PLUGIN_ROOT` later to pick the output JSON shape. So if a
  host ever set `CLAUDE_PLUGIN_ROOT` to something other than where the
  script actually lives, the original would silently ignore that and keep
  reading files relative to `$0`. This patch makes `CLAUDE_PLUGIN_ROOT`
  authoritative for file lookup when set, matching what the variable name
  implies it should do. I don't have evidence this divergence has caused
  a real bug, so I'm not claiming it as a second fix, just disclosing it
  as a behavior change I found, since the existing test suite always sets
  `CLAUDE_PLUGIN_ROOT` to match `$0`'s real location and wouldn't catch
  this either way
- `tests/hooks/test-session-start.sh`: the existing 6 assertions pass
  unmodified, plus 2 new ones I added for the two disclosed behavior
  changes above (8/8 pass). I confirmed both new assertions actually fail
  against the pre-patch script before restoring the fix, so they're real
  regression coverage, not tests that would pass either way
- `scripts/lint-shell.sh hooks/session-start tests/hooks/test-session-start.sh`:
  clean (shellcheck + shfmt), no suppressions added
- `bash -n hooks/session-start`: syntax OK

## Evaluation

- Initial prompt: none. This PR originates from reading issue #2081, not
  from a session where I personally hit the bug.
- Eval sessions run after the change: not applicable. This is a mechanical
  subprocess-count fix, not a change to skill-behavior content, so there's
  no agent behavior to eval. Correctness was verified by
  byte-identical-output comparison (see Environment tested) rather than
  session evals.

## Rigor

- [ ] If this is a skills change: N/A. This touches `hooks/session-start`,
      not skill content.
- [x] This change was tested adversarially, not just on the happy path
      (missing-file error path, no-slash `$0`, all 4 output-shape
      branches, mismatched `CLAUDE_PLUGIN_ROOT`)
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language). This PR touches only
      shell mechanics in one hook script.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
