### PR TITLE
docs: add Qwen Code install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [Kimi Code](#kimi-code)
   - [OpenCode](#opencode)
   - [Pi](#pi)
+  - [Qwen Code](#qwen-code)
   - [Hermes Agent](#hermes-agent)
 - [The Basic Workflow](#the-basic-workflow)
 - [Community](#community)
@@ -245,6 +246,22 @@ pi -e /path/to/superpowers
 ```
 
 The Pi package loads the Superpowers skills and a small extension that injects the `using-superpowers` bootstrap at session startup and again after compaction. Pi has native skills, so no compatibility `Skill` tool is required. Subagent and task-list tools remain optional Pi companion packages.
+
+### Qwen Code
+
+Qwen Code installs plugins from Claude Code marketplaces directly.
+
+- Install the plugin from this repository, and pick `superpowers` when prompted:
+
+  ```bash
+  qwen extensions install obra/superpowers
+  ```
+
+- Update later:
+
+  ```bash
+  qwen extensions update superpowers
+  ```
 
 ### Hermes Agent
 


### PR DESCRIPTION
## What this does

Adds the Qwen Code install/update instructions to the README (section + TOC entry). This is a rebase-and-rework of #2108 (@arittr) onto the post-v6.3.0 README, which had made that PR CONFLICTING.

## Differences from #2108, and why

- **Kept:** the Qwen Code section verbatim — commands and the acceptance evidence are Drew's (real interactive Qwen Code session in #2108's transcript showing `brainstorming` auto-triggering).
- **Dropped — obsolete:** the Hermes TOC entry (the v6.3.0 README rework already added it) and the Quickstart harness-list edit (that line no longer exists).
- **Dropped — incorrect for current dev:** the deletion of the Hermes post-compaction caveat. Verified against `.hermes-plugin/__init__.py`: the bootstrap is injected only on `is_first_turn` via `pre_llm_call`, with no post-compaction re-injection, so the caveat ('a very long session that compacts over its first turn loses the bootstrap') is still accurate. @arittr — if you removed it because Hermes shipped a post-compaction hook we're not using yet, say the word and we'll wire it up instead.

Drew is credited via Co-authored-by on the commit.

## Who is submitting

Written by Claude Fable 5 on Claude Code 2.1.228, triage session run by @obra, who directed this PR and reviews the diff. Original change authored and Qwen-tested by @arittr in #2108.

Supersedes and closes #2108.