### PR TITLE
docs(testing): rename Drill references to Quorum (eval harness renamed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Skills are not prose — they are code that shapes agent behavior. If you modify
 
 ## Eval harness
 
-Skill-behavior evals live in [superpowers-evals](https://github.com/prime-radiant-inc/superpowers-evals/), cloned into `evals/` — see `evals/README.md` for setup. Drill (the harness) drives real tmux sessions of Claude Code / Codex / Gemini CLI and judges skill compliance with an LLM verifier. Plugin-infrastructure tests still live at `tests/`.
+Skill-behavior evals live in [superpowers-evals](https://github.com/prime-radiant-inc/superpowers-evals/), cloned into `evals/` — see `evals/README.md` for setup. Quorum (the harness) drives real tmux sessions of Claude Code / Codex / Gemini CLI and judges skill compliance with an LLM verifier. Plugin-infrastructure tests still live at `tests/`.
 
 ## Understand the Project Before Contributing
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,22 +14,22 @@ Live in `tests/`. Currently:
 - `tests/codex-plugin-sync/` — bash sync verification.
 - `tests/kimi/` — bash/Python checks for Kimi plugin manifest wiring.
 - `tests/claude-code/test-helpers.sh`, `analyze-token-usage.py` — utilities used by remaining bash tests.
-- `tests/claude-code/test-subagent-driven-development.sh` — agent-can-describe-SDD test (no drill counterpart; tests description-recall, not behavior).
-- `tests/claude-code/test-subagent-driven-development-integration.sh` — extended SDD integration with token analysis (drill covers the YAGNI subset; bash adds commit-count, Claude Code task-tracking, and token telemetry assertions).
-- `tests/claude-code/test-worktree-native-preference.sh` — RED-GREEN-REFACTOR validation for worktree skill (drill covers the PRESSURE phase; bash also covers RED/GREEN baselines).
-- `tests/explicit-skill-requests/` — Haiku-specific, multi-turn, and skill-name-prompted tests not covered by drill.
+- `tests/claude-code/test-subagent-driven-development.sh` — agent-can-describe-SDD test (no quorum counterpart; tests description-recall, not behavior).
+- `tests/claude-code/test-subagent-driven-development-integration.sh` — extended SDD integration with token analysis (quorum covers the YAGNI subset; bash adds commit-count, Claude Code task-tracking, and token telemetry assertions).
+- `tests/claude-code/test-worktree-native-preference.sh` — RED-GREEN-REFACTOR validation for worktree skill (quorum covers the PRESSURE phase; bash also covers RED/GREEN baselines).
+- `tests/explicit-skill-requests/` — Haiku-specific, multi-turn, and skill-name-prompted tests not covered by quorum.
 
 Run plugin tests via the relevant directory's `run-*.sh` or `npm test`.
 
 ## Skill behavior evals
 
-Live in `evals/`. Drill is the harness; scenarios live at `evals/scenarios/*.yaml`. See `evals/README.md` for setup. Quick start:
+Live in `evals/`. Quorum is the harness; scenarios live at `evals/scenarios/*.yaml`. See `evals/README.md` for setup. Quick start:
 
 ```bash
 cd evals
 uv sync --extra dev
 export ANTHROPIC_API_KEY=sk-...
-uv run drill run triggering-test-driven-development -b claude
+uv run quorum run triggering-test-driven-development -b claude
 ```
 
-Drill scenarios are slow (3-30+ minutes each) and run real LLM sessions. They are not part of CI today; the natural follow-up is a tiered model (fast subset on PR, full sweep nightly + on-demand).
+Quorum scenarios are slow (3-30+ minutes each) and run real LLM sessions. They are not part of CI today; the natural follow-up is a tiered model (fast subset on PR, full sweep nightly + on-demand).


### PR DESCRIPTION
## What problem are you trying to solve?

`docs/testing.md` and `CLAUDE.md` say "Drill" in six places when
referring to the eval harness in
[prime-radiant-inc/superpowers-evals](https://github.com/prime-radiant-inc/superpowers-evals).
The harness was renamed to **Quorum** — that name now appears in:

- `prime-radiant-inc/superpowers-evals` `package.json` `bin`
- `prime-radiant-inc/superpowers-evals` `README.md` (every heading and
  command uses "Quorum" / `quorum`)
- The new CLI invocation is `bun run quorum run ...` / `bun run quorum check`,
  not `uv run drill run ...`

A new contributor reading `docs/testing.md` would run the quick-start
`uv run drill run ...` and hit "command not found" because there is no
`drill` binary in the eval repo anymore.

## What does this PR change?

Six text replacements across two files:

- `docs/testing.md` (5): "drill" / "Drill" → "quorum" / "Quorum" in four
  parentheticals, the harness name, and the `uv run` quick-start command
- `CLAUDE.md` (1): "Drill (the harness)" → "Quorum (the harness)"

Pure documentation. No code change, no behavior change, no plugin change.

## What alternatives did you consider?

- **Do nothing.** Rejected — leaves new contributors with a broken
  quick-start command and a stale harness name in the contributor docs.
- **Rewrite the historical plan and spec files that mention drill** (e.g.
  `docs/superpowers/plans/2026-05-06-lift-drill-into-evals.md`).
  Rejected — those files describe the historical operation of lifting
  drill into evals; rewriting them would falsify the record. The current
  contributor docs (this PR's scope) are the only right place to fix.

## Is this change appropriate for the core library?

Yes. `docs/testing.md` and `CLAUDE.md` are general contributor-facing
docs that apply to anyone setting up the eval harness from this repo.
No project-specific or third-party promotion; just keeping the docs in
sync with the canonical tool name.

## Does this PR contain multiple unrelated changes?

No. Single theme: "the eval harness is named Quorum, not Drill;
update current contributor docs to match." Two files, six text
replacements.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none. Searched for `drill` / `quorum` / `eval harness` in
  open and recently-closed issues and PRs; no prior art for this rename.

## Environment tested

Not applicable. Pure documentation change; no plugin code, no harness
code, no behavior to test.

## New harness support

Not applicable.

## Evaluation

Not applicable. Documentation-only; no behavior to evaluate.

## Rigor

- [x] Not a skills change — `writing-skills` methodology does not apply.
- [x] Not a behavior-shaping change — no agent behavior, no eval needed.
- [x] Adversarially spot-checked: I read the eval repo README in full to
  confirm Quorum is the canonical name; I verified the new `uv run
  quorum run` command matches what's documented in the eval repo's
  own README and package.json.

## Human review

- [x] A human (Jonathan F. Waskin) reviewed the complete proposed diff
  before submission. The diff is 2 files, 8 lines, all text.
