### PR TITLE
fix(sdd): reject empty or non-descendant BASE..HEAD ranges in review-package

### DIFF
--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -22,6 +22,11 @@ head=$3
 git rev-parse --verify --quiet "$base" >/dev/null || { echo "bad BASE: $base" >&2; exit 2; }
 git rev-parse --verify --quiet "$head" >/dev/null || { echo "bad HEAD: $head" >&2; exit 2; }
 
+# Range guards (exit 3): a wrong-branch HEAD yields a range that is empty or
+# not rooted at BASE; either would silently produce a bogus review package.
+git merge-base --is-ancestor "$base" "$head" || { echo "HEAD is not a descendant of BASE: ${base}..${head}" >&2; exit 3; }
+[ "$(git rev-list --count "${base}..${head}")" -gt 0 ] || { echo "empty commit range: ${base}..${head}" >&2; exit 3; }
+
 if [ $# -eq 4 ]; then
   out=$4
 else

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -165,6 +165,30 @@ PLAN
         echo "    got: $rp_explicit"
     fi
 
+    # --- range guards: BASE must be an ancestor of HEAD, range must be non-empty ---
+    local divergent
+    divergent="$(cd "$repo" && git "${git_id[@]}" commit-tree 'HEAD~1^{tree}' -p 'HEAD~1' -m divergent)"
+    rc=0
+    local guard_err
+    guard_err="$(cd "$repo" && "$SDD_SCRIPTS/review-package" plan-a.md "$divergent" HEAD 2>&1 >/dev/null)" || rc=$?
+    if [[ "$rc" -eq 3 && "$guard_err" == *"not a descendant"* ]]; then
+        pass "review-package rejects a BASE that is not an ancestor of HEAD with exit 3"
+    else
+        fail "review-package rejects a BASE that is not an ancestor of HEAD with exit 3"
+        echo "    exit: $rc"
+        echo "    stderr: $guard_err"
+    fi
+
+    rc=0
+    guard_err="$(cd "$repo" && "$SDD_SCRIPTS/review-package" plan-a.md HEAD HEAD 2>&1 >/dev/null)" || rc=$?
+    if [[ "$rc" -eq 3 && "$guard_err" == *"empty commit range"* ]]; then
+        pass "review-package rejects an empty BASE..HEAD range with exit 3"
+    else
+        fail "review-package rejects an empty BASE..HEAD range with exit 3"
+        echo "    exit: $rc"
+        echo "    stderr: $guard_err"
+    fi
+
     # --- Worktree isolation: a linked worktree resolves its own workspace ---
     local wt="$TEST_ROOT/wt"
     ( cd "$repo" && git worktree add -q "$wt" -b wt-feature )


### PR DESCRIPTION
## Problem

`review-package` builds a review package from whatever BASE/HEAD range it's handed. When an SDD subagent commits to the wrong branch (#2050's reported failure: an implementer committed to main instead of its worktree), the range is either empty — the reviewer sees nothing and approves 'clean' work — or contains commits that aren't descendants of the expected base. Both silently corrupt the review chain SDD's correctness depends on.

## Fix

Five lines after the existing BASE/HEAD validation, in the script's own style:
- `git merge-base --is-ancestor "$base" "$head"` — reject with 'HEAD is not a descendant of BASE', exit 3
- `git rev-list --count` — reject an empty range, exit 3

Exit 3 distinguishes range corruption from usage errors (exit 2). This is the mechanical-enforcement shape requested on #1588; prompt-side wording changes are deliberately out of scope (they need evals).

## TDD evidence

Two new assertions in `tests/claude-code/test-sdd-workspace.sh` (divergent BASE built via `commit-tree`, and BASE==HEAD). RED against the unmodified script (both cases: exit 0, no stderr), GREEN with the guards; all 15 suite assertions pass.

Note: this touches `review-package` near PR #2134's hunk — whichever lands second gets a trivial rebase.

Reported by @conradstorz in #2050; guard shape credited to closed PR #2082 (@stantheman0128). Fixes #2050.

## Who is submitting

Claude Fable 5 on Claude Code 2.1.228 (implementation subagent + controller review), working the triage build queue directed by @obra, who reviews the diff.

@arittr @ada-sen — review requested.