### PR TITLE
fix(skills): reconcile task review verification guidance

### DIFF
--- a/skills/subagent-driven-development/task-reviewer-prompt.md
+++ b/skills/subagent-driven-development/task-reviewer-prompt.md
@@ -73,13 +73,16 @@ Subagent (general-purpose):
     ## Tests
 
     The implementer already ran the tests and reported results with TDD
-    evidence for exactly this code. Do not re-run the suite to confirm their
-    report. Run a test only when reading the code raises a specific doubt
-    that no existing run answers — and then a focused test, never a
-    package-wide suite, race detector run, or repeated/high-count loop. If
-    heavy validation seems warranted, recommend it in your report instead of
-    running it. If you cannot run commands in this environment, name the
-    test you would run.
+    evidence for exactly this code. That fresh, task-specific run is the
+    verification evidence for this review: inspect the reported command and
+    result against the diff rather than duplicating the full suite. Do not
+    re-run the suite to confirm their report. Run a test only when reading
+    the code raises a specific doubt that no existing run answers — and then
+    a focused test, never a package-wide suite, race detector run, or
+    repeated/high-count loop. If heavy validation seems warranted, recommend
+    it in your report instead of running it. If you cannot run commands in
+    this environment, name the test you would run. This task-review
+    exception does not replace verification at the final completion boundary.
 
     Warnings or other noise in the implementer's reported test output are
     findings — test output should be pristine.

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -35,6 +35,13 @@ BEFORE claiming any status or expressing satisfaction:
 Skip any step = lying, not verifying
 ```
 
+When reviewing a task implementation, reviewing the implementer's fresh,
+task-specific verification evidence against the diff satisfies the reviewer's
+evidence check; the reviewer does not need to duplicate the full suite. This
+does not permit stale evidence, skip a focused test when review raises a
+specific doubt, or replace the final verification required before a completion
+claim.
+
 ## Common Failures
 
 | Claim | Requires | Not Sufficient |


### PR DESCRIPTION
## Issue

Issue #1961 has conflicting guidance: task reviewers are told not to rerun the suite, while verification-before-completion requires fresh verification evidence.

## Fix

Clarified that the implementer’s fresh, task-specific test run is the evidence the reviewer evaluates, while preserving focused tests for specific doubts and final completion verification.
