### PR TITLE
fix(sdd): invoke sdd-workspace via bash so helpers survive stripped exec bits

### DIFF
--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -25,7 +25,9 @@ git rev-parse --verify --quiet "$head" >/dev/null || { echo "bad HEAD: $head" >&
 if [ $# -eq 4 ]; then
   out=$4
 else
-  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace" "$plan")
+  # Invoke via bash rather than direct exec: some extractors (Python zipfile)
+  # strip Unix exec bits when unpacking marketplace packages (#2040).
+  dir=$("${BASH:-bash}" "$(cd "$(dirname "$0")" && pwd)/sdd-workspace" "$plan")
   out="$dir/review-$(git rev-parse --short "$base")..$(git rev-parse --short "$head").diff"
 fi
 

--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -21,7 +21,9 @@ n=$2
 if [ $# -eq 3 ]; then
   out=$3
 else
-  dir=$("$(cd "$(dirname "$0")" && pwd)/sdd-workspace" "$plan")
+  # Invoke via bash rather than direct exec: some extractors (Python zipfile)
+  # strip Unix exec bits when unpacking marketplace packages (#2040).
+  dir=$("${BASH:-bash}" "$(cd "$(dirname "$0")" && pwd)/sdd-workspace" "$plan")
   out="$dir/task-${n}-brief.md"
 fi
 

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -189,6 +189,21 @@ PLAN
         echo "    status: $wt_status"
     fi
 
+    # --- helpers survive a mode-stripping extractor dropping exec bits (#2040) ---
+    local stripped="$TEST_ROOT/stripped-scripts"
+    mkdir -p "$stripped"
+    cp "$SDD_SCRIPTS/sdd-workspace" "$SDD_SCRIPTS/task-brief" "$SDD_SCRIPTS/review-package" "$stripped/"
+    chmod -x "$stripped"/*
+    local noexec_out noexec_rc=0
+    noexec_out="$(cd "$repo" && bash "$stripped/task-brief" plan-b.md 1 2>&1)" || noexec_rc=$?
+    if [[ "$noexec_rc" -eq 0 && -f "$repo/.superpowers/sdd/plan-b/task-1-brief.md" ]]; then
+        pass "task-brief works with no exec bit on sdd-workspace"
+    else
+        fail "task-brief works with no exec bit on sdd-workspace"
+        echo "    rc: $noexec_rc"
+        echo "    output: $noexec_out"
+    fi
+
     echo ""
     if [[ "$FAILURES" -ne 0 ]]; then
         echo "FAILED: $FAILURES assertion(s)."


### PR DESCRIPTION
## Problem

Codex marketplace users get `Permission denied` when SDD helpers run (#2040): `task-brief` and `review-package` direct-exec their sibling `sdd-workspace`, which requires the executable bit — and some consumer-side extractors (Python `zipfile`) discard Unix mode attributes when unpacking. Our own packaging is not the culprit: `git archive | tar -xpf` preserves 0755 and the existing packaging test asserts it, so a packaging-side chmod (the approach in closed PR #2069) would guard a link that isn't broken.

## Fix

Two call sites: invoke the sibling via `"${BASH:-bash}"` instead of direct exec, making the exec bit irrelevant no matter what mangled the modes.

## TDD evidence

New regression case in `tests/claude-code/test-sdd-workspace.sh`: copy the three helpers to a temp dir, `chmod -x`, run `task-brief` via bash. RED on dev with exactly the reported failure (`rc=126 ... sdd-workspace: Permission denied`), GREEN with the fix; full suite passes.

Reported by @michaelholcomb-creator in #2040; diagnosis refined during triage (closed PR #2069 by @arimu1 identified the invocation change as part of a larger diff). Fixes #2040.

## Who is submitting

Claude Fable 5 on Claude Code 2.1.228, working the triage build queue directed by @obra, who reviews the diff.

@arittr @ada-sen — review requested.