### PR TITLE
fix(tests): unhang the Claude Code skill suite and realign SDD assertions with the current skill

### DIFF
--- a/tests/claude-code/test-helpers.sh
+++ b/tests/claude-code/test-helpers.sh
@@ -15,8 +15,9 @@ run_claude() {
         cmd+=(--allowed-tools="$allowed_tools")
     fi
 
-    # Run Claude in headless mode with timeout
-    if timeout "$timeout" "${cmd[@]}" > "$output_file" 2>&1; then
+    # Run Claude in headless mode with timeout. Redirect stdin from
+    # /dev/null so the CLI can't block waiting for input and hang the suite.
+    if timeout "$timeout" "${cmd[@]}" > "$output_file" 2>&1 < /dev/null; then
         cat "$output_file"
         rm -f "$output_file"
         return 0

--- a/tests/claude-code/test-subagent-driven-development-integration.sh
+++ b/tests/claude-code/test-subagent-driven-development-integration.sh
@@ -23,7 +23,7 @@ echo "========================================"
 echo ""
 echo "This test executes a real plan using the skill and verifies:"
 echo "  1. Plan is read once (not per task)"
-echo "  2. Full task text provided to subagents"
+echo "  2. Task requirements routed to subagents via brief files"
 echo "  3. Subagents perform self-review"
 echo "  4. Spec compliance review before code quality"
 echo "  5. Review loops when issues found"
@@ -136,7 +136,7 @@ I want you to execute the implementation plan at docs/superpowers/plans/implemen
 
 IMPORTANT: Follow the skill exactly. I will be verifying that you:
 1. Read the plan once at the beginning
-2. Provide full task text to subagents (don't make them read files)
+2. Route each task's requirements to subagents via a task brief file (don't make them read the whole plan)
 3. Ensure subagents do self-review before reporting
 4. Run spec compliance review before code quality review
 5. Use review loops when issues are found
@@ -150,7 +150,7 @@ PROMPT="Execute the implementation plan at docs/superpowers/plans/implementation
 
 IMPORTANT: Follow the skill exactly. I will be verifying that you:
 1. Read the plan once at the beginning
-2. Provide full task text to subagents (don't make them read files)
+2. Route each task's requirements to subagents via a task brief file (don't make them read the whole plan)
 3. Ensure subagents do self-review before reporting
 4. Run spec compliance review before code quality review
 5. Use review loops when issues are found
@@ -164,7 +164,7 @@ PLUGIN_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
 # other concurrent claude sessions.
 echo "Running Claude (plugin-dir: $PLUGIN_DIR, cwd: $TEST_PROJECT)..."
 echo "================================================================================"
-cd "$TEST_PROJECT" && timeout 1800 claude -p "$PROMPT" --plugin-dir "$PLUGIN_DIR" --allowed-tools=all --permission-mode bypassPermissions 2>&1 | tee "$OUTPUT_FILE" || {
+cd "$TEST_PROJECT" && timeout 1800 claude -p "$PROMPT" --plugin-dir "$PLUGIN_DIR" --allowed-tools=all --permission-mode bypassPermissions < /dev/null 2>&1 | tee "$OUTPUT_FILE" || {
     echo ""
     echo "================================================================================"
     echo "EXECUTION FAILED (exit code: $?)"
@@ -316,7 +316,7 @@ if [ $FAILED -eq 0 ]; then
     echo ""
     echo "The subagent-driven-development skill correctly:"
     echo "  ✓ Reads plan once at start"
-    echo "  ✓ Provides full task text to subagents"
+    echo "  ✓ Routes task requirements via brief files"
     echo "  ✓ Enforces self-review"
     echo "  ✓ Runs spec compliance before code quality"
     echo "  ✓ Spec reviewer verifies independently"

--- a/tests/claude-code/test-subagent-driven-development.sh
+++ b/tests/claude-code/test-subagent-driven-development.sh
@@ -4,7 +4,7 @@
 #
 # No drill coverage: this test asks the agent to *describe* SDD (string-
 # matches its verbal explanation against expected keywords like
-# "self-review", "skeptical", "worktree", "Step 1", "loop"). Drill scenarios
+# "self-review", "skeptical", "worktree", "setup", "loop"). Drill scenarios
 # test behavior (real subagent dispatch, plan-following, review loops),
 # not description-recall. Kept by design.
 set -euo pipefail
@@ -83,7 +83,7 @@ else
     exit 1
 fi
 
-if assert_contains "$output" "Step 1\|beginning\|start\|Load Plan" "Read at beginning"; then
+if assert_contains "$output" "beginning\|start\|setup\|before.*dispatch\|before.*task" "Read at beginning"; then
     : # pass
 else
     exit 1
@@ -133,16 +133,16 @@ echo ""
 echo "Test 7: Task context provision..."
 
 output=$(run_claude "In subagent-driven-development, how does the controller provide task information to the implementer subagent? Answer using exactly this structure:
-Controller provides: <directly or by file>
-Implementer must read plan file: <yes or no>" "$CLAUDE_PROMPT_TIMEOUT")
+Controller provides: <brief file or whole plan file>
+Implementer must read whole plan file: <yes or no>" "$CLAUDE_PROMPT_TIMEOUT")
 
-if assert_contains "$output" "provide.*directly\|full.*text\|paste\|include.*prompt" "Provides text directly"; then
+if assert_contains "$output" "task-brief\|brief file\|brief.*path\|Controller provides:.*brief" "Provides task brief file"; then
     : # pass
 else
     exit 1
 fi
 
-if assert_contains "$output" "Implementer must read plan file:.*no" "Doesn't make subagent read file"; then
+if assert_contains "$output" "Implementer must read whole plan file:.*no" "Doesn't make subagent read whole plan"; then
     : # pass
 else
     exit 1


### PR DESCRIPTION
## Problem (tracked in #2130)

Four defects left the Claude Code skill suite unable to pass:
1. `test-helpers.sh` spawned the CLI under `timeout` with stdin left open — the CLI can block on stdin and hang the whole suite.
2. `test-subagent-driven-development.sh:86` asserted pre-rename step names (`Step 1|Load Plan`) that no longer exist in the skill — a live run yesterday failed exactly here while the model's answer was correct ('during setup').
3. Line ~139 asserted the removed provide-text-directly behavior; SDD now routes briefs via `scripts/task-brief`.
4. Sweep found the same two defect classes in `test-subagent-driven-development-integration.sh`: its prompt *instructed the model to violate the current skill* ('Provide full task text to subagents'), and its direct `claude -p` invocation also lacked the stdin guard.

## Fix

- `< /dev/null` on both CLI spawn sites (helper + integration test).
- Assertions and prompts rewritten against the current SKILL.md: setup-phase reading accepted ('beginning|start|setup|before dispatch'), task-brief flow asserted instead of paste-the-text. Patterns tolerate correct paraphrases without going vacuous.
- `test-worktree-native-preference.sh`'s 'Step 1a' checked and left alone — that's its own RED/GREEN terminology, not the SDD rename.

## Verification

`bash -n` clean on all touched files. The stdin fix has a deterministic falsification: a stub `claude` that reads stdin — pre-fix helper blocks until timeout (exit 124), post-fix exits immediately (exit 0). The prose assertions are live-LLM by nature; they were rewritten from the current skill text, and the previously-failing 'Read at beginning' case now matches yesterday's observed correct answer.

Findings originally reported in PR #2071 (@ericyen97903-lab, closed on process grounds), verified during triage and tracked in #2130. Fixes #2130.

## Who is submitting

Claude Fable 5 on Claude Code 2.1.228 (implementation subagent + controller review), working the triage build queue directed by @obra, who reviews the diff.

@arittr @ada-sen — review requested.