### PR TITLE
sdd: warn review-package on foreign-ticket commits in range

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -402,7 +402,8 @@ parked-with-ruling at the cap.
 
 ## Final Review
 
-The final whole-branch review gets a package too: run
+The final whole-branch review gets a package too (heed any foreign-ticket
+warning it prints): run
 `scripts/review-package PLAN_FILE MERGE_BASE HEAD` (MERGE_BASE = the commit the
 branch started from, e.g. `git merge-base main HEAD`) and include the
 printed path in the final review dispatch, so the final reviewer reads

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -270,6 +270,18 @@ needed.
   call. Use the BASE you recorded before dispatching the implementer —
   never `HEAD~1`, which silently truncates multi-commit tasks. Never
   dispatch a task reviewer without a diff file.
+- `review-package` warns — non-fatally, on stderr and in a header section
+  of the output file — when `BASE..HEAD` contains a commit whose message
+  references a different ticket ID than the plan file's own. On a shared,
+  non-worktree-isolated checkout, other sessions can land unrelated
+  commits in that window; a review package that silently includes them
+  wastes the reviewer's attention on work outside this task's scope. When
+  the warning fires: re-scope (a narrower BASE, or a path-filtered diff)
+  before dispatching the reviewer, or — if the inclusion is genuinely
+  intentional, e.g. a deliberate merge of a finished sibling branch —
+  proceed and say so in the reviewer dispatch. A plan file with no
+  identifiable ticket ID in its name is unaffected; the check only runs
+  when one is found.
 - **Reviewer inputs:** the task reviewer gets three paths — the same brief
   file, the report file, and the review package — plus the global
   constraints that bind the task.

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -46,15 +46,27 @@ plan_base=$(basename "$plan")
 plan_tail=$(printf '%s' "$plan_base" | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}-//')
 own_ticket_raw=$(printf '%s' "$plan_tail" | grep -oE "$ticket_regex" | head -n1 || true)
 
+# Best-effort heuristic: matches any letters+digits token that looks like a
+# ticket ID, so an unrelated alphanumeric token (sha256, iso8601, ...) in a
+# commit subject with no real ticket ref can rarely produce a false-alarm
+# warning. Non-fatal, so the cost of a false positive is one spurious line.
 foreign_block=""
 if [ -n "$own_ticket_raw" ]; then
   own_ticket=$(normalize_ticket "$own_ticket_raw")
   while IFS=$'\t' read -r hash subject; do
     [ -n "$hash" ] || continue
-    match=$(printf '%s' "$subject" | grep -oE "$ticket_regex" | head -n1 || true)
-    [ -n "$match" ] || continue
-    if [ "$(normalize_ticket "$match")" != "$own_ticket" ]; then
-      foreign_block="${foreign_block}$(printf '%s\t%s\n' "$hash" "$subject")"
+    own_seen=0
+    other=""
+    while IFS= read -r m; do
+      [ -n "$m" ] || continue
+      if [ "$(normalize_ticket "$m")" = "$own_ticket" ]; then
+        own_seen=1
+        break
+      fi
+      [ -n "$other" ] || other=$m
+    done < <(printf '%s' "$subject" | grep -oE "$ticket_regex" || true)
+    if [ "$own_seen" -eq 0 ] && [ -n "$other" ]; then
+      foreign_block="${foreign_block}${hash}"$'\t'"${subject}"$'\n'
     fi
   done < <(git log --format='%h%x09%s' "${base}..${head}")
 fi

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -7,6 +7,12 @@
 # Usage: review-package PLAN_FILE BASE HEAD [OUTFILE]
 # Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-basename>/review-<base7>..<head7>.diff
 # (named per range, so a re-review after fixes gets a distinct fresh file).
+#
+# Foreign-ticket detection: if PLAN_FILE's basename (after its date prefix)
+# contains a ticket ID, any commit in BASE..HEAD whose subject references a
+# DIFFERENT ticket ID triggers a non-fatal warning on stderr and a header
+# section in OUTFILE — a signal that another session's work may have
+# landed in this range on a shared, non-isolated checkout.
 set -euo pipefail
 
 if [ $# -lt 3 ] || [ $# -gt 4 ]; then
@@ -29,7 +35,45 @@ else
   out="$dir/review-$(git rev-parse --short "$base")..$(git rev-parse --short "$head").diff"
 fi
 
+# --- foreign-ticket detection -------------------------------------------
+ticket_regex='[A-Za-z]{3,}[#-]?[0-9]{2,}'
+
+normalize_ticket() {
+  printf '%s' "$1" | tr '[:lower:]' '[:upper:]' | sed -E 's/[#-]//g'
+}
+
+plan_base=$(basename "$plan")
+plan_tail=$(printf '%s' "$plan_base" | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}-//')
+own_ticket_raw=$(printf '%s' "$plan_tail" | grep -oE "$ticket_regex" | head -n1 || true)
+
+foreign_block=""
+if [ -n "$own_ticket_raw" ]; then
+  own_ticket=$(normalize_ticket "$own_ticket_raw")
+  while IFS=$'\t' read -r hash subject; do
+    [ -n "$hash" ] || continue
+    match=$(printf '%s' "$subject" | grep -oE "$ticket_regex" | head -n1 || true)
+    [ -n "$match" ] || continue
+    if [ "$(normalize_ticket "$match")" != "$own_ticket" ]; then
+      foreign_block="${foreign_block}$(printf '%s\t%s\n' "$hash" "$subject")"
+    fi
+  done < <(git log --format='%h%x09%s' "${base}..${head}")
+fi
+
+warning=""
+if [ -n "$foreign_block" ]; then
+  warning="WARNING: this range (${base}..${head}) includes commit(s) referencing a ticket other than this plan's own (${own_ticket}):
+${foreign_block}
+Another session's work may have landed in between. Re-scope (narrower BASE, or a path filter) before handing this package to a reviewer, or confirm the inclusion is intentional."
+  echo "$warning" >&2
+fi
+
 {
+  if [ -n "$warning" ]; then
+    echo "## ⚠ Foreign-ticket commits in this range"
+    echo
+    echo "$warning"
+    echo
+  fi
   echo "# Review package: ${base}..${head}"
   echo
   echo "## Commits"

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -207,6 +207,23 @@ PLAN
         echo "    stderr: $(cat "$TEST_ROOT/mixed.stderr")"
     fi
 
+    ( cd "$repo" \
+        && printf 'c\n' > foreign2.txt && git add foreign2.txt \
+        && git "${git_id[@]}" commit -qm "chore: another unrelated change (BUG-300)" )
+    local multi_head
+    multi_head="$(cd "$repo" && git rev-parse HEAD)"
+
+    local multi_out multi_path
+    multi_out="$(cd "$repo" && "$SDD_SCRIPTS/review-package" 2026-01-01-FEATURE-100-sample.md "$own_base" "$multi_head" 2>"$TEST_ROOT/multi.stderr")"
+    multi_path="$(printf '%s\n' "$multi_out" | sed -n 's/^wrote \(.*\): [0-9].*$/\1/p')"
+    if grep -q "^[a-f0-9]\+	fix: unrelated change (FEATURE#200)$" "$TEST_ROOT/multi.stderr" \
+        && grep -q "^[a-f0-9]\+	chore: another unrelated change (BUG-300)$" "$TEST_ROOT/multi.stderr"; then
+        pass "review-package: two foreign-ticket commits each appear on their own line"
+    else
+        fail "review-package: two foreign-ticket commits each appear on their own line"
+        echo "    stderr: $(cat "$TEST_ROOT/multi.stderr")"
+    fi
+
     cat > "$repo/no-ticket-plan.md" <<'PLAN'
 # Untracked plan
 
@@ -222,6 +239,22 @@ PLAN
     else
         fail "review-package: plan with no identifiable ticket skips the check"
         echo "    stderr: $(cat "$TEST_ROOT/notick.stderr")"
+    fi
+
+    ( cd "$repo" \
+        && printf 'd\n' > noref.txt && git add noref.txt \
+        && git "${git_id[@]}" commit -qm "chore: tidy up formatting" )
+    local noref_head
+    noref_head="$(cd "$repo" && git rev-parse HEAD)"
+
+    local noref_out noref_path
+    noref_out="$(cd "$repo" && "$SDD_SCRIPTS/review-package" 2026-01-01-FEATURE-100-sample.md "$noref_head~1" "$noref_head" 2>"$TEST_ROOT/noref.stderr")"
+    noref_path="$(printf '%s\n' "$noref_out" | sed -n 's/^wrote \(.*\): [0-9].*$/\1/p')"
+    if [[ ! -s "$TEST_ROOT/noref.stderr" ]] && ! grep -q "Foreign-ticket" "$noref_path"; then
+        pass "review-package: commit with no ticket reference at all is never flagged"
+    else
+        fail "review-package: commit with no ticket reference at all is never flagged"
+        echo "    stderr: $(cat "$TEST_ROOT/noref.stderr")"
     fi
 
     # --- Worktree isolation: a linked worktree resolves its own workspace ---

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -165,6 +165,65 @@ PLAN
         echo "    got: $rp_explicit"
     fi
 
+    # --- foreign-ticket detection ---------------------------------------
+    cat > "$repo/2026-01-01-FEATURE-100-sample.md" <<'PLAN'
+# Plan FEATURE#100
+
+## Task 1: Sample
+
+Do the thing.
+PLAN
+
+    ( cd "$repo" \
+        && printf 'a\n' > own.txt && git add own.txt \
+        && git "${git_id[@]}" commit -qm "feat: own change (FEATURE#100)" )
+    local own_base own_head
+    own_base="$(cd "$repo" && git rev-parse HEAD~1)"
+    own_head="$(cd "$repo" && git rev-parse HEAD)"
+
+    local own_out own_path
+    own_out="$(cd "$repo" && "$SDD_SCRIPTS/review-package" 2026-01-01-FEATURE-100-sample.md "$own_base" "$own_head" 2>"$TEST_ROOT/own.stderr")"
+    own_path="$(printf '%s\n' "$own_out" | sed -n 's/^wrote \(.*\): [0-9].*$/\1/p')"
+    if [[ ! -s "$TEST_ROOT/own.stderr" ]] && ! grep -q "Foreign-ticket" "$own_path"; then
+        pass "review-package: same-ticket range produces no warning"
+    else
+        fail "review-package: same-ticket range produces no warning"
+        echo "    stderr: $(cat "$TEST_ROOT/own.stderr")"
+    fi
+
+    ( cd "$repo" \
+        && printf 'b\n' > foreign.txt && git add foreign.txt \
+        && git "${git_id[@]}" commit -qm "fix: unrelated change (FEATURE#200)" )
+    local mixed_head
+    mixed_head="$(cd "$repo" && git rev-parse HEAD)"
+
+    local mixed_out mixed_path
+    mixed_out="$(cd "$repo" && "$SDD_SCRIPTS/review-package" 2026-01-01-FEATURE-100-sample.md "$own_base" "$mixed_head" 2>"$TEST_ROOT/mixed.stderr")"
+    mixed_path="$(printf '%s\n' "$mixed_out" | sed -n 's/^wrote \(.*\): [0-9].*$/\1/p')"
+    if grep -q "FEATURE#200" "$TEST_ROOT/mixed.stderr" && grep -q "Foreign-ticket" "$mixed_path"; then
+        pass "review-package: foreign-ticket commit triggers stderr warning and output-file warning block"
+    else
+        fail "review-package: foreign-ticket commit triggers stderr warning and output-file warning block"
+        echo "    stderr: $(cat "$TEST_ROOT/mixed.stderr")"
+    fi
+
+    cat > "$repo/no-ticket-plan.md" <<'PLAN'
+# Untracked plan
+
+## Task 1: Sample
+
+Do the thing.
+PLAN
+    local notick_out notick_path
+    notick_out="$(cd "$repo" && "$SDD_SCRIPTS/review-package" no-ticket-plan.md "$own_base" "$mixed_head" 2>"$TEST_ROOT/notick.stderr")"
+    notick_path="$(printf '%s\n' "$notick_out" | sed -n 's/^wrote \(.*\): [0-9].*$/\1/p')"
+    if [[ ! -s "$TEST_ROOT/notick.stderr" ]] && ! grep -q "Foreign-ticket" "$notick_path"; then
+        pass "review-package: plan with no identifiable ticket skips the check"
+    else
+        fail "review-package: plan with no identifiable ticket skips the check"
+        echo "    stderr: $(cat "$TEST_ROOT/notick.stderr")"
+    fi
+
     # --- Worktree isolation: a linked worktree resolves its own workspace ---
     local wt="$TEST_ROOT/wt"
     ( cd "$repo" && git worktree add -q "$wt" -b wt-feature )


### PR DESCRIPTION
## Summary

- `review-package` now derives an "own" ticket ID from `PLAN_FILE`'s basename and scans `BASE..HEAD` commit subjects for a *different*, explicit ticket ID reference. When found, it non-fatally warns on stderr and prepends a `## ⚠ Foreign-ticket commits in this range` section to the output diff file.
- On a shared, non-worktree-isolated checkout, another session's commits can otherwise land silently inside a review package's range — the exact scenario that motivated this: every review package generated during one real session had to be manually re-scoped because `git log BASE..HEAD` picked up four other in-flight tickets' commits.
- Plan files with no identifiable ticket ID in their name are unaffected (many plans have none — the check is skipped silently). Commits with no ticket reference at all in their subject are never flagged — only an explicit *differing* ticket ID triggers the warning.
- `SKILL.md` documents the warning at both call sites (per-task review, final whole-branch review) and what the controller should do when it fires: re-scope, or proceed and say so if the inclusion is intentional.
- No new CLI arguments — `review-package PLAN_FILE BASE HEAD [OUTFILE]` is unchanged.

This went through this repo's own `subagent-driven-development` process end-to-end: per-task implementation + review for both the script change and the doc change, then a whole-branch final review that caught two real bugs (a command-substitution newline strip that garbled multi-commit warnings, and a `head -n1` that could misflag a commit's own ticket) — both fixed and re-verified before this PR.

## Test plan

- [x] `tests/claude-code/test-sdd-workspace.sh` — 5 new/updated assertions covering: same-ticket range (no warning), single foreign-ticket commit (warning + file section), two foreign-ticket commits (each on its own line), plan with no identifiable ticket (check skipped), commit with no ticket reference at all (never flagged). All 5 pass.
- [x] Note: this same test file has 4 pre-existing, unrelated failing assertions on a fresh Windows Git Bash checkout of `main` with no changes applied (`prints <repo-root>/...`, `task-brief writes its brief...`, `review-package writes its diff...`, `linked worktree resolves...`) — a `/tmp` vs. physical-path resolution quirk in that environment, verified via `git stash` before any of this branch's changes were applied. Not caused by, or related to, this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)