### PR TITLE
Fix brainstorm server crashing on shutdown when the session dir is gone

### DIFF
--- a/skills/brainstorming/scripts/server.cjs
+++ b/skills/brainstorming/scripts/server.cjs
@@ -613,15 +613,26 @@ function startServer() {
   });
   watcher.on('error', (err) => console.error('fs.watch error:', err.message));
 
+  let shuttingDown = false;
   function shutdown(reason) {
+    if (shuttingDown) return;
+    shuttingDown = true;
     console.log(JSON.stringify({ type: 'server-stopped', reason }));
-    const infoFile = path.join(STATE_DIR, 'server-info');
-    if (fs.existsSync(infoFile)) fs.unlinkSync(infoFile);
-    fs.writeFileSync(
-      path.join(STATE_DIR, 'server-stopped'),
-      JSON.stringify({ reason, timestamp: Date.now() }) + '\n'
-    );
-    watcher.close();
+    // State-dir bookkeeping is best effort. The session directory can be removed
+    // while the server sits idle, and a missing or read-only state dir must never
+    // abort shutdown -- throwing here would skip every cleanup step below and kill
+    // the process with an uncaught exception instead of exiting 0.
+    try {
+      if (fs.existsSync(STATE_DIR)) {
+        const infoFile = path.join(STATE_DIR, 'server-info');
+        if (fs.existsSync(infoFile)) fs.unlinkSync(infoFile);
+        fs.writeFileSync(
+          path.join(STATE_DIR, 'server-stopped'),
+          JSON.stringify({ reason, timestamp: Date.now() }) + '\n'
+        );
+      }
+    } catch (e) { /* best effort */ }
+    try { watcher.close(); } catch (e) { /* content dir may be gone */ }
     clearInterval(lifecycleCheck);
     // Close any upgraded WebSocket sockets so server.close() can complete and
     // the process actually exits instead of lingering on an open connection.

--- a/tests/brainstorm-server/lifecycle.test.js
+++ b/tests/brainstorm-server/lifecycle.test.js
@@ -508,6 +508,27 @@ async function runTests() {
     assert(exited, 'idle shutdown must still fire despite a flood of unauthenticated requests');
   });
 
+  await test('idle shutdown exits 0 when the session dir was removed', async () => {
+    const dir = fs.mkdtempSync('/tmp/bs-life-');
+    const srv = spawn('node', [SERVER], { env: { ...process.env, BRAINSTORM_PORT: 3420, BRAINSTORM_DIR: dir, BRAINSTORM_IDLE_TIMEOUT_MS: 400, BRAINSTORM_LIFECYCLE_CHECK_MS: 100 } });
+    let out = ''; srv.stdout.on('data', d => out += d.toString());
+    let err = ''; srv.stderr.on('data', d => err += d.toString());
+    let code = null; srv.on('exit', c => { code = c; });
+    for (let i = 0; i < 60 && !out.includes('server-started'); i++) await sleep(50);
+
+    // The session dir can be cleaned up while the server sits idle. Shutdown
+    // bookkeeping is best effort: if writing state/server-stopped throws, the
+    // cleanup below it never runs and the process dies on an uncaught exception.
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    for (let i = 0; i < 40 && code === null; i++) await sleep(100);
+    if (code === null) await killAndWait(srv);
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    assert.strictEqual(code, 0, `idle shutdown must exit 0 with the session dir gone, got ${code}: ${err}`);
+    assert(!/ENOENT/.test(err), `shutdown must not throw ENOENT, got: ${err}`);
+  });
+
   console.log(`\n--- Results: ${passed} passed, ${failed} failed ---`);
   if (failed > 0) process.exit(1);
 }


### PR DESCRIPTION
## Problem

`shutdown()` in `skills/brainstorming/scripts/server.cjs` writes `state/server-stopped` without checking that `STATE_DIR` still exists:

```js
function shutdown(reason) {
  console.log(JSON.stringify({ type: 'server-stopped', reason }));
  const infoFile = path.join(STATE_DIR, 'server-info');
  if (fs.existsSync(infoFile)) fs.unlinkSync(infoFile);
  fs.writeFileSync(                                   // ← throws ENOENT
    path.join(STATE_DIR, 'server-stopped'),
    JSON.stringify({ reason, timestamp: Date.now() }) + '\n'
  );
  watcher.close();                                    // never runs
  clearInterval(lifecycleCheck);                      // never runs
  for (const socket of clients) { ... }               // never runs
  server.close(() => process.exit(0));                // never runs
}
```

If the session directory is removed while the server sits idle, the write throws from inside the `lifecycleCheck` interval. The throw is not caught, so **every cleanup step below it is skipped** and the process dies on an uncaught exception with exit code 1 instead of exiting 0.

This is not just a cosmetic exit code — the watcher, the interval, the WebSocket sockets and `server.close()` are all bypassed.

### How I hit it

A brainstorming session finished, the design was committed, and I deleted the scratch `.superpowers/` directory. The server had already begun a normal `idle timeout` shutdown, and supervision reported it as a failed process:

```
{"type":"server-stopped","reason":"idle timeout"}
Error: ENOENT: no such file or directory, open '.../state/server-stopped'
    at shutdown (.../skills/brainstorming/scripts/server.cjs:620:8)
    at Timeout._onTimeout (.../skills/brainstorming/scripts/server.cjs:642:59)
```

### Minimal reproduction

```bash
D=$(mktemp -d); mkdir -p "$D/content" "$D/state"
BRAINSTORM_DIR="$D" BRAINSTORM_PORT=0 \
BRAINSTORM_IDLE_TIMEOUT_MS=1500 BRAINSTORM_LIFECYCLE_CHECK_MS=300 \
  node skills/brainstorming/scripts/server.cjs & P=$!
sleep 1.2; rm -rf "$D/state"; wait $P; echo "exit=$?"
# before: exit=1 + ENOENT
# after:  exit=0
```

## Fix

State-dir bookkeeping becomes best effort, matching the pattern already used a few lines below for `PORT_FILE` (`try { fs.writeFileSync(PORT_FILE, ...) } catch (e) { /* best effort */ }`):

- skip the bookkeeping when `STATE_DIR` is gone, wrap it in `try/catch`, and always fall through to the real cleanup
- guard `watcher.close()` too, since `CONTENT_DIR` disappears in the same scenario
- make `shutdown()` idempotent so a second lifecycle tick cannot call `server.close()` twice

The sentinel is deliberately **not** recreated when the directory is missing — nothing is left to consume it, and re-creating a tree the user just deleted would be surprising.

## Tests

Adds one regression test to `tests/brainstorm-server/lifecycle.test.js` (port 3420, following the existing style in that file): remove the session dir while the server is idle, then assert a clean `exit 0` with no `ENOENT` on stderr.

Verified both directions:

| | new test | full `npm test` |
|---|---|---|
| without the fix | **FAIL** (`13 passed, 1 failed`) | fails |
| with the fix | **PASS** | see below |

Behaviour on the normal path is unchanged — with the state dir present, the sentinel is still written and the process still exits 0.

```
tests/brainstorm-server $ npm test
--- Results: 32 passed, 0 failed ---     ws-protocol
--- Results: 15 passed, 0 failed ---     helper
--- Results:  3 passed, 0 failed ---     browser-launcher
--- Results: 20 passed, 0 failed ---     auth
--- Results:  7 passed, 0 failed ---     branding
--- Results: 33 passed, 0 failed ---     server
--- Results: 14 passed, 0 failed ---     lifecycle   ← +1 new test
--- Results:  4 passed, 0 failed ---     start-server.sh
--- Results:  6 passed, 1 failed ---     stop-server.sh
```

### Note on the one remaining failure

`stop-server.sh :: persistent stop writes server-stopped` fails, but it is **pre-existing and unrelated to this change**. I reproduced it on pristine `main` (`b36e082`) in the same environment, before and after applying the patch — identical `6 passed, 1 failed` both times. I left it alone rather than widen the scope of this PR.

Environment: macOS 25.6.0 (arm64), Node v26.5.1.
