### PR TITLE
fix(requesting-code-review): anchor BASE_SHA to the merge base, not a moving ref

### DIFF
--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -25,9 +25,15 @@ Dispatch a code reviewer subagent to catch issues before they cascade. The revie
 
 **1. Get git SHAs:**
 ```bash
-BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
+BASE_SHA=$(git merge-base origin/main HEAD)  # or HEAD~1 for a single commit
 HEAD_SHA=$(git rev-parse HEAD)
 ```
+
+`BASE_SHA` must be an **ancestor** of `HEAD_SHA`, because the reviewer diffs `BASE_SHA..HEAD_SHA`
+(two dots). A moving ref like `origin/main` is not an ancestor once `main` advances, and two-dot
+compares tip-to-tip — so everything `main` gained after you branched is shown to the reviewer as
+**deletions your branch appears to be making**. `git merge-base` is an ancestor by definition, so the
+diff matches what GitHub's Files-changed tab shows.
 
 **2. Dispatch code reviewer subagent:**
 


### PR DESCRIPTION
Fixes #2118.

## The bug

`skills/requesting-code-review/SKILL.md:28` offers two values for `BASE_SHA`:

```bash
BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
```

That value is consumed by `code-reviewer.md:29-30` in a **two-dot** range, which requires `BASE_SHA` to be an **ancestor** of `HEAD_SHA`:

```
git diff --stat [BASE_SHA]..[HEAD_SHA]
git diff [BASE_SHA]..[HEAD_SHA]
```

`HEAD~1` always is an ancestor, so the documented default is correct. **`origin/main` stops being one the moment `main` advances** — and two-dot compares tip-to-tip, so every file `main` gained after the branch point is rendered as a deletion *the branch appears to be making*. The reviewer subagent cannot see how its diff was produced, so it has no way to tell an invented deletion from a real one.

## Reproduction

Two-commit feature branch; a teammate lands 200 lines on `main` meanwhile:

| `BASE_SHA` | `git diff --stat $BASE_SHA..HEAD` |
|---|---|
| `$(git rev-parse HEAD~1)` — documented default | `1 file changed, 1 insertion(+)` ✅ |
| `origin/main` — the `# or origin/main` alternative | `2 files changed, 1 insertion(+), 200 deletions(-)` ❌ |
| three-dot `origin/main...HEAD` (= GitHub Files-changed) | `1 file changed, 1 insertion(+)` |

```
$ git diff --diff-filter=D --name-only origin/main..HEAD
teammate_module.py
```

The branch never touched that file. Full repro script in #2118.

## The fix

```diff
-BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
+BASE_SHA=$(git merge-base origin/main HEAD)  # or HEAD~1 for a single commit
```

`git merge-base` returns an ancestor by definition, so `[BASE_SHA]..[HEAD_SHA]` downstream becomes equivalent to the three-dot diff. **`code-reviewer.md` needs no change** — that is deliberate, to keep the diff minimal.

Plus a short paragraph explaining the ancestor requirement, so the next person editing this does not reintroduce a moving ref.

## Why `merge-base` rather than switching the reviewer to three dots

Superpowers already does it this way. `skills/subagent-driven-development/scripts/review-package` computes a merge base before its `${base}..${head}` diff — which is exactly why the final-review path does not have this bug while the per-task path does. This change makes `requesting-code-review` consistent with that, rather than introducing a second convention.

## Scope

One file, 7 insertions, 1 deletion. No version file in this skill's frontmatter, no tests reference `BASE_SHA`, and I left the worked example at line ~61 alone — `git log | grep "Task 1"` selects a commit on the branch's own history, which is an ancestor and therefore correct.

The same `[BASE_SHA]..[HEAD_SHA]` pattern in `subagent-driven-development/task-reviewer-prompt.md:44` and `re-review-prompt.md:40-41` is safe or unsafe depending on what the dispatcher substitutes; fixing the source of `BASE_SHA` covers the documented path without touching those.

## Why I noticed

We traced a wrong-diff false alarm in our own repo to the same two-dot/three-dot confusion — it cost two investigations in an afternoon, and the mis-measured figure reached five documents before anyone re-ran it. Superpowers is not where our instance originated, but `requesting-code-review` is the most-reached place the same shape is written down.

The failure is silent and intermittent — it only appears once `main` moves, so it will not reproduce for whoever investigates it later. That is what makes it worth fixing rather than documenting.
