### PR TITLE
docs: show how to override spec and plan output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ turn loses the bootstrap — start a fresh session if skills stop triggering.
 
 ## Customizing output paths
 
-By default, brainstorming writes design specs to `docs/superpowers/specs/` and writing-plans writes implementation plans to `docs/superpowers/plans/`. Both skills defer to your stated preference for where those files go.
+By default, brainstorming writes design specs (on its architectural path) to `docs/superpowers/specs/` and writing-plans writes implementation plans to `docs/superpowers/plans/`. Both skills state that a preference you set overrides those defaults.
 
-To move them, state the override as a direct instruction in the project file your harness loads at session start (`CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`). A table on its own is sometimes honored and sometimes lost — the skill hands the agent a concrete path to copy, so the reliable form is an imperative that names both the new location and the default it replaces:
+To move them, put the override in the project file your harness loads at session start (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, or your harness's equivalent). A table on its own is sometimes honored and sometimes lost — the skill hands the agent a concrete path to copy. Adding an imperative that names both the new location and the default it replaces is what worked in the case reported in [#939](https://github.com/obra/superpowers/issues/939):
 
 ```markdown
 ## Output Paths
@@ -291,10 +291,10 @@ To move them, state the override as a direct instruction in the project file you
 | Design specs | `docs/design-docs/` |
 | Implementation plans | `docs/exec-plans/` |
 
-**Design specs MUST be saved to `docs/design-docs/`, NOT `docs/superpowers/specs/`. Implementation plans MUST be saved to `docs/exec-plans/`, NOT `docs/superpowers/plans/`.**
+**IMPORTANT: Design specs MUST be saved to `docs/design-docs/`, NOT `docs/superpowers/specs/`. Implementation plans MUST be saved to `docs/exec-plans/`, NOT `docs/superpowers/plans/`.**
 ```
 
-The table keeps the choice readable for humans; the imperative is what the agent acts on.
+The table keeps the choice readable for humans; the imperative is the part that carries the override.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ turn loses the bootstrap — start a fresh session if skills stop triggering.
 
 ## Customizing output paths
 
-By default, brainstorming writes design specs to `docs/superpowers/specs/` and writing-plans writes implementation plans to `docs/superpowers/plans/`.
+By default, brainstorming writes design specs to `docs/superpowers/specs/` and writing-plans writes implementation plans to `docs/superpowers/plans/`. Both skills defer to your stated preference for where those files go.
 
-To use different locations, put **both** an Output Paths table and a direct instruction in the project file your harness loads at session start (`CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`). A table alone is not enough — agents follow the concrete path in the skill unless the override is also stated as an imperative.
+To move them, state the override as a direct instruction in the project file your harness loads at session start (`CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`). A table on its own is sometimes honored and sometimes lost — the skill hands the agent a concrete path to copy, so the reliable form is an imperative that names both the new location and the default it replaces:
 
 ```markdown
 ## Output Paths
@@ -293,6 +293,8 @@ To use different locations, put **both** an Output Paths table and a direct inst
 
 **Design specs MUST be saved to `docs/design-docs/`, NOT `docs/superpowers/specs/`. Implementation plans MUST be saved to `docs/exec-plans/`, NOT `docs/superpowers/plans/`.**
 ```
+
+The table keeps the choice readable for humans; the imperative is what the agent acts on.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [Pi](#pi)
   - [Hermes Agent](#hermes-agent)
 - [The Basic Workflow](#the-basic-workflow)
+- [Customizing output paths](#customizing-output-paths)
 - [Community](#community)
 - [What's Inside](#whats-inside)
 - [Philosophy](#philosophy)
@@ -275,6 +276,23 @@ turn loses the bootstrap — start a fresh session if skills stop triggering.
 7. **finishing-a-development-branch** - Activates when tasks complete. Verifies tests, presents options (merge/PR/keep/discard), cleans up worktree.
 
 **The agent checks for relevant skills before any task.** Mandatory workflows, not suggestions.
+
+## Customizing output paths
+
+By default, brainstorming writes design specs to `docs/superpowers/specs/` and writing-plans writes implementation plans to `docs/superpowers/plans/`.
+
+To use different locations, put **both** an Output Paths table and a direct instruction in the project file your harness loads at session start (`CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`). A table alone is not enough — agents follow the concrete path in the skill unless the override is also stated as an imperative.
+
+```markdown
+## Output Paths
+
+| Artifact | Location |
+|---|---|
+| Design specs | `docs/design-docs/` |
+| Implementation plans | `docs/exec-plans/` |
+
+**Design specs MUST be saved to `docs/design-docs/`, NOT `docs/superpowers/specs/`. Implementation plans MUST be saved to `docs/exec-plans/`, NOT `docs/superpowers/plans/`.**
+```
 
 ## Community
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Commit 1 (`9113eee`): Cursor Grok 4.6 extra high. Commits 2-3 (`fa950d6`, `90cab80`, both responses to review feedback): Claude Opus 5 (1M context) |
| Harness + version | Commit 1: Cursor 3.15.6. Commits 2-3: Claude Code 2.1.259 |
| All plugins installed | Cursor: no marketplace plugins; Superpowers not installed; Cursor built-in skills + gstack + frontend-design; MCP browser + Atlassian. Claude Code: claude-hud 0.1.0; Superpowers not installed as a plugin |
| Human partner who reviewed this diff | szsunyuan |

## What problem are you trying to solve?

#939: brainstorming and writing-plans hardcode `docs/superpowers/specs/` and `docs/superpowers/plans/`. A CLAUDE.md Output Paths table is ignored; the concrete skill path wins. The issue author showed that a table plus a MUST/NOT sentence in the project instruction file does override. obra asked for a README example of that form, not a skill rewrite.

## What does this PR change?

Adds a README section (and TOC link) documenting the default paths and the reported override: table + imperative, in `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / equivalent. No skill or test changes. Commits 2 and 3 are wording passes responding to review feedback on this PR — they walked back a deterministic claim about agent behavior that the PR has no evals for, and restored the example to the exact string reported working in #939.

## Is this change appropriate for the core library?

Yes. It documents how core spec/plan artifacts are relocated for any project. It does not add a dependency, a skill, or a third-party service.

## What alternatives did you consider?

- Editing brainstorming/writing-plans to check an Output Paths table first — rejected; that is #1020, and obra already said the right fix is a README example. Skill edits need evals this change does not.
- A README grep test — rejected; #1593 was closed as tautological.
- An env var (`SUPERPOWERS_PLANS_DIR`) — rejected; #337/#340 were closed in favor of project instruction overrides.
- Documenting how to tell whether the override took (`writing-plans/SKILL.md:157` hardcodes `docs/superpowers/plans/` in the completion message the agent recites, so it can quote the default even when the file lands elsewhere) — rejected for this PR; the fix belongs in the skill, not in a README caveat. Happy to file it separately.

## Does this PR contain multiple unrelated changes?

No. One README section for one docs gap.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1020, #1593, #1624

#1020 bundled skill edits with a table-only README and ignored the template. #1593 matched the README shape but was part of a 17-PR batch and added a decorative grep test; obra left #939 open and invited a clean README-only PR with no such test. #1624 was that README-only retry from the same author days later and was closed as spam. This PR is a single README change against `dev`, no test file, not part of a batch, human-reviewed.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Cursor | 3.15.6 | Grok 4.6 extra high | Cursor Grok 4.6 extra high |
| Claude Code | 2.1.259 | Claude Opus 5 | claude-opus-5[1m] |

These are the environments the change was authored and reviewed in. Because this is a README-only change, "tested" here means the markdown was verified, not that a skill session was run: TOC anchor matches the heading, the nested markdown code fence balances and its inner `## Output Paths` heading renders as literal text rather than entering the document outline, the diff adds no non-ASCII beyond the em dash already used elsewhere in the file, and every path and behavior claim was checked against `skills/brainstorming/SKILL.md:33,44,100,206-207` and `skills/writing-plans/SKILL.md:18-19` on `dev`.

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add support for a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Not applicable: this PR does not add harness support.

</details>

## Evaluation

- What was the initial prompt you (or your human partner) used to start the session that led to this change?
  Document the #939 workaround in the shape obra asked for (README example), after reviewing #1020/#1593/#1624.
- How many eval sessions did you run AFTER making the change?
  0 skill-behavior evals. This is not a skill change, and no claim in the section rests on a run of our own.
- How did outcomes change compared to before the change?
  Before: `dev` README had no override example; users only had the issue comment. After: the reported table + IMPORTANT/MUST/NOT form is in the README, attributed to #939. We did not re-run Superpowers. Because of that, the review round on this PR was used to strip every sentence that asserted agent behavior we had not measured — the section now describes the table-only case as "sometimes honored and sometimes lost" (the issue reports it failing, a reviewer here had it honored 2/2) and attributes the imperative form to the #939 report rather than calling it reliable.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Boxes 1 and 2 are both n/a, not skipped. Box 1: no skill files are touched. Box 2: the change documents an externally reported behavior and alters no code, skill, or hook, so there is no happy path to pressure-test — the adversarial work that applied was on the claims themselves, and it removed the ones that outran the evidence (see Evaluation).

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission