### PR TITLE
brainstorming: orient before asking design questions

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -71,6 +71,9 @@ artifact, never the approval.
 | "The spike works, so I'll keep the code" | A spike's output is an answer. Keeping the code is a new request — classify it. |
 | "It grew, but I'm almost done — no need to re-classify" | Hidden complexity upgrades the path mid-task. Stop and say so. |
 | "They approved the spike, so the follow-up change is approved too" | Each task gets its own classification and its own approval. |
+| "The checklist says to ask questions, so I should ask one now" | Questions resolve material ambiguity after orientation; they are not a required ceremony. |
+| "My human partner must choose the technical parameters" | Own expert design choices. Recommend a default with context; ask only for product preferences or authority decisions. |
+| "A precise threshold makes the design rigorous" | Precision without evidence is invented policy. Name the metric and what evidence or product decision would establish the bound. |
 
 ## Checklist
 
@@ -86,21 +89,23 @@ your path and complete them in order.
 
 **Bounded:**
 1. **Explore project context** — check files, docs, recent commits
-2. **Ask clarifying questions** — one at a time, the ones that matter
-3. **Present short design in chat** — approach, files touched, testing
-4. **Get approval** — STOP and wait for an explicit yes; presenting the design and starting in the same breath is skipping the gate
-5. **Implement** — proceed with the normal development workflow (TDD applies); no plan document
+2. **Orient your human partner** — summarize the goal, constraints, inferred preferences, success criteria, hard parts, and decisions ahead
+3. **Ask clarifying questions** — one at a time, only the ones that materially change the design and cannot be resolved from context
+4. **Present short design in chat** — approach, files touched, testing
+5. **Get approval** — STOP and wait for an explicit yes; presenting the design and starting in the same breath is skipping the gate
+6. **Implement** — proceed with the normal development workflow (TDD applies); no plan document
 
 **Architectural:**
 1. **Explore project context** — check files, docs, recent commits
-2. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
-3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
-4. **Propose 2-3 approaches** — with trade-offs and your recommendation
-5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+2. **Orient your human partner** — summarize the goal, constraints, inferred preferences, success criteria, hard parts, and decisions ahead
+3. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
+4. **Ask clarifying questions** — one at a time, only the ones that materially change the design and cannot be resolved from context
+5. **Propose 2-3 approaches** — with trade-offs and your recommendation
+6. **Present design** — in sections scaled to their complexity, get user approval after each section
+7. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+8. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+9. **User reviews written spec** — ask user to review the spec file before proceeding
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
@@ -113,7 +118,9 @@ digraph brainstorming {
     "Human approves?" [shape=diamond];
     "Investigate; report recommendation" [shape=doublecircle];
     "Implement via normal workflow (no plan doc)" [shape=doublecircle];
+    "Explore existing flow" [shape=box];
     "Explore project context" [shape=box];
+    "Orient: goals, criteria, challenges, decisions" [shape=box];
     "Ask clarifying questions" [shape=box];
     "Propose 2-3 approaches" [shape=box];
     "Present design sections" [shape=box];
@@ -125,15 +132,18 @@ digraph brainstorming {
     "Hidden complexity? Upgrade path" [shape=box];
 
     "Classify: spike / bounded / architectural" -> "Present question + probe (2-3 sentences)" [label="spike"];
-    "Classify: spike / bounded / architectural" -> "Ask clarifying questions (bounded)" [label="bounded"];
+    "Classify: spike / bounded / architectural" -> "Explore existing flow" [label="bounded"];
     "Classify: spike / bounded / architectural" -> "Explore project context" [label="architectural"];
     "Present question + probe (2-3 sentences)" -> "Human approves?";
+    "Explore existing flow" -> "Orient: goals, criteria, challenges, decisions";
+    "Orient: goals, criteria, challenges, decisions" -> "Ask clarifying questions (bounded)" [label="bounded"];
     "Ask clarifying questions (bounded)" -> "Present short design in chat";
     "Present short design in chat" -> "Human approves?";
     "Human approves?" -> "Investigate; report recommendation" [label="spike: yes"];
     "Human approves?" -> "Implement via normal workflow (no plan doc)" [label="bounded: yes"];
     "Hidden complexity? Upgrade path" -> "Classify: spike / bounded / architectural";
-    "Explore project context" -> "Ask clarifying questions";
+    "Explore project context" -> "Orient: goals, criteria, challenges, decisions";
+    "Orient: goals, criteria, challenges, decisions" -> "Ask clarifying questions" [label="architectural"];
     "Ask clarifying questions" -> "Propose 2-3 approaches";
     "Propose 2-3 approaches" -> "Present design sections";
     "Present design sections" -> "User approves design?";
@@ -166,21 +176,28 @@ is the whole process.
 - Check out the current project state first (files, docs, recent commits)
 - Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
 - If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
-- For appropriately-scoped projects, ask questions one at a time to refine the idea
+- Before the first design question, orient your human partner. Synthesize what you understand: goals, constraints, preferences demonstrated in the conversation, candidate success criteria, hard parts, decisions ahead, and your likely direction. Scale this to the path: one or two sentences for bounded work, a short section for architectural work.
+- Classify unknowns before asking about them:
+  1. **Discoverable facts** — inspect the code, docs, or environment yourself.
+  2. **Expert design choices** — recommend a default and explain the trade-offs.
+  3. **Product, preference, or authority choices** — ask your human partner after supplying enough context to make the choice meaningful.
+- Ask a question only when its answer materially changes the design and you cannot responsibly infer or discover it. Explain why the decision matters, the viable options and consequences, and which option you recommend based on your human partner's expressed preferences.
+- "One question per message" is a maximum, not a quota. Do not turn discovery into a serial questionnaire.
+- If your human partner asks you to lead, says they lack context, or asks for a proposal, present a coherent default design; do not ask them to invent technical parameters.
 - Prefer multiple choice questions when possible, but open-ended is fine too
-- Only one question per message - if a topic needs more exploration, break it into multiple questions
-- Focus on understanding: purpose, constraints, success criteria
+- Ground success criteria. Distinguish established requirements, proposed criteria, and unresolved product policy. Never invent a precise threshold without evidence; name the metric and explain what evidence or decision would establish its bound.
 
 **Exploring approaches:**
 
 - Propose 2-3 different approaches with trade-offs
 - Present options conversationally with your recommendation and reasoning
-- Lead with your recommended option and explain why
+- Lead with your recommended option and explain why it fits the goals, constraints, and preferences already expressed
 - YAGNI ruthlessly - remove unnecessary features from every approach and design
 
 **Presenting the design:**
 
 - Once you believe you understand what you're building, present the design
+- Start with the design frame — goals/non-goals, success criteria, key challenges, and the important decisions — before component details
 - Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
 - Ask after each section whether it looks right so far
 - Cover: architecture, components, data flow, error handling, testing


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5 (Codex API; serving snapshot not exposed) |
| Harness + version | Codex CLI 0.144.1 on Linux |
| All plugins installed | superpowers-dev 5.1.0 |
| Human partner who reviewed this diff | Allen Wang (@allenwang28) |

## What problem are you trying to solve?

During a real design session for low-overhead CUDA instrumentation, the
brainstorming workflow repeatedly asked the human partner to choose technical
experiment parameters before explaining the design space. It proposed a new
duration sweep, asked the partner to define absolute and relative overhead
bounds, and then suggested unsupported 250 ns / 5% screening thresholds. The
partner explicitly said they lacked the context to make those choices.

The agent later identified the cause: it followed the skill's literal ordering
of "ask clarifying questions" before "propose approaches" and conflated
obtaining approval with making the partner supply the experiment design.

Current `dev` is already better than the installed 5.1 skill, but a fresh
baseline still reproduced the ordering failure. Given a request to design a
lightweight job-progress monitor, the agent classified the task and immediately
asked the partner to choose a hang-signal model. It did not first explain the
inferred success criteria, monitor-liveness problem, threshold uncertainty, or
recommended direction.

## What does this PR change?

The brainstorming skill now requires a concise orientation before design
questions, classifies unknowns by who should resolve them, and treats one
question per message as a ceiling rather than a quota. It also requires
recommendations grounded in expressed preferences and forbids unsupported
numerical precision in success criteria.

## Is this change appropriate for the core library?

Yes. The failure is general to collaborative design, not CUDA or any particular
project. The before/after evaluations cover research design, a product feature,
and a security-critical internal system. The change adds no dependency,
third-party integration, or project-specific policy.

## What alternatives did you consider?

- **Rely on users to request context-first collaboration explicitly.** This
  produced a good baseline response, but requires the least-informed participant
  to know and prescribe the correct design protocol.
- **Move all approach presentation before all questions.** Rejected because a
  genuinely product-defining unknown can make approaches premature. The change
  instead requires orientation first and permits only material questions that
  cannot be discovered or responsibly inferred.
- **Remove the one-question rule.** Rejected. The rule remains useful as a cap on
  cognitive load; the patch clarifies that it is not a requirement to ask.
- **Add prompt-specific CUDA guidance.** Rejected as non-general and unsuitable
  for core.

## Does this PR contain multiple unrelated changes?

No. It changes one skill for one behavior: orienting the human partner before
asking them to make design decisions.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #462, #607

#462 established the brainstorming hard gate and process flow. This PR preserves
that gate and the three-path workflow while addressing a newly observed failure
inside the question phase. #607 proposed a post-design context reset and is not
a duplicate. Searches for `brainstorming context`, `clarifying questions
brainstorming`, and `success criteria brainstorming` found no open duplicate.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI | 0.144.1 | GPT-5 | serving snapshot not exposed |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR changes a skill only and adds no harness support.

## Evaluation

- Initial human request: "Can you update the design skill so that agents can
  articulate [success criteria and challenges] up front and then approach them
  collaboratively while giving me context for the decisions?"
- RED: three fresh sessions against unchanged current `dev`. Two already gave
  good context-first designs; one followed the literal classify-then-question
  sequence and asked for a technical choice without orientation. The agent's
  meta-evaluation explicitly cited the checklist ordering as the cause.
- GREEN: the same three scenarios after the change. All three oriented first,
  articulated success criteria and hard parts, recommended a design based on
  stated preferences, and asked no context-free technical question.
- REFACTOR pressure: one additional session combined a next-day deadline,
  executive demand for precise thresholds, a week of sunk cost, and unrealistic
  load-test evidence. The response refused false empirical precision and chose
  only limits grounded in controller invariants.
- Eval sessions after the change: 4.

Representative before/after for the job-progress monitor:

| Before | After |
|--------|-------|
| Classified the task, then immediately asked whether stage changes stop during a hang. | Explained goals/non-goals, hang-vs-long-stage ambiguity, monitor-liveness risk, and the out-of-process staleness-detector recommendation before seeking approval. |
| No threshold rationale. | Proposed shadow-mode measurement and stage-specific bounds derived from observed successful durations and the response-window policy. |

Static verification:

```text
python .../quick_validate.py skills/brainstorming
Skill is valid!

git diff --check
exit 0
```

The optional Graphviz renderer could not run because `dot` is not installed in
the authoring environment. The DOT block was structurally inspected; the change
adds only nodes and edges corresponding to the checklist ordering.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

The three added Red Flags entries came directly from the observed session and
RED-agent rationalizations. Existing entries and project terminology are
unchanged.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

The complete one-file diff was shown inline and approved before this branch was
committed or published.
