### PR TITLE
fix(sdd): slug the workspace by plan path, not basename

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -135,7 +135,7 @@ a ledger file, not only in todos.
 
 - Each plan owns a workspace: at skill start, run this skill's
   `scripts/sdd-workspace PLAN_FILE` — it prints the plan's git-ignored
-  directory (`<repo-root>/.superpowers/sdd/<plan-basename>/`), home to
+  directory (`<repo-root>/.superpowers/sdd/<plan-slug>/`), home to
   every artifact for THIS plan: ledger, briefs, reports, review packages.
   Another plan's directory is never yours to read or write.
 - Check for this plan's ledger at `<workspace>/progress.md`. If its first

--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -5,7 +5,7 @@
 # tasks intact.
 #
 # Usage: review-package PLAN_FILE BASE HEAD [OUTFILE]
-# Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-basename>/review-<base7>..<head7>.diff
+# Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-slug>/review-<base7>..<head7>.diff
 # (named per range, so a re-review after fixes gets a distinct fresh file).
 set -euo pipefail
 

--- a/skills/subagent-driven-development/scripts/sdd-workspace
+++ b/skills/subagent-driven-development/scripts/sdd-workspace
@@ -3,7 +3,7 @@
 # short-lived artifacts: task briefs, implementer reports, review packages,
 # and the progress ledger. Print the plan directory's absolute path.
 #
-# One directory per plan (.superpowers/sdd/<plan-basename>/) so a follow-up
+# One directory per plan (.superpowers/sdd/<plan-slug>/) so a follow-up
 # plan in the same working tree can never read or overwrite another plan's
 # artifacts. A stale ledger misread as current progress makes controllers
 # skip whole task sequences — plan-scoping removes that failure structurally.
@@ -28,11 +28,33 @@ fi
 plan=$1
 [ -f "$plan" ] || { echo "no such plan file: $plan" >&2; exit 2; }
 
-slug=$(basename "$plan" .md)
+root=$(git rev-parse --show-toplevel)
+root_named=$(cd "$(git rev-parse --show-cdup)." && pwd -L)
+
+# Slug from the plan's path relative to the repo root, not its basename:
+# foldered plans (docs/alpha/plan.md and docs/beta/plan.md) both slug to
+# "plan" otherwise. Two spellings of one name (docs/alpha/plan.md and
+# docs/alpha-plan.md) still share a slug; any single-character join is
+# ambiguous, since / is the one byte a filename cannot hold.
+#
+# Strip like against like. The caller's spelling against the tree as the
+# caller names it covers a symlinked directory inside the tree; the resolved
+# path against the resolved tree covers an absolute path given in resolved
+# form. Mixing the two makes the slug depend on which symlink was crossed.
+plan_dir=$(dirname "$plan")
+plan_file=$(basename "$plan")
+named="$(cd "$plan_dir" && pwd -L)/$plan_file"
+resolved="$(cd "$plan_dir" && pwd -P)/$plan_file"
+
+rel=""
+case "$named" in "$root_named"/*) rel=${named#"$root_named"/} ;; esac
+if [ -z "$rel" ]; then
+  case "$resolved" in "$root"/*) rel=${resolved#"$root"/} ;; esac
+fi
+[ -n "$rel" ] || { echo "plan file is outside the repository: $plan" >&2; exit 2; }
+slug=$(printf '%s' "${rel%.md}" | tr '/' '-')
 [ -n "$slug" ] && [ "$slug" != "." ] && [ "$slug" != ".." ] \
   || { echo "cannot derive a workspace name from: $plan" >&2; exit 2; }
-
-root=$(git rev-parse --show-toplevel)
 base="$root/.superpowers/sdd"
 dir="$base/$slug"
 mkdir -p "$dir"

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -4,7 +4,7 @@
 # through the controller's context.
 #
 # Usage: task-brief PLAN_FILE TASK_NUMBER [OUTFILE]
-# Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-basename>/task-<N>-brief.md
+# Default OUTFILE: <repo-root>/.superpowers/sdd/<plan-slug>/task-<N>-brief.md
 # (per plan and per worktree; concurrent runs of the SAME plan in the same
 # working tree share it).
 set -euo pipefail

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -70,15 +70,27 @@ PLAN
         echo "    exit: $rc"
     fi
 
+    printf '# Outside\n' > "$TEST_ROOT/outside.md"
+    local outside_err
+    rc=0
+    outside_err="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace" "$TEST_ROOT/outside.md" 2>&1 >/dev/null)" || rc=$?
+    if [[ "$rc" -eq 2 && "$outside_err" == *"outside the repository"* ]]; then
+        pass "sdd-workspace with a plan outside the repo errors with exit 2"
+    else
+        fail "sdd-workspace with a plan outside the repo errors with exit 2"
+        echo "    exit: $rc"
+        echo "    err:  $outside_err"
+    fi
+
     # --- per-plan resolution ---
     local dir_a dir_b
     dir_a="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace" plan-a.md)"
     dir_b="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace" plan-b.md)"
 
     if [[ "$dir_a" == "$repo/.superpowers/sdd/plan-a" ]]; then
-        pass "prints <repo-root>/.superpowers/sdd/<plan-basename>"
+        pass "prints <repo-root>/.superpowers/sdd/<plan-slug>"
     else
-        fail "prints <repo-root>/.superpowers/sdd/<plan-basename>"
+        fail "prints <repo-root>/.superpowers/sdd/<plan-slug>"
         echo "    got: $dir_a"
     fi
 
@@ -187,6 +199,110 @@ PLAN
     else
         fail "worktree workspace invisible to git status"
         echo "    status: $wt_status"
+    fi
+
+    # --- Foldered plans: one directory per plan path, not per basename ---
+    mkdir -p "$repo/docs/alpha" "$repo/docs/beta"
+    cat > "$repo/docs/alpha/plan.md" <<'PLAN'
+# Alpha
+
+## Task 1: Alpha thing
+
+Alpha requirements: MAGIC_CONST=7.
+PLAN
+    cat > "$repo/docs/beta/plan.md" <<'PLAN'
+# Beta
+
+## Task 1: Beta thing
+
+Beta requirements.
+PLAN
+
+    local dir_alpha dir_beta
+    dir_alpha="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace" docs/alpha/plan.md)"
+    dir_beta="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace" docs/beta/plan.md)"
+
+    if [[ "$dir_alpha" == "$repo/.superpowers/sdd/docs-alpha-plan" \
+       && "$dir_beta" == "$repo/.superpowers/sdd/docs-beta-plan" \
+       && -d "$dir_alpha" && -d "$dir_beta" ]]; then
+        pass "plans sharing a basename resolve to distinct directories"
+    else
+        fail "plans sharing a basename resolve to distinct directories"
+        echo "    alpha: $dir_alpha"
+        echo "    beta:  $dir_beta"
+    fi
+
+    ( cd "$repo" && "$SDD_SCRIPTS/task-brief" docs/alpha/plan.md 1 >/dev/null )
+    ( cd "$repo" && "$SDD_SCRIPTS/task-brief" docs/beta/plan.md 1 >/dev/null )
+    if grep -q 'MAGIC_CONST=7' "$dir_alpha/task-1-brief.md" 2>/dev/null; then
+        pass "a second plan's task-brief leaves the first plan's brief intact"
+    else
+        fail "a second plan's task-brief leaves the first plan's brief intact"
+        echo "    alpha brief: $(cat "$dir_alpha/task-1-brief.md" 2>/dev/null || echo '<missing>')"
+    fi
+
+    # --- A name that strips to a degenerate slug is rejected, not built ---
+    # Asserts the message too: three separate paths exit 2, so the code alone
+    # would pass this test for the wrong reason.
+    printf '# Dot\n' > "$repo/..md"
+    local degenerate_err
+    rc=0
+    degenerate_err="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace" ..md 2>&1 >/dev/null)" || rc=$?
+    rm -f "$repo/..md"
+    if [[ "$rc" -eq 2 && "$degenerate_err" == *"cannot derive a workspace name"* ]]; then
+        pass "a plan whose slug would be '.' errors with exit 2"
+    else
+        fail "a plan whose slug would be '.' errors with exit 2"
+        echo "    exit: $rc"
+        echo "    err:  $degenerate_err"
+    fi
+
+    # --- Symlinks: the slug follows the spelling, wherever the link points ---
+    mkdir -p "$TEST_ROOT/shared-specs" "$repo/real-specs"
+    cat > "$TEST_ROOT/shared-specs/plan.md" <<'PLAN'
+# Shared
+
+## Task 1: Shared thing
+
+Shared requirements.
+PLAN
+    cp "$TEST_ROOT/shared-specs/plan.md" "$repo/real-specs/plan.md"
+    ln -s "$TEST_ROOT/shared-specs" "$repo/linked-out"
+    ln -s "$repo/real-specs" "$repo/linked-in"
+
+    local dir_out dir_in
+    rc=0
+    dir_out="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace" linked-out/plan.md 2>&1)" || rc=$?
+    if [[ "$rc" -eq 0 && "$dir_out" == "$repo/.superpowers/sdd/linked-out-plan" ]]; then
+        pass "a plan under a symlink pointing outside the tree resolves by spelling"
+    else
+        fail "a plan under a symlink pointing outside the tree resolves by spelling"
+        echo "    exit: $rc"
+        echo "    got:  $dir_out"
+    fi
+
+    rc=0
+    dir_in="$(cd "$repo" && "$SDD_SCRIPTS/sdd-workspace" linked-in/plan.md 2>&1)" || rc=$?
+    if [[ "$rc" -eq 0 && "$dir_in" == "$repo/.superpowers/sdd/linked-in-plan" ]]; then
+        pass "a plan under a symlink pointing inside the tree resolves by spelling"
+    else
+        fail "a plan under a symlink pointing inside the tree resolves by spelling"
+        echo "    exit: $rc"
+        echo "    got:  $dir_in"
+    fi
+
+    # --- The same tree reached through a symlinked prefix resolves alike ---
+    ln -s "$repo" "$TEST_ROOT/link-to-repo"
+    local dir_via_link
+    rc=0
+    dir_via_link="$(cd "$TEST_ROOT/link-to-repo" && "$SDD_SCRIPTS/sdd-workspace" linked-out/plan.md 2>&1)" || rc=$?
+    if [[ "$rc" -eq 0 && "$dir_via_link" == "$dir_out" ]]; then
+        pass "a tree reached through a symlink resolves to the same workspace"
+    else
+        fail "a tree reached through a symlink resolves to the same workspace"
+        echo "    exit:   $rc"
+        echo "    direct: $dir_out"
+        echo "    linked: $dir_via_link"
     fi
 
     echo ""


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 5 (1M context), model ID `claude-opus-5[1m]` |
| Harness + version | Claude Code 2.1.227 |
| All plugins installed | `canon`, `claude-session-driver`, `double-shot-latte`, `elements-of-style`, `episodic-memory`, `mattpocock-skills`, `private-journal-mcp`, `sentry`, `slack`, `superpowers`, `superpowers-chrome`, `superpowers-dev`, `superpowers-developing-for-claude-code`, `superpowers-lab` (all enabled) |
| Human partner who reviewed this diff | Cris Nahine (@crisnahine) |

## What problem are you trying to solve?

Fixes #2045.

To be straight about provenance: I did not hit this in my own SDD session. @CRGDan reported it with a reproduction, after being asked in #2012 to re-report if it survived #1943. I reproduced it independently before writing any code, on released v6.2.0 (`3dcbd5c`) and on current `origin/dev` (`034958f`). The two trees are identical for these files.

`sdd-workspace` keys the workspace on the plan's basename, so any two plans that share one collide. Foldered plans, one directory per feature or per sprint, hit this immediately: `plan.md`, `implementation-plan.md`, and `README.md` are exactly the basenames that repeat.

Reproduction on `origin/dev`, macOS:

```
$ sdd-workspace docs/alpha/plan.md
<repo>/.superpowers/sdd/plan
$ sdd-workspace docs/beta/plan.md
<repo>/.superpowers/sdd/plan          # same directory

$ task-brief docs/alpha/plan.md 1     # writes alpha's brief, 59 bytes
$ task-brief docs/beta/plan.md 1      # overwrites it, no warning
$ cat .superpowers/sdd/plan/task-1-brief.md
## Task 1: Beta thing

Beta requirements.
```

Alpha's brief is gone. SKILL.md makes the brief "the single source of requirements", so exact values, magic strings, and signatures live only there. A subagent dispatched against a clobbered brief implements the wrong plan's task with no way to notice, and the directory is gitignored so there is no history to recover from.

## What does this PR change?

`sdd-workspace` now derives the workspace slug from the plan's repo-relative path (`docs/alpha/plan.md` becomes `docs-alpha-plan`) instead of its basename. Root-level plans keep the directory name they already have, so existing flat layouts are unaffected. A plan outside the repository now exits 2 instead of slugging its whole absolute path.

The slug follows how the plan is spelled from the repo root. Keeping that true around symlinks means stripping like against like: the caller's spelling against the tree as the caller names it, then the resolved path against the resolved tree. A symlinked directory inside the tree then keeps its own name whether it points inside or outside the repo, and a tree entered through a symlink resolves to the same workspace as the tree entered directly.

## Is this change appropriate for the core library?

Yes. `sdd-workspace` is core SDD infrastructure, and the failure is triggered by an ordinary repo layout rather than anything project-specific. Any repo that keeps one plan per feature directory is exposed today.

## What alternatives did you consider?

**Mirror the path as nested directories** (`.superpowers/sdd/docs/alpha/plan/`). Fully lossless, but a plan at `docs.md` then owns the parent of `docs/alpha/plan.md`'s workspace, and SKILL.md's end-of-plan `rm -rf <workspace>` would delete the other plan's artifacts. Traded one collision for a worse one.

**Checksum suffix** (`docs-alpha-plan-3f9a2c1`). Unambiguous, and this is roughly what #1858 proposes. Rejected because it renames every existing workspace including flat ones, and SKILL.md asks controllers to recognize their own workspace by name, which a hash makes harder to eyeball.

**Escape `-` before joining** (`/` to `-`, `-` to `--`). Fully unambiguous, but `plan-a.md` becomes `plan--a`, which breaks the flat-layout compatibility the simpler form keeps for free.

Landed on the repo-relative path with `/` replaced by `-`, which is what the issue proposes.

**Known limitation, stated plainly:** `docs/alpha/plan.md` and `docs/alpha-plan.md` still slug to `docs-alpha-plan`. Any single-character join is ambiguous, since `/` is the only byte a filename cannot contain. This needs both spellings of the same name in one repo, where the reported case needs only the normal foldered layout. Happy to switch to the checksum form if you would rather close the last case than keep readable names.

## Does this PR contain multiple unrelated changes?

No. One problem: plans that share a basename share a workspace.

The outside-the-repo guard is part of the same change, not a second one. Deriving a slug from a repo-relative path has to define what happens when there is no repo-relative path, and without the guard the fallback is a directory named after the full absolute path.

#2045 also reports a second defect: `task-brief` redirects `awk` output with `>`, which truncates the destination before the not-found check, so a failed extraction leaves a zero-byte brief. I reproduced that too (59 bytes to 0 on exit 3). It is deliberately **not** in this PR. It is a separate failure mode with a separate fix, and it stops being destructive to other plans once this lands. Happy to send it as a follow-up.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1943, #1858, #1949, #1952

**#1943 (merged)** introduced plan-scoping keyed on basename. This PR fixes the collision that survived in what shipped, which is the follow-up #2012 asked for.

**#1858 (open, predates #1943)** proposes `<safe-plan-slug>-<checksum>`, which would also disambiguate. It also adds a plan-identity argument, a legacy fallback directory, and a new test file under `tests/subagent-driven-dev/`. This PR is a 13-line change to the helper that shipped, and it keeps existing directory names.

**#1949 (open, predates #1943)** namespaces by basename, the same key that merged, so it does not address this.

**#1952 (open)** combines the basename with a session id to separate concurrent sessions on one checkout. Orthogonal: still basename-keyed, so two foldered plans in one session still collide.

No open PR addresses the basename collision itself.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Claude Code | 2.1.227 | Claude Opus 5 (1M context) | `claude-opus-5[1m]` |

macOS 26.5.2 (darwin 25.5.0), bash 3.2.57, git 2.50.1, shellcheck 0.11.0.

`tests/claude-code/test-sdd-workspace.sh`: 20 passed, 0 failed (13 pre-existing, 7 new).
`scripts/lint-shell.sh --strict` on the changed files: clean.

Running every `tests/**/test-*.sh`: 14 passed, 7 failed. I ran each failure against a clean `origin/dev` worktree. Six fail there identically and predate this change:

- `tests/shell-lint/test-lint-shell.sh` and `tests/version-bump/test-bump-version.sh` are not executable in a fresh checkout, so they exit 126 before running anything.
- `tests/writing-skills/test-render-graphs.sh` needs a graph renderer that is not installed on my machine.
- `tests/codex/test-package-codex-plugin.sh`, `zip archive normalizes entry timestamps`, expects hour 0 and gets hour 8. A UTC+8 artifact, not something this PR touches.
- `test-subagent-driven-development.sh` and `test-worktree-native-preference.sh` drive live agent sessions and fail on `origin/dev` too.

The seventh needs stating plainly rather than filing under "unrelated": **`test-subagent-driven-development-integration.sh` passed on clean `origin/dev` and failed once on this branch.** It is a live agent session costing roughly $18 a run, so I have one observation on each side and will not call that a signal.

What I can show is that the script this PR touches is not the variable. The test builds its project with `mktemp -d`, which on macOS is a `/var` symlink to `/private/var`, so it lands squarely in the path handling this PR changes. Running `origin/dev`'s `sdd-workspace`, this PR's first revision, and its final revision against that exact setup gives byte-identical output, from both the logical and the resolved cwd:

```
mktemp gave:  /var/folders/.../T/tmp.ePGYWdCh7V
resolved:     /private/var/folders/.../T/tmp.ePGYWdCh7V

--- invoked from the logical cwd ---
  origin/dev  -> /private/var/folders/.../tmp.ePGYWdCh7V/.superpowers/sdd/plan
  this PR v1  -> /private/var/folders/.../tmp.ePGYWdCh7V/.superpowers/sdd/plan
  this PR v2  -> /private/var/folders/.../tmp.ePGYWdCh7V/.superpowers/sdd/plan
--- invoked from the physical cwd ---
  origin/dev  -> /private/var/folders/.../tmp.ePGYWdCh7V/.superpowers/sdd/plan
  this PR v1  -> /private/var/folders/.../tmp.ePGYWdCh7V/.superpowers/sdd/plan
  this PR v2  -> /private/var/folders/.../tmp.ePGYWdCh7V/.superpowers/sdd/plan
```

A single-plan project at the repo root is exactly the case this change is designed to leave alone. Happy to run the eval again for a second data point, or to have someone whose global config is stock run it instead.
## New harness support (required if this PR adds a new harness)

N/A. This PR does not add harness support.

## Evaluation

**Initial prompt.** My human partner asked me to make a real contribution rather than a speculative one. I searched the tracker for an open, unclaimed, code-level bug that had a reproduction, picked #2045, and reproduced it before writing anything.

**Eval sessions after the change: none, and here is why.** This is a shell helper, not behavior-shaping content. The one SKILL.md edit changes the string `<plan-basename>` to `<plan-slug>` in a path description, so there is no agent behavior for an eval to measure. If you want an eval anyway, say which scenario and I will run it.

**Before and after.** The two new foldered-plan assertions fail on `origin/dev` for the right reason, both plans printing `.superpowers/sdd/plan` and alpha's brief holding beta's text, and pass after the change. The 13 pre-existing assertions pass both before and after, including the one pinning `plan-a.md` to `.superpowers/sdd/plan-a`, which is what shows flat layouts keep their current directory.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Not a skills change in the behavioral sense: one factual path string in SKILL.md, no Red Flags table, rationalization list, or "human partner" language touched.

Written test-first with `superpowers:test-driven-development`: each new assertion was run and watched fail against unmodified `origin/dev` before the fix existed.

Adversarial cases run by hand, since the same plan must resolve to the same directory no matter how a controller spells the path:

| input | result |
|---|---|
| `flat.md`, `./flat.md` | `flat` (unchanged from today) |
| `docs/alpha/plan.md`, `./docs/alpha/plan.md`, absolute path | all `docs-alpha-plan` |
| `plan.md` invoked from inside `docs/alpha/` | `docs-alpha-plan` |
| `../../flat.md` invoked from a subdirectory | `flat` |
| `with space/plan.md` | `with space-plan` |
| `linked-in/plan.md`, symlink to a directory inside the repo | `linked-in-plan` |
| `linked-out/plan.md`, symlink to a directory outside the repo | `linked-out-plan` |
| the same repo entered through a symlinked path | same workspace as entering it directly |
| `..md`, `...md`, `.md` (slug strips to `.`, `..`, empty) | exit 2, clear message |
| plan outside the repo | exit 2, clear message |
| linked worktree | resolves against the worktree root, covered by the existing assertion |

Symlinks need both spellings, not one. `git rev-parse --show-toplevel` resolves them, so on macOS, where `mktemp` lives under `/var` linked to `/private/var`, an unresolved plan path will not strip against that root. Resolving the plan alone breaks the other direction: a symlinked directory inside the tree resolves out of it and the plan looks foreign, which the basename slug never did. So the strip runs twice and each run compares paths of the same kind: `pwd -L` against the toplevel as the caller names it (`git rev-parse --show-cdup`), then `pwd -P` against `--show-toplevel`.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

