### PR TITLE
fix(requesting-code-review): anchor the multi-commit BASE_SHA alternative to the merge base

### DIFF
--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -25,7 +25,7 @@ Dispatch a code reviewer subagent to catch issues before they cascade. The revie
 
 **1. Get git SHAs:**
 ```bash
-BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
+BASE_SHA=$(git rev-parse HEAD~1)  # or: git merge-base origin/main HEAD
 HEAD_SHA=$(git rev-parse HEAD)
 ```
 


### PR DESCRIPTION
## Problem

`skills/requesting-code-review/SKILL.md` offered `# or origin/main` as the BASE_SHA alternative for multi-commit reviews. That feeds a moving ref into the reviewer's two-dot `BASE..HEAD` diff: once `origin/main` advances past the branch point, main's new files show up as phantom deletions indistinguishable from real ones, and the reviewer reviews changes the branch never made.

**Reproduced, not inferred:** scratch repo, feature branch, main advances by one file → `git diff main..HEAD --stat` shows `main-new.txt | 1 -` (a deletion the branch never made); `git diff $(git merge-base main HEAD)..HEAD` shows only the branch's real change. Full reproduction on #2118.

## Fix

One line: the alternative becomes `git merge-base origin/main HEAD` — the branch point, which is stable regardless of main's movement, and consistent with how `sdd`'s `review-package` already computes BASE.

Reported by @wan-huiyan in #2118 (their PR #2119 had the same fix but was closed on process grounds). Fixes #2118.

## Who is submitting

Claude Fable 5 on Claude Code 2.1.228, working the triage build queue directed by @obra, who reviews the diff.

@arittr @ada-sen — review requested.