### PR TITLE
Fix Windows/Git-Bash path comparison in test-sdd-workspace.sh

### DIFF
--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -17,6 +17,16 @@ fail() {
     FAILURES=$((FAILURES + 1))
 }
 
+# Push a path through the same `cd ... && pwd` normalization that
+# sdd-workspace's own printed output goes through, so both sides of a
+# string comparison are guaranteed to be spelled identically. On Windows
+# Git Bash/MSYS, `git rev-parse --show-toplevel` (Windows-style,
+# C:/Users/...) and `cd ... && pwd` (MSYS-style, /c/Users/...) can print
+# different spellings of the identical physical directory; on Linux/macOS
+# this is a no-op since the two already agree (module the resolved-symlink
+# /var -> /private/var case handled by the mktemp comment above).
+physical_path() { (cd "$1" && pwd); }
+
 cleanup() {
     if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
         rm -rf "$TEST_ROOT"
@@ -35,6 +45,7 @@ main() {
     git init -q -b main "$TEST_ROOT/repo"
     local repo
     repo="$(cd "$TEST_ROOT/repo" && git rev-parse --show-toplevel)"
+    repo="$(physical_path "$repo")"
 
     cat > "$repo/plan-a.md" <<'PLAN'
 # Plan A
@@ -170,6 +181,7 @@ PLAN
     ( cd "$repo" && git worktree add -q "$wt" -b wt-feature )
     local wt_root wt_dir
     wt_root="$(cd "$wt" && git rev-parse --show-toplevel)"
+    wt_root="$(physical_path "$wt_root")"
     wt_dir="$(cd "$wt" && "$SDD_SCRIPTS/sdd-workspace" plan-a.md)"
     if [[ "$wt_dir" == "$wt_root/.superpowers/sdd/plan-a" && "$wt_dir" != "$dir_a" ]]; then
         pass "linked worktree resolves its own distinct workspace"


### PR DESCRIPTION
## Summary

- `tests/claude-code/test-sdd-workspace.sh` string-compares a `git rev-parse --show-toplevel` result against `sdd-workspace`'s own printed output, which is always normalized through a final `cd "$dir" && pwd`.
- On Windows Git Bash/MSYS these two commands can print different spellings of the identical physical directory (`git rev-parse --show-toplevel` prints Windows-style `C:/Users/...`, while `cd ... && pwd` prints MSYS-style `/c/Users/...`). The string comparison then fails even though both sides name the same directory — 5 of 13 assertions failed on a Windows 10 + Git Bash machine before this fix.
- Adds a `physical_path()` helper (`(cd "$1" && pwd)`) and applies it to both places the test derives a comparison root from `git rev-parse --show-toplevel` (`repo` and `wt_root`), pushing them through the same normalization `sdd-workspace`'s printed output already goes through.
- No-op on Linux/macOS, where `git rev-parse --show-toplevel` and `cd ... && pwd` already agree (modulo the resolved-symlink `/var` → `/private/var` case the existing comment already handles) — `cd "$X" && pwd` on an already-canonical path returns `$X` unchanged.

## Test plan

- [x] `bash tests/claude-code/test-sdd-workspace.sh` — 13/13 assertions pass on Windows 10 + Git Bash after this change (5 previously failed: "prints `<repo-root>/.superpowers/sdd/<plan>`", "task-brief writes its brief…", "review-package writes its diff…", "linked worktree resolves its own distinct workspace", plus a related worktree assertion)
- [x] Confirmed the change is additive-only (a normalization pass, not a change to what's compared) — no regression risk on platforms where the two forms already agree