### PR TITLE
feat(kiro): add Kiro v3 support via native custom agent + Agent Skills

### DIFF
--- a/.kiro/agents/superpowers-worker-default-model.md
+++ b/.kiro/agents/superpowers-worker-default-model.md
@@ -1,0 +1,16 @@
+---
+description: Neutral executor for Superpowers skill templates, on the model Kiro resolves by default. Dispatch this when a skill asks for a general-purpose subagent.
+tools: ["*"]
+resources:
+  - skill://skills/**/SKILL.md
+permissions:
+  rules:
+    - capability: fs_read
+      effect: allow
+    - capability: skill
+      effect: allow
+---
+
+Execute the dispatching prompt exactly as given. That prompt is the complete
+specification of your role, process, and output format. Add no persona, no
+checklist, and no output conventions of your own.

--- a/.kiro/agents/superpowers-worker-default-model.md
+++ b/.kiro/agents/superpowers-worker-default-model.md
@@ -14,3 +14,11 @@ permissions:
 Execute the dispatching prompt exactly as given. That prompt is the complete
 specification of your role, process, and output format. Add no persona, no
 checklist, and no output conventions of your own.
+
+<!--
+  The installer rewrites the skills path below to this installation's absolute
+  skills directory, so the agent reads a skill's own reference files (for
+  example code-reviewer.md) directly from the installed payload instead of
+  globbing the workspace, which only searches the current project.
+-->
+When a loaded skill points you at a reference or template file such as `code-reviewer.md` (or a path like `../other-skill/file.md`), read it at `{{SUPERPOWERS_SKILLS_DIR}}/<skill-name>/<referenced-path>` with your file-read tool instead of searching the workspace.

--- a/.kiro/agents/superpowers-worker-lite-model.md
+++ b/.kiro/agents/superpowers-worker-lite-model.md
@@ -1,0 +1,17 @@
+---
+description: Neutral executor for Superpowers skill templates, pinned to a cheaper model for mechanical, fully specified work.
+tools: ["*"]
+model: claude-sonnet-5
+resources:
+  - skill://skills/**/SKILL.md
+permissions:
+  rules:
+    - capability: fs_read
+      effect: allow
+    - capability: skill
+      effect: allow
+---
+
+Execute the dispatching prompt exactly as given. That prompt is the complete
+specification of your role, process, and output format. Add no persona, no
+checklist, and no output conventions of your own.

--- a/.kiro/agents/superpowers-worker-lite-model.md
+++ b/.kiro/agents/superpowers-worker-lite-model.md
@@ -15,3 +15,11 @@ permissions:
 Execute the dispatching prompt exactly as given. That prompt is the complete
 specification of your role, process, and output format. Add no persona, no
 checklist, and no output conventions of your own.
+
+<!--
+  The installer rewrites the skills path below to this installation's absolute
+  skills directory, so the agent reads a skill's own reference files (for
+  example code-reviewer.md) directly from the installed payload instead of
+  globbing the workspace, which only searches the current project.
+-->
+When a loaded skill points you at a reference or template file such as `code-reviewer.md` (or a path like `../other-skill/file.md`), read it at `{{SUPERPOWERS_SKILLS_DIR}}/<skill-name>/<referenced-path>` with your file-read tool instead of searching the workspace.

--- a/.kiro/agents/superpowers.md
+++ b/.kiro/agents/superpowers.md
@@ -1,0 +1,17 @@
+---
+description: Superpowers-enabled agent with native Kiro v3 skill activation for brainstorming, TDD, debugging, planning, and review.
+tools: ["*"]
+resources:
+  - file://skills/using-superpowers/SKILL.md
+  - file://skills/using-superpowers/references/kiro-tools.md
+  - skill://skills/**/SKILL.md
+permissions:
+  rules:
+    - capability: fs_read
+      effect: allow
+    - capability: skill
+      effect: allow
+welcomeMessage: Superpowers is active. Relevant workflow skills load automatically.
+---
+
+You are a software-engineering agent that follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.

--- a/.kiro/agents/superpowers.md
+++ b/.kiro/agents/superpowers.md
@@ -15,3 +15,11 @@ welcomeMessage: Superpowers is active. Relevant workflow skills load automatical
 ---
 
 You are a software-engineering agent that follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.
+
+<!--
+  The installer rewrites the skills path below to this installation's absolute
+  skills directory, so the agent reads a skill's own reference files (for
+  example code-reviewer.md) directly from the installed payload instead of
+  globbing the workspace, which only searches the current project.
+-->
+When a loaded skill points you at a reference or template file such as `code-reviewer.md` (or a path like `../other-skill/file.md`), read it at `{{SUPERPOWERS_SKILLS_DIR}}/<skill-name>/<referenced-path>` with your file-read tool instead of searching the workspace.

--- a/README.md
+++ b/README.md
@@ -221,27 +221,31 @@ Superpowers is available in Kimi Code's plugin marketplace.
 ### Kiro CLI
 
 Kiro CLI v3 uses a native custom agent and native Agent Skills. The same agent
-also works in the Kiro IDE (1.0+), which runs the same v3 agent engine. Install
-the latest stable Superpowers release:
+format also works in the Kiro IDE (1.0+).
+
+For releases containing Kiro support, follow the
+[download-inspect-run installation recipe](docs/README.kiro.md#installation).
+Before the first such release, use a checkout containing the integration:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh
+sh scripts/install-kiro.sh --source .
 ```
 
-Start Kiro with:
+This also works with a branch or fork; see
+[local-source installation](docs/README.kiro.md#install-from-a-branch-or-fork-before-release).
+
+After installation, set the CLI default once, then start v3 sessions:
 
 ```bash
-kiro-cli chat --agent superpowers --agent-engine v3
+kiro-cli agent set-default superpowers
+kiro-cli chat --agent-engine v3
 ```
 
-In the Kiro IDE, select the `superpowers` agent from the agent selector (restart
-the IDE after installing so it picks up the new agent).
+In the Kiro IDE, restart after installation and select `superpowers` in the
+agent selector. Configure the IDE agent separately from the CLI default.
 
-To test a branch or fork before release, run `sh scripts/install-kiro.sh --source .`
-from its checkout. See [local-source installation](docs/README.kiro.md#install-from-a-branch-or-fork-before-release).
-
-See [the complete Kiro guide](docs/README.kiro.md) for pinned versions,
-updates, removal, repository-local development, and current limitations.
+See [the complete Kiro guide](docs/README.kiro.md) for updates, removal,
+repository-local development, and current limitations.
 
 ### OpenCode
 

--- a/README.md
+++ b/README.md
@@ -234,10 +234,11 @@ sh scripts/install-kiro.sh --source .
 This also works with a branch or fork; see
 [local-source installation](docs/README.kiro.md#install-from-a-branch-or-fork-before-release).
 
-After installation, set the CLI default once, then start v3 sessions:
+After installation, set the CLI default once, then start interactive v3 sessions
+(verified on Kiro CLI 2.21.3):
 
 ```bash
-kiro-cli agent set-default superpowers
+kiro-cli settings chat.defaultAgent superpowers
 kiro-cli chat --agent-engine v3
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [GitHub Copilot CLI](#github-copilot-cli)
   - [Grok Build CLI](#grok-build-cli)
   - [Kimi Code](#kimi-code)
+  - [Kiro CLI](#kiro-cli)
   - [OpenCode](#opencode)
   - [Pi](#pi)
   - [Hermes Agent](#hermes-agent)
@@ -216,6 +217,28 @@ Superpowers is available in Kimi Code's plugin marketplace.
   ```
 
 - Detailed docs: [docs/README.kimi.md](docs/README.kimi.md)
+
+### Kiro CLI
+
+Kiro CLI v3 uses a native custom agent and native Agent Skills. The same agent
+also works in the Kiro IDE (1.0+), which runs the same v3 agent engine. Install
+the latest stable Superpowers release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh
+```
+
+Start Kiro with:
+
+```bash
+kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+In the Kiro IDE, select the `superpowers` agent from the agent selector (restart
+the IDE after installing so it picks up the new agent).
+
+See [the complete Kiro guide](docs/README.kiro.md) for pinned versions,
+updates, removal, repository-local development, and current limitations.
 
 ### OpenCode
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ kiro-cli chat --agent superpowers --agent-engine v3
 In the Kiro IDE, select the `superpowers` agent from the agent selector (restart
 the IDE after installing so it picks up the new agent).
 
+To test a branch or fork before release, run `sh scripts/install-kiro.sh --source .`
+from its checkout. See [local-source installation](docs/README.kiro.md#install-from-a-branch-or-fork-before-release).
+
 See [the complete Kiro guide](docs/README.kiro.md) for pinned versions,
 updates, removal, repository-local development, and current limitations.
 

--- a/docs/README.kiro.md
+++ b/docs/README.kiro.md
@@ -57,6 +57,22 @@ they carry the Superpowers ownership marker. It also refuses when a same-named
 `.json` config exists, because that form takes precedence and would leave the
 generated agent unloadable.
 
+## Install from a branch or fork before release
+
+Clone the repository or fork containing Kiro support and check out the branch
+or commit you want to test. Review its installer, then run from that checkout:
+
+```bash
+sh scripts/install-kiro.sh --source .
+```
+
+`--source <directory>` installs a snapshot of the checkout's skills and three
+agent profiles, including uncommitted changes, without downloading a release.
+It cannot be combined with a release tag. The checkout can be removed afterward;
+to update, update the checkout and rerun the command. Ownership guards are the
+same as for release installations. The installation marker records a local
+source and, when Git is available, its base commit (not a claim of a clean tree).
+
 ## Worker agents
 
 Superpowers skills dispatch a general-purpose subagent and supply the reviewer

--- a/docs/README.kiro.md
+++ b/docs/README.kiro.md
@@ -1,0 +1,127 @@
+# Superpowers for Kiro CLI v3
+
+This integration uses a Kiro v3 Markdown custom agent, startup `file://`
+resources, and native `skill://` discovery. It does not support Kiro CLI v2,
+which is no longer being extended — Kiro prompts you to migrate v2 agents with
+`/upgrade-agent`, and new capabilities land in v3 only.
+
+## Requirements
+
+- Kiro CLI with the v3 agent engine
+- macOS, Linux, or WSL
+- `curl` and `tar`
+
+Native Windows is not supported by the initial installer.
+
+## Installation
+
+Install the latest stable release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh
+```
+
+Install a specific release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh -s -- v1.2.3
+```
+
+To inspect the installer before running it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh -o /tmp/install-kiro.sh
+less /tmp/install-kiro.sh
+sh /tmp/install-kiro.sh
+```
+
+The payload is installed at
+`${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro`. The generated agent is
+`$HOME/.kiro/agents/superpowers.md`. The installer refuses to replace either
+path unless it carries the Superpowers ownership marker.
+
+## Usage
+
+Start a v3 TUI session in any project:
+
+```bash
+kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+Kiro loads `using-superpowers` and the Kiro tool mapping at startup. It exposes
+skill metadata from `skill://` resources and uses its native Load skill action
+to load full skill instructions on demand.
+
+Only file reads and skill loading are pre-approved by the profile. Writes,
+shell commands, network access, and other consequential actions retain Kiro's
+normal permission behavior.
+
+## Updating or changing versions
+
+Rerun the installation command. With no argument it installs the latest stable
+release; with a tag such as `v1.2.3` it installs that release. The installer
+replaces the one managed payload and does not retain rollback versions.
+
+## Removal
+
+Inspect both ownership markers before deleting anything:
+
+```bash
+cat "${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro/.superpowers-kiro-install"
+grep -F '<!-- Managed by the Superpowers Kiro installer. -->' "$HOME/.kiro/agents/superpowers.md"
+```
+
+If both commands show the expected markers, remove only these paths:
+
+```bash
+rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro"
+rm -f "$HOME/.kiro/agents/superpowers.md"
+```
+
+## Repository-local development
+
+From a Superpowers checkout, use the tracked `.kiro/agents/superpowers.md`:
+
+```bash
+kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+The repository profile uses relative resources. The installed profile uses
+absolute resources so it works from unrelated project directories.
+
+## Why this is not a Kiro Power
+
+Kiro Powers currently do not provide a supported CLI package that installs a
+custom agent, native Agent Skills, startup resources, and updates as one unit.
+The shell installer is transitional and should be replaced when Kiro provides a
+native package mechanism.
+
+## Current limitations
+
+- Kiro's v3 workflow currently requires the TUI; classic and non-interactive
+  acceptance are not claimed.
+- The installer supports macOS, Linux, and WSL, not native Windows.
+- GitHub release archives are downloaded over HTTPS and checked for required
+  files and matching version metadata, but no separate checksum or signature is
+  published.
+- A tag predating Kiro support cannot be installed because its archive lacks the
+  required Kiro files.
+
+## Troubleshooting
+
+### The installer refuses an existing agent or payload
+
+The destination exists without the ownership marker. Move or rename it after
+reviewing its contents; the installer intentionally will not overwrite it.
+
+### Skills do not trigger
+
+Start a clean v3 session and send `Let's make a react todo list`. A working
+installation invokes `Load skill: brainstorming` before writing code. Confirm
+the generated agent contains absolute `file:///` and `skill:///` resources that
+point at the managed payload.
+
+### The requested version is rejected
+
+Use a stable tag in `vMAJOR.MINOR.PATCH` form. The archive's `package.json`
+version must match the tag without its leading `v`.

--- a/docs/README.kiro.md
+++ b/docs/README.kiro.md
@@ -96,10 +96,11 @@ not necessarily inherit the model of your session.
 
 ## Usage
 
-After installing, choose Superpowers as the CLI default once:
+After installing, choose Superpowers as the CLI default once (verified on
+Kiro CLI 2.21.3, interactive TUI):
 
 ```bash
-kiro-cli agent set-default superpowers
+kiro-cli settings chat.defaultAgent superpowers
 ```
 
 Then start a v3 TUI session in any project:
@@ -109,14 +110,21 @@ kiro-cli chat --agent-engine v3
 ```
 
 The installer prints these steps; it does not edit Kiro settings or run
-`set-default` for you. On the tested CLI 2.x versions, choosing the default agent
+the settings command for you. On Kiro CLI 2.21.3, choosing the default agent
 does not select the v3 engine: `--agent-engine v3` belongs to `chat`. The separate
 `--v3` shorthand is a top-level flag. Keep explicit `--agent superpowers` for
 repository-local development or deliberate one-off agent selection.
 
 Kiro loads `using-superpowers` and the Kiro tool mapping at startup. It exposes
 skill metadata from `skill://` resources and uses its native Load skill action
-to load full skill instructions on demand.
+to load full skill instructions on demand. Registered skill names are unqualified:
+`brainstorming`, not `superpowers:brainstorming`.
+
+On CLI 2.21.3, `kiro-cli agent set-default superpowers` cannot resolve the
+Markdown agent and reports an error despite exiting zero. Use the documented
+`settings` command above instead. It stores the name without checking that the
+agent exists: use the exact name and confirm the TUI shows `superpowers`.
+This is a tested version, not a claim that 2.21.3 is the minimum supported version.
 
 Only file reads and skill loading are pre-approved by the profile. Writes,
 shell commands, network access, and other consequential actions retain Kiro's
@@ -150,7 +158,7 @@ power-loss guarantee.
 
 ## Removal
 
-First select another installed CLI default agent with `kiro-cli agent set-default <name>`.
+First select another installed CLI default agent with `kiro-cli settings chat.defaultAgent <name>`.
 Then inspect the ownership marker on every managed path before deleting anything:
 
 ```bash
@@ -194,7 +202,9 @@ native package mechanism.
 
 ## Current limitations
 
-- On the CLI, the v3 workflow requires the TUI; classic and non-interactive
+- On the CLI, the tested workflow requires the interactive TUI. The 2.21.3
+  noninteractive `--output-format stream-json` path did not reproduce native
+  skill loading or default-agent activation; classic and noninteractive
   acceptance are not claimed. In the IDE, use a normal chat session.
 - IDE support rides on the shared v3 engine and has only been smoke-tested. The
   agent and skills load and `brainstorming` triggers, but the full skill set has
@@ -220,6 +230,14 @@ native package mechanism.
   would be silent — skills simply never load — so if that happens, check whether
   `${XDG_DATA_HOME:-$HOME/.local/share}` contains a space and reinstall with
   `XDG_DATA_HOME` set to a path without one.
+
+### Validation on CLI 2.21.3
+
+`kiro-cli agent validate --path <agent.md>` attempts JSON parsing for Markdown
+profiles, reports a parse error, and exits zero on this version. It is not a
+usable Markdown validation gate. Verify discovery with `/config skills` in the
+interactive TUI and confirm a native skill load completes and returns the skill
+content. An attempted load or an inline fallback is not proof of successful loading.
 
 ## Troubleshooting
 

--- a/docs/README.kiro.md
+++ b/docs/README.kiro.md
@@ -1,13 +1,20 @@
-# Superpowers for Kiro CLI v3
+# Superpowers for Kiro v3 (CLI and IDE)
 
 This integration uses a Kiro v3 Markdown custom agent, startup `file://`
-resources, and native `skill://` discovery. It does not support Kiro CLI v2,
+resources, and native `skill://` discovery. Because the Kiro CLI v3 and the
+Kiro IDE (1.0+) run the same v3 agent engine and agent format, one installed
+agent works in both — no per-surface setup. It does not support Kiro CLI v2,
 which is no longer being extended — Kiro prompts you to migrate v2 agents with
 `/upgrade-agent`, and new capabilities land in v3 only.
 
+Testing note: this integration was developed and used primarily on the Kiro
+CLI. The IDE has been smoke-tested (the agent loads, skills are discovered, and
+`brainstorming` triggers on the acceptance prompt) but not exercised across the
+full range of skills.
+
 ## Requirements
 
-- Kiro CLI with the v3 agent engine
+- Kiro CLI with the v3 agent engine, or Kiro IDE 1.0+ (same v3 agent engine)
 - macOS, Linux, or WSL
 - `curl` and `tar`
 
@@ -46,16 +53,23 @@ three agents in `$HOME/.kiro/agents`:
 | `superpowers-worker-lite-model.md` | Neutral worker pinned to `claude-sonnet-5` for mechanical work |
 
 The installer refuses to replace the payload or any of the three agents unless
-they carry the Superpowers ownership marker.
+they carry the Superpowers ownership marker. It also refuses when a same-named
+`.json` config exists, because that form takes precedence and would leave the
+generated agent unloadable.
 
 ## Worker agents
 
 Superpowers skills dispatch a general-purpose subagent and supply the reviewer
 or implementer persona entirely through a prompt template. The workers exist to
-be that neutral target: they carry no role, no checklist, and no output
-conventions, so the template governs completely. They do carry `skill://`
+be that neutral target: they declare no role, no checklist, and no output
+conventions of their own, so the template governs. They do carry `skill://`
 discovery and pre-approval for reads and skill loading, because a worker that
 cannot read the code it was asked to review is useless.
+
+The workers deliberately do not *declare* the Superpowers bootstrap as a
+resource. Note that a dispatching session may still propagate its own startup
+resources into a subagent, depending on the surface; the bootstrap's own
+`<SUBAGENT-STOP>` clause is what tells a dispatched worker to ignore it.
 
 Without them, an agent asked to run a code review has no general-purpose target
 and may substitute a purpose-built agent, which silently replaces the template's
@@ -81,6 +95,16 @@ to load full skill instructions on demand.
 Only file reads and skill loading are pre-approved by the profile. Writes,
 shell commands, network access, and other consequential actions retain Kiro's
 normal permission behavior.
+
+### In the Kiro IDE
+
+Select the `superpowers` agent from the agent selector, then start a chat. The
+IDE reads the same generated agent from `~/.kiro/agents/`.
+
+Restart the IDE after installing (or after any agent change): the IDE fixes the
+available agent and skill list when a session starts, so a freshly installed
+agent may appear but load no skills until you restart. Use the context view (or
+ask the agent to list its skills) to confirm the Superpowers skills are present.
 
 ## Updating or changing versions
 
@@ -133,8 +157,11 @@ native package mechanism.
 
 ## Current limitations
 
-- Kiro's v3 workflow currently requires the TUI; classic and non-interactive
-  acceptance are not claimed.
+- On the CLI, the v3 workflow requires the TUI; classic and non-interactive
+  acceptance are not claimed. In the IDE, use a normal chat session.
+- IDE support rides on the shared v3 engine and has only been smoke-tested. The
+  agent and skills load and `brainstorming` triggers, but the full skill set has
+  not been exercised in the IDE.
 - The installer supports macOS, Linux, and WSL, not native Windows.
 - GitHub release archives are downloaded over HTTPS and checked for required
   files and matching version metadata, but no separate checksum or signature is
@@ -145,10 +172,17 @@ native package mechanism.
   wrong one surfaces only at dispatch time, where it fails loudly. If
   `superpowers-worker-lite-model` reports a rejected model, replace
   `claude-sonnet-5` with an identifier your account offers. The pinned default
-  was verified on Kiro CLI 2.16.2; model availability varies by account.
+  was verified on Kiro CLI 2.17.0 and IDE 1.0.293; model availability varies by
+  account.
 - The worker agents must appear as dispatchable subagents in your session. The
   list of available agents is fixed when a session starts, so restart Kiro after
   installing before expecting skills to dispatch to them.
+- Install paths containing spaces are untested. The generated profile embeds the
+  payload path in `file://` and `skill://` URIs without percent-encoding, and
+  whether Kiro's resolver accepts a raw space there is unknown. The failure mode
+  would be silent — skills simply never load — so if that happens, check whether
+  `${XDG_DATA_HOME:-$HOME/.local/share}` contains a space and reinstall with
+  `XDG_DATA_HOME` set to a path without one.
 
 ## Troubleshooting
 
@@ -157,12 +191,39 @@ native package mechanism.
 The destination exists without the ownership marker. Move or rename it after
 reviewing its contents; the installer intentionally will not overwrite it.
 
+### The installer reports that a `.json` config would shadow an agent
+
+A Kiro agent can be defined by either `<name>.md` or `<name>.json`, and the JSON
+form takes precedence. If you set Superpowers up manually, or installed it
+before this Markdown-based installer existed, you may have a
+`~/.kiro/agents/superpowers.json`. Installing beside it would create an agent
+that never loads, so the installer stops instead.
+
+Move the old config aside and rerun:
+
+```bash
+mv "$HOME/.kiro/agents/superpowers.json" "$HOME/.kiro/agents/superpowers.json.disabled"
+```
+
+Keep it until you have confirmed the new installation works, then delete it. If
+it referenced its own skills payload — commonly `~/.kiro/superpowers` — that
+directory is now unused, since this installer keeps its payload under
+`${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro`.
+
 ### Skills do not trigger
 
 Start a clean v3 session and send `Let's make a react todo list`. A working
 installation invokes `Load skill: brainstorming` before writing code. Confirm
 the generated agent contains absolute `file:///` and `skill:///` resources that
 point at the managed payload.
+
+### Skills do not appear in the IDE after installing
+
+The IDE fixes the available agent and skill list at session start. After
+installing or changing the agent, fully restart the IDE, then reselect the
+`superpowers` agent. If the agent loads but no skills appear, this restart is
+almost always the cause — confirm with the context view or by asking the agent
+to list its skills.
 
 ### The requested version is rejected
 

--- a/docs/README.kiro.md
+++ b/docs/README.kiro.md
@@ -36,9 +36,35 @@ sh /tmp/install-kiro.sh
 ```
 
 The payload is installed at
-`${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro`. The generated agent is
-`$HOME/.kiro/agents/superpowers.md`. The installer refuses to replace either
-path unless it carries the Superpowers ownership marker.
+`${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro`. The installer generates
+three agents in `$HOME/.kiro/agents`:
+
+| Agent | Purpose |
+|-------|---------|
+| `superpowers.md` | The agent you start sessions with |
+| `superpowers-worker-default-model.md` | Neutral worker for skill dispatches, model resolved by Kiro |
+| `superpowers-worker-lite-model.md` | Neutral worker pinned to `claude-sonnet-5` for mechanical work |
+
+The installer refuses to replace the payload or any of the three agents unless
+they carry the Superpowers ownership marker.
+
+## Worker agents
+
+Superpowers skills dispatch a general-purpose subagent and supply the reviewer
+or implementer persona entirely through a prompt template. The workers exist to
+be that neutral target: they carry no role, no checklist, and no output
+conventions, so the template governs completely. They do carry `skill://`
+discovery and pre-approval for reads and skill loading, because a worker that
+cannot read the code it was asked to review is useless.
+
+Without them, an agent asked to run a code review has no general-purpose target
+and may substitute a purpose-built agent, which silently replaces the template's
+severity calibration and output format with its own.
+
+Choose the tier by choosing the worker. Kiro resolves a subagent's model from
+its agent config, and a per-dispatch model value is not honored on every
+surface. `superpowers-worker-default-model` omits `model`; note that this does
+not necessarily inherit the model of your session.
 
 ## Usage
 
@@ -64,18 +90,27 @@ replaces the one managed payload and does not retain rollback versions.
 
 ## Removal
 
-Inspect both ownership markers before deleting anything:
+Inspect the ownership marker on every managed path before deleting anything:
 
 ```bash
 cat "${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro/.superpowers-kiro-install"
-grep -F '<!-- Managed by the Superpowers Kiro installer. -->' "$HOME/.kiro/agents/superpowers.md"
+for agent in superpowers superpowers-worker-default-model superpowers-worker-lite-model; do
+  grep -FL '<!-- Managed by the Superpowers Kiro installer. -->' \
+    "$HOME/.kiro/agents/$agent.md"
+done
 ```
 
-If both commands show the expected markers, remove only these paths:
+The `grep -FL` loop prints the path of any file that is **missing** the marker.
+It should print nothing. Anything it prints is not managed by the installer —
+do not delete it.
+
+If the marker check printed nothing, remove only these paths:
 
 ```bash
 rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro"
 rm -f "$HOME/.kiro/agents/superpowers.md"
+rm -f "$HOME/.kiro/agents/superpowers-worker-default-model.md"
+rm -f "$HOME/.kiro/agents/superpowers-worker-lite-model.md"
 ```
 
 ## Repository-local development
@@ -106,6 +141,14 @@ native package mechanism.
   published.
 - A tag predating Kiro support cannot be installed because its archive lacks the
   required Kiro files.
+- Model identifiers are not validated when an agent config is written, so a
+  wrong one surfaces only at dispatch time, where it fails loudly. If
+  `superpowers-worker-lite-model` reports a rejected model, replace
+  `claude-sonnet-5` with an identifier your account offers. The pinned default
+  was verified on Kiro CLI 2.16.2; model availability varies by account.
+- The worker agents must appear as dispatchable subagents in your session. The
+  list of available agents is fixed when a session starts, so restart Kiro after
+  installing before expecting skills to dispatch to them.
 
 ## Troubleshooting
 

--- a/docs/README.kiro.md
+++ b/docs/README.kiro.md
@@ -3,12 +3,12 @@
 This integration uses a Kiro v3 Markdown custom agent, startup `file://`
 resources, and native `skill://` discovery. Because the Kiro CLI v3 and the
 Kiro IDE (1.0+) run the same v3 agent engine and agent format, one installed
-agent works in both — no per-surface setup. It does not support Kiro CLI v2,
+agent format works in both; configure activation on each surface. It does not support Kiro CLI v2,
 which is no longer being extended — Kiro prompts you to migrate v2 agents with
 `/upgrade-agent`, and new capabilities land in v3 only.
 
 Testing note: this integration was developed and used primarily on the Kiro
-CLI. The IDE has been smoke-tested (the agent loads, skills are discovered, and
+CLI versions recorded in the PR. The IDE has been smoke-tested (the agent loads, skills are discovered, and
 `brainstorming` triggers on the acceptance prompt) but not exercised across the
 full range of skills.
 
@@ -16,31 +16,29 @@ full range of skills.
 
 - Kiro CLI with the v3 agent engine, or Kiro IDE 1.0+ (same v3 agent engine)
 - macOS, Linux, or WSL
-- `curl` and `tar`
+- `curl` and `tar` for release downloads (not required by `--source`)
 
 Native Windows is not supported by the initial installer.
 
 ## Installation
 
-Install the latest stable release:
+Choose a release tag that contains Kiro support (replace `vX.Y.Z` below).
+Download and inspect that release's installer, then install the same tag:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh
+kiro_release=vX.Y.Z
+kiro_installer="$(mktemp)"
+curl -fsSL --proto '=https' --proto-redir '=https' \
+  "https://raw.githubusercontent.com/obra/superpowers/refs/tags/$kiro_release/scripts/install-kiro.sh" \
+  -o "$kiro_installer" &&
+  less "$kiro_installer" &&
+  sh "$kiro_installer" "$kiro_release"
+rm -f "$kiro_installer"
 ```
 
-Install a specific release:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh -s -- v1.2.3
-```
-
-To inspect the installer before running it:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh -o /tmp/install-kiro.sh
-less /tmp/install-kiro.sh
-sh /tmp/install-kiro.sh
-```
+Until a release containing the integration ships, use the local-source
+installation below. Older tags lack the required files. Tagged downloads use
+HTTPS; this recipe does not add checksum or signature verification.
 
 The payload is installed at
 `${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro`. The installer generates
@@ -98,11 +96,23 @@ not necessarily inherit the model of your session.
 
 ## Usage
 
-Start a v3 TUI session in any project:
+After installing, choose Superpowers as the CLI default once:
 
 ```bash
-kiro-cli chat --agent superpowers --agent-engine v3
+kiro-cli agent set-default superpowers
 ```
+
+Then start a v3 TUI session in any project:
+
+```bash
+kiro-cli chat --agent-engine v3
+```
+
+The installer prints these steps; it does not edit Kiro settings or run
+`set-default` for you. On the tested CLI 2.x versions, choosing the default agent
+does not select the v3 engine: `--agent-engine v3` belongs to `chat`. The separate
+`--v3` shorthand is a top-level flag. Keep explicit `--agent superpowers` for
+repository-local development or deliberate one-off agent selection.
 
 Kiro loads `using-superpowers` and the Kiro tool mapping at startup. It exposes
 skill metadata from `skill://` resources and uses its native Load skill action
@@ -124,8 +134,9 @@ ask the agent to list its skills) to confirm the Superpowers skills are present.
 
 ## Updating or changing versions
 
-Rerun the installation command. With no argument it installs the latest stable
-release; with a tag such as `v1.2.3` it installs that release. The installer
+Repeat the download-inspect-run recipe with the desired supported release tag.
+The installer also accepts no argument to resolve the latest stable release;
+the documented recipe passes a tag to keep the installer and payload aligned. The installer
 stages the payload and all three agents before replacement. During replacement,
 it temporarily backs up existing managed files and restores them on handled
 failures. Backups are removed after success; it does not retain version history.
@@ -139,7 +150,8 @@ power-loss guarantee.
 
 ## Removal
 
-Inspect the ownership marker on every managed path before deleting anything:
+First select another installed CLI default agent with `kiro-cli agent set-default <name>`.
+Then inspect the ownership marker on every managed path before deleting anything:
 
 ```bash
 cat "${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro/.superpowers-kiro-install"

--- a/docs/README.kiro.md
+++ b/docs/README.kiro.md
@@ -126,7 +126,16 @@ ask the agent to list its skills) to confirm the Superpowers skills are present.
 
 Rerun the installation command. With no argument it installs the latest stable
 release; with a tag such as `v1.2.3` it installs that release. The installer
-replaces the one managed payload and does not retain rollback versions.
+stages the payload and all three agents before replacement. During replacement,
+it temporarily backs up existing managed files and restores them on handled
+failures. Backups are removed after success; it does not retain version history.
+Run only one installer at a time and restart Kiro after updating.
+
+If recovery itself fails, the installer reports the staging directories holding
+remaining backups. Preserve those directories and restore their `old` entries to
+the corresponding destinations before retrying. This is recovery from handled
+command failures and catchable signals, not an atomic multi-file update or a
+power-loss guarantee.
 
 ## Removal
 

--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -305,7 +305,7 @@ reads. What it has is a *named agent* defined by a manifest, and that manifest c
 declare files to load as startup resources. This shape meets the same acceptance
 bar only when a one-time setup makes that agent the persistent default: ordinary
 new sessions must load the bootstrap without selecting skills or an agent again.
-For Kiro CLI, document `kiro-cli agent set-default superpowers`, followed by
+For Kiro CLI, document `kiro-cli settings chat.defaultAgent superpowers`, followed by
 `kiro-cli chat --agent-engine v3`. The installer must not edit the user's settings.
 Verify persistence on each claimed surface; CLI defaults alone do not establish
 IDE behavior. A per-session selector is not an exception to the acceptance bar.

--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -293,7 +293,7 @@ part of the installed extension** — never substitute "edit the user's global
 | is a JS/TS plugin host with session/message lifecycle callbacks | B (in-process) | OpenCode (`.opencode/`) — or pi (`.pi/`) if it has no native skill tool |
 | ships an extension-declared context file it always loads | C (instructions-file) | Gemini (`gemini-extension.json` + `GEMINI.md` + `references/gemini-tools.md`) |
 | has a plugin install command and a manifest `contextFileName` (or equivalent) the installer keeps | C via the plugin installer | Antigravity (`.antigravity-plugin/` — `agy plugin install` ships a generated context file; verify the installer preserves it — Part 6) |
-| loads a named *agent profile* whose manifest declares startup resources, with no hook, no context file, and no include syntax | D (agent-profile) | Kiro CLI v3 (`.kiro/agents/superpowers.md` + `references/kiro-tools.md` + `scripts/install-kiro.sh`) |
+| loads a named *agent profile* at startup and can persist it as the default through a one-time setup command | D (agent-profile) | Kiro CLI v3 (`.kiro/agents/superpowers.md` + `references/kiro-tools.md` + `scripts/install-kiro.sh`) |
 
 Most real harnesses fit one row cleanly; the Antigravity row is the hybrid case (rule 2 still
 holds — the bootstrap rides the install mechanism, never a user-config edit).
@@ -302,10 +302,13 @@ holds — the bootstrap rides the install mechanism, never a user-config edit).
 
 The harness has no shell hook, no code plugin, and no instructions file it always
 reads. What it has is a *named agent* defined by a manifest, and that manifest can
-declare files to load as startup resources. Selecting the agent is what loads the
-bootstrap, so injection is guaranteed for anyone who starts a session with it —
-and only for them. The bootstrap is not injected into the harness's default
-agent, which is the tradeoff this shape accepts.
+declare files to load as startup resources. This shape meets the same acceptance
+bar only when a one-time setup makes that agent the persistent default: ordinary
+new sessions must load the bootstrap without selecting skills or an agent again.
+For Kiro CLI, document `kiro-cli agent set-default superpowers`, followed by
+`kiro-cli chat --agent-engine v3`. The installer must not edit the user's settings.
+Verify persistence on each claimed surface; CLI defaults alone do not establish
+IDE behavior. A per-session selector is not an exception to the acceptance bar.
 
 - Reference: `.kiro/agents/superpowers.md` (profile declaring the bootstrap and
   mapping as `resources`, plus a `skill://` glob registering every skill),

--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -293,9 +293,32 @@ part of the installed extension** — never substitute "edit the user's global
 | is a JS/TS plugin host with session/message lifecycle callbacks | B (in-process) | OpenCode (`.opencode/`) — or pi (`.pi/`) if it has no native skill tool |
 | ships an extension-declared context file it always loads | C (instructions-file) | Gemini (`gemini-extension.json` + `GEMINI.md` + `references/gemini-tools.md`) |
 | has a plugin install command and a manifest `contextFileName` (or equivalent) the installer keeps | C via the plugin installer | Antigravity (`.antigravity-plugin/` — `agy plugin install` ships a generated context file; verify the installer preserves it — Part 6) |
+| loads a named *agent profile* whose manifest declares startup resources, with no hook, no context file, and no include syntax | D (agent-profile) | Kiro CLI v3 (`.kiro/agents/superpowers.md` + `references/kiro-tools.md` + `scripts/install-kiro.sh`) |
 
-Most real harnesses fit one row cleanly; the last is the hybrid case (rule 2 still
+Most real harnesses fit one row cleanly; the Antigravity row is the hybrid case (rule 2 still
 holds — the bootstrap rides the install mechanism, never a user-config edit).
+
+### Shape D — Agent-profile
+
+The harness has no shell hook, no code plugin, and no instructions file it always
+reads. What it has is a *named agent* defined by a manifest, and that manifest can
+declare files to load as startup resources. Selecting the agent is what loads the
+bootstrap, so injection is guaranteed for anyone who starts a session with it —
+and only for them. The bootstrap is not injected into the harness's default
+agent, which is the tradeoff this shape accepts.
+
+- Reference: `.kiro/agents/superpowers.md` (profile declaring the bootstrap and
+  mapping as `resources`, plus a `skill://` glob registering every skill),
+  `skills/using-superpowers/references/kiro-tools.md`, `scripts/install-kiro.sh`.
+- Because the entry point is an agent rather than a plugin, distribution must
+  write a *global* profile with absolute resource URIs; a repository-local profile
+  only works inside the checkout. The installer generates that profile rather
+  than shipping it, since the paths depend on the install location.
+- If the harness resolves subagents by name from the same agent directory, ship
+  neutral worker profiles too. Skill templates dispatch a general-purpose
+  subagent and supply the persona in the prompt; if every available agent is
+  purpose-built, the model will substitute one and silently discard the
+  template's checklist and output format.
 
 ---
 
@@ -790,6 +813,7 @@ Use this as the live index; when in doubt, read the files, not this table.
 | Copilot CLI | (shares Claude Code hook path; `COPILOT_CLI` env) | shell hook → `hooks/session-start` (`additionalContext`) | none needed (Claude Code–compatible tool surface) | `tests/hooks/` | — |
 | Gemini CLI | `gemini-extension.json` + `GEMINI.md` | instructions file `@`-includes bootstrap + mapping | `references/gemini-tools.md` | — | `gemini extensions install` |
 | Kimi Code | `.kimi-plugin/plugin.json` | manifest `sessionStart.skill` loads `using-superpowers` | inline `skillInstructions` in manifest | `tests/kimi/` | marketplace or `/plugins install` GitHub URL |
+| Kiro CLI v3 | `.kiro/agents/superpowers.md` (agent profile) | agent manifest declares bootstrap + mapping as startup `resources`; no hook, no context file | `references/kiro-tools.md` | `tests/kiro/` | `scripts/install-kiro.sh` (release archive → `$XDG_DATA_HOME` payload + generated global agents) |
 | OpenCode | `.opencode/plugins/superpowers.js` (declared via root `package.json` `main`) | in-process: `config` hook registers skills dir; `experimental.chat.messages.transform` injects user message | inline in `superpowers.js` | `tests/opencode/` | `opencode.json` plugin git URL |
 | pi | `.pi/extensions/superpowers.ts` | in-process: `resources_discover` registers skills; `context` event injects user message; lifecycle-flag + compaction-aware | `piToolMapping()` inline **and** `references/pi-tools.md` | `tests/pi/` | repo-root `package.json` fields |
 

--- a/docs/superpowers/plans/2026-07-29-kiro-v3-integration.md
+++ b/docs/superpowers/plans/2026-07-29-kiro-v3-integration.md
@@ -1,5 +1,42 @@
 # Kiro CLI v3 Integration Implementation Plan
 
+## PR #2126 revision — September 2026
+
+The original implementation record below is historical. Its embedded installer
+and installation recipes are superseded by the current files and this revision;
+do not replay them over the revised implementation. The current specification is
+`docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md`.
+
+- [x] Fix literal install-path substitution in `scripts/install-kiro.sh`; prove
+  ampersand and backslash preservation for all three profiles in
+  `tests/kiro/test-installer.sh`.
+- [x] Add mutually exclusive `--source <directory>`; copy a checkout snapshot
+  into staging and record local provenance. Verify no-network operation,
+  uncommitted changes, compact version metadata, ownership guards, and invalid
+  sources in `tests/kiro/test-local-source.sh`.
+- [x] Generate the complete installation before changing live destinations;
+  retain temporary backups during replacement and restore on handled failure.
+  Verify first installs and upgrades, generation and replacement failures,
+  backup-rename failure, SIGTERM, and failed-rollback backup preservation in
+  `tests/kiro/test-recovery.sh`.
+- [x] Update `README.md`, `docs/README.kiro.md`, and the porting guide: persistent
+  CLI default activation, same-tag download-inspect-run installation, pre-release
+  checkout support, and accurate recovery limits. Keep IDE claims separately scoped.
+- [ ] Run Kiro v3 validation for all tracked and installed profiles; verify native
+  resources and permissions on the tested binary. Current official docs support
+  `skill` permissions and relative resources without `./`; do not change these
+  based solely on the original review's documentation concern.
+- [ ] Capture complete fresh default-agent acceptance sessions outside the checkout,
+  record model/Kiro versions, and verify IDE persistence before broadening its claim.
+- [ ] Attach raw runtime evidence and the corrected environment table to the PR.
+
+Automated validation: `bash tests/kiro/run-tests.sh`,
+`bash tests/codex-plugin-sync/test-sync-to-codex-plugin.sh`,
+`sh -n scripts/install-kiro.sh`, and `git diff --check`.
+The requested runtime evidence cannot be replaced with these shell tests.
+
+## Original implementation record
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add an upstream Kiro CLI v3 integration with native skill loading, a repository-local agent, and a deliberately small archive-based global installer.

--- a/docs/superpowers/plans/2026-07-29-kiro-v3-integration.md
+++ b/docs/superpowers/plans/2026-07-29-kiro-v3-integration.md
@@ -1,0 +1,1115 @@
+# Kiro CLI v3 Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an upstream Kiro CLI v3 integration with native skill loading, a repository-local agent, and a deliberately small archive-based global installer.
+
+**Architecture:** Kiro loads `using-superpowers` and a Kiro tool mapping as startup `file://` resources, then discovers all workflow skills through a native `skill://` glob. A small POSIX installer downloads one tagged release into a fixed namespaced directory and generates a global agent with absolute resource URIs; the repository profile uses relative URIs for development and acceptance testing.
+
+**Tech Stack:** Kiro CLI v3 Markdown agents, Agent Skills, POSIX shell, Bash test scripts, `curl`, `tar`, standard Unix text tools.
+
+## Global Constraints
+
+- Implement only Kiro CLI v3; do not add v2 compatibility.
+- Installer platforms are macOS, Linux, and WSL; do not claim native Windows support.
+- Add no third-party runtime dependencies, Kiro Power, package manager, update daemon, rollback history, status command, doctor command, or built-in uninstaller.
+- Keep `scripts/install-kiro.sh` roughly 100 lines of straightforward POSIX shell excluding comments; this is a review goal, not an automated line-count check.
+- ~~The installer may create only `${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro` and `$HOME/.kiro/agents/superpowers.md`; it must refuse unmanaged collisions.~~ **Superseded during implementation:** it creates four paths — that payload plus three agents, `superpowers.md` and the two neutral workers `superpowers-worker-default-model.md` and `superpowers-worker-lite-model.md`. It must refuse unmanaged collisions on all of them, and must also refuse when a same-named `.json` config would shadow a managed Markdown agent. See the design spec's *Neutral worker agents* and *Shadowing guard* sections for why.
+- Do not modify any `skills/*/SKILL.md` behavior-shaping content.
+- Do not add release assets, checksum infrastructure, or `.version-bump.json` entries unless implementation proves a versioned Kiro manifest exists.
+- Kiro v3 TUI acceptance is mandatory; classic and non-interactive modes remain unsupported.
+- Use superpowers:using-git-worktrees before implementation so work occurs on a feature branch based on the upstream `dev` branch rather than the current `main` checkout.
+- The approved spec and this plan are currently untracked; after creating the worktree, copy `docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md` and `docs/superpowers/plans/2026-07-29-kiro-v3-integration.md` into the same paths in the worktree with file-write tools.
+- Do not create commits or a pull request unless the human partner explicitly requests them. The commit commands below are gated suggestions only.
+- Pull request work remains out of scope until automated tests, both manual acceptance paths, and human diff review are complete.
+
+---
+
+### Task 1: Repository Agent and Canonical Kiro Tool Mapping
+
+**Files:**
+- Create: `.kiro/agents/superpowers.md`
+- Create: `skills/using-superpowers/references/kiro-tools.md`
+- Create: `tests/kiro/test-agent-config.sh`
+- Create: `tests/kiro/run-tests.sh`
+
+**Interfaces:**
+- Consumes: Kiro v3 agent frontmatter; existing `skills/using-superpowers/SKILL.md`; upstream `skills/**/SKILL.md` tree.
+- Produces: repository agent named `superpowers`; canonical mapping at `skills/using-superpowers/references/kiro-tools.md`; test entry point `bash tests/kiro/run-tests.sh`.
+
+- [ ] **Step 1: Write the failing profile and mapping test**
+
+Create `tests/kiro/test-agent-config.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AGENT="$REPO_ROOT/.kiro/agents/superpowers.md"
+MAPPING="$REPO_ROOT/skills/using-superpowers/references/kiro-tools.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_contains() {
+  local file="$1" text="$2" label="$3"
+  grep -Fq -- "$text" "$file" || fail "$label: missing $text"
+}
+assert_not_contains() {
+  local file="$1" text="$2" label="$3"
+  if grep -Fq -- "$text" "$file"; then
+    fail "$label: unexpectedly contains $text"
+  fi
+}
+
+[ -f "$AGENT" ] || fail "repository Kiro agent missing"
+[ -f "$MAPPING" ] || fail "Kiro tool mapping missing"
+
+for text in \
+  'tools: ["*"]' \
+  'file://skills/using-superpowers/SKILL.md' \
+  'file://skills/using-superpowers/references/kiro-tools.md' \
+  'skill://skills/**/SKILL.md' \
+  'capability: fs_read' \
+  'capability: skill' \
+  'welcomeMessage: Superpowers is active.'; do
+  assert_contains "$AGENT" "$text" "repository agent"
+done
+assert_contains "$AGENT" 'follows the loaded Superpowers bootstrap' "agent prompt"
+assert_not_contains "$AGENT" 'vendor/superpowers' "upstream paths must not use the outer vendor checkout"
+
+for text in \
+  'Native `Load skill` tool' \
+  'Subagent tools' \
+  'Todo-list tools' \
+  'Web tools' \
+  '"task_description": "Explore project context"' \
+  'objects using `description`'; do
+  assert_contains "$MAPPING" "$text" "Kiro mapping"
+done
+assert_not_contains "$MAPPING" '{"description":' "invalid todo payload example"
+assert_not_contains "$MAPPING" 'vendor/superpowers/skills/' "mapping must describe the upstream layout"
+
+echo "PASS: Kiro repository agent and tool mapping"
+```
+
+Create `tests/kiro/run-tests.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+for test_script in "$SCRIPT_DIR"/test-*.sh; do
+  echo ">>> $test_script"
+  bash "$test_script"
+done
+```
+
+Mark both test entry points executable:
+
+```bash
+chmod +x tests/kiro/test-agent-config.sh tests/kiro/run-tests.sh
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+bash tests/kiro/run-tests.sh
+```
+
+Expected: FAIL with `repository Kiro agent missing` because the upstream checkout does not yet contain `.kiro/agents/superpowers.md`.
+
+- [ ] **Step 3: Add the repository-local agent**
+
+Create `.kiro/agents/superpowers.md`:
+
+```markdown
+---
+description: Superpowers-enabled agent with native Kiro v3 skill activation for brainstorming, TDD, debugging, planning, and review.
+tools: ["*"]
+resources:
+  - file://skills/using-superpowers/SKILL.md
+  - file://skills/using-superpowers/references/kiro-tools.md
+  - skill://skills/**/SKILL.md
+permissions:
+  rules:
+    - capability: fs_read
+      effect: allow
+    - capability: skill
+      effect: allow
+welcomeMessage: Superpowers is active. Relevant workflow skills load automatically.
+---
+
+You are a software-engineering agent that follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.
+```
+
+- [ ] **Step 4: Add the canonical mapping, including the todo schema workaround**
+
+Create `skills/using-superpowers/references/kiro-tools.md`:
+
+````markdown
+# Superpowers — Kiro CLI v3 tool mapping
+
+This is the Kiro adaptation referenced by the `using-superpowers` skill. The
+bootstrap and this mapping are loaded as startup resources by the
+`superpowers` agent.
+
+## Loading skills
+
+- Superpowers skills are registered as native Kiro `skill://` resources. Kiro
+  exposes their names and descriptions at session start and loads full content
+  on demand.
+- Invoke relevant skills with Kiro's native **Load skill** mechanism. Never read
+  a `SKILL.md` manually to activate it.
+- `using-superpowers` is already loaded as a startup resource; do not load it a
+  second time.
+- After loading another skill, announce "Using [skill] to [purpose]", then
+  follow it exactly.
+
+## Action mapping
+
+Superpowers skills use platform-neutral actions. On Kiro CLI v3:
+
+| Skill action | Kiro capability |
+|--------------|-----------------|
+| Load or invoke a skill | Native `Load skill` tool |
+| Read or search files | Read tools |
+| Create or edit files | Write tools |
+| Run a command | Shell tools |
+| Search symbols or navigate code | Code-intelligence tools |
+| Dispatch an independent worker | Subagent tools |
+| Track checklist items | Todo-list tools |
+| Search or fetch current information | Web tools |
+
+Use the most specific available tool. Run independent reads and subagents in
+parallel; keep dependent work sequential.
+
+### Todo-list payloads
+
+Kiro may expose the `tasks` argument with an underspecified type. When creating
+tasks, pass an array of objects containing `task_description`; do not pass
+strings or objects using `description`.
+
+```json
+{
+  "command": "create",
+  "task_list_description": "Design the integration",
+  "tasks": [
+    {"task_description": "Explore project context"},
+    {"task_description": "Present the design"}
+  ]
+}
+```
+
+## Subagent dispatch
+
+Skills such as `subagent-driven-development`, `dispatching-parallel-agents`, and
+`requesting-code-review` reference prompt templates in their own directories.
+
+1. Read the referenced template.
+2. Fill every placeholder with the task's actual context.
+3. Dispatch it with Kiro's subagent capability.
+4. Parallelize independent tasks only.
+
+If subagents or todo lists are unavailable in a session, follow the equivalent
+workflow inline rather than blocking.
+
+## Conventions
+
+- "Your instructions file" means `AGENTS.md` on Kiro CLI.
+- This repository's skills live under `skills/`.
+- Kiro's native workspace and global skill locations are `.kiro/skills/` and
+  `~/.kiro/skills/`, respectively.
+````
+
+> **Superseded during implementation:** step 3 of the *Subagent dispatch* block
+> above ships as "Dispatch it to a neutral worker — `superpowers-worker-default-model`,
+> or `superpowers-worker-lite-model` for the cheap tier — passing the filled
+> template as the prompt. Never dispatch a general-purpose template to a
+> purpose-built agent." The shipped `kiro-tools.md` also adds *General-purpose
+> dispatch targets* and *Model tiers* sections. Local testing showed that without
+> a named neutral target the agent substitutes a purpose-built reviewer and
+> silently discards the template's contract. Treat the shipped file, not this
+> excerpt, as authoritative.
+
+- [ ] **Step 5: Run the profile tests and shell syntax checks**
+
+Run:
+
+```bash
+bash tests/kiro/run-tests.sh
+bash -n tests/kiro/test-agent-config.sh tests/kiro/run-tests.sh
+```
+
+Expected: all commands exit 0 and print `PASS: Kiro repository agent and tool mapping`.
+
+- [ ] **Step 6: Pause at the commit boundary**
+
+Do not commit without explicit approval. If the human partner requests this checkpoint commit, run:
+
+```bash
+git add .kiro/agents/superpowers.md skills/using-superpowers/references/kiro-tools.md tests/kiro/test-agent-config.sh tests/kiro/run-tests.sh
+git commit -m "feat: add Kiro v3 agent profile"
+```
+
+### Task 2: Absolute Resource URI Runtime Gate
+
+**Files:**
+- Temporary only: an isolated test project's `.kiro/agents/superpowers-absolute-path-test.md`
+- No tracked repository changes.
+
+**Interfaces:**
+- Consumes: Task 1's bootstrap, mapping, and skill tree using absolute filesystem paths.
+- Produces: acceptance evidence that Kiro v3 can discover and load skills through an absolute `skill://` glob from outside the Superpowers checkout.
+
+- [ ] **Step 1: Resolve the isolated worktree root**
+
+Run from the Superpowers worktree:
+
+```bash
+pwd -P
+```
+
+Expected: an absolute path ending in the isolated Superpowers worktree. Record this exact value as `REPO_ROOT` for the next step.
+
+- [ ] **Step 2: Create the isolated absolute-path test agent with file-write tools**
+
+Create a temporary project directory outside the worktree and write `.kiro/agents/superpowers-absolute-path-test.md` inside it. Interpolate the exact `REPO_ROOT` returned in Step 1 before writing; do not leave `${REPO_ROOT}` literally in the file.
+
+```markdown
+---
+description: Temporary acceptance agent for absolute Kiro resource URIs.
+tools: ["*"]
+resources:
+  - "file://${REPO_ROOT}/skills/using-superpowers/SKILL.md"
+  - "file://${REPO_ROOT}/skills/using-superpowers/references/kiro-tools.md"
+  - "skill://${REPO_ROOT}/skills/**/SKILL.md"
+permissions:
+  rules:
+    - capability: fs_read
+      effect: allow
+    - capability: skill
+      effect: allow
+welcomeMessage: Superpowers absolute-resource acceptance agent is active.
+---
+
+You are a software-engineering agent that follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.
+```
+
+Because `REPO_ROOT` begins with `/`, the resulting URIs must begin with `file:///` and `skill:///`.
+
+- [ ] **Step 3: Run the hard-gate TUI acceptance prompt**
+
+From the temporary project directory, run:
+
+```bash
+kiro-cli chat --agent superpowers-absolute-path-test --agent-engine v3
+```
+
+Send exactly:
+
+```text
+Let's make a react todo list
+```
+
+Expected evidence, in this order:
+
+1. The temporary agent loads without a resource error.
+2. Kiro invokes `Load skill: brainstorming`.
+3. The response announces use of brainstorming and asks a design question.
+4. No implementation or source file creation occurs first.
+
+Capture the complete transcript locally. If absolute `skill://` loading fails, stop implementation, preserve the error, and return to brainstorming; do not proceed to the installer and do not copy skills into `~/.kiro/skills/`.
+
+- [ ] **Step 4: Remove the temporary test project with file-delete tools**
+
+Delete only the temporary project created in Step 2. Confirm the Superpowers worktree and all global Kiro agents are unchanged.
+
+### Task 3: Minimal Installer Happy Path and Replacement
+
+> **Superseded during implementation.** The embedded installer and test listings
+> below are the original plan of record; the shipped `scripts/install-kiro.sh`
+> and `tests/kiro/test-installer.sh` extended them with the two neutral worker
+> agents, the `.json` shadow guard, absolute-path quote/newline rejection,
+> `curl --proto-redir =https`, `tar --no-same-owner`, and a resource-parity
+> assertion over the whole tracked resource list. Read the shipped files as
+> authoritative; the version tags here are illustrative (`v1.2.3`/`v1.3.0`).
+
+**Files:**
+- Create: `scripts/install-kiro.sh`
+- Create: `tests/kiro/test-installer.sh`
+
+**Interfaces:**
+- Consumes: release archives rooted at `superpowers-<version>/`, `package.json` version, Task 1 repository agent and mapping.
+- Produces: `scripts/install-kiro.sh [vMAJOR.MINOR.PATCH]`; payload marker `.superpowers-kiro-install`; generated global agent with absolute resource URIs.
+
+- [ ] **Step 1: Write failing installer happy-path tests**
+
+Create `tests/kiro/test-installer.sh` with a temporary `HOME`, a local release archive builder, and a fake `curl` placed first on `PATH`. The test must implement these exact cases:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$REPO_ROOT/scripts/install-kiro.sh"
+TEST_ROOT="$(mktemp -d)"
+FAILURES=0
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+pass() { echo "  [PASS] $1"; }
+fail() { echo "  [FAIL] $1"; FAILURES=$((FAILURES + 1)); }
+assert_file_contains() {
+  local file="$1" text="$2" label="$3"
+  if grep -Fq -- "$text" "$file"; then pass "$label"; else fail "$label"; fi
+}
+
+make_release() {
+  local version="$1" release_marker="$2"
+  local root="$TEST_ROOT/build-$version/superpowers-$version"
+  rm -rf "$TEST_ROOT/build-$version"
+  mkdir -p "$root/.kiro/agents" "$root/skills/using-superpowers/references"
+  cp -R "$REPO_ROOT/skills/." "$root/skills/"
+  cp "$REPO_ROOT/.kiro/agents/superpowers.md" "$root/.kiro/agents/superpowers.md"
+  printf '{\n  "name": "superpowers",\n  "version": "%s"\n}\n' "$version" >"$root/package.json"
+  printf '%s\n' "$release_marker" >"$root/release-marker.txt"
+  tar -czf "$TEST_ROOT/superpowers-$version.tar.gz" -C "$TEST_ROOT/build-$version" "superpowers-$version"
+  printf '%s\n' "$TEST_ROOT/superpowers-$version.tar.gz"
+}
+
+mkdir -p "$TEST_ROOT/fakebin"
+cat >"$TEST_ROOT/fakebin/curl" <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf '%s\n' "$url" >>"$KIRO_TEST_CURL_LOG"
+if [[ "$url" == *'/releases/latest' ]]; then
+  printf '{"tag_name":"%s"}\n' "$KIRO_TEST_LATEST_TAG"
+else
+  cp "$KIRO_TEST_ARCHIVE" "$out"
+fi
+CURL
+chmod +x "$TEST_ROOT/fakebin/curl"
+
+run_installer() {
+  local home="$1" archive="$2"
+  shift 2
+  HOME="$home" \
+  XDG_DATA_HOME="$home/data" \
+  PATH="$TEST_ROOT/fakebin:$PATH" \
+  KIRO_TEST_ARCHIVE="$archive" \
+  KIRO_TEST_LATEST_TAG="v1.2.3" \
+  KIRO_TEST_CURL_LOG="$TEST_ROOT/curl.log" \
+    sh "$INSTALLER" "$@"
+}
+
+archive_620="$(make_release 1.2.3 release-620)"
+home="$TEST_ROOT/home"
+mkdir -p "$home"
+: >"$TEST_ROOT/curl.log"
+
+if output="$(run_installer "$home" "$archive_620" v1.2.3 2>&1)"; then
+  pass "installs an explicit stable release"
+else
+  fail "installs an explicit stable release"
+  printf '%s\n' "$output"
+fi
+install_root="$home/data/superpowers/kiro"
+agent="$home/.kiro/agents/superpowers.md"
+assert_file_contains "$install_root/.superpowers-kiro-install" '1.2.3' "records installed version"
+assert_file_contains "$agent" "file://$install_root/skills/using-superpowers/SKILL.md" "generates absolute bootstrap URI"
+assert_file_contains "$agent" "skill://$install_root/skills/**/SKILL.md" "generates absolute skill URI"
+assert_file_contains "$agent" '<!-- Managed by the Superpowers Kiro installer. -->' "marks generated agent"
+for text in \
+  'tools: ["*"]' \
+  'capability: fs_read' \
+  'capability: skill' \
+  'welcomeMessage: Superpowers is active. Relevant workflow skills load automatically.' \
+  'follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.'; do
+  assert_file_contains "$agent" "$text" "keeps repository and installed agent semantics aligned"
+done
+assert_file_contains "$install_root/release-marker.txt" 'release-620' "installs release payload"
+assert_file_contains "$TEST_ROOT/curl.log" '/archive/refs/tags/v1.2.3.tar.gz' "downloads selected tag"
+
+archive_630="$(make_release 6.3.0 release-630)"
+if run_installer "$home" "$archive_630" v6.3.0 >/dev/null 2>&1; then
+  pass "replaces a managed installation"
+else
+  fail "replaces a managed installation"
+fi
+assert_file_contains "$install_root/.superpowers-kiro-install" '6.3.0' "updates version marker"
+assert_file_contains "$install_root/release-marker.txt" 'release-630' "replaces old payload"
+
+latest_home="$TEST_ROOT/latest-home"
+mkdir -p "$latest_home"
+: >"$TEST_ROOT/curl.log"
+if run_installer "$latest_home" "$archive_620" >/dev/null 2>&1; then
+  pass "resolves the latest release"
+else
+  fail "resolves the latest release"
+fi
+assert_file_contains "$TEST_ROOT/curl.log" '/releases/latest' "queries GitHub latest release"
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES Kiro installer test(s) failed"
+  exit 1
+fi
+echo "PASS: Kiro installer happy path and replacement"
+```
+
+Mark the installer test executable:
+
+```bash
+chmod +x tests/kiro/test-installer.sh
+```
+
+- [ ] **Step 2: Run the Kiro tests and verify RED**
+
+Run:
+
+```bash
+bash tests/kiro/run-tests.sh
+```
+
+Expected: `test-agent-config.sh` passes, then `test-installer.sh` fails because `scripts/install-kiro.sh` does not exist.
+
+- [ ] **Step 3: Implement the minimal installer happy path**
+
+Create `scripts/install-kiro.sh` as a `#!/bin/sh` script using `set -eu`. Implement these concrete operations:
+
+```sh
+#!/bin/sh
+set -eu
+
+REPOSITORY="obra/superpowers"
+PAYLOAD_MARKER=".superpowers-kiro-install"
+AGENT_MARKER="<!-- Managed by the Superpowers Kiro installer. -->"
+
+die() { echo "error: $*" >&2; exit 1; }
+for tool in cat curl dirname tar grep sed mkdir rm mv; do
+  command -v "$tool" >/dev/null 2>&1 || die "required tool '$tool' is not on PATH"
+done
+[ "$#" -le 1 ] || die "usage: $0 [vMAJOR.MINOR.PATCH]"
+
+tag="${1:-}"
+if [ -z "$tag" ]; then
+  tag="$(curl -fsSL "https://api.github.com/repos/$REPOSITORY/releases/latest" \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | sed -n '1p')"
+fi
+printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  || die "release must look like v1.2.3"
+version="${tag#v}"
+
+install_root="${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro"
+agent_path="$HOME/.kiro/agents/superpowers.md"
+work_dir="${TMPDIR:-/tmp}/superpowers-kiro.$$"
+(umask 077 && mkdir "$work_dir") || die "cannot create temporary directory"
+agent_tmp="$agent_path.tmp.$$"
+cleanup() { rm -rf "$work_dir"; rm -f "$agent_tmp"; }
+trap cleanup 0
+trap 'exit 1' 1 2 15
+
+archive="$work_dir/release.tar.gz"
+curl -fsSL "https://github.com/$REPOSITORY/archive/refs/tags/$tag.tar.gz" -o "$archive"
+tar -xzf "$archive" -C "$work_dir"
+source_root="$work_dir/superpowers-$version"
+for required in \
+  package.json \
+  .kiro/agents/superpowers.md \
+  skills/using-superpowers/SKILL.md \
+  skills/using-superpowers/references/kiro-tools.md \
+  skills/brainstorming/SKILL.md; do
+  [ -f "$source_root/$required" ] || die "release is missing $required"
+done
+archive_version="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$source_root/package.json" | sed -n '1p')"
+[ "$archive_version" = "$version" ] || die "release version does not match $tag"
+printf '%s\n' "$version" >"$source_root/$PAYLOAD_MARKER"
+
+mkdir -p "$(dirname "$install_root")" "$(dirname "$agent_path")"
+rm -rf "$install_root"
+mv "$source_root" "$install_root"
+
+(umask 077 && : >"$agent_tmp")
+cat >"$agent_tmp" <<EOF
+---
+description: Superpowers-enabled agent with native Kiro v3 skill activation for brainstorming, TDD, debugging, planning, and review.
+tools: ["*"]
+resources:
+  - "file://$install_root/skills/using-superpowers/SKILL.md"
+  - "file://$install_root/skills/using-superpowers/references/kiro-tools.md"
+  - "skill://$install_root/skills/**/SKILL.md"
+permissions:
+  rules:
+    - capability: fs_read
+      effect: allow
+    - capability: skill
+      effect: allow
+welcomeMessage: Superpowers is active. Relevant workflow skills load automatically.
+---
+
+$AGENT_MARKER
+You are a software-engineering agent that follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.
+EOF
+mv "$agent_tmp" "$agent_path"
+printf 'Installed Superpowers %s for Kiro CLI v3.\n' "$version"
+printf 'Start it with: kiro-cli chat --agent superpowers --agent-engine v3\n'
+```
+
+Mark the installer executable:
+
+```bash
+chmod +x scripts/install-kiro.sh
+```
+
+Do not add collision checks yet; Task 4 drives those through failing tests. Keep the script POSIX—no arrays, `[[ ... ]]`, `local`, or Bash-only parameter expansion.
+
+- [ ] **Step 4: Run installer tests and verify GREEN**
+
+Run:
+
+```bash
+bash tests/kiro/run-tests.sh
+sh -n scripts/install-kiro.sh
+```
+
+Expected: all Kiro tests pass, both explicit and latest URLs are exercised through fake `curl`, and `sh -n` exits 0.
+
+- [ ] **Step 5: Pause at the commit boundary**
+
+Do not commit without explicit approval. If requested:
+
+```bash
+git add scripts/install-kiro.sh tests/kiro/test-installer.sh
+git commit -m "feat: add minimal Kiro installer"
+```
+
+### Task 4: Installer Collision and Invalid-Archive Safety
+
+> **Superseded during implementation.** The single-agent guard sketched below
+> shipped as a loop over three managed agents (`superpowers.md` plus the two
+> workers), each also refusing a same-named `.json` shadow. The shipped tests
+> assert that a refused run installs nothing at all. Read the shipped files as
+> authoritative.
+
+**Files:**
+- Modify: `scripts/install-kiro.sh`
+- Modify: `tests/kiro/test-installer.sh`
+
+**Interfaces:**
+- Consumes: payload ownership file `.superpowers-kiro-install`; agent ownership text `<!-- Managed by the Superpowers Kiro installer. -->`.
+- Produces: refusal behavior for unmanaged destinations and staged validation before managed replacement.
+
+- [ ] **Step 1: Add failing unmanaged-collision tests**
+
+Before the final `FAILURES` check in `tests/kiro/test-installer.sh`, add cases that:
+
+```bash
+unmanaged_agent_home="$TEST_ROOT/unmanaged-agent-home"
+mkdir -p "$unmanaged_agent_home/.kiro/agents"
+printf '%s\n' 'personal agent content' >"$unmanaged_agent_home/.kiro/agents/superpowers.md"
+if run_installer "$unmanaged_agent_home" "$archive_620" v1.2.3 >/dev/null 2>&1; then
+  fail "refuses unmanaged agent collision"
+else
+  pass "refuses unmanaged agent collision"
+fi
+assert_file_contains "$unmanaged_agent_home/.kiro/agents/superpowers.md" 'personal agent content' "preserves unmanaged agent"
+
+unmanaged_payload_home="$TEST_ROOT/unmanaged-payload-home"
+mkdir -p "$unmanaged_payload_home/data/superpowers/kiro"
+printf '%s\n' 'personal payload content' >"$unmanaged_payload_home/data/superpowers/kiro/personal.txt"
+if run_installer "$unmanaged_payload_home" "$archive_620" v1.2.3 >/dev/null 2>&1; then
+  fail "refuses unmanaged payload collision"
+else
+  pass "refuses unmanaged payload collision"
+fi
+assert_file_contains "$unmanaged_payload_home/data/superpowers/kiro/personal.txt" 'personal payload content' "preserves unmanaged payload"
+```
+
+- [ ] **Step 2: Add a failing invalid-archive preservation test**
+
+Add a helper that creates `superpowers-6.4.0.tar.gz` without `skills/using-superpowers/references/kiro-tools.md`. Install a valid managed fixture first, then run the invalid archive and assert:
+
+```bash
+invalid_home="$TEST_ROOT/invalid-home"
+mkdir -p "$invalid_home"
+run_installer "$invalid_home" "$archive_620" v1.2.3 >/dev/null
+invalid_archive="$(make_release 6.4.0 invalid-release)"
+tar -xzf "$invalid_archive" -C "$TEST_ROOT"
+rm "$TEST_ROOT/superpowers-6.4.0/skills/using-superpowers/references/kiro-tools.md"
+tar -czf "$TEST_ROOT/invalid-6.4.0.tar.gz" -C "$TEST_ROOT" superpowers-6.4.0
+rm -rf "$TEST_ROOT/superpowers-6.4.0"
+if run_installer "$invalid_home" "$TEST_ROOT/invalid-6.4.0.tar.gz" v6.4.0 >/dev/null 2>&1; then
+  fail "rejects archive missing Kiro mapping"
+else
+  pass "rejects archive missing Kiro mapping"
+fi
+assert_file_contains "$invalid_home/data/superpowers/kiro/release-marker.txt" 'release-620' "preserves managed payload after invalid archive"
+```
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+Run:
+
+```bash
+bash tests/kiro/test-installer.sh
+```
+
+Expected: unmanaged-agent and unmanaged-payload cases fail because the Task 3 installer currently overwrites both. The invalid-archive preservation case should already pass because archive validation precedes replacement.
+
+- [ ] **Step 4: Add minimal ownership checks before network or deletion**
+
+In `scripts/install-kiro.sh`, calculate `install_root` and `agent_path` before resolving the tag, then add:
+
+```sh
+if { [ -e "$agent_path" ] || [ -L "$agent_path" ]; } \
+  && ! grep -Fq "$AGENT_MARKER" "$agent_path" 2>/dev/null; then
+  die "refusing to overwrite unmanaged agent: $agent_path"
+fi
+if { [ -e "$install_root" ] || [ -L "$install_root" ]; } \
+  && [ ! -f "$install_root/$PAYLOAD_MARKER" ]; then
+  die "refusing to overwrite unmanaged payload: $install_root"
+fi
+```
+
+Keep all download and extraction work after these checks. Do not add backup retention, locking, rollback history, or an uninstall command.
+
+- [ ] **Step 5: Run safety, syntax, and shell-quality validation**
+
+Run:
+
+```bash
+bash tests/kiro/run-tests.sh
+sh -n scripts/install-kiro.sh
+bash -n tests/kiro/test-agent-config.sh tests/kiro/test-installer.sh tests/kiro/run-tests.sh
+scripts/lint-shell.sh scripts/install-kiro.sh tests/kiro/test-agent-config.sh tests/kiro/test-installer.sh tests/kiro/run-tests.sh
+```
+
+Expected: tests pass; syntax checks exit 0; ShellCheck reports no warning-or-higher findings. If `shellcheck` is unavailable, record that limitation and run the syntax checks rather than claiming lint passed.
+
+- [ ] **Step 6: Pause at the commit boundary**
+
+Do not commit without explicit approval. If requested:
+
+```bash
+git add scripts/install-kiro.sh tests/kiro/test-installer.sh
+git commit -m "test: protect Kiro installer destinations"
+```
+
+### Task 5: Kiro User Documentation
+
+> **Superseded during implementation.** The embedded guide below is the original
+> draft; the shipped `docs/README.kiro.md` is authoritative. The removal section
+> covers all three managed agents plus the payload, and the integration also
+> registers the port in `docs/porting-to-a-new-harness.md` (new Shape D) and
+> `docs/testing.md`, and excludes `/.kiro/` from the Codex plugin sync
+> (`scripts/sync-to-codex-plugin.sh`), each with test coverage.
+
+**Files:**
+- Create: `docs/README.kiro.md`
+- Create: `tests/kiro/test-docs.sh`
+- Modify: `README.md:12-14`
+- Modify: `README.md` installation section between Kimi Code and OpenCode
+
+**Interfaces:**
+- Consumes: installer command and paths from Tasks 3–4; runtime behavior from Tasks 1–2.
+- Produces: concise main README entry and complete Kiro install/update/removal/troubleshooting guide.
+
+- [ ] **Step 1: Write the failing documentation contract test**
+
+Create `tests/kiro/test-docs.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+README="$REPO_ROOT/README.md"
+DOC="$REPO_ROOT/docs/README.kiro.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$DOC" ] || fail "docs/README.kiro.md missing"
+for text in \
+  '### Kiro CLI' \
+  'scripts/install-kiro.sh' \
+  'docs/README.kiro.md'; do
+  grep -Fq -- "$text" "$README" || fail "README missing $text"
+done
+for text in \
+  'Kiro CLI v3' \
+  'kiro-cli chat --agent superpowers --agent-engine v3' \
+  'XDG_DATA_HOME' \
+  '.superpowers-kiro-install' \
+  'Native Windows is not supported' \
+  'Kiro Powers' \
+  'Load skill' \
+  'TUI'; do
+  grep -Fq -- "$text" "$DOC" || fail "Kiro guide missing $text"
+done
+
+echo "PASS: Kiro documentation contract"
+```
+
+Mark the documentation test executable:
+
+```bash
+chmod +x tests/kiro/test-docs.sh
+```
+
+- [ ] **Step 2: Run documentation tests and verify RED**
+
+Run:
+
+```bash
+bash tests/kiro/run-tests.sh
+```
+
+Expected: existing Kiro tests pass, then `test-docs.sh` fails with `docs/README.kiro.md missing`.
+
+- [ ] **Step 3: Add the concise root README entry**
+
+Add `Kiro CLI` to the Quickstart link list between `Kimi Code` and `OpenCode`. Add this installation section between the existing Kimi and OpenCode sections:
+
+````markdown
+### Kiro CLI
+
+Kiro CLI v3 uses a native custom agent and native Agent Skills. Install the
+latest stable Superpowers release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh
+```
+
+Start Kiro with:
+
+```bash
+kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+See [the complete Kiro guide](docs/README.kiro.md) for pinned versions,
+updates, removal, repository-local development, and current limitations.
+````
+
+- [ ] **Step 4: Write the complete Kiro guide**
+
+Create `docs/README.kiro.md` with these concrete sections and commands:
+
+````markdown
+# Superpowers for Kiro CLI v3
+
+This integration uses a Kiro v3 Markdown custom agent, startup `file://`
+resources, and native `skill://` discovery. It does not support Kiro CLI v2.
+
+## Requirements
+
+- Kiro CLI with the v3 agent engine
+- macOS, Linux, or WSL
+- `curl` and `tar`
+
+Native Windows is not supported by the initial installer.
+
+## Installation
+
+Install the latest stable release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh
+```
+
+Install a specific release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh -s -- v1.2.3
+```
+
+To inspect the installer before running it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh -o /tmp/install-kiro.sh
+less /tmp/install-kiro.sh
+sh /tmp/install-kiro.sh
+```
+
+The payload is installed at
+`${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro`. The generated agent is
+`$HOME/.kiro/agents/superpowers.md`. The installer refuses to replace either
+path unless it carries the Superpowers ownership marker.
+
+## Usage
+
+Start a v3 TUI session in any project:
+
+```bash
+kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+Kiro loads `using-superpowers` and the Kiro tool mapping at startup. It exposes
+skill metadata from `skill://` resources and uses its native Load skill action
+to load full skill instructions on demand.
+
+Only file reads and skill loading are pre-approved by the profile. Writes,
+shell commands, network access, and other consequential actions retain Kiro's
+normal permission behavior.
+
+## Updating or changing versions
+
+Rerun the installation command. With no argument it installs the latest stable
+release; with a tag such as `v1.2.3` it installs that release. The installer
+replaces the one managed payload and does not retain rollback versions.
+
+## Removal
+
+Inspect both ownership markers before deleting anything:
+
+```bash
+cat "${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro/.superpowers-kiro-install"
+grep -F '<!-- Managed by the Superpowers Kiro installer. -->' "$HOME/.kiro/agents/superpowers.md"
+```
+
+If both commands show the expected markers, remove only these paths:
+
+```bash
+rm -rf "${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro"
+rm -f "$HOME/.kiro/agents/superpowers.md"
+```
+
+## Repository-local development
+
+From a Superpowers checkout, use the tracked `.kiro/agents/superpowers.md`:
+
+```bash
+kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+The repository profile uses relative resources. The installed profile uses
+absolute resources so it works from unrelated project directories.
+
+## Why this is not a Kiro Power
+
+Kiro Powers currently do not provide a supported CLI package that installs a
+custom agent, native Agent Skills, startup resources, and updates as one unit.
+The shell installer is transitional and should be replaced when Kiro provides a
+native package mechanism.
+
+## Current limitations
+
+- Kiro's v3 workflow currently requires the TUI; classic and non-interactive
+  acceptance are not claimed.
+- The installer supports macOS, Linux, and WSL, not native Windows.
+- GitHub release archives are downloaded over HTTPS and checked for required
+  files and matching version metadata, but no separate checksum or signature is
+  published.
+- A tag predating Kiro support cannot be installed because its archive lacks the
+  required Kiro files.
+
+## Troubleshooting
+
+### The installer refuses an existing agent or payload
+
+The destination exists without the ownership marker. Move or rename it after
+reviewing its contents; the installer intentionally will not overwrite it.
+
+### Skills do not trigger
+
+Start a clean v3 session and send `Let's make a react todo list`. A working
+installation invokes `Load skill: brainstorming` before writing code. Confirm
+the generated agent contains absolute `file:///` and `skill:///` resources that
+point at the managed payload.
+
+### The requested version is rejected
+
+Use a stable tag in `vMAJOR.MINOR.PATCH` form. The archive's `package.json`
+version must match the tag without its leading `v`.
+````
+
+- [ ] **Step 5: Run documentation and full Kiro tests**
+
+Run:
+
+```bash
+bash tests/kiro/run-tests.sh
+git diff --check
+```
+
+Expected: all Kiro tests pass and `git diff --check` produces no output.
+
+- [ ] **Step 6: Pause at the commit boundary**
+
+Do not commit without explicit approval. If requested:
+
+```bash
+git add README.md docs/README.kiro.md tests/kiro/test-docs.sh
+git commit -m "docs: document Kiro v3 integration"
+```
+
+### Task 6: Full Validation and Both TUI Acceptance Paths
+
+**Files:**
+- Verify only; modify implementation files only if validation exposes a real defect.
+- Keep acceptance transcripts outside tracked files until later PR preparation.
+
+**Interfaces:**
+- Consumes: all tracked deliverables from Tasks 1–5.
+- Produces: automated test evidence, repository-profile transcript, installed-profile transcript, and a human-reviewable diff; no PR.
+
+- [ ] **Step 1: Run the complete automated validation set**
+
+Run:
+
+```bash
+bash tests/kiro/run-tests.sh
+sh -n scripts/install-kiro.sh
+bash -n tests/kiro/test-agent-config.sh tests/kiro/test-installer.sh tests/kiro/test-docs.sh tests/kiro/run-tests.sh
+scripts/lint-shell.sh scripts/install-kiro.sh tests/kiro/test-agent-config.sh tests/kiro/test-installer.sh tests/kiro/test-docs.sh tests/kiro/run-tests.sh
+bash tests/kimi/test-plugin-manifest.sh
+bash tests/antigravity/test-antigravity-tools.sh
+node --test tests/pi/test-pi-extension.mjs
+bash tests/hooks/test-session-start.sh
+git diff --check
+```
+
+Expected: all commands exit 0. If a required optional validator such as `shellcheck` is unavailable, record exactly which command could not run; do not report it as passing.
+
+- [ ] **Step 2: Run repository-local clean-session acceptance**
+
+From the isolated Superpowers worktree:
+
+```bash
+kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+Send exactly:
+
+```text
+Let's make a react todo list
+```
+
+Capture the complete transcript. Verify `Load skill: brainstorming` appears before implementation and that the response begins the brainstorming workflow rather than creating code.
+
+- [ ] **Step 3: Build a complete local release archive for installed-profile acceptance**
+
+Run from the Superpowers worktree to derive the current package version and build a GitHub-shaped archive without `.git`:
+
+```bash
+ACCEPTANCE_ROOT="$(mktemp -d)"
+ACCEPTANCE_HOME="$ACCEPTANCE_ROOT/home"
+ACCEPTANCE_FAKEBIN="$ACCEPTANCE_ROOT/bin"
+ACCEPTANCE_VERSION="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | sed -n '1p')"
+ACCEPTANCE_TAG="v$ACCEPTANCE_VERSION"
+ACCEPTANCE_SOURCE="$ACCEPTANCE_ROOT/source/superpowers-$ACCEPTANCE_VERSION"
+ACCEPTANCE_ARCHIVE="$ACCEPTANCE_ROOT/superpowers-$ACCEPTANCE_VERSION.tar.gz"
+mkdir -p "$ACCEPTANCE_HOME" "$ACCEPTANCE_FAKEBIN" "$ACCEPTANCE_SOURCE"
+tar --exclude='.git' -cf - . | tar -xf - -C "$ACCEPTANCE_SOURCE"
+tar -czf "$ACCEPTANCE_ARCHIVE" -C "$ACCEPTANCE_ROOT/source" "superpowers-$ACCEPTANCE_VERSION"
+```
+
+Create `$ACCEPTANCE_FAKEBIN/curl` with executable mode and this exact content:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf '%s\n' "$url" >>"$KIRO_TEST_CURL_LOG"
+if [[ "$url" == *'/releases/latest' ]]; then
+  printf '{"tag_name":"%s"}\n' "$KIRO_TEST_LATEST_TAG"
+else
+  cp "$KIRO_TEST_ARCHIVE" "$out"
+fi
+```
+
+Mark the shim executable:
+
+```bash
+chmod +x "$ACCEPTANCE_FAKEBIN/curl"
+```
+
+Run the installer against the local archive and isolated home:
+
+```bash
+HOME="$ACCEPTANCE_HOME" \
+XDG_DATA_HOME="$ACCEPTANCE_HOME/data" \
+PATH="$ACCEPTANCE_FAKEBIN:$PATH" \
+KIRO_TEST_ARCHIVE="$ACCEPTANCE_ARCHIVE" \
+KIRO_TEST_LATEST_TAG="$ACCEPTANCE_TAG" \
+KIRO_TEST_CURL_LOG="$ACCEPTANCE_ROOT/curl.log" \
+  sh scripts/install-kiro.sh "$ACCEPTANCE_TAG"
+```
+
+Expected: the installer prints the installed version and Kiro invocation command; the generated agent contains absolute paths under `$ACCEPTANCE_HOME/data/superpowers/kiro`.
+
+- [ ] **Step 4: Run installed-profile clean-session acceptance from an unrelated project**
+
+Create an empty project outside both the worktree and installed payload:
+
+```bash
+ACCEPTANCE_PROJECT="$ACCEPTANCE_ROOT/project"
+mkdir -p "$ACCEPTANCE_PROJECT"
+```
+
+Run this command with `$ACCEPTANCE_PROJECT` as the shell tool's working directory:
+
+```bash
+HOME="$ACCEPTANCE_HOME" kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+If the isolated home has no Kiro credentials, authenticate that temporary home through Kiro's normal login flow before retrying; do not copy secret files into the repository.
+
+Send exactly:
+
+```text
+Let's make a react todo list
+```
+
+Capture the complete transcript outside `$ACCEPTANCE_ROOT`. Verify the agent loads both absolute `file://` resources, discovers the absolute `skill://` glob, invokes `Load skill: brainstorming`, and begins brainstorming before implementation. This is a hard completion gate. After preserving the transcript, delete only `$ACCEPTANCE_ROOT` with the file-delete tool.
+
+- [ ] **Step 5: Review the final local diff and installer size**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+git diff -- README.md
+for new_file in \
+  .kiro/agents/superpowers.md \
+  skills/using-superpowers/references/kiro-tools.md \
+  scripts/install-kiro.sh \
+  tests/kiro/*.sh \
+  docs/README.kiro.md \
+  docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md \
+  docs/superpowers/plans/2026-07-29-kiro-v3-integration.md; do
+  git diff --no-index -- /dev/null "$new_file" || test "$?" -eq 1
+done
+awk 'BEGIN { n=0 } /^[[:space:]]*#/ { next } /^[[:space:]]*$/ { next } { n++ } END { print n }' scripts/install-kiro.sh
+```
+
+Expected: only the approved Kiro integration, tests, docs, spec, and plan are changed. Treat the line count as a maintainer-review signal, not a pass/fail threshold. Show the complete diff and both transcripts to the human partner.
+
+- [ ] **Step 6: Stop before commits or pull-request work**
+
+Do not commit, push, or create a PR without a new explicit request. Record any unverified item accurately. PR preparation later requires searching open and closed prior PRs, completing every PR-template field, targeting `dev`, and obtaining explicit human approval of the complete diff.
+
+The shipped installer is 116 non-comment lines rather than the ~100 this plan targets, because of the two worker configs and the shadowing guard added during implementation. The line target was a review signal, not a threshold.

--- a/docs/superpowers/plans/2026-07-29-kiro-v3-integration.md
+++ b/docs/superpowers/plans/2026-07-29-kiro-v3-integration.md
@@ -22,12 +22,16 @@ do not replay them over the revised implementation. The current specification is
 - [x] Update `README.md`, `docs/README.kiro.md`, and the porting guide: persistent
   CLI default activation, same-tag download-inspect-run installation, pre-release
   checkout support, and accurate recovery limits. Keep IDE claims separately scoped.
-- [ ] Run Kiro v3 validation for all tracked and installed profiles; verify native
-  resources and permissions on the tested binary. Current official docs support
-  `skill` permissions and relative resources without `./`; do not change these
-  based solely on the original review's documentation concern.
-- [ ] Capture complete fresh default-agent acceptance sessions outside the checkout,
-  record model/Kiro versions, and verify IDE persistence before broadening its claim.
+- [x] Inspect supplied Kiro CLI 2.21.3 / KAS 0.60.10 interactive-TUI evidence:
+  installed and repository-local discovery, successful native brainstorming,
+  explicit claude-sonnet-5 and gpt-5.6-sol acceptance, and two default-agent sessions.
+- [x] Verify one-time setup from an absent default using
+  `kiro-cli settings chat.defaultAgent superpowers`; replace the failing
+  `agent set-default` instructions. The installer still only prints the command.
+- [x] Record that the tested Markdown validator attempts JSON parsing and exits
+  zero despite errors. No usable Markdown validation route was demonstrated.
+- [ ] Verify IDE persistence before broadening its claim. Lite-worker dispatch
+  was not rerun in the supplied revision validation.
 - [ ] Attach raw runtime evidence and the corrected environment table to the PR.
 
 Automated validation: `bash tests/kiro/run-tests.sh`,

--- a/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
+++ b/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
@@ -1,7 +1,7 @@
 # Kiro CLI v3 Integration Design
 
 **Date:** 2026-07-29
-**Status:** Implemented and locally verified on Kiro CLI 2.16.2; pull request creation deferred
+**Status:** PR #2126 revision implemented; automated checks pass on macOS. Fresh Kiro validation and default-agent acceptance are pending runtime access. Earlier runtime observations below describe the original PR, not the revised installer.
 **Scope:** Local implementation and validation only
 
 Sections below marked ~~struck~~ record decisions superseded during implementation and local acceptance testing. The surrounding text is the shipped design.
@@ -44,7 +44,7 @@ The installer downloads a selected stable release into one fixed namespaced dire
 
 Repository-local installation is not the canonical user path. Existing harnesses use native plugin, extension, marketplace, or package installation; Pi's checkout-based mode is explicitly a local-development path. The repository profile serves the same development and acceptance role for Kiro.
 
-For the porting guide's taxonomy this is a new shape: an **agent-profile** integration, where selecting a named agent is what loads the bootstrap. There is no shell hook, no code plugin, and no always-read instructions file.
+For the porting guide taxonomy this is an **agent-profile** integration. One-time `kiro-cli agent set-default superpowers` must persist activation for ordinary `kiro-cli chat --agent-engine v3` sessions. The installer prints these commands and never changes settings itself. Per-session selection does not satisfy the acceptance bar; IDE persistence must be established separately.
 
 ## Package Layout
 
@@ -160,16 +160,17 @@ Arrays of strings and objects using `description` are explicitly identified as i
 
 ### Interface
 
-The script supports only two installation forms:
+The script supports release installation and a local checkout snapshot:
 
 ```bash
 ./scripts/install-kiro.sh             # latest stable release
 ./scripts/install-kiro.sh v1.2.3      # selected stable release
+./scripts/install-kiro.sh --source . # local checkout, including uncommitted edits
 ```
 
 The latest form resolves the latest GitHub release tag; a failure to resolve it reports that specifically rather than blaming a version argument the user did not pass. The selected form downloads the matching tagged source archive. The script requires standard POSIX tools, `curl`, and `tar`; it does not require Git, Node.js, Python, or `jq`.
 
-The implementation should remain roughly 100 lines of straightforward POSIX shell, excluding comments. This is a review goal, not a test-enforced line limit. The shipped script is 116 lines; the overshoot is the two worker configs and the shadowing guard, both added after the original design.
+Keep the installer reviewable POSIX shell without new runtime dependencies. The earlier roughly 100-line goal is superseded by the approved local-source and handled-failure recovery requirements; tests check behavior, not line count.
 
 ### Destinations
 
@@ -188,13 +189,22 @@ The implementation should remain roughly 100 lines of straightforward POSIX shel
 6. Validate the required agent, worker, bootstrap, mapping, and skill files.
 7. Confirm that the archive's declared version matches the selected tag after normalizing the tag's `v` prefix.
 8. Add the ownership/version marker to the staged payload.
-9. Replace the single managed payload directory.
-10. Generate the three global agents by transforming the tracked `.kiro/agents/*.md` shipped in the payload — substituting the `{{SUPERPOWERS_SKILLS_DIR}}` placeholder with the absolute skills directory, inserting the install root into each resource URI, and adding the ownership marker — rather than embedding copies. Each is written to a temporary file renamed into place.
-11. Print the command that starts the Superpowers agent.
+9. Copy the payload into a private staging directory beside its destination, then generate all three agents into private staging slots beside their destinations. Generated resources reference the final payload path. Literal string splicing preserves ampersands and backslashes without awk replacement interpretation.
+10. For each of the four destinations, retain the existing managed artifact in its staging slot, then rename the new artifact into place. These renames stay on the destination filesystem.
+11. On handled failure or catchable interruption, restore existing artifacts and remove newly installed artifacts that had no predecessor. If restoration fails, retain staging directories and report their paths. Remove temporary backups after success.
+12. Print the one-time default-agent command and the v3 session command.
 
-All refusals precede tag resolution and the download, so a refused run leaves the filesystem untouched. Staging ensures that download or extraction failures do not damage an existing installation. Because the staged payload already contains its ownership marker, an interruption after payload replacement remains recognizable as managed state and a rerun can repair the installation. The script does not implement multi-destination transaction coordination or retained rollback state.
+Ownership and shadowing refusals happen before downloads or staging. Download,
+copy, validation, and generation failures leave installed artifacts unchanged.
+Run one installer at a time. Recovery is not a multi-path atomic transaction or
+a guarantee against power loss or SIGKILL. There is no retained version history.
 
-**Accepted without change:** there is no rollback across the three agent writes. A failure leaves a partial install, recovered by rerunning; the ownership guard makes a rerun safe, and rollback logic would cost more than the failure it prevents.
+With `--source <directory>`, skip the release download and tag comparison. Copy
+`skills/`, the three tracked profiles, and `package.json` into staging, materializing
+skill symlinks so the result is independent of the checkout. Require version
+metadata. Record `source: local` and an optional `base-commit` when Git is
+available; the snapshot includes uncommitted edits, so this is not a clean-tree
+attestation. Reject a combined source and release tag.
 
 ### Shadowing guard
 
@@ -214,37 +224,35 @@ The installer downloads GitHub-generated release archives over HTTPS, refusing r
 
 ### Explicitly omitted complexity
 
-Version history and rollback; status, doctor, repair, or migration commands; lock management; background or automatic updates; built-in uninstallation; checksums or signatures; a general-purpose installation framework; a Power wrapper.
+Retained version history; status, doctor, repair, or migration commands; lock management; background or automatic updates; built-in uninstallation; checksums or signatures; a general-purpose installation framework; a Power wrapper.
 
 ## Documentation
 
-`README.md` contains a short Kiro entry and links to `docs/README.kiro.md`. The detailed document covers Kiro CLI v3 prerequisites; latest and pinned installation; a download-inspect-run alternative to piping remote shell code; updating by rerunning the installer; manual removal with ownership-marker checks on every managed path; global and repository-local invocation; the worker agents and how tiers are chosen; native skill activation and permissions; TUI and non-interactive limitations; collision, shadowing, and resource-loading troubleshooting; why Kiro Powers are not used initially; and the installer's transitional status pending native Kiro package installation.
+`README.md` contains a short Kiro entry and links to `docs/README.kiro.md`. The detailed document covers Kiro CLI v3 prerequisites; latest and pinned installation; the primary download-inspect-run recipe and a local-source alternative; updating by rerunning the installer; manual removal with ownership-marker checks on every managed path; global and repository-local invocation; the worker agents and how tiers are chosen; native skill activation and permissions; TUI and non-interactive limitations; collision, shadowing, and resource-loading troubleshooting; why Kiro Powers are not used initially; and the installer's transitional status pending native Kiro package installation.
 
 Known limitations are stated rather than implied: model identifiers are not validated when a config is written, so a wrong one surfaces only at dispatch; the agent list is fixed at session start, so a restart is required after installing; and install paths containing spaces are untested, because the generated URIs embed the payload path without percent-encoding.
 
-The concise install form is:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh
-```
-
-A pinned release is passed as the script's positional argument.
+The primary release recipe downloads the installer from a user-selected tag to
+a temporary file for inspection, then passes that same tag to the installer.
+See `docs/README.kiro.md` for the exact command. The first supported release is
+not assumed available; before release, use `sh scripts/install-kiro.sh --source .`
+from a reviewed checkout containing the integration.
 
 ## Testing
 
 ### Automated tests
 
-`tests/kiro/` covers the repository profile's resources, tools, permissions, prompt, and welcome message; worker neutrality as a closed property, asserting the permitted frontmatter keys and exact body so any added persona fails; required entries and the valid todo payload in the canonical mapping; the documentation contract; successful installation into a temporary `HOME` using local archive fixtures and a stubbed `curl` on `PATH`; generated absolute startup and skill resource paths; a second installation replacing the first managed version; refusal to overwrite an unmanaged agent, an unmanaged worker, or an unmanaged payload; refusal to install beside a shadowing `.json` config; refusal of a relative `XDG_DATA_HOME`; an accurate error when the latest release cannot be resolved; rejection of an archive missing required files; preservation of unmanaged content on every tested failure, plus the absence of any other artifact after a refusal; and semantic parity between repository-local and generated profiles.
+`tests/kiro/` covers the repository profile's resources, tools, permissions, prompt, and welcome message; worker neutrality as a closed property, asserting the permitted frontmatter keys and exact body so any added persona fails; required entries and the valid todo payload in the canonical mapping; the documentation contract; successful installation into a temporary `HOME` using local archive fixtures and a stubbed `curl` on `PATH`; generated absolute startup and skill resource paths; a second installation replacing the first managed version; refusal to overwrite an unmanaged agent, an unmanaged worker, or an unmanaged payload; refusal to install beside a shadowing `.json` config; refusal of a relative `XDG_DATA_HOME`; an accurate error when the latest release cannot be resolved; rejection of an archive missing required files; preservation of unmanaged content on every tested failure, plus local checkout snapshots, compact version metadata, literal paths, generation failure, every replacement failure, backup failure, catchable interruption, and failed-restoration backup preservation; and semantic parity between repository-local and generated profiles.
 
 Tests do not make live network requests, depend on GitHub availability, test shell implementation details, or enforce an exact installer line count.
 
 ### Manual runtime acceptance
 
-Kiro v3 currently requires its TUI, so runtime acceptance is manual rather than automated through brittle terminal control. Both paths passed and are a hard completion gate.
+Kiro v3 currently requires its TUI, so runtime acceptance is manual rather than automated through brittle terminal control. The original explicit-agent paths passed. The revised default-agent path remains a hard completion gate and is not yet verified.
 
 Repository-local: start a clean session with the repository profile, send exactly `Let's make a react todo list`, and confirm `Load skill: brainstorming` occurs before any implementation action.
 
-Installed-profile: install into a temporary home, start Kiro from a project outside the Superpowers checkout, send the same prompt, and confirm the absolute resources resolve and native `brainstorming` precedes implementation.
+Installed-profile: install into an isolated test home, run `kiro-cli agent set-default superpowers` once, then start fresh sessions with `kiro-cli chat --agent-engine v3` from a project outside the checkout. Send the same prompt and confirm absolute resources resolve and native `brainstorming` precedes implementation. Record full session evidence and Kiro/model versions. Run the v3 validator on all tracked and installed profiles; successful validation alone does not prove skill loading.
 
 Worker acceptance, on Kiro CLI 2.16.2:
 
@@ -269,7 +277,7 @@ If maintainers interpret the harness-owned-installation rule as requiring a Kiro
 
 ## Success Criteria
 
-All met at the time of writing:
+Original PR criteria below were reported met before this revision. Fresh default-agent acceptance, validator output, and unabridged transcripts remain outstanding; automated installer tests do not establish those runtime results:
 
 - The repository-local agent auto-loads the bootstrap and mapping.
 - Native Kiro skill discovery exposes all upstream Superpowers skills.

--- a/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
+++ b/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
@@ -168,7 +168,7 @@ The script supports release installation and a local checkout snapshot:
 ./scripts/install-kiro.sh --source . # local checkout, including uncommitted edits
 ```
 
-The latest form resolves the latest GitHub release tag; a failure to resolve it reports that specifically rather than blaming a version argument the user did not pass. The selected form downloads the matching tagged source archive. The script requires standard POSIX tools, `curl`, and `tar`; it does not require Git, Node.js, Python, or `jq`.
+The latest form resolves the latest GitHub release tag; a failure to resolve it reports that specifically rather than blaming a version argument the user did not pass. The selected form downloads the matching tagged source archive. The script requires standard POSIX tools, plus `curl` and `tar` for release downloads; it does not require Git, Node.js, Python, or `jq`.
 
 Keep the installer reviewable POSIX shell without new runtime dependencies. The earlier roughly 100-line goal is superseded by the approved local-source and handled-failure recovery requirements; tests check behavior, not line count.
 

--- a/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
+++ b/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
@@ -90,7 +90,7 @@ kiro-cli chat --agent superpowers --agent-engine v3
 
 ### Installed profile
 
-The global profile has the same tools, resource roles, permissions, prompt, and welcome message. Its resource URIs are absolute because users invoke it from arbitrary project directories. Conceptually, it contains:
+The global profile has the same tools, resource roles, permissions, prompt, and welcome message. Its resource URIs are absolute because users invoke it from arbitrary project directories. The installer produces each global agent by transforming the matching tracked `.kiro/agents/*.md` from the payload — inserting the install root into every resource URI and adding the ownership marker — so the tracked files remain the single source of truth and cannot drift from what is installed. Conceptually, it contains:
 
 ```yaml
 resources:
@@ -118,7 +118,7 @@ Model tiering is expressed by choosing a worker, not by passing a model per disp
 
 **Rejected:** one worker per skill role, which multiplies configs without adding capability; a per-dispatch model argument, which is not reliably honored; and a third read-only worker for review dispatches, which would enforce the review template's read-only promise at config level but exceeds the agreed two workers, and one worker must serve implementers that legitimately write. The read-only constraint stays prose in the template, as upstream intends.
 
-**Accepted costs:** the installer grew from 75 to 116 non-comment lines and manages three agent files instead of one.
+**Accepted costs:** the installer manages three agent files instead of one. It generates all three by transforming the tracked profiles rather than embedding copies, which keeps it around 95 non-comment lines.
 
 ### Startup and skill activation
 
@@ -185,11 +185,11 @@ The implementation should remain roughly 100 lines of straightforward POSIX shel
 3. Refuse when a same-named `.json` config sits beside a managed Markdown agent.
 4. Refuse an existing payload directory that lacks the ownership marker.
 5. Download and extract the release into a temporary directory over HTTPS only.
-6. Validate the required agent, bootstrap, mapping, and skill files.
+6. Validate the required agent, worker, bootstrap, mapping, and skill files.
 7. Confirm that the archive's declared version matches the selected tag after normalizing the tag's `v` prefix.
 8. Add the ownership/version marker to the staged payload.
 9. Replace the single managed payload directory.
-10. Generate the three agents, each into a temporary file renamed into place.
+10. Generate the three global agents by transforming the tracked `.kiro/agents/*.md` shipped in the payload — inserting the install root into each resource URI and adding the ownership marker — rather than embedding copies. Each is written to a temporary file renamed into place.
 11. Print the command that starts the Superpowers agent.
 
 All refusals precede tag resolution and the download, so a refused run leaves the filesystem untouched. Staging ensures that download or extraction failures do not damage an existing installation. Because the staged payload already contains its ownership marker, an interruption after payload replacement remains recognizable as managed state and a rerun can repair the installation. The script does not implement multi-destination transaction coordination or retained rollback state.

--- a/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
+++ b/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
@@ -90,7 +90,7 @@ kiro-cli chat --agent superpowers --agent-engine v3
 
 ### Installed profile
 
-The global profile has the same tools, resource roles, permissions, prompt, and welcome message. Its resource URIs are absolute because users invoke it from arbitrary project directories. The installer produces each global agent by transforming the matching tracked `.kiro/agents/*.md` from the payload — inserting the install root into every resource URI and adding the ownership marker — so the tracked files remain the single source of truth and cannot drift from what is installed. Conceptually, it contains:
+The global profile has the same tools, resource roles, permissions, prompt, and welcome message. Its resource URIs are absolute because users invoke it from arbitrary project directories. The installer produces each global agent by transforming the matching tracked `.kiro/agents/*.md` from the payload — substituting the `{{SUPERPOWERS_SKILLS_DIR}}` placeholder with the absolute skills directory (so the agent reads a skill's own reference files, such as `code-reviewer.md`, straight from the payload rather than globbing the workspace), inserting the install root into every resource URI, and adding the ownership marker — so the tracked files remain the single source of truth and cannot drift from what is installed. Conceptually, it contains:
 
 ```yaml
 resources:
@@ -189,7 +189,7 @@ The implementation should remain roughly 100 lines of straightforward POSIX shel
 7. Confirm that the archive's declared version matches the selected tag after normalizing the tag's `v` prefix.
 8. Add the ownership/version marker to the staged payload.
 9. Replace the single managed payload directory.
-10. Generate the three global agents by transforming the tracked `.kiro/agents/*.md` shipped in the payload — inserting the install root into each resource URI and adding the ownership marker — rather than embedding copies. Each is written to a temporary file renamed into place.
+10. Generate the three global agents by transforming the tracked `.kiro/agents/*.md` shipped in the payload — substituting the `{{SUPERPOWERS_SKILLS_DIR}}` placeholder with the absolute skills directory, inserting the install root into each resource URI, and adding the ownership marker — rather than embedding copies. Each is written to a temporary file renamed into place.
 11. Print the command that starts the Superpowers agent.
 
 All refusals precede tag resolution and the download, so a refused run leaves the filesystem untouched. Staging ensures that download or extraction failures do not damage an existing installation. Because the staged payload already contains its ownership marker, an interruption after payload replacement remains recognizable as managed state and a rerun can repair the installation. The script does not implement multi-destination transaction coordination or retained rollback state.

--- a/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
+++ b/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
@@ -1,0 +1,283 @@
+# Kiro CLI v3 Integration Design
+
+**Date:** 2026-07-29
+**Status:** Implemented and locally verified on Kiro CLI 2.16.2; pull request creation deferred
+**Scope:** Local implementation and validation only
+
+Sections below marked ~~struck~~ record decisions superseded during implementation and local acceptance testing. The surrounding text is the shipped design.
+
+## Context
+
+Upstream Superpowers has no Kiro support of any kind. This design introduces it.
+
+The starting point was a personal, unofficial configuration maintained by the contributor: a Kiro v2 JSON agent, never part of upstream. It proved that the general approach works — an agent that loads `using-superpowers` and a Kiro tool mapping at session startup, registers all Superpowers skills through native `skill://` resources, and invokes matching skills through Kiro's native **Load skill** tool. Nothing of it is carried over. The v3 Markdown agent described here is new work, and the JSON form is treated as prior art rather than a baseline to preserve compatibility with.
+
+Because the integration is new, there is also no Kiro installation or update path to extend. Kiro Powers cannot currently package native custom agents and Agent Skills as one CLI-installable artifact, and Kiro CLI has no supported plugin installation command equivalent to the mature harness integrations.
+
+This design therefore adds a deliberately thin transitional installer while preserving a repository-local profile for development and acceptance testing. The installer is intended to be removed when Kiro provides a native package mechanism.
+
+## Goals
+
+- Provide a Kiro CLI v3 integration that automatically loads the Superpowers bootstrap at session start.
+- Use native Kiro skill discovery and activation rather than manual `SKILL.md` reads.
+- Provide a simple global install and update path that does not require Git.
+- Install only new, namespaced artifacts and never patch existing personal configuration.
+- Keep the Kiro-specific installer small enough for upstream maintainers to review and remove easily.
+- Support repository-local development and the upstream clean-session acceptance test.
+- Preserve normal Kiro permission behavior for consequential tools.
+- Give Superpowers skill templates a neutral general-purpose subagent to dispatch to.
+
+## Non-goals
+
+- Kiro CLI v2 compatibility. v2 is on its way out: it is no longer being extended, Kiro itself prompts users to migrate with `/upgrade-agent`, and new capabilities land in v3 only. Supporting both would mean maintaining two agent formats for a surface that is being retired, so the integration targets v3 exclusively — including deliberately not carrying forward the contributor's prior v2 JSON agent.
+- Native Windows support in the first version. The supported installer environments are macOS, Linux, and WSL.
+- A Kiro Power, package manager, version manager, update daemon, doctor command, or rollback history.
+- Cryptographic signing or a new Superpowers release-asset pipeline.
+- Classic or non-interactive Kiro execution while v3 requires its TUI.
+- Pull request creation or submission before local branch testing is complete.
+
+## Chosen Approach
+
+Use a thin mutable global installation plus a repository-local development profile.
+
+The installer downloads a selected stable release into one fixed namespaced directory and creates global Kiro agents that reference that directory. Running the installer again replaces the managed payload. It does not retain old versions or reproduce functionality expected from a future native Kiro package manager.
+
+Repository-local installation is not the canonical user path. Existing harnesses use native plugin, extension, marketplace, or package installation; Pi's checkout-based mode is explicitly a local-development path. The repository profile serves the same development and acceptance role for Kiro.
+
+For the porting guide's taxonomy this is a new shape: an **agent-profile** integration, where selecting a named agent is what loads the bootstrap. There is no shell hook, no code plugin, and no always-read instructions file.
+
+## Package Layout
+
+The upstream repository adds or updates these paths:
+
+- `.kiro/agents/superpowers.md` — repository-local Kiro v3 profile.
+- `.kiro/agents/superpowers-worker-default-model.md`, `.kiro/agents/superpowers-worker-lite-model.md` — neutral workers for skill-template dispatch.
+- `skills/using-superpowers/references/kiro-tools.md` — canonical Kiro action-to-tool mapping.
+- `scripts/install-kiro.sh` — minimal POSIX installer and updater.
+- `docs/README.kiro.md` — detailed installation, runtime, limitation, and troubleshooting documentation.
+- `README.md` — concise Kiro installation entry linking to the detailed document.
+- `docs/porting-to-a-new-harness.md`, `docs/testing.md` — register the new shape and the test directory.
+- `scripts/sync-to-codex-plugin.sh` — exclude `/.kiro/` alongside the other harness dotdirs.
+- `tests/kiro/` — profile, mapping, installer, and generated-resource tests.
+
+No Superpowers skill body is changed. No Kiro Power is added.
+
+## Runtime Architecture
+
+### Repository-local profile
+
+The profile uses workspace-relative resources:
+
+```yaml
+tools: ["*"]
+resources:
+  - file://skills/using-superpowers/SKILL.md
+  - file://skills/using-superpowers/references/kiro-tools.md
+  - skill://skills/**/SKILL.md
+permissions:
+  rules:
+    - capability: fs_read
+      effect: allow
+    - capability: skill
+      effect: allow
+```
+
+The relative paths resolve from the Kiro session's working directory. This profile is run from the Superpowers checkout with:
+
+```bash
+kiro-cli chat --agent superpowers --agent-engine v3
+```
+
+### Installed profile
+
+The global profile has the same tools, resource roles, permissions, prompt, and welcome message. Its resource URIs are absolute because users invoke it from arbitrary project directories. Conceptually, it contains:
+
+```yaml
+resources:
+  - file:///absolute/install/root/skills/using-superpowers/SKILL.md
+  - file:///absolute/install/root/skills/using-superpowers/references/kiro-tools.md
+  - skill:///absolute/install/root/skills/**/SKILL.md
+```
+
+~~Absolute `skill://` glob behavior has not yet been verified. Proving it from a project outside the Superpowers checkout is the first runtime implementation gate. If Kiro does not support the absolute skill resource, implementation stops and the installation design is revised.~~ **Verified:** an installed-profile session started from an unrelated project resolved both absolute `file://` resources and the absolute `skill://` glob, and invoked `brainstorming` before implementation. The gate passed, so the fallback of copying skills into Kiro's global skills directory was never needed and remains prohibited.
+
+### Neutral worker agents
+
+Superpowers skill templates dispatch `Subagent (general-purpose):` and supply the persona, checklist, and output format entirely in the prompt — the template *is* the worker's role. Kiro exposes only purpose-built agents, so a `requesting-code-review` dispatch had no neutral target and substituted a named reviewer, silently replacing the template's checklist, severity calibration, read-only constraint, and output format with that agent's own contract. This was found in local testing, not in the original design.
+
+The integration therefore ships two neutral workers, in the repository profile and from the installer:
+
+- `superpowers-worker-default-model` — omits `model`, so Kiro resolves it.
+- `superpowers-worker-lite-model` — pins `claude-sonnet-5` for mechanical, fully specified work.
+
+Both grant `tools: ["*"]`, pre-approve `fs_read` and `skill` for the same reason the main profile does, and register `skill://` discovery so a template may name a skill. Their body instructs them to treat the dispatching prompt as the complete specification, and they carry no role, checklist, or output conventions.
+
+They deliberately do not *declare* the bootstrap resources. That is defense in depth rather than a guarantee: on at least one surface a dispatching session propagates its own startup resources into the subagent regardless, and what actually protects the template is the bootstrap's own `<SUBAGENT-STOP>` clause. The assertion in `tests/kiro/test-agent-config.sh` tests the declaration, not the runtime context.
+
+Model tiering is expressed by choosing a worker, not by passing a model per dispatch, because a per-stage model value is not honored on every surface and can be dropped silently. Omitting `model` does not necessarily inherit the parent session's model.
+
+**Rejected:** one worker per skill role, which multiplies configs without adding capability; a per-dispatch model argument, which is not reliably honored; and a third read-only worker for review dispatches, which would enforce the review template's read-only promise at config level but exceeds the agreed two workers, and one worker must serve implementers that legitimately write. The read-only constraint stays prose in the template, as upstream intends.
+
+**Accepted costs:** the installer grew from 75 to 116 non-comment lines and manages three agent files instead of one.
+
+### Startup and skill activation
+
+At startup, Kiro:
+
+1. Loads `using-superpowers` through the first `file://` resource.
+2. Loads the Kiro tool mapping through the second `file://` resource.
+3. Discovers metadata for all matching `SKILL.md` files through the `skill://` glob.
+4. Loads full skill content on demand through native **Load skill** invocation.
+
+The bootstrap mapping states that `using-superpowers` is already loaded and must not be loaded a second time.
+
+### Permissions
+
+The profile exposes the normal Kiro tool set through `tools: ["*"]`. Only workspace reads and native skill activation are pre-approved. Shell commands, writes, network access, and other consequential operations retain Kiro's normal permission behavior. The integration does not alter global permission settings.
+
+## Kiro Tool Mapping
+
+The canonical mapping translates platform-neutral Superpowers actions into Kiro capabilities. It covers native skill loading; file reads, writes, and searches; shell commands; code intelligence; subagent dispatch; todo-list tracking; web search and retrieval; and fallback behavior when subagent or todo tools are unavailable.
+
+For subagent dispatch it names the worker in the step that performs the dispatch, rather than stating the rule elsewhere on the page, and forbids substituting a purpose-built agent — requiring the agent to stop and say so instead. If a dispatch fails because a pinned model is rejected, the fallback is the default-model worker, never a purpose-built agent, with the rejected identifier reported.
+
+The mapping also documents a Kiro tool-schema compatibility issue: `todo_list.tasks` may be exposed with an underspecified type. Creation calls must pass an array of objects containing `task_description`:
+
+```json
+{
+  "command": "create",
+  "task_list_description": "Design the integration",
+  "tasks": [
+    {"task_description": "Explore project context"},
+    {"task_description": "Present the design"}
+  ]
+}
+```
+
+Arrays of strings and objects using `description` are explicitly identified as invalid.
+
+## Installer Design
+
+### Interface
+
+The script supports only two installation forms:
+
+```bash
+./scripts/install-kiro.sh             # latest stable release
+./scripts/install-kiro.sh v1.2.3      # selected stable release
+```
+
+The latest form resolves the latest GitHub release tag; a failure to resolve it reports that specifically rather than blaming a version argument the user did not pass. The selected form downloads the matching tagged source archive. The script requires standard POSIX tools, `curl`, and `tar`; it does not require Git, Node.js, Python, or `jq`.
+
+The implementation should remain roughly 100 lines of straightforward POSIX shell, excluding comments. This is a review goal, not a test-enforced line limit. The shipped script is 116 lines; the overshoot is the two worker configs and the shadowing guard, both added after the original design.
+
+### Destinations
+
+- Payload: `${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro`
+- Agents: `$HOME/.kiro/agents/superpowers.md` and the two worker profiles
+
+~~The installer creates only the payload and `superpowers.md`.~~ **Superseded:** it creates four paths, the payload plus three agents. The fixed payload path keeps the generated agents stable across updates. A relative `XDG_DATA_HOME` is refused, because it would install into the current working directory and emit relative resource URIs while still reporting success.
+
+### Installation flow
+
+1. Validate required commands, arguments, and that the payload path is absolute.
+2. Refuse any managed agent path that lacks the Superpowers installer ownership marker.
+3. Refuse when a same-named `.json` config sits beside a managed Markdown agent.
+4. Refuse an existing payload directory that lacks the ownership marker.
+5. Download and extract the release into a temporary directory over HTTPS only.
+6. Validate the required agent, bootstrap, mapping, and skill files.
+7. Confirm that the archive's declared version matches the selected tag after normalizing the tag's `v` prefix.
+8. Add the ownership/version marker to the staged payload.
+9. Replace the single managed payload directory.
+10. Generate the three agents, each into a temporary file renamed into place.
+11. Print the command that starts the Superpowers agent.
+
+All refusals precede tag resolution and the download, so a refused run leaves the filesystem untouched. Staging ensures that download or extraction failures do not damage an existing installation. Because the staged payload already contains its ownership marker, an interruption after payload replacement remains recognizable as managed state and a rerun can repair the installation. The script does not implement multi-destination transaction coordination or retained rollback state.
+
+**Accepted without change:** there is no rollback across the three agent writes. A failure leaves a partial install, recovered by rerunning; the ownership guard makes a rerun safe, and rollback logic would cost more than the failure it prevents.
+
+### Shadowing guard
+
+A Kiro agent may be defined by either `<name>.md` or `<name>.json`, and the JSON form takes precedence. The original ownership guard inspected only the Markdown paths, so an existing `superpowers.json` — from a manual setup, or from an install predating this Markdown installer — was invisible: the installer reported success while writing an agent that never loads. This was hit in practice during local acceptance testing.
+
+The guard therefore also refuses when a same-named `.json` config exists next to any managed Markdown path, naming both files. It never deletes or rewrites the JSON config; the user moves it aside. **Rejected:** silently preferring the Markdown agent, or writing JSON instead — both guess at intent for a file the installer does not own.
+
+**Open question:** the guard checks exactly `${managed%.md}.json`. Only `.md` and `.json` are known to be honored; if Kiro v3 loads agent configs from another extension, the same silent-shadowing bug recurs with that suffix.
+
+### Updating, removal, and archive integrity
+
+Running the same command again replaces the managed payload with the latest or selected release. There is no separate updater and no automatic update check.
+
+The script has no uninstall mode. Documentation provides the manual removals and instructs users to inspect the ownership marker on every managed path — not just one — before deleting anything, so a hand-written worker config cannot be destroyed by following the recipe.
+
+The installer downloads GitHub-generated release archives over HTTPS, refusing redirects to other protocols, and validates their required structure and declared version. It does not claim cryptographic checksum or signature verification because Superpowers does not currently publish corresponding release assets. Adding signed artifacts is a separate release-system project.
+
+### Explicitly omitted complexity
+
+Version history and rollback; status, doctor, repair, or migration commands; lock management; background or automatic updates; built-in uninstallation; checksums or signatures; a general-purpose installation framework; a Power wrapper.
+
+## Documentation
+
+`README.md` contains a short Kiro entry and links to `docs/README.kiro.md`. The detailed document covers Kiro CLI v3 prerequisites; latest and pinned installation; a download-inspect-run alternative to piping remote shell code; updating by rerunning the installer; manual removal with ownership-marker checks on every managed path; global and repository-local invocation; the worker agents and how tiers are chosen; native skill activation and permissions; TUI and non-interactive limitations; collision, shadowing, and resource-loading troubleshooting; why Kiro Powers are not used initially; and the installer's transitional status pending native Kiro package installation.
+
+Known limitations are stated rather than implied: model identifiers are not validated when a config is written, so a wrong one surfaces only at dispatch; the agent list is fixed at session start, so a restart is required after installing; and install paths containing spaces are untested, because the generated URIs embed the payload path without percent-encoding.
+
+The concise install form is:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/obra/superpowers/refs/heads/main/scripts/install-kiro.sh | sh
+```
+
+A pinned release is passed as the script's positional argument.
+
+## Testing
+
+### Automated tests
+
+`tests/kiro/` covers the repository profile's resources, tools, permissions, prompt, and welcome message; worker neutrality as a closed property, asserting the permitted frontmatter keys and exact body so any added persona fails; required entries and the valid todo payload in the canonical mapping; the documentation contract; successful installation into a temporary `HOME` using local archive fixtures and a stubbed `curl` on `PATH`; generated absolute startup and skill resource paths; a second installation replacing the first managed version; refusal to overwrite an unmanaged agent, an unmanaged worker, or an unmanaged payload; refusal to install beside a shadowing `.json` config; refusal of a relative `XDG_DATA_HOME`; an accurate error when the latest release cannot be resolved; rejection of an archive missing required files; preservation of unmanaged content on every tested failure, plus the absence of any other artifact after a refusal; and semantic parity between repository-local and generated profiles.
+
+Tests do not make live network requests, depend on GitHub availability, test shell implementation details, or enforce an exact installer line count.
+
+### Manual runtime acceptance
+
+Kiro v3 currently requires its TUI, so runtime acceptance is manual rather than automated through brittle terminal control. Both paths passed and are a hard completion gate.
+
+Repository-local: start a clean session with the repository profile, send exactly `Let's make a react todo list`, and confirm `Load skill: brainstorming` occurs before any implementation action.
+
+Installed-profile: install into a temporary home, start Kiro from a project outside the Superpowers checkout, send the same prompt, and confirm the absolute resources resolve and native `brainstorming` precedes implementation.
+
+Worker acceptance, on Kiro CLI 2.16.2:
+
+- **Markdown workers are dispatchable.** A `requesting-code-review` run dispatched `Subagent superpowers-worker-default-model` and delivered the `code-reviewer.md` template verbatim, with no substitution.
+- **The per-agent model pin is honored.** The default-model worker recorded `claude-opus-5` in its sub-execution transcript. The lite worker records no model, because it emits no reasoning payloads for an identifier to attach to, so a probe agent pinned to a deliberately invalid identifier was dispatched instead: that dispatch failed with a rejected-model error. A rejected pin fails loudly, so an accepted pin is applied — `claude-sonnet-5` is valid on the tested account and the two workers run different models. The same probe incidentally exercised the rejected-model fallback rule.
+
+A subagent cannot read its own agent name from its context, so worker attribution comes from Kiro's `sub_agent_start` records rather than from self-report.
+
+## Release and Maintenance
+
+The integration introduces no release assets, package registry, checksums, or new release workflow. Existing Superpowers release archives naturally include the Kiro files. The Kiro profile has no embedded version field, so `.version-bump.json` does not need an entry unless implementation reveals an upstream registration requirement.
+
+The installer is intentionally disposable. When Kiro supplies a supported native plugin or package mechanism, the agent profiles, tool mapping, and tests should be reused while the shell installer and transitional documentation are removed. Kiro Powers are not that mechanism yet: as of Kiro CLI 2.16.2 and IDE 1.0.288 a Power bundles skills and MCP servers but cannot deliver an agent, which this integration requires.
+
+## Upstream Contribution Strategy
+
+Pull request creation is deferred until the local branch passes automated tests, both TUI acceptance paths, and human diff review.
+
+A later PR will target `dev`; contain only Kiro harness support; include the clean-session transcripts and tested Kiro/model versions; explain that the installer creates new namespaced artifacts and never patches settings, startup files, or existing agents; identify the installer as the only policy-sensitive component; explain why repository-local use alone is not presented as complete end-user installation; record that ShellCheck was unavailable locally so that gate is unrun rather than claimed; and invite replacement by Kiro's future native package mechanism.
+
+If maintainers interpret the harness-owned-installation rule as requiring a Kiro-provided install command, the integration should wait for that capability rather than claim repository-local setup as complete support.
+
+## Success Criteria
+
+All met at the time of writing:
+
+- The repository-local agent auto-loads the bootstrap and mapping.
+- Native Kiro skill discovery exposes all upstream Superpowers skills.
+- The thin installer installs and replaces a stable release without Git.
+- Managed-artifact collision checks protect existing user files, including against a shadowing `.json` config.
+- A global agent launched from an unrelated project resolves absolute resources.
+- Both acceptance runs invoke `brainstorming` before implementation.
+- Skill templates dispatch to a neutral worker rather than a purpose-built agent.
+- Automated Kiro tests pass without network access.
+- Documentation accurately states supported platforms, permissions, and limitations.
+- No PR is created until the user separately approves submission after local testing.

--- a/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
+++ b/docs/superpowers/specs/2026-07-29-kiro-v3-integration-design.md
@@ -1,7 +1,7 @@
 # Kiro CLI v3 Integration Design
 
 **Date:** 2026-07-29
-**Status:** PR #2126 revision implemented; automated checks pass on macOS. Fresh Kiro validation and default-agent acceptance are pending runtime access. Earlier runtime observations below describe the original PR, not the revised installer.
+**Status:** Automated checks pass on macOS. Supplied runtime evidence verifies the settings-command setup and two fresh default-agent acceptance sessions on Kiro CLI 2.21.3 / KAS 0.60.10 (interactive TUI). Markdown validation is unavailable through the tested JSON-only validator; IDE persistence remains unverified. Earlier version-specific observations below are historical.
 **Scope:** Local implementation and validation only
 
 Sections below marked ~~struck~~ record decisions superseded during implementation and local acceptance testing. The surrounding text is the shipped design.
@@ -44,7 +44,7 @@ The installer downloads a selected stable release into one fixed namespaced dire
 
 Repository-local installation is not the canonical user path. Existing harnesses use native plugin, extension, marketplace, or package installation; Pi's checkout-based mode is explicitly a local-development path. The repository profile serves the same development and acceptance role for Kiro.
 
-For the porting guide taxonomy this is an **agent-profile** integration. One-time `kiro-cli agent set-default superpowers` must persist activation for ordinary `kiro-cli chat --agent-engine v3` sessions. The installer prints these commands and never changes settings itself. Per-session selection does not satisfy the acceptance bar; IDE persistence must be established separately.
+For the porting guide taxonomy this is an **agent-profile** integration. One-time `kiro-cli settings chat.defaultAgent superpowers` must persist activation for ordinary `kiro-cli chat --agent-engine v3` sessions. The installer prints these commands and never changes settings itself. Per-session selection does not satisfy the acceptance bar; IDE persistence must be established separately.
 
 ## Package Layout
 
@@ -248,11 +248,11 @@ Tests do not make live network requests, depend on GitHub availability, test she
 
 ### Manual runtime acceptance
 
-Kiro v3 currently requires its TUI, so runtime acceptance is manual rather than automated through brittle terminal control. The original explicit-agent paths passed. The revised default-agent path remains a hard completion gate and is not yet verified.
+Kiro v3 currently requires its TUI, so runtime acceptance is manual rather than automated through brittle terminal control. The original explicit-agent paths passed. The revised settings-command default-agent path also passed in two fresh interactive sessions on CLI 2.21.3, from an absent default. Supplied TUI records show completed native brainstorming loads on claude-sonnet-5 and explicit-agent acceptance on gpt-5.6-sol.
 
 Repository-local: start a clean session with the repository profile, send exactly `Let's make a react todo list`, and confirm `Load skill: brainstorming` occurs before any implementation action.
 
-Installed-profile: install into an isolated test home, run `kiro-cli agent set-default superpowers` once, then start fresh sessions with `kiro-cli chat --agent-engine v3` from a project outside the checkout. Send the same prompt and confirm absolute resources resolve and native `brainstorming` precedes implementation. Record full session evidence and Kiro/model versions. Run the v3 validator on all tracked and installed profiles; successful validation alone does not prove skill loading.
+Installed-profile: install into an isolated test home, run `kiro-cli settings chat.defaultAgent superpowers` once, then start fresh sessions with `kiro-cli chat --agent-engine v3` from a project outside the checkout. Send the same prompt and confirm absolute resources resolve and native `brainstorming` precedes implementation. Record full session evidence and Kiro/model versions. On 2.21.3 the tested validator parses Markdown as JSON and errors despite exit zero, so it cannot certify these profiles. Use successful native skill loading as runtime evidence and record the validator limitation separately.
 
 Worker acceptance, on Kiro CLI 2.16.2:
 
@@ -277,7 +277,7 @@ If maintainers interpret the harness-owned-installation rule as requiring a Kiro
 
 ## Success Criteria
 
-Original PR criteria below were reported met before this revision. Fresh default-agent acceptance, validator output, and unabridged transcripts remain outstanding; automated installer tests do not establish those runtime results:
+Original PR criteria below were reported met before this revision. Fresh default-agent acceptance and original session records are now supplied for CLI 2.21.3. The tested Markdown validator is unusable and IDE persistence remains unverified; attaching reviewed evidence to the PR is still outstanding:
 
 - The repository-local agent auto-loads the bootstrap and mapping.
 - Native Kiro skill discovery exposes all upstream Superpowers skills.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,6 +13,7 @@ Live in `tests/`. Currently:
 - `tests/opencode/` — bash tests for OpenCode plugin loading, bootstrap caching, and tool registration.
 - `tests/codex-plugin-sync/` — bash sync verification.
 - `tests/kimi/` — bash/Python checks for Kimi plugin manifest wiring.
+- `tests/kiro/` — bash checks for the Kiro v3 agent profile and tool-mapping contract, the installer (offline, using local archives and a stubbed `curl`), and the documentation contract.
 - `tests/claude-code/test-helpers.sh`, `analyze-token-usage.py` — utilities used by remaining bash tests.
 - `tests/claude-code/test-subagent-driven-development.sh` — agent-can-describe-SDD test (no drill counterpart; tests description-recall, not behavior).
 - `tests/claude-code/test-subagent-driven-development-integration.sh` — extended SDD integration with token analysis (drill covers the YAGNI subset; bash adds commit-count, Claude Code task-tracking, and token telemetry assertions).

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -12,6 +12,18 @@ done
 [ "$#" -le 1 ] || die "usage: $0 [vMAJOR.MINOR.PATCH]"
 
 install_root="${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro"
+# A relative XDG_DATA_HOME would install into the current directory and emit
+# relative resource URIs, which defeats the absolute-path profile. A quote or
+# newline in the path would produce unparseable YAML in the generated agents.
+newline='
+'
+case "$install_root" in
+  /*) ;;
+  *) die "XDG_DATA_HOME must be an absolute path: $install_root" ;;
+esac
+case "$install_root" in
+  *'"'*|*"$newline"*) die "install path must not contain quotes or newlines: $install_root" ;;
+esac
 agent_path="$HOME/.kiro/agents/superpowers.md"
 worker_default_model_path="$HOME/.kiro/agents/superpowers-worker-default-model.md"
 worker_lite_model_path="$HOME/.kiro/agents/superpowers-worker-lite-model.md"
@@ -19,6 +31,14 @@ for managed in "$agent_path" "$worker_default_model_path" "$worker_lite_model_pa
   if { [ -e "$managed" ] || [ -L "$managed" ]; } \
     && ! grep -Fq "$AGENT_MARKER" "$managed" 2>/dev/null; then
     die "refusing to overwrite unmanaged agent: $managed"
+  fi
+  # A same-named .json config defines the same agent and takes precedence, so
+  # installing beside one would silently shadow the agent written here. The
+  # suffix is hardcoded to .json because that is the only non-Markdown agent
+  # form Kiro loads today; see the design spec's "Shadowing guard" open question.
+  shadow="${managed%.md}.json"
+  if [ -e "$shadow" ] || [ -L "$shadow" ]; then
+    die "$shadow defines the same agent and would shadow $managed; move it aside first"
   fi
 done
 if { [ -e "$install_root" ] || [ -L "$install_root" ]; } \
@@ -28,12 +48,15 @@ fi
 
 tag="${1:-}"
 if [ -z "$tag" ]; then
-  tag="$(curl -fsSL "https://api.github.com/repos/$REPOSITORY/releases/latest" \
+  tag="$(curl -fsSL --proto '=https' --proto-redir '=https' "https://api.github.com/repos/$REPOSITORY/releases/latest" \
     | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
     | sed -n '1p')"
+  # Distinguish a lookup failure from a malformed argument: the user gave none.
+  [ -n "$tag" ] \
+    || die "could not resolve the latest release; pass a tag explicitly, e.g. $0 v1.2.3"
 fi
 printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-  || die "release must look like v6.2.0"
+  || die "release must look like v1.2.3"
 version="${tag#v}"
 
 work_dir="${TMPDIR:-/tmp}/superpowers-kiro.$$"
@@ -44,8 +67,9 @@ trap cleanup 0
 trap 'exit 1' 1 2 15
 
 archive="$work_dir/release.tar.gz"
-curl -fsSL "https://github.com/$REPOSITORY/archive/refs/tags/$tag.tar.gz" -o "$archive"
-tar -xzf "$archive" -C "$work_dir"
+curl -fsSL --proto '=https' --proto-redir '=https' \
+  "https://github.com/$REPOSITORY/archive/refs/tags/$tag.tar.gz" -o "$archive"
+tar -xzf "$archive" --no-same-owner -C "$work_dir"
 source_root="$work_dir/superpowers-$version"
 for required in \
   package.json \

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -eu
+
+REPOSITORY="obra/superpowers"
+PAYLOAD_MARKER=".superpowers-kiro-install"
+AGENT_MARKER="<!-- Managed by the Superpowers Kiro installer. -->"
+
+die() { echo "error: $*" >&2; exit 1; }
+for tool in cat curl dirname tar grep sed mkdir rm mv; do
+  command -v "$tool" >/dev/null 2>&1 || die "required tool '$tool' is not on PATH"
+done
+[ "$#" -le 1 ] || die "usage: $0 [vMAJOR.MINOR.PATCH]"
+
+install_root="${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro"
+agent_path="$HOME/.kiro/agents/superpowers.md"
+if { [ -e "$agent_path" ] || [ -L "$agent_path" ]; } \
+  && ! grep -Fq "$AGENT_MARKER" "$agent_path" 2>/dev/null; then
+  die "refusing to overwrite unmanaged agent: $agent_path"
+fi
+if { [ -e "$install_root" ] || [ -L "$install_root" ]; } \
+  && [ ! -f "$install_root/$PAYLOAD_MARKER" ]; then
+  die "refusing to overwrite unmanaged payload: $install_root"
+fi
+
+tag="${1:-}"
+if [ -z "$tag" ]; then
+  tag="$(curl -fsSL "https://api.github.com/repos/$REPOSITORY/releases/latest" \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | sed -n '1p')"
+fi
+printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  || die "release must look like v6.2.0"
+version="${tag#v}"
+
+work_dir="${TMPDIR:-/tmp}/superpowers-kiro.$$"
+(umask 077 && mkdir "$work_dir") || die "cannot create temporary directory"
+agent_tmp="$agent_path.tmp.$$"
+cleanup() { rm -rf "$work_dir"; rm -f "$agent_tmp"; }
+trap cleanup 0
+trap 'exit 1' 1 2 15
+
+archive="$work_dir/release.tar.gz"
+curl -fsSL "https://github.com/$REPOSITORY/archive/refs/tags/$tag.tar.gz" -o "$archive"
+tar -xzf "$archive" -C "$work_dir"
+source_root="$work_dir/superpowers-$version"
+for required in \
+  package.json \
+  .kiro/agents/superpowers.md \
+  skills/using-superpowers/SKILL.md \
+  skills/using-superpowers/references/kiro-tools.md \
+  skills/brainstorming/SKILL.md; do
+  [ -f "$source_root/$required" ] || die "release is missing $required"
+done
+archive_version="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$source_root/package.json" | sed -n '1p')"
+[ "$archive_version" = "$version" ] || die "release version does not match $tag"
+printf '%s\n' "$version" >"$source_root/$PAYLOAD_MARKER"
+
+mkdir -p "$(dirname "$install_root")" "$(dirname "$agent_path")"
+rm -rf "$install_root"
+mv "$source_root" "$install_root"
+
+(umask 077 && : >"$agent_tmp")
+cat >"$agent_tmp" <<EOF
+---
+description: Superpowers-enabled agent with native Kiro v3 skill activation for brainstorming, TDD, debugging, planning, and review.
+tools: ["*"]
+resources:
+  - "file://$install_root/skills/using-superpowers/SKILL.md"
+  - "file://$install_root/skills/using-superpowers/references/kiro-tools.md"
+  - "skill://$install_root/skills/**/SKILL.md"
+permissions:
+  rules:
+    - capability: fs_read
+      effect: allow
+    - capability: skill
+      effect: allow
+welcomeMessage: Superpowers is active. Relevant workflow skills load automatically.
+---
+
+$AGENT_MARKER
+You are a software-engineering agent that follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.
+EOF
+mv "$agent_tmp" "$agent_path"
+printf 'Installed Superpowers %s for Kiro CLI v3.\n' "$version"
+printf 'Start it with: kiro-cli chat --agent superpowers --agent-engine v3\n'

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -227,5 +227,5 @@ done
 replacing=0
 
 printf 'Installed Superpowers %s for Kiro CLI v3.\n' "$version"
-printf 'Set the CLI default once: kiro-cli agent set-default superpowers\n'
+printf 'Set the CLI default once: kiro-cli settings chat.defaultAgent superpowers\n'
 printf 'Start a session: kiro-cli chat --agent-engine v3\n'

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -13,10 +13,14 @@ done
 
 install_root="${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro"
 agent_path="$HOME/.kiro/agents/superpowers.md"
-if { [ -e "$agent_path" ] || [ -L "$agent_path" ]; } \
-  && ! grep -Fq "$AGENT_MARKER" "$agent_path" 2>/dev/null; then
-  die "refusing to overwrite unmanaged agent: $agent_path"
-fi
+worker_default_model_path="$HOME/.kiro/agents/superpowers-worker-default-model.md"
+worker_lite_model_path="$HOME/.kiro/agents/superpowers-worker-lite-model.md"
+for managed in "$agent_path" "$worker_default_model_path" "$worker_lite_model_path"; do
+  if { [ -e "$managed" ] || [ -L "$managed" ]; } \
+    && ! grep -Fq "$AGENT_MARKER" "$managed" 2>/dev/null; then
+    die "refusing to overwrite unmanaged agent: $managed"
+  fi
+done
 if { [ -e "$install_root" ] || [ -L "$install_root" ]; } \
   && [ ! -f "$install_root/$PAYLOAD_MARKER" ]; then
   die "refusing to overwrite unmanaged payload: $install_root"
@@ -35,7 +39,7 @@ version="${tag#v}"
 work_dir="${TMPDIR:-/tmp}/superpowers-kiro.$$"
 (umask 077 && mkdir "$work_dir") || die "cannot create temporary directory"
 agent_tmp="$agent_path.tmp.$$"
-cleanup() { rm -rf "$work_dir"; rm -f "$agent_tmp"; }
+cleanup() { rm -rf "$work_dir"; rm -f "$agent_tmp" "$worker_default_model_path.tmp.$$" "$worker_lite_model_path.tmp.$$"; }
 trap cleanup 0
 trap 'exit 1' 1 2 15
 
@@ -81,5 +85,37 @@ $AGENT_MARKER
 You are a software-engineering agent that follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.
 EOF
 mv "$agent_tmp" "$agent_path"
+
+# Neutral workers: skills dispatch a general-purpose subagent and supply the
+# whole persona in the prompt, so these carry no role of their own. They get
+# skill:// discovery so a template may name a skill, but deliberately not the
+# bootstrap resources, whose mandate would compete with the template.
+write_worker() {
+  worker_path="$1" worker_desc="$2" worker_model="$3"
+  worker_tmp="$worker_path.tmp.$$"
+  (umask 077 && : >"$worker_tmp")
+  {
+    printf '%s\n' '---'
+    printf 'description: "%s"\n' "$worker_desc"
+    printf '%s\n' 'tools: ["*"]'
+    if [ -n "$worker_model" ]; then printf 'model: %s\n' "$worker_model"; fi
+    printf '%s\n' 'resources:' \
+      "  - \"skill://$install_root/skills/**/SKILL.md\"" \
+      'permissions:' '  rules:' '    - capability: fs_read' \
+      '      effect: allow' '    - capability: skill' '      effect: allow' '---' ''
+    printf '%s\n' "$AGENT_MARKER"
+    printf '%s\n' 'Execute the dispatching prompt exactly as given. That prompt is the complete'
+    printf '%s\n' 'specification of your role, process, and output format. Add no persona, no'
+    printf '%s\n' 'checklist, and no output conventions of your own.'
+  } >"$worker_tmp"
+  mv "$worker_tmp" "$worker_path"
+}
+write_worker "$worker_default_model_path" \
+  'Neutral executor for Superpowers skill templates, on the model Kiro resolves by default. Dispatch this when a skill asks for a general-purpose subagent.' \
+  ''
+write_worker "$worker_lite_model_path" \
+  'Neutral executor for Superpowers skill templates, pinned to a cheaper model for mechanical, fully specified work.' \
+  'claude-sonnet-5'
+
 printf 'Installed Superpowers %s for Kiro CLI v3.\n' "$version"
 printf 'Start it with: kiro-cli chat --agent superpowers --agent-engine v3\n'

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -6,10 +6,25 @@ PAYLOAD_MARKER=".superpowers-kiro-install"
 AGENT_MARKER="<!-- Managed by the Superpowers Kiro installer. -->"
 
 die() { echo "error: $*" >&2; exit 1; }
-for tool in cat curl dirname tar grep sed mkdir rm mv awk; do
+for tool in cat cp dirname grep sed mkdir rm mv awk; do
   command -v "$tool" >/dev/null 2>&1 || die "required tool '$tool' is not on PATH"
 done
-[ "$#" -le 1 ] || die "usage: $0 [vMAJOR.MINOR.PATCH]"
+source_dir=""
+tag=""
+usage() { die "usage: $0 [vMAJOR.MINOR.PATCH] | --source <directory>"; }
+case "${1:-}" in
+  --source)
+    [ "$#" -eq 2 ] && [ -n "$2" ] || usage
+    source_dir="$(cd -- "$2" && pwd -P)" || die "source directory does not exist: $2"
+    ;;
+  *)
+    [ "$#" -le 1 ] || usage
+    tag="${1:-}"
+    for tool in curl tar; do
+      command -v "$tool" >/dev/null 2>&1 || die "required tool '$tool' is not on PATH"
+    done
+    ;;
+esac
 
 install_root="${XDG_DATA_HOME:-$HOME/.local/share}/superpowers/kiro"
 # A relative XDG_DATA_HOME would install into the current directory and emit
@@ -46,7 +61,7 @@ if { [ -e "$install_root" ] || [ -L "$install_root" ]; } \
   die "refusing to overwrite unmanaged payload: $install_root"
 fi
 
-tag="${1:-}"
+if [ -z "$source_dir" ]; then
 if [ -z "$tag" ]; then
   tag="$(curl -fsSL --proto '=https' --proto-redir '=https' "https://api.github.com/repos/$REPOSITORY/releases/latest" \
     | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
@@ -58,6 +73,7 @@ fi
 printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
   || die "release must look like v1.2.3"
 version="${tag#v}"
+fi
 
 work_dir="${TMPDIR:-/tmp}/superpowers-kiro.$$"
 (umask 077 && mkdir "$work_dir") || die "cannot create temporary directory"
@@ -66,11 +82,21 @@ cleanup() { rm -rf "$work_dir"; rm -f "$agents_dir"/*.tmp.$$; }
 trap cleanup 0
 trap 'exit 1' 1 2 15
 
+if [ -n "$source_dir" ]; then
+  source_root="$work_dir/source"
+  mkdir -p "$source_root/.kiro/agents"
+  cp -RL "$source_dir/skills" "$source_root/"
+  cp "$source_dir/package.json" "$source_root/"
+  for name in superpowers superpowers-worker-default-model superpowers-worker-lite-model; do
+    cp "$source_dir/.kiro/agents/$name.md" "$source_root/.kiro/agents/"
+  done
+else
 archive="$work_dir/release.tar.gz"
 curl -fsSL --proto '=https' --proto-redir '=https' \
   "https://github.com/$REPOSITORY/archive/refs/tags/$tag.tar.gz" -o "$archive"
 tar -xzf "$archive" --no-same-owner -C "$work_dir"
 source_root="$work_dir/superpowers-$version"
+fi
 for required in \
   package.json \
   .kiro/agents/superpowers.md \
@@ -82,8 +108,19 @@ for required in \
   [ -f "$source_root/$required" ] || die "release is missing $required"
 done
 archive_version="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$source_root/package.json" | sed -n '1p')"
-[ "$archive_version" = "$version" ] || die "release version does not match $tag"
-printf '%s\n' "$version" >"$source_root/$PAYLOAD_MARKER"
+[ -n "$archive_version" ] || die "source package.json is missing version metadata"
+if [ -n "$source_dir" ]; then
+  version="$archive_version"
+  printf '%s\nsource: local\n' "$version" >"$source_root/$PAYLOAD_MARKER"
+  # A commit identifies the checkout base; the snapshot also includes local edits.
+  if command -v git >/dev/null 2>&1 && [ -e "$source_dir/.git" ]; then
+    commit="$(git -C "$source_dir" rev-parse --verify HEAD 2>/dev/null || true)"
+    [ -z "$commit" ] || printf 'base-commit: %s\n' "$commit" >>"$source_root/$PAYLOAD_MARKER"
+  fi
+else
+  [ "$archive_version" = "$version" ] || die "release version does not match $tag"
+  printf '%s\n' "$version" >"$source_root/$PAYLOAD_MARKER"
+fi
 
 mkdir -p "$(dirname "$install_root")" "$(dirname "$agent_path")"
 rm -rf "$install_root"

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -148,7 +148,7 @@ for required in \
   skills/brainstorming/SKILL.md; do
   [ -f "$source_root/$required" ] || die "release is missing $required"
 done
-archive_version="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$source_root/package.json" | sed -n '1p')"
+archive_version="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$source_root/package.json" | sed -n '1p')"
 [ -n "$archive_version" ] || die "source package.json is missing version metadata"
 if [ -n "$source_dir" ]; then
   version="$archive_version"

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -90,11 +90,13 @@ rm -rf "$install_root"
 mv "$source_root" "$install_root"
 
 # Generate each global agent from the tracked profile shipped in the payload,
-# instead of embedding a second copy here. The only differences from the tracked
-# file are absolute resource URIs (Kiro loads the global agent from unrelated
-# project directories, so relative URIs would not resolve) and the ownership
-# marker used by the collision guard. Keeping the tracked `.kiro/agents/*.md` as
-# the single source means the installed agents cannot drift from them.
+# instead of embedding a second copy here. The transform makes three defined
+# changes: it substitutes the `{{SUPERPOWERS_SKILLS_DIR}}` placeholder with this
+# installation's absolute skills directory, makes the resource URIs absolute
+# (Kiro loads the global agent from unrelated project directories, so relative
+# URIs would not resolve), and inserts the ownership marker used by the collision
+# guard. Keeping the tracked `.kiro/agents/*.md` as the single source means the
+# installed agents cannot drift from them.
 generate_agent() {
   name="$1"
   src="$install_root/.kiro/agents/$name.md"
@@ -103,6 +105,7 @@ generate_agent() {
   [ -f "$src" ] || die "payload is missing agent $name.md"
   (umask 077 && : >"$tmp")
   awk -v root="$install_root" -v marker="$AGENT_MARKER" '
+    { gsub(/\{\{SUPERPOWERS_SKILLS_DIR\}\}/, root "/skills") }
     /^---$/ { print; fm++; if (fm == 2) print marker; next }
     fm == 1 && /^[[:space:]]*-[[:space:]]+(file|skill):\/\// {
       sub(/:\/\//, "://" root "/"); print; next

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -62,23 +62,64 @@ if { [ -e "$install_root" ] || [ -L "$install_root" ]; } \
 fi
 
 if [ -z "$source_dir" ]; then
-if [ -z "$tag" ]; then
-  tag="$(curl -fsSL --proto '=https' --proto-redir '=https' "https://api.github.com/repos/$REPOSITORY/releases/latest" \
-    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
-    | sed -n '1p')"
-  # Distinguish a lookup failure from a malformed argument: the user gave none.
-  [ -n "$tag" ] \
-    || die "could not resolve the latest release; pass a tag explicitly, e.g. $0 v1.2.3"
-fi
-printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-  || die "release must look like v1.2.3"
-version="${tag#v}"
+  if [ -z "$tag" ]; then
+    tag="$(curl -fsSL --proto '=https' --proto-redir '=https' "https://api.github.com/repos/$REPOSITORY/releases/latest" \
+      | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+      | sed -n '1p')"
+    # Distinguish a lookup failure from a malformed argument: the user gave none.
+    [ -n "$tag" ] \
+      || die "could not resolve the latest release; pass a tag explicitly, e.g. $0 v1.2.3"
+  fi
+  printf '%s\n' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    || die "release must look like v1.2.3"
+  version="${tag#v}"
 fi
 
 work_dir="${TMPDIR:-/tmp}/superpowers-kiro.$$"
 (umask 077 && mkdir "$work_dir") || die "cannot create temporary directory"
 agents_dir="$HOME/.kiro/agents"
-cleanup() { rm -rf "$work_dir"; rm -f "$agents_dir"/*.tmp.$$; }
+payload_stage=""
+agent_stage=""
+replacing=0
+# Each destination has its own same-filesystem staging slot with new/old entries.
+select_slot() {
+  case "$1" in
+    0) slot="$payload_stage/0"; destination="$install_root" ;;
+    1) slot="$agent_stage/1"; destination="$agent_path" ;;
+    2) slot="$agent_stage/2"; destination="$worker_default_model_path" ;;
+    3) slot="$agent_stage/3"; destination="$worker_lite_model_path" ;;
+  esac
+}
+cleanup() {
+  status=$?
+  trap - 0
+  trap '' 1 2 15
+  set +e
+  recovery_failed=0
+  if [ "$replacing" -eq 1 ]; then
+    for index in 3 2 1 0; do
+      select_slot "$index"
+      [ -f "$slot/started" ] || continue
+      if [ -e "$slot/old" ] || [ -L "$slot/old" ]; then
+        if ! rm -rf "$destination" || ! mv "$slot/old" "$destination"; then
+          recovery_failed=1
+        fi
+      elif [ ! -f "$slot/had-original" ]; then
+        rm -rf "$destination" || recovery_failed=1
+      fi
+    done
+  fi
+  if [ "$recovery_failed" -eq 1 ]; then
+    printf 'error: recovery incomplete; preserve backups in %s and %s\n' \
+      "$payload_stage" "$agent_stage" >&2
+    status=1
+  else
+    [ -z "$payload_stage" ] || rm -rf "$payload_stage"
+    [ -z "$agent_stage" ] || rm -rf "$agent_stage"
+  fi
+  rm -rf "$work_dir"
+  exit "$status"
+}
 trap cleanup 0
 trap 'exit 1' 1 2 15
 
@@ -91,11 +132,11 @@ if [ -n "$source_dir" ]; then
     cp "$source_dir/.kiro/agents/$name.md" "$source_root/.kiro/agents/"
   done
 else
-archive="$work_dir/release.tar.gz"
-curl -fsSL --proto '=https' --proto-redir '=https' \
-  "https://github.com/$REPOSITORY/archive/refs/tags/$tag.tar.gz" -o "$archive"
-tar -xzf "$archive" --no-same-owner -C "$work_dir"
-source_root="$work_dir/superpowers-$version"
+  archive="$work_dir/release.tar.gz"
+  curl -fsSL --proto '=https' --proto-redir '=https' \
+    "https://github.com/$REPOSITORY/archive/refs/tags/$tag.tar.gz" -o "$archive"
+  tar -xzf "$archive" --no-same-owner -C "$work_dir"
+  source_root="$work_dir/superpowers-$version"
 fi
 for required in \
   package.json \
@@ -122,9 +163,16 @@ else
   printf '%s\n' "$version" >"$source_root/$PAYLOAD_MARKER"
 fi
 
-mkdir -p "$(dirname "$install_root")" "$(dirname "$agent_path")"
-rm -rf "$install_root"
-mv "$source_root" "$install_root"
+mkdir -p "$(dirname "$install_root")" "$agents_dir"
+stage_candidate="$(dirname "$install_root")/.superpowers-kiro-stage.$$"
+(umask 077 && mkdir "$stage_candidate") || die "cannot stage payload"
+payload_stage="$stage_candidate"
+stage_candidate="$agents_dir/.superpowers-kiro-stage.$$"
+(umask 077 && mkdir "$stage_candidate") || die "cannot stage agents"
+agent_stage="$stage_candidate"
+mkdir "$payload_stage/0" "$agent_stage/1" "$agent_stage/2" "$agent_stage/3"
+# Copy before touching live paths, even when TMPDIR is on another filesystem.
+cp -R "$source_root" "$payload_stage/0/new"
 
 # Generate each global agent from the tracked profile shipped in the payload,
 # instead of embedding a second copy here. The transform makes three defined
@@ -136,9 +184,8 @@ mv "$source_root" "$install_root"
 # installed agents cannot drift from them.
 generate_agent() {
   name="$1"
-  src="$install_root/.kiro/agents/$name.md"
-  dest="$HOME/.kiro/agents/$name.md"
-  tmp="$dest.tmp.$$"
+  src="$payload_stage/0/new/.kiro/agents/$name.md"
+  tmp="$slot/new"
   [ -f "$src" ] || die "payload is missing agent $name.md"
   (umask 077 && : >"$tmp")
   KIRO_INSTALL_ROOT="$install_root" awk -v marker="$AGENT_MARKER" '
@@ -158,11 +205,26 @@ generate_agent() {
     }
     { print }
   ' "$src" >"$tmp"
-  mv "$tmp" "$dest"
 }
-for name in superpowers superpowers-worker-default-model superpowers-worker-lite-model; do
-  generate_agent "$name"
+for index in 1 2 3; do
+  select_slot "$index"
+  name="${destination##*/}"
+  generate_agent "${name%.md}"
 done
+
+replacing=1
+for index in 0 1 2 3; do
+  select_slot "$index"
+  if [ -e "$destination" ] || [ -L "$destination" ]; then
+    : > "$slot/had-original"
+  fi
+  : > "$slot/started"
+  if [ -f "$slot/had-original" ]; then
+    mv "$destination" "$slot/old"
+  fi
+  mv "$slot/new" "$destination"
+done
+replacing=0
 
 printf 'Installed Superpowers %s for Kiro CLI v3.\n' "$version"
 printf 'Start it with: kiro-cli chat --agent superpowers --agent-engine v3\n'

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -61,8 +61,8 @@ version="${tag#v}"
 
 work_dir="${TMPDIR:-/tmp}/superpowers-kiro.$$"
 (umask 077 && mkdir "$work_dir") || die "cannot create temporary directory"
-agent_tmp="$agent_path.tmp.$$"
-cleanup() { rm -rf "$work_dir"; rm -f "$agent_tmp" "$worker_default_model_path.tmp.$$" "$worker_lite_model_path.tmp.$$"; }
+agents_dir="$HOME/.kiro/agents"
+cleanup() { rm -rf "$work_dir"; rm -f "$agents_dir"/*.tmp.$$; }
 trap cleanup 0
 trap 'exit 1' 1 2 15
 
@@ -74,6 +74,8 @@ source_root="$work_dir/superpowers-$version"
 for required in \
   package.json \
   .kiro/agents/superpowers.md \
+  .kiro/agents/superpowers-worker-default-model.md \
+  .kiro/agents/superpowers-worker-lite-model.md \
   skills/using-superpowers/SKILL.md \
   skills/using-superpowers/references/kiro-tools.md \
   skills/brainstorming/SKILL.md; do
@@ -87,59 +89,31 @@ mkdir -p "$(dirname "$install_root")" "$(dirname "$agent_path")"
 rm -rf "$install_root"
 mv "$source_root" "$install_root"
 
-(umask 077 && : >"$agent_tmp")
-cat >"$agent_tmp" <<EOF
----
-description: Superpowers-enabled agent with native Kiro v3 skill activation for brainstorming, TDD, debugging, planning, and review.
-tools: ["*"]
-resources:
-  - "file://$install_root/skills/using-superpowers/SKILL.md"
-  - "file://$install_root/skills/using-superpowers/references/kiro-tools.md"
-  - "skill://$install_root/skills/**/SKILL.md"
-permissions:
-  rules:
-    - capability: fs_read
-      effect: allow
-    - capability: skill
-      effect: allow
-welcomeMessage: Superpowers is active. Relevant workflow skills load automatically.
----
-
-$AGENT_MARKER
-You are a software-engineering agent that follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.
-EOF
-mv "$agent_tmp" "$agent_path"
-
-# Neutral workers: skills dispatch a general-purpose subagent and supply the
-# whole persona in the prompt, so these carry no role of their own. They get
-# skill:// discovery so a template may name a skill, but deliberately not the
-# bootstrap resources, whose mandate would compete with the template.
-write_worker() {
-  worker_path="$1" worker_desc="$2" worker_model="$3"
-  worker_tmp="$worker_path.tmp.$$"
-  (umask 077 && : >"$worker_tmp")
-  {
-    printf '%s\n' '---'
-    printf 'description: "%s"\n' "$worker_desc"
-    printf '%s\n' 'tools: ["*"]'
-    if [ -n "$worker_model" ]; then printf 'model: %s\n' "$worker_model"; fi
-    printf '%s\n' 'resources:' \
-      "  - \"skill://$install_root/skills/**/SKILL.md\"" \
-      'permissions:' '  rules:' '    - capability: fs_read' \
-      '      effect: allow' '    - capability: skill' '      effect: allow' '---' ''
-    printf '%s\n' "$AGENT_MARKER"
-    printf '%s\n' 'Execute the dispatching prompt exactly as given. That prompt is the complete'
-    printf '%s\n' 'specification of your role, process, and output format. Add no persona, no'
-    printf '%s\n' 'checklist, and no output conventions of your own.'
-  } >"$worker_tmp"
-  mv "$worker_tmp" "$worker_path"
+# Generate each global agent from the tracked profile shipped in the payload,
+# instead of embedding a second copy here. The only differences from the tracked
+# file are absolute resource URIs (Kiro loads the global agent from unrelated
+# project directories, so relative URIs would not resolve) and the ownership
+# marker used by the collision guard. Keeping the tracked `.kiro/agents/*.md` as
+# the single source means the installed agents cannot drift from them.
+generate_agent() {
+  name="$1"
+  src="$install_root/.kiro/agents/$name.md"
+  dest="$HOME/.kiro/agents/$name.md"
+  tmp="$dest.tmp.$$"
+  [ -f "$src" ] || die "payload is missing agent $name.md"
+  (umask 077 && : >"$tmp")
+  awk -v root="$install_root" -v marker="$AGENT_MARKER" '
+    /^---$/ { print; fm++; if (fm == 2) print marker; next }
+    fm == 1 && /^[[:space:]]*-[[:space:]]+(file|skill):\/\// {
+      sub(/:\/\//, "://" root "/"); print; next
+    }
+    { print }
+  ' "$src" >"$tmp"
+  mv "$tmp" "$dest"
 }
-write_worker "$worker_default_model_path" \
-  'Neutral executor for Superpowers skill templates, on the model Kiro resolves by default. Dispatch this when a skill asks for a general-purpose subagent.' \
-  ''
-write_worker "$worker_lite_model_path" \
-  'Neutral executor for Superpowers skill templates, pinned to a cheaper model for mechanical, fully specified work.' \
-  'claude-sonnet-5'
+for name in superpowers superpowers-worker-default-model superpowers-worker-lite-model; do
+  generate_agent "$name"
+done
 
 printf 'Installed Superpowers %s for Kiro CLI v3.\n' "$version"
 printf 'Start it with: kiro-cli chat --agent superpowers --agent-engine v3\n'

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -227,4 +227,5 @@ done
 replacing=0
 
 printf 'Installed Superpowers %s for Kiro CLI v3.\n' "$version"
-printf 'Start it with: kiro-cli chat --agent superpowers --agent-engine v3\n'
+printf 'Set the CLI default once: kiro-cli agent set-default superpowers\n'
+printf 'Start a session: kiro-cli chat --agent-engine v3\n'

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -6,7 +6,7 @@ PAYLOAD_MARKER=".superpowers-kiro-install"
 AGENT_MARKER="<!-- Managed by the Superpowers Kiro installer. -->"
 
 die() { echo "error: $*" >&2; exit 1; }
-for tool in cat curl dirname tar grep sed mkdir rm mv; do
+for tool in cat curl dirname tar grep sed mkdir rm mv awk; do
   command -v "$tool" >/dev/null 2>&1 || die "required tool '$tool' is not on PATH"
 done
 [ "$#" -le 1 ] || die "usage: $0 [vMAJOR.MINOR.PATCH]"
@@ -104,11 +104,20 @@ generate_agent() {
   tmp="$dest.tmp.$$"
   [ -f "$src" ] || die "payload is missing agent $name.md"
   (umask 077 && : >"$tmp")
-  awk -v root="$install_root" -v marker="$AGENT_MARKER" '
-    { gsub(/\{\{SUPERPOWERS_SKILLS_DIR\}\}/, root "/skills") }
+  KIRO_INSTALL_ROOT="$install_root" awk -v marker="$AGENT_MARKER" '
+    BEGIN { root = ENVIRON["KIRO_INSTALL_ROOT"]; token = "{{SUPERPOWERS_SKILLS_DIR}}" }
+    {
+      line = $0; result = ""
+      while ((at = index(line, token)) > 0) {
+        result = result substr(line, 1, at - 1) root "/skills"
+        line = substr(line, at + length(token))
+      }
+      $0 = result line
+    }
     /^---$/ { print; fm++; if (fm == 2) print marker; next }
     fm == 1 && /^[[:space:]]*-[[:space:]]+(file|skill):\/\// {
-      sub(/:\/\//, "://" root "/"); print; next
+      at = index($0, "://") + 3
+      $0 = substr($0, 1, at - 1) root "/" substr($0, at); print; next
     }
     { print }
   ' "$src" >"$tmp"

--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -55,6 +55,7 @@ EXCLUDES=(
   "/.gitignore"
   "/.gitmodules"
   "/.kimi-plugin/"
+  "/.kiro/"
   "/.opencode/"
   "/.pi/"
   "/.pre-commit-config.yaml"

--- a/skills/using-superpowers/references/kiro-tools.md
+++ b/skills/using-superpowers/references/kiro-tools.md
@@ -58,11 +58,50 @@ Skills such as `subagent-driven-development`, `dispatching-parallel-agents`, and
 
 1. Read the referenced template.
 2. Fill every placeholder with the task's actual context.
-3. Dispatch it with Kiro's subagent capability.
+3. Dispatch it to a neutral worker — `superpowers-worker-default-model`, or
+   `superpowers-worker-lite-model` for the cheap tier — passing the filled template as
+   the prompt. Never dispatch a general-purpose template to a purpose-built agent.
 4. Parallelize independent tasks only.
 
 If subagents or todo lists are unavailable in a session, follow the equivalent
 workflow inline rather than blocking.
+
+### General-purpose dispatch targets
+
+Templates dispatch `Subagent (general-purpose):` and supply the entire persona,
+checklist, and output format in the prompt. The template *is* the worker's role.
+Kiro's other agents are purpose-built: they carry their own instructions and
+output contracts, which compete with the template and usually win.
+
+Two neutral workers exist for this:
+
+| Dispatch case | Kiro agent |
+|---------------|------------|
+| `Subagent (general-purpose):` | `superpowers-worker-default-model` |
+| Cheap tier for mechanical, fully specified work | `superpowers-worker-lite-model` |
+
+Dispatch a worker and pass the filled template as the prompt. The workers carry
+`skill://` discovery, so a template may tell a worker to load a skill, but they
+carry no bootstrap and no role of their own.
+
+**Never substitute a purpose-built agent** such as a named reviewer or coder for
+a general-purpose dispatch. Doing so silently discards the template's checklist,
+severity calibration, read-only constraints, and output format. If neither worker
+is available, say so and stop rather than substituting.
+
+If a worker dispatch fails because its pinned model is rejected, fall back to
+`superpowers-worker-default-model` — never to a purpose-built agent — and report
+the rejected identifier.
+
+### Model tiers
+
+Pick the tier by choosing the worker, not by passing a model argument. Kiro
+resolves a subagent's model from its agent config; a per-dispatch model value is
+not honored on every surface and can be dropped silently.
+
+`superpowers-worker-default-model` omits `model`, so Kiro resolves it. Note that
+this does not necessarily inherit the parent session's model. When a skill calls
+for a cheaper tier, dispatch `superpowers-worker-lite-model`.
 
 ## Conventions
 

--- a/skills/using-superpowers/references/kiro-tools.md
+++ b/skills/using-superpowers/references/kiro-tools.md
@@ -1,0 +1,72 @@
+# Superpowers — Kiro CLI v3 tool mapping
+
+This is the Kiro adaptation referenced by the `using-superpowers` skill. The
+bootstrap and this mapping are loaded as startup resources by the
+`superpowers` agent.
+
+## Loading skills
+
+- Superpowers skills are registered as native Kiro `skill://` resources. Kiro
+  exposes their names and descriptions at session start and loads full content
+  on demand.
+- Invoke relevant skills with Kiro's native **Load skill** mechanism. Never read
+  a `SKILL.md` manually to activate it.
+- `using-superpowers` is already loaded as a startup resource; do not load it a
+  second time.
+- After loading another skill, announce "Using [skill] to [purpose]", then
+  follow it exactly.
+
+## Action mapping
+
+Superpowers skills use platform-neutral actions. On Kiro CLI v3:
+
+| Skill action | Kiro capability |
+|--------------|-----------------|
+| Load or invoke a skill | Native `Load skill` tool |
+| Read or search files | Read tools |
+| Create or edit files | Write tools |
+| Run a command | Shell tools |
+| Search symbols or navigate code | Code-intelligence tools |
+| Dispatch an independent worker | Subagent tools |
+| Track checklist items | Todo-list tools |
+| Search or fetch current information | Web tools |
+
+Use the most specific available tool. Run independent reads and subagents in
+parallel; keep dependent work sequential.
+
+### Todo-list payloads
+
+Kiro may expose the `tasks` argument with an underspecified type. When creating
+tasks, pass an array of objects containing `task_description`; do not pass
+strings or objects using `description`.
+
+```json
+{
+  "command": "create",
+  "task_list_description": "Design the integration",
+  "tasks": [
+    {"task_description": "Explore project context"},
+    {"task_description": "Present the design"}
+  ]
+}
+```
+
+## Subagent dispatch
+
+Skills such as `subagent-driven-development`, `dispatching-parallel-agents`, and
+`requesting-code-review` reference prompt templates in their own directories.
+
+1. Read the referenced template.
+2. Fill every placeholder with the task's actual context.
+3. Dispatch it with Kiro's subagent capability.
+4. Parallelize independent tasks only.
+
+If subagents or todo lists are unavailable in a session, follow the equivalent
+workflow inline rather than blocking.
+
+## Conventions
+
+- "Your instructions file" means `AGENTS.md` on Kiro CLI.
+- This repository's skills live under `skills/`.
+- Kiro's native workspace and global skill locations are `.kiro/skills/` and
+  `~/.kiro/skills/`, respectively.

--- a/tests/codex-plugin-sync/test-sync-to-codex-plugin.sh
+++ b/tests/codex-plugin-sync/test-sync-to-codex-plugin.sh
@@ -176,6 +176,7 @@ write_upstream_fixture() {
     mkdir -p \
         "$repo/.codex-plugin" \
         "$repo/.kimi-plugin" \
+        "$repo/.kiro/agents" \
         "$repo/.private-journal" \
         "$repo/assets" \
         "$repo/evals/drill" \
@@ -237,6 +238,12 @@ EOF
 }
 EOF
 
+    cat > "$repo/.kiro/agents/superpowers.md" <<'EOF'
+---
+description: Kiro-only fixture
+---
+EOF
+
     cat > "$repo/assets/superpowers-small.svg" <<'EOF'
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>
 EOF
@@ -293,6 +300,7 @@ EOF
     git -C "$repo" add \
         .codex-plugin/plugin.json \
         .kimi-plugin/plugin.json \
+        .kiro/agents/superpowers.md \
         .gitignore \
         .gitmodules \
         .pre-commit-config.yaml \
@@ -445,13 +453,16 @@ write_stale_ignored_destination_fixture() {
 
     mkdir -p \
         "$repo/plugins/superpowers/.kimi-plugin" \
+        "$repo/plugins/superpowers/.kiro/agents" \
         "$repo/plugins/superpowers/.private-journal"
     printf 'fixture keep\n' > "$repo/plugins/superpowers/.fixture-keep"
     printf '{"name":"stale-kimi"}\n' > "$repo/plugins/superpowers/.kimi-plugin/plugin.json"
+    printf '%s\n' 'stale Kiro agent' > "$repo/plugins/superpowers/.kiro/agents/superpowers.md"
     printf 'stale ignored leak\n' > "$repo/plugins/superpowers/.private-journal/leak.txt"
     git -C "$repo" add \
         plugins/superpowers/.fixture-keep \
-        plugins/superpowers/.kimi-plugin/plugin.json
+        plugins/superpowers/.kimi-plugin/plugin.json \
+        plugins/superpowers/.kiro/agents/superpowers.md
 
     commit_fixture "$repo" "Initial stale ignored destination fixture"
 }
@@ -652,6 +663,7 @@ main() {
     assert_not_contains "$preview_output" "Version:  $PACKAGE_VERSION" "Preview does not use package.json version"
     assert_contains "$preview_section" ".codex-plugin/plugin.json" "Preview includes manifest path"
     assert_not_contains "$preview_section" ".kimi-plugin/plugin.json" "Preview excludes Kimi manifest from Codex sync"
+    assert_not_contains "$preview_section" ".kiro/agents/superpowers.md" "Preview excludes Kiro agent config from Codex sync"
     assert_contains "$preview_section" "assets/superpowers-small.svg" "Preview includes SVG asset"
     assert_contains "$preview_section" "assets/app-icon.png" "Preview includes PNG asset"
     assert_contains "$preview_section" "hooks/hooks-codex.json" "Preview includes Codex hook manifest"
@@ -681,6 +693,7 @@ main() {
     echo "Convergence assertions..."
     assert_equals "$stale_preview_status" "0" "Stale ignored destination preview exits successfully"
     assert_matches "$stale_preview_section" "\\*deleting +\\.kimi-plugin/plugin\\.json" "Preview deletes stale Kimi manifest from Codex plugin"
+    assert_matches "$stale_preview_section" "\\*deleting +\\.kiro/agents/superpowers\\.md" "Preview deletes stale Kiro agent config from Codex plugin"
     assert_matches "$stale_preview_section" "\\*deleting +\\.private-journal/leak\\.txt" "Preview deletes stale ignored destination file"
 
     echo ""

--- a/tests/kiro/run-tests.sh
+++ b/tests/kiro/run-tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+for test_script in "$SCRIPT_DIR"/test-*.sh; do
+  echo ">>> $test_script"
+  bash "$test_script"
+done

--- a/tests/kiro/test-agent-config.sh
+++ b/tests/kiro/test-agent-config.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 AGENT="$REPO_ROOT/.kiro/agents/superpowers.md"
+WORKER_DEFAULT="$REPO_ROOT/.kiro/agents/superpowers-worker-default-model.md"
+WORKER_LITE="$REPO_ROOT/.kiro/agents/superpowers-worker-lite-model.md"
 MAPPING="$REPO_ROOT/skills/using-superpowers/references/kiro-tools.md"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
@@ -34,13 +36,57 @@ done
 assert_contains "$AGENT" 'follows the loaded Superpowers bootstrap' "agent prompt"
 assert_not_contains "$AGENT" 'vendor/superpowers' "upstream paths must not use the outer vendor checkout"
 
+# Neutral workers. Superpowers skill templates dispatch a general-purpose
+# subagent and supply the entire persona in the prompt, so a worker must carry
+# no agenda of its own or the template's checklist and output format lose.
+[ -f "$WORKER_DEFAULT" ] || fail "default-model worker agent missing"
+[ -f "$WORKER_LITE" ] || fail "lite worker agent missing"
+
+for worker in "$WORKER_DEFAULT" "$WORKER_LITE"; do
+  label="worker $(basename "$worker")"
+  assert_contains "$worker" 'tools: ["*"]' "$label"
+  assert_contains "$worker" 'skill://skills/**/SKILL.md' "$label grants skill discovery"
+  assert_contains "$worker" 'capability: fs_read' "$label pre-approves reads"
+  assert_contains "$worker" 'capability: skill' "$label pre-approves skill loading"
+  # Neutrality is a closed property: assert the exact body, so ANY added
+  # persona fails rather than only the personas someone thought to forbid.
+  for sentence in \
+    'Execute the dispatching prompt exactly as given. That prompt is the complete' \
+    'specification of your role, process, and output format. Add no persona, no' \
+    'checklist, and no output conventions of your own.'; do
+    assert_contains "$worker" "$sentence" "$label body"
+  done
+  # The bootstrap must not reach a worker: its mandate would compete with the
+  # dispatching template, which is the defect the workers exist to fix.
+  assert_not_contains "$worker" 'using-superpowers/SKILL.md' "$label must not load the bootstrap"
+  assert_not_contains "$worker" 'welcomeMessage' "$label"
+  # Only these frontmatter keys are permitted on a neutral worker.
+  while read -r key; do
+    case "$key" in
+      description|tools|model|resources|permissions) ;;
+      *) fail "$label: unexpected frontmatter key '$key'" ;;
+    esac
+  done <<EOF
+$(awk '/^---$/ { n++; next } n == 1 && /^[a-zA-Z]+:/ { sub(":.*", ""); print }' "$worker")
+EOF
+done
+
+assert_contains "$WORKER_LITE" 'model: claude-sonnet-5' "lite worker pins the cheaper model"
+if grep -q '^model:' "$WORKER_DEFAULT"; then
+  fail "default-model worker must omit model so Kiro resolves it"
+fi
+
 for text in \
   'Native `Load skill` tool' \
   'Subagent tools' \
   'Todo-list tools' \
   'Web tools' \
   '"task_description": "Explore project context"' \
-  'objects using `description`'; do
+  'objects using `description`' \
+  'superpowers-worker-default-model' \
+  'superpowers-worker-lite-model' \
+  'Subagent (general-purpose)' \
+  'Never substitute a purpose-built agent'; do
   assert_contains "$MAPPING" "$text" "Kiro mapping"
 done
 assert_not_contains "$MAPPING" '{"description":' "invalid todo payload example"

--- a/tests/kiro/test-agent-config.sh
+++ b/tests/kiro/test-agent-config.sh
@@ -56,8 +56,10 @@ for worker in "$WORKER_DEFAULT" "$WORKER_LITE"; do
     'checklist, and no output conventions of your own.'; do
     assert_contains "$worker" "$sentence" "$label body"
   done
-  # The bootstrap must not reach a worker: its mandate would compete with the
-  # dispatching template, which is the defect the workers exist to fix.
+  # The bootstrap must not be DECLARED on a worker: its mandate would compete
+  # with the dispatching template. This asserts the config only -- a dispatching
+  # session may still propagate its own startup resources at runtime, which the
+  # bootstrap's own <SUBAGENT-STOP> clause handles.
   assert_not_contains "$worker" 'using-superpowers/SKILL.md' "$label must not load the bootstrap"
   assert_not_contains "$worker" 'welcomeMessage' "$label"
   # Only these frontmatter keys are permitted on a neutral worker.

--- a/tests/kiro/test-agent-config.sh
+++ b/tests/kiro/test-agent-config.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AGENT="$REPO_ROOT/.kiro/agents/superpowers.md"
+MAPPING="$REPO_ROOT/skills/using-superpowers/references/kiro-tools.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_contains() {
+  local file="$1" text="$2" label="$3"
+  grep -Fq -- "$text" "$file" || fail "$label: missing $text"
+}
+assert_not_contains() {
+  local file="$1" text="$2" label="$3"
+  if grep -Fq -- "$text" "$file"; then
+    fail "$label: unexpectedly contains $text"
+  fi
+}
+
+[ -f "$AGENT" ] || fail "repository Kiro agent missing"
+[ -f "$MAPPING" ] || fail "Kiro tool mapping missing"
+
+for text in \
+  'tools: ["*"]' \
+  'file://skills/using-superpowers/SKILL.md' \
+  'file://skills/using-superpowers/references/kiro-tools.md' \
+  'skill://skills/**/SKILL.md' \
+  'capability: fs_read' \
+  'capability: skill' \
+  'welcomeMessage: Superpowers is active.'; do
+  assert_contains "$AGENT" "$text" "repository agent"
+done
+assert_contains "$AGENT" 'follows the loaded Superpowers bootstrap' "agent prompt"
+assert_not_contains "$AGENT" 'vendor/superpowers' "upstream paths must not use the outer vendor checkout"
+
+for text in \
+  'Native `Load skill` tool' \
+  'Subagent tools' \
+  'Todo-list tools' \
+  'Web tools' \
+  '"task_description": "Explore project context"' \
+  'objects using `description`'; do
+  assert_contains "$MAPPING" "$text" "Kiro mapping"
+done
+assert_not_contains "$MAPPING" '{"description":' "invalid todo payload example"
+assert_not_contains "$MAPPING" 'vendor/superpowers/skills/' "mapping must describe the upstream layout"
+
+echo "PASS: Kiro repository agent and tool mapping"

--- a/tests/kiro/test-docs.sh
+++ b/tests/kiro/test-docs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+README="$REPO_ROOT/README.md"
+DOC="$REPO_ROOT/docs/README.kiro.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+[ -f "$DOC" ] || fail "docs/README.kiro.md missing"
+for text in \
+  '### Kiro CLI' \
+  'scripts/install-kiro.sh' \
+  'docs/README.kiro.md'; do
+  grep -Fq -- "$text" "$README" || fail "README missing $text"
+done
+for text in \
+  'Kiro CLI v3' \
+  'kiro-cli chat --agent superpowers --agent-engine v3' \
+  'XDG_DATA_HOME' \
+  '.superpowers-kiro-install' \
+  'Native Windows is not supported' \
+  'Kiro Powers' \
+  'Load skill' \
+  'TUI'; do
+  grep -Fq -- "$text" "$DOC" || fail "Kiro guide missing $text"
+done
+
+echo "PASS: Kiro documentation contract"

--- a/tests/kiro/test-docs.sh
+++ b/tests/kiro/test-docs.sh
@@ -16,7 +16,7 @@ for text in \
 done
 for text in \
   'Kiro CLI v3' \
-  'kiro-cli agent set-default superpowers' \
+  'kiro-cli settings chat.defaultAgent superpowers' \
   'kiro-cli chat --agent-engine v3' \
   '--source .' \
   'kiro-cli chat --agent superpowers --agent-engine v3' \

--- a/tests/kiro/test-docs.sh
+++ b/tests/kiro/test-docs.sh
@@ -16,6 +16,9 @@ for text in \
 done
 for text in \
   'Kiro CLI v3' \
+  'kiro-cli agent set-default superpowers' \
+  'kiro-cli chat --agent-engine v3' \
+  '--source .' \
   'kiro-cli chat --agent superpowers --agent-engine v3' \
   'XDG_DATA_HOME' \
   '.superpowers-kiro-install' \

--- a/tests/kiro/test-docs.sh
+++ b/tests/kiro/test-docs.sh
@@ -25,6 +25,8 @@ for text in \
   'superpowers-worker-default-model' \
   'superpowers-worker-lite-model' \
   'claude-sonnet-5' \
+  'would shadow' \
+  'superpowers.json.disabled' \
   'TUI'; do
   grep -Fq -- "$text" "$DOC" || fail "Kiro guide missing $text"
 done

--- a/tests/kiro/test-docs.sh
+++ b/tests/kiro/test-docs.sh
@@ -22,6 +22,9 @@ for text in \
   'Native Windows is not supported' \
   'Kiro Powers' \
   'Load skill' \
+  'superpowers-worker-default-model' \
+  'superpowers-worker-lite-model' \
+  'claude-sonnet-5' \
   'TUI'; do
   grep -Fq -- "$text" "$DOC" || fail "Kiro guide missing $text"
 done

--- a/tests/kiro/test-installer.sh
+++ b/tests/kiro/test-installer.sh
@@ -15,6 +15,14 @@ assert_file_contains() {
   local file="$1" text="$2" label="$3"
   if grep -Fq -- "$text" "$file"; then pass "$label"; else fail "$label"; fi
 }
+assert_file_not_contains() {
+  local file="$1" text="$2" label="$3"
+  if grep -Fq -- "$text" "$file" 2>/dev/null; then fail "$label"; else pass "$label"; fi
+}
+assert_absent() {
+  local path="$1" label="$2"
+  if [ -e "$path" ]; then fail "$label"; else pass "$label"; fi
+}
 
 make_release() {
   local version="$1" release_marker="$2"
@@ -102,6 +110,39 @@ done
 assert_file_contains "$install_root/release-marker.txt" 'release-620' "installs release payload"
 assert_file_contains "$TEST_ROOT/curl.log" '/archive/refs/tags/v6.2.0.tar.gz' "downloads selected tag"
 
+# Neutral workers give the skills a general-purpose dispatch target, so the
+# reviewer template is not substituted with a purpose-built agent.
+worker_default="$home/.kiro/agents/superpowers-worker-default-model.md"
+worker_lite="$home/.kiro/agents/superpowers-worker-lite-model.md"
+for worker in "$worker_default" "$worker_lite"; do
+  label="generates $(basename "$worker")"
+  if [ -f "$worker" ]; then pass "$label"; else fail "$label"; continue; fi
+  assert_file_contains "$worker" 'tools: ["*"]' "$(basename "$worker") grants tools"
+  assert_file_contains "$worker" "skill://$install_root/skills/**/SKILL.md" \
+    "$(basename "$worker") gets absolute skill discovery"
+  assert_file_contains "$worker" 'capability: fs_read' "$(basename "$worker") pre-approves reads"
+  assert_file_contains "$worker" '<!-- Managed by the Superpowers Kiro installer. -->' \
+    "$(basename "$worker") is marked"
+  # The generated body must match the tracked config, which is an independent
+  # copy of the same text.
+  for sentence in \
+    'Execute the dispatching prompt exactly as given. That prompt is the complete' \
+    'specification of your role, process, and output format. Add no persona, no' \
+    'checklist, and no output conventions of your own.'; do
+    assert_file_contains "$worker" "$sentence" "$(basename "$worker") body matches tracked config"
+  done
+  assert_file_not_contains "$worker" 'using-superpowers/SKILL.md' \
+    "$(basename "$worker") must not load the bootstrap"
+done
+assert_file_contains "$worker_lite" 'model: claude-sonnet-5' "lite worker pins the cheaper model"
+if [ ! -f "$worker_default" ]; then
+  fail "default-model worker omits model"
+elif grep -q '^model:' "$worker_default"; then
+  fail "default-model worker omits model"
+else
+  pass "default-model worker omits model"
+fi
+
 archive_630="$(make_release 6.3.0 release-630)"
 if run_installer "$home" "$archive_630" v6.3.0 >/dev/null 2>&1; then
   pass "replaces a managed installation"
@@ -140,6 +181,38 @@ else
   pass "refuses unmanaged payload collision"
 fi
 assert_file_contains "$unmanaged_payload_home/data/superpowers/kiro/personal.txt" 'personal payload content' "preserves unmanaged payload"
+
+unmanaged_worker_home="$TEST_ROOT/unmanaged-worker-home"
+mkdir -p "$unmanaged_worker_home/.kiro/agents"
+printf '%s\n' 'personal worker content' \
+  >"$unmanaged_worker_home/.kiro/agents/superpowers-worker-lite-model.md"
+if run_installer "$unmanaged_worker_home" "$archive_620" v6.2.0 >/dev/null 2>&1; then
+  fail "refuses unmanaged worker collision"
+else
+  pass "refuses unmanaged worker collision"
+fi
+assert_file_contains "$unmanaged_worker_home/.kiro/agents/superpowers-worker-lite-model.md" \
+  'personal worker content' "preserves unmanaged worker"
+# The guard runs before the download, so a refusal must install nothing at all.
+assert_absent "$unmanaged_worker_home/data/superpowers/kiro" \
+  "refused run installs no payload"
+assert_absent "$unmanaged_worker_home/.kiro/agents/superpowers.md" \
+  "refused run creates no main agent"
+assert_absent "$unmanaged_worker_home/.kiro/agents/superpowers-worker-default-model.md" \
+  "refused run creates no other worker"
+
+# Both worker paths must be guarded, not just the one.
+unmanaged_default_home="$TEST_ROOT/unmanaged-default-home"
+mkdir -p "$unmanaged_default_home/.kiro/agents"
+printf '%s\n' 'personal default worker content' \
+  >"$unmanaged_default_home/.kiro/agents/superpowers-worker-default-model.md"
+if run_installer "$unmanaged_default_home" "$archive_620" v6.2.0 >/dev/null 2>&1; then
+  fail "refuses unmanaged default-model worker collision"
+else
+  pass "refuses unmanaged default-model worker collision"
+fi
+assert_file_contains "$unmanaged_default_home/.kiro/agents/superpowers-worker-default-model.md" \
+  'personal default worker content' "preserves unmanaged default-model worker"
 
 invalid_home="$TEST_ROOT/invalid-home"
 mkdir -p "$invalid_home"

--- a/tests/kiro/test-installer.sh
+++ b/tests/kiro/test-installer.sh
@@ -330,6 +330,24 @@ else
 fi
 assert_file_contains "$invalid_home/data/superpowers/kiro/release-marker.txt" 'release-123' "preserves managed payload after invalid archive"
 
+# Literal paths must survive both awk variable passing and replacement.
+for suffix in 'data&more' 'data\backslash'; do
+  special_home="$TEST_ROOT/$suffix"
+  mkdir -p "$special_home"
+  if run_installer "$special_home" "$archive_123" v1.2.3 >/dev/null 2>&1; then
+    for name in superpowers superpowers-worker-default-model superpowers-worker-lite-model; do
+      assert_file_contains "$special_home/.kiro/agents/$name.md" \
+        "skill://$special_home/data/superpowers/kiro/skills/**/SKILL.md" \
+        "$name preserves literal path $suffix"
+      assert_file_contains "$special_home/.kiro/agents/$name.md" \
+        "$special_home/data/superpowers/kiro/skills/<skill-name>/" \
+        "$name preserves literal reference path $suffix"
+    done
+  else
+    fail "installs at literal path $suffix"
+  fi
+done
+
 if [[ "$FAILURES" -ne 0 ]]; then
   echo "$FAILURES Kiro installer test(s) failed"
   exit 1

--- a/tests/kiro/test-installer.sh
+++ b/tests/kiro/test-installer.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$REPO_ROOT/scripts/install-kiro.sh"
+TEST_ROOT="$(mktemp -d)"
+FAILURES=0
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+trap cleanup EXIT
+pass() { echo "  [PASS] $1"; }
+fail() { echo "  [FAIL] $1"; FAILURES=$((FAILURES + 1)); }
+assert_file_contains() {
+  local file="$1" text="$2" label="$3"
+  if grep -Fq -- "$text" "$file"; then pass "$label"; else fail "$label"; fi
+}
+
+make_release() {
+  local version="$1" release_marker="$2"
+  local root="$TEST_ROOT/build-$version/superpowers-$version"
+  rm -rf "$TEST_ROOT/build-$version"
+  mkdir -p "$root/.kiro/agents" "$root/skills/using-superpowers/references"
+  cp -R "$REPO_ROOT/skills/." "$root/skills/"
+  cp "$REPO_ROOT/.kiro/agents/superpowers.md" "$root/.kiro/agents/superpowers.md"
+  printf '{\n  "name": "superpowers",\n  "version": "%s"\n}\n' "$version" >"$root/package.json"
+  printf '%s\n' "$release_marker" >"$root/release-marker.txt"
+  tar -czf "$TEST_ROOT/superpowers-$version.tar.gz" -C "$TEST_ROOT/build-$version" "superpowers-$version"
+  printf '%s\n' "$TEST_ROOT/superpowers-$version.tar.gz"
+}
+
+make_release_without_kiro_mapping() {
+  local version="$1" release_marker="$2"
+  local archive
+  archive="$(make_release "$version" "$release_marker")"
+  tar -xzf "$archive" -C "$TEST_ROOT"
+  rm "$TEST_ROOT/superpowers-$version/skills/using-superpowers/references/kiro-tools.md"
+  tar -czf "$TEST_ROOT/invalid-$version.tar.gz" -C "$TEST_ROOT" "superpowers-$version"
+  rm -rf "$TEST_ROOT/superpowers-$version"
+  printf '%s\n' "$TEST_ROOT/invalid-$version.tar.gz"
+}
+
+mkdir -p "$TEST_ROOT/fakebin"
+cat >"$TEST_ROOT/fakebin/curl" <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf '%s\n' "$url" >>"$KIRO_TEST_CURL_LOG"
+if [[ "$url" == *'/releases/latest' ]]; then
+  printf '{"tag_name":"%s"}\n' "$KIRO_TEST_LATEST_TAG"
+else
+  cp "$KIRO_TEST_ARCHIVE" "$out"
+fi
+CURL
+chmod +x "$TEST_ROOT/fakebin/curl"
+
+run_installer() {
+  local home="$1" archive="$2"
+  shift 2
+  HOME="$home" \
+  XDG_DATA_HOME="$home/data" \
+  PATH="$TEST_ROOT/fakebin:$PATH" \
+  KIRO_TEST_ARCHIVE="$archive" \
+  KIRO_TEST_LATEST_TAG="v6.2.0" \
+  KIRO_TEST_CURL_LOG="$TEST_ROOT/curl.log" \
+    sh "$INSTALLER" "$@"
+}
+
+archive_620="$(make_release 6.2.0 release-620)"
+home="$TEST_ROOT/home"
+mkdir -p "$home"
+: >"$TEST_ROOT/curl.log"
+
+if output="$(run_installer "$home" "$archive_620" v6.2.0 2>&1)"; then
+  pass "installs an explicit stable release"
+else
+  fail "installs an explicit stable release"
+  printf '%s\n' "$output"
+fi
+install_root="$home/data/superpowers/kiro"
+agent="$home/.kiro/agents/superpowers.md"
+assert_file_contains "$install_root/.superpowers-kiro-install" '6.2.0' "records installed version"
+assert_file_contains "$agent" "file://$install_root/skills/using-superpowers/SKILL.md" "generates absolute bootstrap URI"
+assert_file_contains "$agent" "skill://$install_root/skills/**/SKILL.md" "generates absolute skill URI"
+assert_file_contains "$agent" '<!-- Managed by the Superpowers Kiro installer. -->' "marks generated agent"
+for text in \
+  'tools: ["*"]' \
+  'capability: fs_read' \
+  'capability: skill' \
+  'welcomeMessage: Superpowers is active. Relevant workflow skills load automatically.' \
+  'follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.'; do
+  assert_file_contains "$agent" "$text" "keeps repository and installed agent semantics aligned"
+done
+assert_file_contains "$install_root/release-marker.txt" 'release-620' "installs release payload"
+assert_file_contains "$TEST_ROOT/curl.log" '/archive/refs/tags/v6.2.0.tar.gz' "downloads selected tag"
+
+archive_630="$(make_release 6.3.0 release-630)"
+if run_installer "$home" "$archive_630" v6.3.0 >/dev/null 2>&1; then
+  pass "replaces a managed installation"
+else
+  fail "replaces a managed installation"
+fi
+assert_file_contains "$install_root/.superpowers-kiro-install" '6.3.0' "updates version marker"
+assert_file_contains "$install_root/release-marker.txt" 'release-630' "replaces old payload"
+
+latest_home="$TEST_ROOT/latest-home"
+mkdir -p "$latest_home"
+: >"$TEST_ROOT/curl.log"
+if run_installer "$latest_home" "$archive_620" >/dev/null 2>&1; then
+  pass "resolves the latest release"
+else
+  fail "resolves the latest release"
+fi
+assert_file_contains "$TEST_ROOT/curl.log" '/releases/latest' "queries GitHub latest release"
+
+unmanaged_agent_home="$TEST_ROOT/unmanaged-agent-home"
+mkdir -p "$unmanaged_agent_home/.kiro/agents"
+printf '%s\n' 'personal agent content' >"$unmanaged_agent_home/.kiro/agents/superpowers.md"
+if run_installer "$unmanaged_agent_home" "$archive_620" v6.2.0 >/dev/null 2>&1; then
+  fail "refuses unmanaged agent collision"
+else
+  pass "refuses unmanaged agent collision"
+fi
+assert_file_contains "$unmanaged_agent_home/.kiro/agents/superpowers.md" 'personal agent content' "preserves unmanaged agent"
+
+unmanaged_payload_home="$TEST_ROOT/unmanaged-payload-home"
+mkdir -p "$unmanaged_payload_home/data/superpowers/kiro"
+printf '%s\n' 'personal payload content' >"$unmanaged_payload_home/data/superpowers/kiro/personal.txt"
+if run_installer "$unmanaged_payload_home" "$archive_620" v6.2.0 >/dev/null 2>&1; then
+  fail "refuses unmanaged payload collision"
+else
+  pass "refuses unmanaged payload collision"
+fi
+assert_file_contains "$unmanaged_payload_home/data/superpowers/kiro/personal.txt" 'personal payload content' "preserves unmanaged payload"
+
+invalid_home="$TEST_ROOT/invalid-home"
+mkdir -p "$invalid_home"
+run_installer "$invalid_home" "$archive_620" v6.2.0 >/dev/null
+invalid_archive="$(make_release_without_kiro_mapping 6.4.0 invalid-release)"
+if run_installer "$invalid_home" "$invalid_archive" v6.4.0 >/dev/null 2>&1; then
+  fail "rejects archive missing Kiro mapping"
+else
+  pass "rejects archive missing Kiro mapping"
+fi
+assert_file_contains "$invalid_home/data/superpowers/kiro/release-marker.txt" 'release-620' "preserves managed payload after invalid archive"
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES Kiro installer test(s) failed"
+  exit 1
+fi
+echo "PASS: Kiro installer happy path and replacement"

--- a/tests/kiro/test-installer.sh
+++ b/tests/kiro/test-installer.sh
@@ -23,6 +23,16 @@ assert_absent() {
   local path="$1" label="$2"
   if [ -e "$path" ]; then fail "$label"; else pass "$label"; fi
 }
+resources_are_present() {
+  local profile="$1" resources="$2"
+  local entry scheme rest
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    scheme="${entry%%://*}"
+    rest="${entry#*://}"
+    grep -Fq -- "$scheme://$install_root/$rest" "$profile" || return 1
+  done <<< "$resources"
+}
 
 make_release() {
   local version="$1" release_marker="$2"
@@ -77,17 +87,18 @@ run_installer() {
   XDG_DATA_HOME="$home/data" \
   PATH="$TEST_ROOT/fakebin:$PATH" \
   KIRO_TEST_ARCHIVE="$archive" \
-  KIRO_TEST_LATEST_TAG="v6.2.0" \
+  KIRO_TEST_LATEST_TAG="v1.2.3" \
   KIRO_TEST_CURL_LOG="$TEST_ROOT/curl.log" \
     sh "$INSTALLER" "$@"
 }
 
-archive_620="$(make_release 6.2.0 release-620)"
+fixture_version="1.2.3"
+archive_123="$(make_release "$fixture_version" release-123)"
 home="$TEST_ROOT/home"
 mkdir -p "$home"
 : >"$TEST_ROOT/curl.log"
 
-if output="$(run_installer "$home" "$archive_620" v6.2.0 2>&1)"; then
+if output="$(run_installer "$home" "$archive_123" v1.2.3 2>&1)"; then
   pass "installs an explicit stable release"
 else
   fail "installs an explicit stable release"
@@ -95,9 +106,96 @@ else
 fi
 install_root="$home/data/superpowers/kiro"
 agent="$home/.kiro/agents/superpowers.md"
-assert_file_contains "$install_root/.superpowers-kiro-install" '6.2.0' "records installed version"
-assert_file_contains "$agent" "file://$install_root/skills/using-superpowers/SKILL.md" "generates absolute bootstrap URI"
-assert_file_contains "$agent" "skill://$install_root/skills/**/SKILL.md" "generates absolute skill URI"
+
+# XDG_DATA_HOME must be absolute. A relative value would write the payload into
+# the current directory and emit relative resource URIs, defeating the absolute
+# path profile while still reporting success.
+relative_home="$TEST_ROOT/relative-home"
+mkdir -p "$relative_home" "$TEST_ROOT/relative-cwd"
+if (cd "$TEST_ROOT/relative-cwd" \
+  && HOME="$relative_home" XDG_DATA_HOME="relative-data" \
+     PATH="$TEST_ROOT/fakebin:$PATH" KIRO_TEST_ARCHIVE="$archive_123" \
+     KIRO_TEST_LATEST_TAG="v1.2.3" KIRO_TEST_CURL_LOG="$TEST_ROOT/curl.log" \
+     sh "$INSTALLER" v1.2.3 >/dev/null 2>&1); then
+  fail "refuses a relative XDG_DATA_HOME"
+else
+  pass "refuses a relative XDG_DATA_HOME"
+fi
+assert_absent "$TEST_ROOT/relative-cwd/relative-data" \
+  "relative XDG_DATA_HOME writes nothing into the working directory"
+
+# These characters would make the generated double-quoted YAML resources
+# invalid or split them across lines, so reject them before any download or
+# filesystem changes.
+quoted_data_home="$TEST_ROOT/data\"quoted"
+quoted_home="$TEST_ROOT/quoted-home"
+mkdir -p "$quoted_home"
+if HOME="$quoted_home" XDG_DATA_HOME="$quoted_data_home" \
+  PATH="$TEST_ROOT/fakebin:$PATH" KIRO_TEST_ARCHIVE="$archive_123" \
+  KIRO_TEST_LATEST_TAG="v1.2.3" KIRO_TEST_CURL_LOG="$TEST_ROOT/curl.log" \
+  sh "$INSTALLER" v1.2.3 >/dev/null 2>&1; then
+  fail "refuses a quote in the install path"
+else
+  pass "refuses a quote in the install path"
+fi
+assert_absent "$quoted_data_home" "quoted install path writes no payload"
+
+newline_data_home="$TEST_ROOT/data"$'\n'"newline"
+newline_home="$TEST_ROOT/newline-home"
+mkdir -p "$newline_home"
+if HOME="$newline_home" XDG_DATA_HOME="$newline_data_home" \
+  PATH="$TEST_ROOT/fakebin:$PATH" KIRO_TEST_ARCHIVE="$archive_123" \
+  KIRO_TEST_LATEST_TAG="v1.2.3" KIRO_TEST_CURL_LOG="$TEST_ROOT/curl.log" \
+  sh "$INSTALLER" v1.2.3 >/dev/null 2>&1; then
+  fail "refuses a newline in the install path"
+else
+  pass "refuses a newline in the install path"
+fi
+assert_absent "$newline_data_home" "newline install path writes no payload"
+
+# A failed "latest" lookup must not be reported as a malformed argument: the
+# user passed no argument at all.
+mkdir -p "$TEST_ROOT/failbin"
+printf '%s\n' '#!/bin/sh' 'exit 22' >"$TEST_ROOT/failbin/curl"
+chmod +x "$TEST_ROOT/failbin/curl"
+latest_fail_home="$TEST_ROOT/latest-fail-home"
+mkdir -p "$latest_fail_home"
+latest_fail_output="$(HOME="$latest_fail_home" \
+  XDG_DATA_HOME="$latest_fail_home/data" PATH="$TEST_ROOT/failbin:$PATH" \
+  sh "$INSTALLER" 2>&1 || true)"
+if printf '%s' "$latest_fail_output" | grep -Fq 'could not resolve the latest release'; then
+  pass "reports a failed latest lookup accurately"
+else
+  fail "reports a failed latest lookup accurately (got: $latest_fail_output)"
+fi
+
+assert_file_contains "$install_root/.superpowers-kiro-install" "$fixture_version" "records installed version"
+# Every resource the tracked profile declares must appear in the generated one,
+# with the install root prefixed. Asserting the whole list rather than two
+# hand-picked entries: a dropped resource silently costs installed users half
+# the bootstrap, and a partial assertion would not notice.
+tracked_resources="$(awk '
+  /^resources:/ { inside = 1; next }
+  inside && /^  - / { sub(/^  - /, ""); gsub(/"/, ""); print; next }
+  inside { inside = 0 }
+' "$REPO_ROOT/.kiro/agents/superpowers.md")"
+if [ -z "$tracked_resources" ]; then
+  fail "could not read resources from the tracked profile"
+elif resources_are_present "$agent" "$tracked_resources"; then
+  pass "generates every resource declared by the tracked profile"
+else
+  fail "generates every resource declared by the tracked profile"
+fi
+
+# Prove the parity check is non-vacuous: removing just the mapping URI from an
+# otherwise valid generated profile must be detected.
+missing_resource_agent="$TEST_ROOT/generated-agent-missing-resource.md"
+sed '/kiro-tools\.md/d' "$agent" > "$missing_resource_agent"
+if resources_are_present "$missing_resource_agent" "$tracked_resources"; then
+  fail "resource parity detects a missing mapping URI"
+else
+  pass "resource parity detects a missing mapping URI"
+fi
 assert_file_contains "$agent" '<!-- Managed by the Superpowers Kiro installer. -->' "marks generated agent"
 for text in \
   'tools: ["*"]' \
@@ -107,8 +205,8 @@ for text in \
   'follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.'; do
   assert_file_contains "$agent" "$text" "keeps repository and installed agent semantics aligned"
 done
-assert_file_contains "$install_root/release-marker.txt" 'release-620' "installs release payload"
-assert_file_contains "$TEST_ROOT/curl.log" '/archive/refs/tags/v6.2.0.tar.gz' "downloads selected tag"
+assert_file_contains "$install_root/release-marker.txt" 'release-123' "installs release payload"
+assert_file_contains "$TEST_ROOT/curl.log" '/archive/refs/tags/v1.2.3.tar.gz' "downloads selected tag"
 
 # Neutral workers give the skills a general-purpose dispatch target, so the
 # reviewer template is not substituted with a purpose-built agent.
@@ -143,19 +241,19 @@ else
   pass "default-model worker omits model"
 fi
 
-archive_630="$(make_release 6.3.0 release-630)"
-if run_installer "$home" "$archive_630" v6.3.0 >/dev/null 2>&1; then
+archive_130="$(make_release 1.3.0 release-130)"
+if run_installer "$home" "$archive_130" v1.3.0 >/dev/null 2>&1; then
   pass "replaces a managed installation"
 else
   fail "replaces a managed installation"
 fi
-assert_file_contains "$install_root/.superpowers-kiro-install" '6.3.0' "updates version marker"
-assert_file_contains "$install_root/release-marker.txt" 'release-630' "replaces old payload"
+assert_file_contains "$install_root/.superpowers-kiro-install" '1.3.0' "updates version marker"
+assert_file_contains "$install_root/release-marker.txt" 'release-130' "replaces old payload"
 
 latest_home="$TEST_ROOT/latest-home"
 mkdir -p "$latest_home"
 : >"$TEST_ROOT/curl.log"
-if run_installer "$latest_home" "$archive_620" >/dev/null 2>&1; then
+if run_installer "$latest_home" "$archive_123" >/dev/null 2>&1; then
   pass "resolves the latest release"
 else
   fail "resolves the latest release"
@@ -165,7 +263,7 @@ assert_file_contains "$TEST_ROOT/curl.log" '/releases/latest' "queries GitHub la
 unmanaged_agent_home="$TEST_ROOT/unmanaged-agent-home"
 mkdir -p "$unmanaged_agent_home/.kiro/agents"
 printf '%s\n' 'personal agent content' >"$unmanaged_agent_home/.kiro/agents/superpowers.md"
-if run_installer "$unmanaged_agent_home" "$archive_620" v6.2.0 >/dev/null 2>&1; then
+if run_installer "$unmanaged_agent_home" "$archive_123" v1.2.3 >/dev/null 2>&1; then
   fail "refuses unmanaged agent collision"
 else
   pass "refuses unmanaged agent collision"
@@ -175,7 +273,7 @@ assert_file_contains "$unmanaged_agent_home/.kiro/agents/superpowers.md" 'person
 unmanaged_payload_home="$TEST_ROOT/unmanaged-payload-home"
 mkdir -p "$unmanaged_payload_home/data/superpowers/kiro"
 printf '%s\n' 'personal payload content' >"$unmanaged_payload_home/data/superpowers/kiro/personal.txt"
-if run_installer "$unmanaged_payload_home" "$archive_620" v6.2.0 >/dev/null 2>&1; then
+if run_installer "$unmanaged_payload_home" "$archive_123" v1.2.3 >/dev/null 2>&1; then
   fail "refuses unmanaged payload collision"
 else
   pass "refuses unmanaged payload collision"
@@ -186,7 +284,7 @@ unmanaged_worker_home="$TEST_ROOT/unmanaged-worker-home"
 mkdir -p "$unmanaged_worker_home/.kiro/agents"
 printf '%s\n' 'personal worker content' \
   >"$unmanaged_worker_home/.kiro/agents/superpowers-worker-lite-model.md"
-if run_installer "$unmanaged_worker_home" "$archive_620" v6.2.0 >/dev/null 2>&1; then
+if run_installer "$unmanaged_worker_home" "$archive_123" v1.2.3 >/dev/null 2>&1; then
   fail "refuses unmanaged worker collision"
 else
   pass "refuses unmanaged worker collision"
@@ -206,7 +304,7 @@ unmanaged_default_home="$TEST_ROOT/unmanaged-default-home"
 mkdir -p "$unmanaged_default_home/.kiro/agents"
 printf '%s\n' 'personal default worker content' \
   >"$unmanaged_default_home/.kiro/agents/superpowers-worker-default-model.md"
-if run_installer "$unmanaged_default_home" "$archive_620" v6.2.0 >/dev/null 2>&1; then
+if run_installer "$unmanaged_default_home" "$archive_123" v1.2.3 >/dev/null 2>&1; then
   fail "refuses unmanaged default-model worker collision"
 else
   pass "refuses unmanaged default-model worker collision"
@@ -214,16 +312,37 @@ fi
 assert_file_contains "$unmanaged_default_home/.kiro/agents/superpowers-worker-default-model.md" \
   'personal default worker content' "preserves unmanaged default-model worker"
 
+# A same-named .json config defines the same agent and wins over the Markdown
+# one this installer writes, so installing beside it would silently shadow the
+# new agent. Manual and pre-Markdown setups look exactly like this.
+for shadow in superpowers superpowers-worker-default-model superpowers-worker-lite-model; do
+  shadow_home="$TEST_ROOT/shadow-home-$shadow"
+  mkdir -p "$shadow_home/.kiro/agents"
+  printf '%s\n' "{\"name\":\"$shadow\",\"description\":\"hand-written\"}" \
+    >"$shadow_home/.kiro/agents/$shadow.json"
+  if run_installer "$shadow_home" "$archive_123" v1.2.3 >/dev/null 2>&1; then
+    fail "refuses shadowing $shadow.json"
+  else
+    pass "refuses shadowing $shadow.json"
+  fi
+  assert_file_contains "$shadow_home/.kiro/agents/$shadow.json" 'hand-written' \
+    "preserves hand-written $shadow.json"
+  assert_absent "$shadow_home/.kiro/agents/superpowers.md" \
+    "shadowed run creates no Markdown agent for $shadow.json"
+  assert_absent "$shadow_home/data/superpowers/kiro" \
+    "shadowed run installs no payload for $shadow.json"
+done
+
 invalid_home="$TEST_ROOT/invalid-home"
 mkdir -p "$invalid_home"
-run_installer "$invalid_home" "$archive_620" v6.2.0 >/dev/null
+run_installer "$invalid_home" "$archive_123" v1.2.3 >/dev/null
 invalid_archive="$(make_release_without_kiro_mapping 6.4.0 invalid-release)"
 if run_installer "$invalid_home" "$invalid_archive" v6.4.0 >/dev/null 2>&1; then
   fail "rejects archive missing Kiro mapping"
 else
   pass "rejects archive missing Kiro mapping"
 fi
-assert_file_contains "$invalid_home/data/superpowers/kiro/release-marker.txt" 'release-620' "preserves managed payload after invalid archive"
+assert_file_contains "$invalid_home/data/superpowers/kiro/release-marker.txt" 'release-123' "preserves managed payload after invalid archive"
 
 if [[ "$FAILURES" -ne 0 ]]; then
   echo "$FAILURES Kiro installer test(s) failed"

--- a/tests/kiro/test-installer.sh
+++ b/tests/kiro/test-installer.sh
@@ -15,23 +15,38 @@ assert_file_contains() {
   local file="$1" text="$2" label="$3"
   if grep -Fq -- "$text" "$file"; then pass "$label"; else fail "$label"; fi
 }
-assert_file_not_contains() {
-  local file="$1" text="$2" label="$3"
-  if grep -Fq -- "$text" "$file" 2>/dev/null; then fail "$label"; else pass "$label"; fi
-}
 assert_absent() {
   local path="$1" label="$2"
   if [ -e "$path" ]; then fail "$label"; else pass "$label"; fi
 }
-resources_are_present() {
-  local profile="$1" resources="$2"
-  local entry scheme rest
-  while IFS= read -r entry; do
-    [ -n "$entry" ] || continue
-    scheme="${entry%%://*}"
-    rest="${entry#*://}"
-    grep -Fq -- "$scheme://$install_root/$rest" "$profile" || return 1
-  done <<< "$resources"
+# The installed agent must be the tracked repository profile with only two
+# changes: every resource URI made absolute under the install root, and the
+# ownership marker inserted. Stripping those back must reproduce the tracked
+# file byte-for-byte. This one check replaces a pile of hand-picked string
+# assertions and catches any drift — body, frontmatter, or permissions.
+assert_matches_tracked() {
+  local name="$1"
+  local generated="$home/.kiro/agents/$name.md"
+  local tracked="$REPO_ROOT/.kiro/agents/$name.md"
+  if [ ! -f "$generated" ]; then fail "generates $name.md"; return; fi
+  assert_file_contains "$generated" '<!-- Managed by the Superpowers Kiro installer. -->' \
+    "$name.md carries the ownership marker"
+  # Non-vacuity: the transform must change something. If the raw files were
+  # already identical, the normalized comparison below would pass for free.
+  if diff -q "$generated" "$tracked" >/dev/null 2>&1; then
+    fail "$name.md differs from the tracked profile before normalization"
+  else
+    pass "$name.md differs from the tracked profile before normalization"
+  fi
+  local normalized
+  normalized="$(sed -e "s#$install_root/##g" \
+    -e '/^<!-- Managed by the Superpowers Kiro installer\. -->$/d' "$generated")"
+  if [ "$normalized" = "$(cat "$tracked")" ]; then
+    pass "$name.md equals the tracked profile modulo install root and marker"
+  else
+    fail "$name.md equals the tracked profile modulo install root and marker"
+    diff <(printf '%s\n' "$normalized") "$tracked" | sed 's/^/    /' | head -20
+  fi
 }
 
 make_release() {
@@ -40,7 +55,10 @@ make_release() {
   rm -rf "$TEST_ROOT/build-$version"
   mkdir -p "$root/.kiro/agents" "$root/skills/using-superpowers/references"
   cp -R "$REPO_ROOT/skills/." "$root/skills/"
-  cp "$REPO_ROOT/.kiro/agents/superpowers.md" "$root/.kiro/agents/superpowers.md"
+  cp "$REPO_ROOT/.kiro/agents/superpowers.md" \
+     "$REPO_ROOT/.kiro/agents/superpowers-worker-default-model.md" \
+     "$REPO_ROOT/.kiro/agents/superpowers-worker-lite-model.md" \
+     "$root/.kiro/agents/"
   printf '{\n  "name": "superpowers",\n  "version": "%s"\n}\n' "$version" >"$root/package.json"
   printf '%s\n' "$release_marker" >"$root/release-marker.txt"
   tar -czf "$TEST_ROOT/superpowers-$version.tar.gz" -C "$TEST_ROOT/build-$version" "superpowers-$version"
@@ -170,72 +188,27 @@ else
 fi
 
 assert_file_contains "$install_root/.superpowers-kiro-install" "$fixture_version" "records installed version"
-# Every resource the tracked profile declares must appear in the generated one,
-# with the install root prefixed. Asserting the whole list rather than two
-# hand-picked entries: a dropped resource silently costs installed users half
-# the bootstrap, and a partial assertion would not notice.
-tracked_resources="$(awk '
-  /^resources:/ { inside = 1; next }
-  inside && /^  - / { sub(/^  - /, ""); gsub(/"/, ""); print; next }
-  inside { inside = 0 }
-' "$REPO_ROOT/.kiro/agents/superpowers.md")"
-if [ -z "$tracked_resources" ]; then
-  fail "could not read resources from the tracked profile"
-elif resources_are_present "$agent" "$tracked_resources"; then
-  pass "generates every resource declared by the tracked profile"
-else
-  fail "generates every resource declared by the tracked profile"
-fi
-
-# Prove the parity check is non-vacuous: removing just the mapping URI from an
-# otherwise valid generated profile must be detected.
-missing_resource_agent="$TEST_ROOT/generated-agent-missing-resource.md"
-sed '/kiro-tools\.md/d' "$agent" > "$missing_resource_agent"
-if resources_are_present "$missing_resource_agent" "$tracked_resources"; then
-  fail "resource parity detects a missing mapping URI"
-else
-  pass "resource parity detects a missing mapping URI"
-fi
-assert_file_contains "$agent" '<!-- Managed by the Superpowers Kiro installer. -->' "marks generated agent"
-for text in \
-  'tools: ["*"]' \
-  'capability: fs_read' \
-  'capability: skill' \
-  'welcomeMessage: Superpowers is active. Relevant workflow skills load automatically.' \
-  'follows the loaded Superpowers bootstrap and Kiro tool-mapping instructions.'; do
-  assert_file_contains "$agent" "$text" "keeps repository and installed agent semantics aligned"
-done
+# The installed main agent must be the tracked profile with only absolute
+# resource URIs and the ownership marker added.
+assert_matches_tracked superpowers
+assert_file_contains "$agent" "file://$install_root/skills/using-superpowers/SKILL.md" \
+  "absolutizes the bootstrap file resource"
+assert_file_contains "$agent" "file://$install_root/skills/using-superpowers/references/kiro-tools.md" \
+  "absolutizes the tool-mapping file resource"
+assert_file_contains "$agent" "skill://$install_root/skills/**/SKILL.md" \
+  "absolutizes the skill discovery glob"
 assert_file_contains "$install_root/release-marker.txt" 'release-123' "installs release payload"
 assert_file_contains "$TEST_ROOT/curl.log" '/archive/refs/tags/v1.2.3.tar.gz' "downloads selected tag"
 
 # Neutral workers give the skills a general-purpose dispatch target, so the
-# reviewer template is not substituted with a purpose-built agent.
+# reviewer template is not substituted with a purpose-built agent. Each is the
+# tracked worker profile with only absolute skill discovery and the marker added.
 worker_default="$home/.kiro/agents/superpowers-worker-default-model.md"
 worker_lite="$home/.kiro/agents/superpowers-worker-lite-model.md"
-for worker in "$worker_default" "$worker_lite"; do
-  label="generates $(basename "$worker")"
-  if [ -f "$worker" ]; then pass "$label"; else fail "$label"; continue; fi
-  assert_file_contains "$worker" 'tools: ["*"]' "$(basename "$worker") grants tools"
-  assert_file_contains "$worker" "skill://$install_root/skills/**/SKILL.md" \
-    "$(basename "$worker") gets absolute skill discovery"
-  assert_file_contains "$worker" 'capability: fs_read' "$(basename "$worker") pre-approves reads"
-  assert_file_contains "$worker" '<!-- Managed by the Superpowers Kiro installer. -->' \
-    "$(basename "$worker") is marked"
-  # The generated body must match the tracked config, which is an independent
-  # copy of the same text.
-  for sentence in \
-    'Execute the dispatching prompt exactly as given. That prompt is the complete' \
-    'specification of your role, process, and output format. Add no persona, no' \
-    'checklist, and no output conventions of your own.'; do
-    assert_file_contains "$worker" "$sentence" "$(basename "$worker") body matches tracked config"
-  done
-  assert_file_not_contains "$worker" 'using-superpowers/SKILL.md' \
-    "$(basename "$worker") must not load the bootstrap"
-done
+assert_matches_tracked superpowers-worker-default-model
+assert_matches_tracked superpowers-worker-lite-model
 assert_file_contains "$worker_lite" 'model: claude-sonnet-5' "lite worker pins the cheaper model"
-if [ ! -f "$worker_default" ]; then
-  fail "default-model worker omits model"
-elif grep -q '^model:' "$worker_default"; then
+if [ -f "$worker_default" ] && grep -q '^model:' "$worker_default"; then
   fail "default-model worker omits model"
 else
   pass "default-model worker omits model"

--- a/tests/kiro/test-installer.sh
+++ b/tests/kiro/test-installer.sh
@@ -19,11 +19,15 @@ assert_absent() {
   local path="$1" label="$2"
   if [ -e "$path" ]; then fail "$label"; else pass "$label"; fi
 }
-# The installed agent must be the tracked repository profile with only two
-# changes: every resource URI made absolute under the install root, and the
-# ownership marker inserted. Stripping those back must reproduce the tracked
-# file byte-for-byte. This one check replaces a pile of hand-picked string
-# assertions and catches any drift — body, frontmatter, or permissions.
+assert_file_not_contains() {
+  local file="$1" text="$2" label="$3"
+  if grep -Fq -- "$text" "$file" 2>/dev/null; then fail "$label"; else pass "$label"; fi
+}
+# The installed agent must be the tracked repository profile with three defined
+# changes: resource URIs made absolute, the `{{SUPERPOWERS_SKILLS_DIR}}`
+# placeholder substituted with `<install_root>/skills`, and the ownership marker
+# inserted. Reversing all three must reproduce the tracked file byte-for-byte, so
+# any other drift — body, frontmatter, permissions — fails this check.
 assert_matches_tracked() {
   local name="$1"
   local generated="$home/.kiro/agents/$name.md"
@@ -31,20 +35,29 @@ assert_matches_tracked() {
   if [ ! -f "$generated" ]; then fail "generates $name.md"; return; fi
   assert_file_contains "$generated" '<!-- Managed by the Superpowers Kiro installer. -->' \
     "$name.md carries the ownership marker"
-  # Non-vacuity: the transform must change something. If the raw files were
-  # already identical, the normalized comparison below would pass for free.
+  # The placeholder must be substituted with the absolute skills directory, and
+  # no unsubstituted placeholder may leak into the installed agent.
+  assert_file_contains "$generated" "$install_root/skills/<skill-name>/" \
+    "$name.md resolves reference files under the install root"
+  assert_file_not_contains "$generated" '{{SUPERPOWERS_SKILLS_DIR}}' \
+    "$name.md has no unsubstituted skills-dir placeholder"
+  # Non-vacuity: the transform must change something.
   if diff -q "$generated" "$tracked" >/dev/null 2>&1; then
     fail "$name.md differs from the tracked profile before normalization"
   else
     pass "$name.md differs from the tracked profile before normalization"
   fi
+  # Reverse the three transforms: URI absolutization first (only resource lines
+  # carry `://<root>/`), then the placeholder substitution (only the body now
+  # carries `<root>/skills`), then drop the marker line.
   local normalized
-  normalized="$(sed -e "s#$install_root/##g" \
-    -e '/^<!-- Managed by the Superpowers Kiro installer\. -->$/d' "$generated")"
+  normalized="$(sed -e "s#://$install_root/#://#g" "$generated" \
+    | sed -e "s#$install_root/skills#{{SUPERPOWERS_SKILLS_DIR}}#g" \
+          -e '/^<!-- Managed by the Superpowers Kiro installer\. -->$/d')"
   if [ "$normalized" = "$(cat "$tracked")" ]; then
-    pass "$name.md equals the tracked profile modulo install root and marker"
+    pass "$name.md equals the tracked profile after reversing the transforms"
   else
-    fail "$name.md equals the tracked profile modulo install root and marker"
+    fail "$name.md equals the tracked profile after reversing the transforms"
     diff <(printf '%s\n' "$normalized") "$tracked" | sed 's/^/    /' | head -20
   fi
 }

--- a/tests/kiro/test-local-source.sh
+++ b/tests/kiro/test-local-source.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALLER="$REPO_ROOT/scripts/install-kiro.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+source_dir="$TEST_ROOT/local checkout"
+mkdir -p "$source_dir/.kiro/agents" "$source_dir/.git" "$TEST_ROOT/bin"
+cp -R "$REPO_ROOT/skills" "$source_dir/"
+cp "$REPO_ROOT"/.kiro/agents/*.md "$source_dir/.kiro/agents/"
+printf '{\n "version": "6.3.0-dev"\n}\n' > "$source_dir/package.json"
+printf 'uncommitted content\n' > "$source_dir/skills/local-change.txt"
+printf 'exclude me\n' > "$source_dir/unrelated.txt"
+printf '#!/bin/sh\nexit 99\n' > "$TEST_ROOT/bin/curl"
+chmod +x "$TEST_ROOT/bin/curl"
+run() {
+  HOME="$TEST_ROOT/home" XDG_DATA_HOME="$TEST_ROOT/data" \
+    PATH="$TEST_ROOT/bin:$PATH" sh "$INSTALLER" "$@"
+}
+if ! (cd "$TEST_ROOT" && run --source './local checkout') > "$TEST_ROOT/log" 2>&1; then
+  cat "$TEST_ROOT/log"; fail 'installs local source without network access'
+fi
+payload="$TEST_ROOT/data/superpowers/kiro"
+agent="$TEST_ROOT/home/.kiro/agents/superpowers.md"
+cmp "$source_dir/skills/local-change.txt" "$payload/skills/local-change.txt"
+[ ! -e "$payload/.git" ] && [ ! -e "$payload/unrelated.txt" ] || fail 'copies unrelated files'
+grep -Fq 'source: local' "$payload/.superpowers-kiro-install" || fail 'missing local provenance'
+grep -Fq '6.3.0-dev' "$payload/.superpowers-kiro-install" || fail 'missing development version'
+grep -Fq "file://$payload/skills/using-superpowers/SKILL.md" "$agent" || fail 'resources are not installed paths'
+[ ! -e "$source_dir/.superpowers-kiro-install" ] || fail 'modified source checkout'
+cp -R "$payload" "$TEST_ROOT/before"
+cp "$agent" "$TEST_ROOT/agent-before"
+# Invalid sources must preserve the managed installation.
+for args in missing empty incomplete; do
+  bad="$TEST_ROOT/$args"
+  if [ "$args" != missing ]; then mkdir -p "$bad"; fi
+  if run --source "$bad" > "$TEST_ROOT/log" 2>&1; then fail "accepts $args source"; fi
+  diff -r "$TEST_ROOT/before" "$payload"
+  cmp "$TEST_ROOT/agent-before" "$agent"
+done
+for form in missing-argument extra-tag reversed-tag; do
+  case "$form" in
+    missing-argument) set -- --source ;;
+    extra-tag) set -- --source "$source_dir" v6.3.0 ;;
+    reversed-tag) set -- v6.3.0 --source "$source_dir" ;;
+  esac
+  if run "$@" > "$TEST_ROOT/log" 2>&1; then fail "accepts $form"; fi
+  grep -Fq 'usage:' "$TEST_ROOT/log" || fail "unclear $form error"
+done
+# Missing version metadata must not pass local validation.
+printf '{}\n' > "$source_dir/package.json"
+if run --source "$source_dir" > "$TEST_ROOT/log" 2>&1; then fail 'accepts missing version'; fi
+diff -r "$TEST_ROOT/before" "$payload"
+printf '{\n "version": "6.3.0-dev"\n}\n' > "$source_dir/package.json"
+printf 'updated content\n' > "$source_dir/skills/local-change.txt"
+run --source "$source_dir" > /dev/null
+rm -rf "$source_dir"
+grep -Fq 'updated content' "$payload/skills/local-change.txt" || fail 'does not install independent updated snapshot'
+# The local route must still honor unmanaged destination guards.
+printf 'personal agent\n' > "$agent"
+if run --source "$REPO_ROOT" > "$TEST_ROOT/log" 2>&1; then fail 'overwrites unmanaged agent'; fi
+grep -Fxq 'personal agent' "$agent" || fail 'damages unmanaged agent'
+echo 'PASS: local source snapshots, validation, and ownership guards'

--- a/tests/kiro/test-local-source.sh
+++ b/tests/kiro/test-local-source.sh
@@ -54,6 +54,8 @@ if run --source "$source_dir" > "$TEST_ROOT/log" 2>&1; then fail 'accepts missin
 diff -r "$TEST_ROOT/before" "$payload"
 printf '{\n "version": "6.3.0-dev"\n}\n' > "$source_dir/package.json"
 printf 'updated content\n' > "$source_dir/skills/local-change.txt"
+# A valid compact package.json must work too.
+printf '{"name":"superpowers","version":"6.3.0-dev"}\n' > "$source_dir/package.json"
 run --source "$source_dir" > /dev/null
 rm -rf "$source_dir"
 grep -Fq 'updated content' "$payload/skills/local-change.txt" || fail 'does not install independent updated snapshot'

--- a/tests/kiro/test-recovery.sh
+++ b/tests/kiro/test-recovery.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALLER="$REPO_ROOT/scripts/install-kiro.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/source/.kiro/agents"
+cp -R "$REPO_ROOT/skills" "$TEST_ROOT/source/"
+cp "$REPO_ROOT/package.json" "$TEST_ROOT/source/"
+cp "$REPO_ROOT"/.kiro/agents/*.md "$TEST_ROOT/source/.kiro/agents/"
+cat > "$TEST_ROOT/bin/mv" <<'MV'
+#!/bin/sh
+# Fail one chosen replacement; allow backup and recovery renames.
+case "${FAIL_MODE:-replace}:$1" in
+  rollback:*/old)
+    [ "$2" != "$FAIL_DEST" ] || exit 76 ;;
+  backup:*)
+    if [ "$1" = "$FAIL_DEST" ]; then exit 77; fi ;;
+esac
+case "$1" in
+  */new)
+    if [ "$2" = "$FAIL_DEST" ] && [ ! -e "$FAIL_ONCE" ]; then
+      : > "$FAIL_ONCE"
+      if [ "${FAIL_MODE:-replace}" = signal ]; then kill -TERM "$PPID"; fi
+      exit 74
+    fi ;;
+esac
+exec /bin/mv "$@"
+MV
+cat > "$TEST_ROOT/bin/awk" <<'AWK'
+#!/bin/sh
+if [ "${FAIL_GENERATE:-0}" = 1 ]; then exit 75; fi
+exec /usr/bin/awk "$@"
+AWK
+chmod +x "$TEST_ROOT/bin/"*
+run() {
+  HOME="$case_root/home" XDG_DATA_HOME="$case_root/data" \
+    sh "$INSTALLER" --source "$TEST_ROOT/source"
+}
+for initial in existing fresh; do
+  for target in generation payload main default lite; do
+    case_root="$TEST_ROOT/$initial-$target"
+    mkdir -p "$case_root"
+    if [ "$initial" = existing ]; then
+      run > /dev/null
+      cp -R "$case_root/home" "$case_root/home-before"
+      cp -R "$case_root/data" "$case_root/data-before"
+    fi
+    printf '%s\n' "$initial-$target" > "$TEST_ROOT/source/skills/update.txt"
+    case "$target" in
+      generation) dest=unused ;;
+      payload) dest="$case_root/data/superpowers/kiro" ;;
+      main) dest="$case_root/home/.kiro/agents/superpowers.md" ;;
+      default) dest="$case_root/home/.kiro/agents/superpowers-worker-default-model.md" ;;
+      lite) dest="$case_root/home/.kiro/agents/superpowers-worker-lite-model.md" ;;
+    esac
+    export FAIL_DEST="$dest" FAIL_ONCE="$case_root/failed-once" FAIL_GENERATE=0
+    [ "$target" != generation ] || FAIL_GENERATE=1
+    if PATH="$TEST_ROOT/bin:$PATH" run > "$case_root/log" 2>&1; then
+      fail "did not inject $initial $target failure"
+    fi
+    if [ "$initial" = existing ]; then
+      diff -r "$case_root/home-before" "$case_root/home" || fail "$target damaged existing agents"
+      diff -r "$case_root/data-before" "$case_root/data" || fail "$target damaged existing payload"
+    else
+      [ ! -e "$case_root/data/superpowers/kiro" ] || fail "$target left fresh payload"
+      for name in superpowers superpowers-worker-default-model superpowers-worker-lite-model; do
+        [ ! -e "$case_root/home/.kiro/agents/$name.md" ] || fail "$target left fresh agent"
+      done
+    fi
+    unset FAIL_GENERATE
+    run > /dev/null
+    cmp "$TEST_ROOT/source/skills/update.txt" "$case_root/data/superpowers/kiro/skills/update.txt"
+  done
+done
+# Exercise failures before replacement, interruption, and recovery itself.
+for mode in backup signal rollback; do
+  case_root="$TEST_ROOT/$mode"
+  mkdir -p "$case_root"
+  run > /dev/null
+  cp -R "$case_root/home" "$case_root/home-before"
+  cp -R "$case_root/data" "$case_root/data-before"
+  export FAIL_MODE="$mode" FAIL_DEST="$case_root/home/.kiro/agents/superpowers-worker-default-model.md"
+  export FAIL_ONCE="$case_root/failed-once"
+  printf '%s\n' "$mode" > "$TEST_ROOT/source/skills/update.txt"
+  if PATH="$TEST_ROOT/bin:$PATH" run > "$case_root/log" 2>&1; then
+    fail "did not inject $mode failure"
+  fi
+  if [ "$mode" = rollback ]; then
+    grep -Fq 'recovery incomplete' "$case_root/log" || fail 'missing recovery diagnostic'
+    backup=("$case_root/home/.kiro/agents/".superpowers-kiro-stage.*/2/old)
+    [ "${#backup[@]}" -eq 1 ] && [ -f "${backup[0]}" ] || fail 'missing retained backup'
+    cmp "$case_root/home-before/.kiro/agents/superpowers-worker-default-model.md" "${backup[0]}"
+    grep -Fq "${backup[0]%/2/old}" "$case_root/log" || fail 'missing backup location'
+  else
+    diff -r "$case_root/home-before" "$case_root/home" || fail "$mode damaged agents"
+    diff -r "$case_root/data-before" "$case_root/data" || fail "$mode damaged payload"
+  fi
+  unset FAIL_MODE
+done
+echo 'PASS: staging failures and every replacement failure restore or remove installed artifacts'


### PR DESCRIPTION
<!-- This PR adds a new harness (Kiro v3 agent engine: CLI + IDE) and targets `dev`. -->

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 5 (primary); some sessions on Claude Opus 4.8 |
| Harness + version | Kiro CLI 2.17.0 (v3 agent engine); also loads in Kiro IDE 1.0.293, which shares the same v3 agent engine |
| All plugins installed | Superpowers (this integration); no third-party plugins |
| Human partner who reviewed this diff | Alexander Bubeck (abubeck) |

## What problem are you trying to solve?

Superpowers had no working Kiro integration. Kiro users had to hand-adapt files,
and every prior attempt (#618, #527, #363, #788, issue #503) targeted the Kiro
*IDE Powers/steering* model — which either duplicated skill content into steering
files or relied on onboarding writing into `~/.kiro/steering/`. In #618 the
maintainer named the blocker directly: a real integration must load the
`using-superpowers` bootstrap **at session start**, without copying skills or
editing user config, and asked whether Kiro has a startup mechanism for that.

Kiro's v3 agent engine does. This PR uses it. Because the Kiro CLI (v3) and the
Kiro IDE (1.0) run the **same v3 agent engine and agent format**, a single
Markdown custom agent works on both surfaces with no per-surface code.

## What does this PR change?

Adds a native Kiro v3 custom agent (`.kiro/agents/superpowers.md`) whose manifest
loads the `using-superpowers` bootstrap and a Kiro tool-mapping reference as
startup `file://` resources, then discovers all workflow skills through a native
`skill://` glob. A small POSIX installer (`scripts/install-kiro.sh`) installs one
tagged release and generates the global agent with absolute resource URIs; two
neutral worker agents give skills a general-purpose subagent dispatch target. The
same generated agent appears in both the CLI and the IDE agent selector.

The installer generates the global agents by transforming the tracked
`.kiro/agents/*.md` (single source of truth) rather than embedding copies: it
substitutes a `{{SUPERPOWERS_SKILLS_DIR}}` placeholder with the absolute skills
directory, makes resource URIs absolute, and adds an ownership marker. That
placeholder also gives the agent an absolute anchor so it reads a skill's own
reference files (e.g. `requesting-code-review/code-reviewer.md`) straight from the
installed payload instead of globbing the workspace.

## Is this change appropriate for the core library?

Yes — it is harness support, the same category as the existing `.codex/`,
`.opencode/`, and Kimi integrations. It adds no new skills and modifies no
behavior-shaping skill content. It integrates no third-party service; Kiro is the
harness, mirrored on how other harnesses are already supported in core.

## What alternatives did you consider?

- **Kiro IDE Power + steering files (#618/#527/#363/#788).** Rejected: depends on
  copying skills or writing steering into user config, and duplicates bootstrap
  text — the exact blockers the maintainer raised on #618. Powers also distribute
  skills/MCP but not custom agents on the CLI, so a Power cannot ship this agent.
- **Kiro v2 (JSON) agents.** Rejected: v2 is being deprecated and is no longer
  extended (Kiro prompts `/upgrade-agent`); new capabilities land only in v3.
- **Copying/symlinking skills into `~/.kiro/skills/`.** Rejected for the
  maintenance reasons obra cited (withdrawn skills, symlink limitations). The
  `skill://` glob reads skills in place; removing a skill is just deleting a file.
- **One worker per role / a third read-only reviewer worker.** Rejected as
  config-heavy; two neutral workers (default-model and a Sonnet-pinned lite) cover
  the dispatch needs.

## Does this PR contain multiple unrelated changes?

No. Every change serves the single goal of Kiro v3 support: the agent + tool
mapping, the installer, worker agents, tests, user docs, the porting-guide entry
(new "Shape D — agent-profile"), a `docs/testing.md` line, and a one-line
`/.kiro/` exclusion in the Codex-plugin sync so the new directory is not mirrored
downstream.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #618 (open), #527 (closed), #363 (closed), #788 (closed); issues #503 (open), #319 (closed)

Prior attempts built on Kiro IDE Powers/steering and were blocked on bootstrap
loading and skill duplication. This PR is the first to use the Kiro **v3
custom-agent** manifest, which loads the `using-superpowers` bootstrap at session
start as a declared startup resource — directly satisfying the requirement obra
stated on #618 — with zero skill copying and zero user-config edits, on both the
CLI and the IDE.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Kiro CLI (v3 agent engine) — primary test surface | 2.17.0 | Claude Opus | 5 (primary), 4.8; default worker resolved `claude-opus-5`, lite worker pinned `claude-sonnet-5` |
| Kiro IDE (same v3 agent engine) — smoke tested only | 1.0.293 | Claude Opus | 5 |

## New harness support (required)

A working integration loads the `using-superpowers` bootstrap at session start,
which auto-triggers `brainstorming` on the acceptance prompt.

- **CLI (primary):** verified in both the repository-local profile and the
  installed absolute-path profile from an unrelated project directory —
  `brainstorming` auto-triggers before any code is written. Confirmed across two
  clean runs on two different models (`claude-opus-4.8` and `gpt-5.6-sol`), both
  loading `brainstorming` via Kiro's native skill mechanism and opening with a
  design question rather than writing code. Transcripts below are rendered from
  Kiro's own persisted session log (`messages.jsonl`), not scraped from the TUI.
- **IDE (smoke test):** the same installed agent appears in the IDE agent
  selector; after selecting it and starting a fresh session, `/context show`
  lists the Superpowers skills and `brainstorming` triggers on the acceptance
  prompt. Note: the IDE fixes the available agent/skill list at session start, so
  a restart is required after install before skills appear — an initial "skills
  not found" was traced to a missing restart, not the mechanism.

**Honest scope:** testing was done mainly on the CLI. The IDE received only smoke
testing (agent loads, skills discovered via `/context show`, brainstorming
triggers); it was not exercised across the full range of skills and workflows.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Both transcripts are rendered from Kiro's persisted conversation
(`~/.kiro/sessions/.../messages.jsonl`), so they reflect exactly what the agent
did. In both, the first action after the prompt is loading the `brainstorming`
skill, and the agent asks a scoping question before writing any code.

**Run 1 — model `claude-opus-4.8`**

```text
🧑 User
Let's make a react todo list

● Loaded skill: brainstorming   (disclose_context)

🤖 Assistant
Using brainstorming to design the todo list before building anything.

🤖 Assistant
Let me first explore the current project context.

🤖 Assistant
The workspace is empty, so we're starting fresh. Before I build anything, I want
to understand what you're picturing so we build the right thing.

Question 1 of a few: What's the main purpose of this todo list?
  A) A personal learning/demo project — just want a clean, working React example
  B) Something you'll actually use day-to-day and want to keep tidy and functional
  C) A starting point for a bigger app you'll extend later
  D) Something else (tell me)

This shapes how much I invest in things like persistence, polish, and extensibility.
```

**Run 2 — model `gpt-5.6-sol`** (same integration, different model)

```text
🧑 User
Let's make a react todo list

● Loaded skill: brainstorming   (disclose_context)

🤖 Assistant
Using brainstorming to turn the React todo-list idea into an approved design
before implementation.

🤖 Assistant
The workspace is empty, so we'll create a new React project. Which scope do you want?
  A. Basic: add, complete, and delete todos
  B. Practical: basic features plus editing, filters, and localStorage persistence
  C. Advanced: practical features plus due dates, priorities, categories, and search
```

</details>

## Evaluation
- Initial prompt: `Let's make a react todo list` in a clean v3 session.
- Eval sessions run after the change: two clean acceptance runs captured above
  (on two different models), on top of roughly **two weeks of daily use** of this
  setup as my primary Kiro workflow.
- Outcome: with the agent active, `brainstorming` loads before any file is
  created; without it, skills never trigger. The behavior held across both models
  and across two weeks of real daily sessions, not just the acceptance prompt.
  Worker dispatch verified — default worker resolved `claude-opus-5`, the lite
  worker's pinned `claude-sonnet-5` was accepted and an invalid-model probe failed
  loudly, proving the `model:` field is honored. IDE smoke test confirmed the same
  agent loads and triggers skills after a session restart.

## Rigor
- [ ] Skills change — N/A (no skill content modified)
- [x] Tested adversarially, not just happy path (unmanaged-collision refusal,
      `.json` shadow guard, relative/quoted/newline `XDG_DATA_HOME` rejection,
      invalid-archive preservation, resource-parity, Codex-sync `/.kiro/` exclusion)
- [x] Did not modify carefully-tuned behavior-shaping content

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
