### PR TITLE
Recognize worktrunk's _worktrees/ convention in finishing-branch cleanup

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -166,8 +166,11 @@ Step 2, from before that directory change.
 
 **If `GIT_DIR == GIT_COMMON`:** Normal repo, no worktree to clean up. Done.
 
-**If `WORKTREE_PATH` is under `.worktrees/` or `worktrees/`:** Superpowers
-created this worktree — we own cleanup:
+**If `WORKTREE_PATH` is under `.worktrees/`, `worktrees/`, or `_worktrees/`:**
+Either this skill created the worktree (`.worktrees/`/`worktrees/`), or it
+matches a known worktree-manager convention (`_worktrees/<repo>/<branch>`,
+e.g. `worktrunk`'s `wt switch -c`) — either way it's a plain git worktree,
+so `git worktree remove` is safe regardless of which tool registered it:
 
 ```bash
 git worktree remove "$WORKTREE_PATH"
@@ -218,7 +221,7 @@ place. If your platform provides a workspace-exit tool, use it.
 | "They seem done with this feature — I'll offer to discard it" | The menu is complete as written. Discard happens only when your human partner asks for it in so many words. |
 | "'Yeah, get rid of it' counts as confirmation" | Only the typed word `discard` authorizes deletion. |
 | "The PR is up, so the worktree is clutter now" | PR feedback gets fixed in that worktree. It stays until the work lands. |
-| "This other worktree looks stale — I'll clean it too" | Clean up only worktrees under `.worktrees/` or `worktrees/`. Everything else belongs to the host. |
+| "This other worktree looks stale — I'll clean it too" | Clean up only worktrees under `.worktrees/`, `worktrees/`, or `_worktrees/`. Everything else belongs to the host. |
 | "Removal refused — `--force` is just finishing the cleanup" | The refusal means files exist only in that worktree. `--force` destroys them permanently. Show your human partner and ask. |
 | "The merged-result failure is probably flaky" | A failing merged result stops everything. Branch and worktree stay put while you investigate. |
 | "The base branch is obviously main" | Confirm the fork point or ask. Merging into the wrong base is expensive to undo. |


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Sonnet 5 (`claude-sonnet-5`) |
| Harness + version | Claude Code CLI (interactive session) |
| All plugins installed | `superpowers-marketplace` (superpowers, superpowers-chrome, elements-of-style, episodic-memory, superpowers-lab, superpowers-developing-for-claude-code, claude-session-driver, private-journal-mcp, double-shot-latte), `worktrunk`, plus several unrelated third-party marketplaces (agent/command collections not relevant to this change) |
| Human partner who reviewed this diff | tstephx |

## What problem are you trying to solve?

`finishing-a-development-branch`'s Step 6 cleanup only auto-owns worktree
removal for paths under `.worktrees/` or `worktrees/`. This showed up as a
real, repeated friction point in a multi-worktree fleet standardized on
[worktrunk](https://github.com/getworktrunk/worktrunk)'s
`~/Dev/_worktrees/<repo>/<branch>` layout (`wt switch -c`): every
worktree-based session that finished and merged fell through to "leave it
in place, host environment owns it," because the path didn't match either
recognized pattern — even though it's a completely ordinary git worktree
that `git worktree remove` handles fine. Confirmed independently across
two separate sessions on two different repos on 2026-08-13 and 2026-08-14;
both had to defer worktree/branch cleanup to a manual step afterward.
Filed as [tstephx/dotfiles#36](https://github.com/tstephx/dotfiles/issues/36).

## What does this PR change?

Extends the Step 6 path-pattern check to also recognize `_worktrees/`
alongside the existing `.worktrees/`/`worktrees/` patterns, and rewords
the surrounding sentence ("Superpowers created this worktree") since that
framing is no longer accurate once a second convention is recognized.
Also updates the matching row in the Common Rationalizations table.

## Is this change appropriate for the core library?

Yes — worktree lifecycle management is general-purpose finishing-branch
infrastructure, not specific to my project or team. The `_worktrees/`
pattern isn't worktrunk-specific either; it's just a directory-name
convention the skill now also recognizes, the same way it already
recognizes two other conventions. I'm not proposing worktrunk integration
or promoting the tool — worktrunk is named in the doc purely as the
motivating example of who else uses this layout.

## What alternatives did you consider?

The linked issue laid out two directions: (a) extend the path-pattern
match (what this PR does), or (b) have Step 6 explicitly hand off to a
`wt merge`-style external teardown command when a worktree-manager
pattern is detected, instead of silently leaving it in place. I went with
(a) because `git worktree remove` is a plain git operation that works
identically regardless of which tool registered the worktree — there's no
actual dependency on worktrunk's CLI being installed or on shelling out to
a third-party tool, so the simpler, tool-agnostic pattern-match extension
covers the same case without adding a dependency or new failure mode.

## Does this PR contain multiple unrelated changes?

No — single change (the path-pattern list) touching one section of one
file, plus its one corresponding table row.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1933 (merged 2026-07-13) is where the current
  `.worktrees/`/`worktrees/` wording and rationalization-table row
  originated — this PR extends that same pattern rather than duplicating
  it. No open or closed PR already adds `_worktrees/` recognition.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code CLI | (not captured) | Claude Sonnet 5 | claude-sonnet-5 |

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [ ] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

I did load `superpowers:writing-skills` before editing, but this is a
narrow **reference/technique-pattern** change (a path-match rule), not a
discipline-enforcing rule change — per that skill's own "Testing All
Skill Types" guidance, reference/technique edits call for
retrieval/application testing, not the multi-pressure adversarial
protocol built for discipline skills (TDD, verification-before-completion,
etc.). What I actually did: verified the exact `_worktrees/<repo>/<branch>`
pattern against a live worktree before hardcoding it, then ran a single
fresh-context classification check — 4 representative `WORKTREE_PATH`
values (a worktrunk path, a `.worktrees/` path, a path that merely
contains "worktrees" as a substring without matching a path segment, and
a plain non-worktree checkout) — and confirmed all 4 classified correctly
(2 auto-owned, 2 leave-in-place). That's real but narrow — it's not
adversarial pressure testing, and I'm not checking that box or claiming
it is. I did touch one Common Rationalizations row (added `_worktrees/`
to an existing enumeration) without a separate eval pass, which is
exactly the kind of edit the third checkbox is warning about — leaving it
unchecked rather than overclaiming.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Reviewed by tstephx in the finishing session on 2026-08-14: shown the full
`gh pr diff 2151` output (both hunks) and confirmed correct.
