### PR TITLE
feat(brainstorming): research prior art before design

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -95,12 +95,13 @@ your path and complete them in order.
 1. **Explore project context** — check files, docs, recent commits
 2. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
-4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+4. **Research existing solutions** — when the decision depends on unfamiliar or current external knowledge, dispatch one focused, read-only research subagent and wait for its findings before comparing approaches; skip this for self-contained work
+5. **Propose 2-3 approaches** — with trade-offs and your recommendation
+6. **Present design** — in sections scaled to their complexity, get user approval after each section
+7. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+8. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+9. **User reviews written spec** — ask user to review the spec file before proceeding
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -115,6 +116,8 @@ digraph brainstorming {
     "Implement via normal workflow (no plan doc)" [shape=doublecircle];
     "Explore project context" [shape=box];
     "Ask clarifying questions" [shape=box];
+    "External/current implementation uncertainty?" [shape=diamond];
+    "Research existing solutions\nwith one subagent" [shape=box];
     "Propose 2-3 approaches" [shape=box];
     "Present design sections" [shape=box];
     "User approves design?" [shape=diamond];
@@ -134,7 +137,10 @@ digraph brainstorming {
     "Human approves?" -> "Implement via normal workflow (no plan doc)" [label="bounded: yes"];
     "Hidden complexity? Upgrade path" -> "Classify: spike / bounded / architectural";
     "Explore project context" -> "Ask clarifying questions";
-    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Ask clarifying questions" -> "External/current implementation uncertainty?";
+    "External/current implementation uncertainty?" -> "Research existing solutions\nwith one subagent" [label="yes"];
+    "External/current implementation uncertainty?" -> "Propose 2-3 approaches" [label="no"];
+    "Research existing solutions\nwith one subagent" -> "Propose 2-3 approaches";
     "Propose 2-3 approaches" -> "Present design sections";
     "Present design sections" -> "User approves design?";
     "User approves design?" -> "Present design sections" [label="no, revise"];
@@ -157,9 +163,9 @@ reported recommendation.
 
 The subsections below serve the bounded and architectural paths (a
 spike stops at "present the probe, get a nod"). Sections from
-**Exploring approaches** onward are architectural-path depth — for
-bounded work, context plus a few questions plus a short in-chat design
-is the whole process.
+**Researching existing solutions** onward are architectural-path depth
+— for bounded work, context plus a few questions plus a short in-chat
+design is the whole process.
 
 **Understanding the idea:**
 
@@ -170,6 +176,23 @@ is the whole process.
 - Prefer multiple choice questions when possible, but open-ended is fine too
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
 - Focus on understanding: purpose, constraints, success criteria
+
+**Researching existing solutions:**
+
+- Research before proposing approaches when the choice depends on unfamiliar
+  or current external technology, APIs, libraries, established practice, or a
+  difficult-to-reverse architecture decision; skip this when current project
+  context is sufficient
+- Dispatch one focused, read-only research subagent using the research tools
+  available in the current harness; do not perform the research inline or ask
+  the subagent to choose the design
+- Ask it to inspect relevant implementation source files and test files
+  directly—not only READMEs, documentation, issue threads, or popularity
+  metadata—then report reusable patterns, APIs, edge cases, and boundaries,
+  cite attributable evidence when possible, and label missing or contradictory
+  evidence
+- Use the findings in the approach comparison; if subagent dispatch is
+  unavailable, state the evidence gap and keep unsupported claims provisional
 
 **Exploring approaches:**
 


### PR DESCRIPTION
## Summary

This PR adds a conditional, tooling-agnostic prior-art research step before
brainstorming proposes design approaches. It addresses the research portion of [#2093](https://github.com/obra/superpowers/issues/2093), follows up on [#386](https://github.com/obra/superpowers/pull/386), and implements [the maintainer's requested direction](https://github.com/obra/superpowers/pull/386#issuecomment-3824936588):
avoid coupling the workflow to GitHub or `gh`, and explicitly delegate the
research to a subagent.

When a decision depends on unfamiliar or current external knowledge, the skill dispatches one focused, read-only research subagent, asks it to inspect implementation source and tests, and uses the resulting APIs, patterns, edge cases, boundaries, and evidence gaps in the approach comparison. Self-contained work skips the step.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | OpenAI Codex, GPT-5.6 Sol |
| Harness + version | Codex desktop with Codex CLI 0.146.0 |
| All plugins installed | documents@26.805.11740; pdf@26.805.11740; spreadsheets@26.805.11740; presentations@26.805.11740; template-creator@26.805.11740; sites@0.1.31; browser@26.721.41059; chrome@26.721.41059; computer-use@1.0.1000502; visualize@1.0.15; frontend-design@local; superpowers@claude-plugins-official 6.2.0; ponytail@4.9.0; gmail@11c74d6b; slack@11c74d6b; figma@11c74d6b; superpowers@openai-curated 11c74d6b; granola@11c74d6b |
| Human partner who reviewed this diff | @Jonksar — reviewed the complete one-file diff and explicitly approved submission |

## What problem are you trying to solve?

In a background-job architecture brainstorming session, the untreated agent recommended pg-boss over BullMQ and SQLite from model recall. It dispatched no research subagent, inspected no external implementation or tests, and presented unattributed compatibility and durability claims for a difficult-to-reverse infrastructure choice.

The existing workflow asks for 2–3 approaches but has no conditional point that grounds those approaches in current library/API behavior. PR #386 identified the same gap, but remains GitHub/`gh`-specific, targets `main`, has no before/after behavioral evaluation, and has not implemented the maintainer's requested subagent revision.

## What does this PR change?

It adds one conditional step after clarifying questions in the checklist, process graph, and detailed guidance in `skills/brainstorming/SKILL.md`. Research uses the tools available in the current harness, must be delegated to one read-only subagent, and is skipped when project context is sufficient.

## Is this change appropriate for the core library?

Yes. The behavior applies to any project making decisions about external technology, APIs, libraries, established practices, or difficult-to-reverse architecture. It is provider- and domain-agnostic, adds no dependency, and
does not promote a third-party service.

## What alternatives did you consider?

- **Explicit GitHub/`gh` searches:** rejected because it couples core behavior
  to one provider and was the specific concern raised on #386.
- **A separate benchmarking skill:** rejected because research belongs inside
  the brainstorming decision flow and separate invocation was unreliable in
  the untreated eval.
- **Inline research:** rejected because the maintainer requested explicit  subagent delegation and a focused subagent preserves the main design context.
- **Research on every brainstorm:** rejected because the self-contained control showed that conditional skipping keeps trivial decisions proportionate.

## Does this PR contain multiple unrelated changes?

No. The complete diff is one behavior change in one file: 33 additions and 10 deletions in `skills/brainstorming/SKILL.md`.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs:
  - [#386](https://github.com/obra/superpowers/pull/386) — directly related. This PR implements the maintainer-requested tooling-agnostic, delegated design, targets `dev`, and supplies RED/GREEN plus task-completion evals.
    GitHub reports `maintainerCanModify: true`, but that permits obra maintainers to edit the contributor branch; it does not let this contributor take over Vincent-lkm's fork.
  - [#1512](https://github.com/obra/superpowers/pull/1512) — grounds comparisons in named dimensions but does not research current implementation evidence.
  - [#724](https://github.com/obra/superpowers/pull/724) — proposes a separate multi-agent research skill rather than a conditional brainstorming step.
  - [#1911](https://github.com/obra/superpowers/pull/1911) — closed general open-source reuse guidance; it did not alter or evaluate brainstorming.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Codex CLI | 0.146.0 | OpenAI Codex | gpt-5.6-sol |
| Pier + Codex CLI | Pier 0.3.0 / Codex 0.146.0 | OpenAI Codex | gpt-5.6-luna |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add or modify harness support.

## Evaluation

The initial human request was: add the research step described in #2093 to brainstorming, base it on implementation benchmarking, follow the contribution guidance, and validate it with evals.

Three behavioral candidate/control sessions were run after the initial change:
* an initial docs-only attempt
* the refined direct-source/test treatment, 
* and a self-contained control. 
 
Three task-completion treatment sessions were also attempted; two produced valid paired comparisons and one was excluded for violating the read-only protocol.

### Behavioral evals

| Scenario | Research behavior | Result |
|---|---|---:|
| External baseline | No research subagent | **Fail** |
| Initial treatment | One subagent, but docs/issues only | **Indeterminate** |
| Refined treatment | One subagent inspected source and tests | **Pass, 7/7** |
| Self-contained control | Correctly skipped research | **Pass, 5/5** |

### Task-completion evals

| Task | Baseline | Research | Outcome |
|---|---:|---:|---|
| HTTPX cookie store | Reward 0; 1,395/1,396 tests | **Reward 1; 1,396/1,396 tests** | +1 exact solve |
| GraphQL incremental delivery | Reward 0; 826/828 tests | Reward 0; **827/828 tests** | +1 feature test |
| **Aggregate** | **0/2 solved; 2,221/2,224 tests** | **1/2 solved; 2,223/2,224 tests** | Runtime +25.8%; cost -0.2% |

These were one-attempt Luna smoke runs on a targeted DeepSWE subset, not an official score or statistically stable estimate. The FastAPI treatment was excluded when its subagent edited the shared worktree; Yaegi passed at baseline and therefore skipped treatment; KGateway failed during Docker image creation before the model ran.

## Rigor
- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, \"human partner\" language) without extensive evals
      showing the change is an improvement

The external scenario concealed the desired research behavior and added time pressure while asking for a difficult-to-reverse infrastructure recommendation. The RED run made a confident recommendation with zero delegation. The first
GREEN wording exposed a loophole—documentation and issues were treated as implementation evidence—so the wording was tightened to require direct source and test inspection. The refined run then passed 7/7 deterministic checks. A counter-scenario verified that the conditional did not over-trigger for a self-contained wording decision.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

@Jonksar explicitly confirmed review of the complete diff and approved creating
this PR after comparing it with the stalled #386.
