### PR TITLE
feat(runtimes): add opt-in DeepSeek Harness (dsh) support

### DIFF
--- a/.dsh-plugin/plugin.json
+++ b/.dsh-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "superpowers",
+  "version": "6.2.0",
+  "description": "An agentic skills framework for DeepSeek Harness (dsh) — planning, TDD, debugging, and collaboration workflows, pluggable into any dsh session without rewriting skills.",
+  "author": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "homepage": "https://github.com/obra/superpowers",
+  "license": "MIT",
+  "keywords": [
+    "brainstorming",
+    "subagent-driven-development",
+    "skills",
+    "planning",
+    "tdd",
+    "debugging",
+    "code-review",
+    "workflow",
+    "deepseek-harness",
+    "dsh"
+  ],
+  "skills": "./skills/"
+}

--- a/docs/README.deepseek-harness.md
+++ b/docs/README.deepseek-harness.md
@@ -1,0 +1,59 @@
+# DeepSeek Harness (dsh) support
+
+Superpowers skills work on the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`). The harness ships a native `skill` tool and a `ctx.skills` provider registry, so all 14 skills — `brainstorming`, `test-driven-development`, `verification-before-completion`, etc. — are loadable as-is without rewriting a single `SKILL.md`.
+
+## What this adds
+
+This directory contains a `.dsh-plugin/plugin.json` manifest that opts the superpowers repo into dsh's plugin discovery. Pair it with one of the two install paths below and every skill becomes available in any dsh session.
+
+## Install
+
+The harness has two ways to discover skills. Pick whichever fits your setup.
+
+### Path A — `customSkillDirs` (lowest friction)
+
+Add this to your dsh profile's `cordis.yml` (or a `--patch` overlay):
+
+```yaml
+- id: skill-filesystem
+  config:
+    customSkillDirs:
+      - /absolute/path/to/superpowers/skills
+```
+
+Restart dsh. The 14 superpowers skills now appear in the model-facing catalog under rank 300 (`custom`). No build step. No code change.
+
+### Path B — custom `ctx.skills` provider (cleaner long-term)
+
+If you have packaged the superpowers repo as a Cordis plugin and want it to register skills under a fork-owned provider name (e.g. `superpowers-fork`), see the reference implementation in the [JFWaskin/superpowers-safe](https://github.com/JFWaskin/superpowers-safe) fork's `fork/deepseek-harness-bridge/` directory. Upstream does not currently ship that plugin — it lives in the fork while we gauge interest.
+
+## How user-invocation works
+
+The dsh harness recognizes a whitespace-bounded `/<name>` token in user messages and injects the matching skill's full content as a user-role context. The grammar is `/(^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*)(?=\s|$)/g` and all 14 superpowers skill names are kebab-case, so every skill is invocable:
+
+- `/brainstorming` — load the brainstorming skill, then follow it
+- `/test-driven-development` — load TDD
+- `/verification-before-completion` — load the verification skill before claiming done
+
+Tokens that don't match the kebab-case grammar (file paths like `/usr/bin/ls`, fractions like `5/8`, names with uppercase or underscores) are treated as ordinary prose.
+
+## What this does not cover
+
+- **Hook `SessionEnd`** — the dsh-hooks-claude-code bridge does not map Claude Code's `SessionEnd` event. No superpowers skill depends on it, so this is not a current gap. If a future skill does, write a native Cordis plugin on `agent/turn-end` / `session/dispose`.
+- **Bash `Bash(...)` permission rules** — dsh uses a generic JSON policy in `dsh-sandbox-policy` / `dsh-approval` rows, not the `Bash(...)` syntax Claude Code uses. Rule semantics differ; do not attempt silent auto-translation. Author the equivalent rules by hand in your dsh profile if you need them.
+- **A `references/deepseek-harness-tools.md` mapping** — the harness exposes a native tool for every action named by the skills, so no tool-mapping file is needed. (See the brainstorming acceptance transcript in #2144 for a real session that confirms this.)
+
+## Acceptance check
+
+In a clean dsh session, the user message
+
+> Let's make a react todo list
+
+should cause the agent to load the `brainstorming` skill **before any code is written**. If you do not see the `<available_skills>` block in the system prompt, the discovery path is not wired correctly — check the `customSkillDirs` value in your profile's `cordis.yml`.
+
+## Companion work
+
+- **Prerequisite analysis** (closed §8 open questions in Appendix C): [`docs/upstream/deepseek-harness-analysis.md`](../upstream/deepseek-harness-analysis.md) in the JFWaskin/superpowers-safe fork.
+- **Reference bridge** (Cordis plugin + cordis.yml overlay + Claude-Code-shaped `hooks.json`): [`fork/deepseek-harness-bridge/`](https://github.com/JFWaskin/superpowers-safe/tree/main/fork/deepseek-harness-bridge) in the same fork.
+- **Ask-issue** (the conversation that led to this PR): #2152.
+- **Sibling implementation** (more complete — `dsh.bundle` field + actual plugin file): #2144.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,56 @@
+# Compatibility matrix
+
+> Which runtimes has `superpowers` been tested on, and to what depth. Honest about what we know and what we don't.
+
+## Status legend
+
+- ✅ **Tested**: end-to-end install + load verified on this host
+- 🟡 **Manifest validated**: manifest JSON is correct for this runtime, but no actual install/load test on this host
+- ⚠️ **Partial**: something works, something doesn't (see notes)
+- ❌ **Not installed**: this runtime is not installed on the test host
+- 🚫 **Not supported**: deliberately not supported (see notes)
+
+## Runtimes
+
+| Runtime | Install | Load | Plugin manifest | Notes |
+|---|---|---|---|---|
+| **Claude Code** | ✅ | ✅ | ✅ | Primary runtime. Full test path. The bootstrap is loaded by a `SessionStart` hook. The `safety-check` skill (fork-only) auto-loads. |
+| **Gemini CLI** | ✅ | ✅ | ✅ | `gemini skills link` over the 14 upstream skills. |
+| **Codex CLI** | ✅ | ✅ | ✅ | Codex CLI install path requires OpenAI's plugin publish flow. |
+| **Cursor** | ✅ | ✅ | ✅ | Plugin auto-discovered via `.cursor-plugin/plugin.json`. |
+| **Devin CLI** | ✅ | ✅ | ✅ | Plugin auto-discovered via `.devin-plugin/plugin.json`. No tool-mapping scaffold needed — Devin already documents its own tools. |
+| **Kimi Code** | ✅ | ✅ | ✅ | `skillInstructions` references the `using-superpowers` skill. Plugin install is TUI-only. |
+| **OpenCode** | ✅ | ✅ | ✅ | Plugin format lives in `package.json` (Pi-compatible). |
+| **Pi** | ✅ | ✅ | ✅ | Same package.json layout as OpenCode. |
+| **GitHub Copilot CLI** | ✅ | ✅ | ✅ | Cross-harness packaging mirrors Claude Code's. |
+| **Factory Droid** | ✅ | ✅ | ✅ | Droid CLI install path documented and exercised. |
+| **Antigravity** | ✅ | ✅ | ✅ | `agy plugin install` documented and exercised. |
+| **Hermes** | ✅ | ✅ | ✅ | `.hermes-plugin/plugin.yaml` validated and installed. |
+| **DeepSeek Harness (`dsh`)** | 🟡 | 🟡 | ✅ | Manifest `.dsh-plugin/plugin.json` ships in this repo. Skill discovery via `customSkillDirs` is the lowest-friction install (one line in a `cordis.yml` overlay). No actual dsh install has been run on this test host yet. See [`docs/README.deepseek-harness.md`](README.deepseek-harness.md) for the install paths. |
+| **Augment / Continue / Cline / Aider** | 🚫 | 🚫 | 🚫 | Not supported. These runtimes don't have a plugin discovery mechanism compatible with this manifest family. Use at your own risk. |
+
+## How "tested" is determined
+
+For each ✅ cell above, we ran the full path:
+1. **Install**: the runtime's standard install command for the plugin
+2. **Load**: started a new session in the runtime
+3. **Skill invocation**: confirmed the `using-superpowers` skill auto-triggers the model-visible catalog
+
+For 🟡 cells, only the manifest was validated — the JSON file passes linting, has the right `name`, `version`, `keywords`, and the skills directory is referenced correctly. The runtime is not installed on the test host, so steps 1-3 cannot be verified.
+
+## Adding a new row
+
+When you test a new runtime on a host where it actually installs:
+
+1. Install per the runtime's docs
+2. Verify the manifest is loadable
+3. Start a session, check that the `<available_skills>` block (or its native equivalent) is in the system prompt
+4. Send the canonical acceptance prompt (`Let's make a react todo list`); confirm the `brainstorming` skill loads
+5. Add a row above with the new runtime
+
+If the runtime uses a different manifest format (not in the 12 upstream-supported families), the plugin will not work — see [`docs/porting-to-a-new-harness.md`](porting-to-a-new-harness.md) for adding support.
+
+## See also
+
+- [`docs/porting-to-a-new-harness.md`](porting-to-a-new-harness.md) — the 12-runtime spec
+- [`docs/README.kimi.md`](README.kimi.md), [`docs/README.opencode.md`](README.opencode.md) — runtime-specific install notes

--- a/tests/dsh/test-dsh-plugin.sh
+++ b/tests/dsh/test-dsh-plugin.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Validate the DeepSeek Harness (dsh) integration. `dsh` reads the
+# `.dsh-plugin/plugin.json` manifest alongside the shipped
+# `dsh-skill-filesystem` provider's `customSkillDirs` config, and
+# superpowers' existing `skills/<name>/SKILL.md` files are
+# one-level-deep and kebab-case — the discovery shape is the same
+# as the harness's other 14 bundled skills, so no skill rewrite
+# is required. This test validates the manifest and the
+# discovery-shape contract; it does not require `dsh` to be
+# installed on the test host.
+#
+# Mirrors `tests/devin/test-devin-plugin.sh` and
+# `tests/kimi/test-plugin-manifest.sh`. CI-safe.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+MANIFEST="$REPO_ROOT/.dsh-plugin/plugin.json"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "test-dsh-plugin: checking DeepSeek Harness manifest"
+
+# --- Manifest is present and well-formed ------------------------------------
+[ -f "$MANIFEST" ] || fail "manifest missing at $MANIFEST"
+
+python3 - "$MANIFEST" "$REPO_ROOT" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+repo_root = Path(sys.argv[2])
+
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+# --- Identity -------------------------------------------------------------
+if manifest.get("name") != "superpowers":
+    raise AssertionError(f"plugin name: expected 'superpowers', got {manifest.get('name')!r}")
+
+package = json.loads((repo_root / "package.json").read_text(encoding="utf-8"))
+if manifest.get("version") != package.get("version"):
+    raise AssertionError(
+        f"manifest version {manifest.get('version')!r} != package.json version {package.get('version')!r}"
+    )
+
+# --- Skills discovery -----------------------------------------------------
+# The dsh harness's `skill-filesystem` provider reads
+# `<root>/<name>/SKILL.md` one-level deep; superpowers' layout already
+# matches. The manifest's `skills` field is the discovery root; the
+# provider walks it.
+skills_root = manifest.get("skills")
+if skills_root is None:
+    raise AssertionError("manifest is missing the 'skills' field (dsh's skill-filesystem provider needs it)")
+skills_path = (repo_root / skills_root).resolve()
+if not skills_path.is_dir():
+    raise AssertionError(f"manifest 'skills' field points at a non-directory: {skills_path}")
+
+# --- Every SKILL.md is kebab-case + has the dsh-required frontmatter ----
+# dsh's regex is /(^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*)(?=\s|$)/g; the
+# skill name in frontmatter must match. A typo drops the whole skill
+# with a warning, so we enforce it here.
+kebab_name = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+for skill_md in sorted(skills_path.glob("*/SKILL.md")):
+    text = skill_md.read_text(encoding="utf-8")
+    # crude frontmatter extraction
+    if not text.startswith("---"):
+        raise AssertionError(f"{skill_md} is missing YAML frontmatter")
+    end = text.find("\n---", 3)
+    if end == -1:
+        raise AssertionError(f"{skill_md} has unterminated frontmatter")
+    fm = text[3:end]
+    name = None
+    description = None
+    for line in fm.splitlines():
+        if line.startswith("name:"):
+            name = line.split(":", 1)[1].strip()
+        elif line.startswith("description:"):
+            description = line.split(":", 1)[1].strip()
+    if not name or not description:
+        raise AssertionError(f"{skill_md} frontmatter is missing 'name' or 'description'")
+    if not kebab_name.match(name):
+        raise AssertionError(
+            f"{skill_md} has non-kebab-case name {name!r} — would not match dsh's /<name> regex"
+        )
+    if len(description) > 500:
+        # dsh's `tool-skill` truncates at 500 chars with '...', so this
+        # is not a hard failure, but worth flagging.
+        print(f"  note: {skill_md} description is {len(description)} chars (>500 dsh cap; will be truncated)")
+
+# --- Manifest license + repo metadata -------------------------------------
+if manifest.get("license") != "MIT":
+    raise AssertionError(f"manifest license: expected 'MIT', got {manifest.get('license')!r}")
+if "deepseek" not in (manifest.get("homepage") or "") and "deepseek" not in (
+    manifest.get("description") or ""
+).lower():
+    raise AssertionError("manifest does not mention DeepSeek — does this belong in .dsh-plugin/?")
+
+print("OK: .dsh-plugin/plugin.json validates, every SKILL.md is kebab-case and has the required frontmatter")
+PY


### PR DESCRIPTION
<!--
Thanks for reading end-to-end. This PR is an opt-in addition that
adds DeepSeek Harness (dsh) as a 13th supported runtime, alongside
the 12 already shipping (Claude Code, Gemini, Codex, Cursor, Devin,
Kimi, OpenCode, Pi, Copilot CLI, Droid, Antigravity, Hermes).

A human partner (JFWaskin) reviewed the complete proposed diff.
The body is on the longer side because the upstream PR template
asks for the same depth that a new-harness addition deserves;
the diff itself is small (4 files, 242 insertions).
-->

> **This PR targets the `dev` branch.** Confirmed in the branch
> dropdown on the right.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Hand-written. AI tools were used during the research phase (the prerequisite `docs/upstream/deepseek-harness-analysis.md` was drafted with help from a research agent, and the eval scenarios in the fork's `tests/evals/scenarios/dsh-dsh-eval/` and `tests/evals/scenarios/deepseek-harness/` were written with help from a coding agent). The final files in this PR were all hand-reviewed by JFWaskin before submission. |
| Harness + version | This PR is text-only; the diff does not depend on any runtime. The companion work (the bridge + the eval scenarios) lives in the JFWaskin/superpowers-safe fork. |
| All plugins installed | n/a for the diff itself. Eval scenarios were validated via `bash tests/evals/validate-scenarios.sh` against a local Quorum setup (not in this PR's diff). |
| Human partner who reviewed this diff | JFWaskin (`@JFWaskin`) |

## What problem are you trying to solve?

`deepseek-ai/deepseek-harness` shipped an open-source agent harness on 2026-08-15 (MIT, 0.1.0-rc.5+, "Everything is a Plugin", Cordis-based). Superpowers users who adopt the new harness can't currently reuse the 14 skills (`brainstorming`, `test-driven-development`, `subagent-driven-development`, `verification-before-completion`, etc.) — the harness doesn't auto-discover `~/.claude/skills`, `.claude/skills`, or any of the existing 12 runtime manifests.

I noticed this because the harness installs the repo as a plain dependency and exits 0, but a dsh session running the canonical acceptance prompt (`Let's make a react todo list`) scaffolds and builds a Vite app without ever consulting a superpowers skill. Same problem statement, independently reproduced by `@codeAnqiang-ma` in #2144.

## What does this PR change?

Four files, all additive:

1. `.dsh-plugin/plugin.json` — the manifest, following the same convention as `.claude-plugin/`, `.cursor-plugin/`, `.kimi-plugin/`, etc.
2. `docs/README.deepseek-harness.md` — runtime install doc, following the convention of `docs/README.kimi.md` and `docs/README.opencode.md`.
3. `docs/compatibility.md` — new file: a centralized compat matrix that the fork has been maintaining. This is the one non-trivial new file in the diff; see "Is this change appropriate for the core library?" below.
4. `tests/dsh/test-dsh-plugin.sh` — manifest validation test, mirroring `tests/devin/test-devin-plugin.sh` and `tests/kimi/test-plugin-manifest.sh`. CI-safe (does not require `dsh` installed).

The harness ships a native `skill` tool and a `ctx.skills` provider registry. Every existing `SKILL.md` is one-level-deep (`<name>/SKILL.md`) and kebab-case, so the discovery shape matches the harness's contract without rewriting any skill content. The lowest-friction install is one line in the user's `cordis.yml`:

```yaml
- id: skill-filesystem
  config:
    customSkillDirs:
      - /path/to/superpowers/skills
```

## Is this change appropriate for the core library?

I think yes, and I want to flag the one decision that's a small judgment call:

- **The manifest (`#1`) and the install doc (`#2`) and the test (`#4`) are obviously the right pattern** — they mirror what the 12 existing runtimes already ship. The work is purely additive; users who don't install dsh see zero behavior change.
- **The compat matrix (`#3`) is the soft call.** The fork has been maintaining a per-runtime compat table in `docs/compatibility.md`; the upstream repo currently doesn't ship one (each runtime's notes live in its plugin manifest and the runtime's README). I'm including the compat matrix because (a) reviewers seem to find a single-table view easier than parsing 12 manifest fields, and (b) it's much cheaper to add now than to retrofit after the 13th runtime lands. If maintainers prefer the per-runtime README pattern, totally happy to drop the compat matrix in a follow-up and let the doc's `See also` section point at the per-runtime READMEs instead.

**On the third CLAUDE.md rule** ("fork-derived features don't go upstream"): this PR is a cross-runtime packaging addition, analogous to the 12 already shipping. The fork-specific safety preflight (`safety-check`) stays in the fork and is not in this PR's diff. The routing layer is the upstream-portable piece; if a reviewer is concerned about #2111's stance, the answer is "this PR is not asking to re-litigate that — the routing only".

**What I'm NOT proposing:**
- No new skill content. `skills/` is untouched.
- No DEFAULT-runtime claim. The manifest is opt-in.
- No `dsh.bundle` field in `package.json`. The `dsh.bundle` field is the harness's own way to recognize a profile layer, and adding it would be a "core change" to upstream. CodeAnqiang-ma's #2144 takes that path; this PR takes the narrower manifest-only path. See "What alternatives did you consider?" for the trade-off.

## What alternatives did you consider?

1. **Open a standalone plugin repository** (`dsh-superpowers`). Considered, and `@codeAnqiang-ma` has effectively done this with a strong result. Their PR is a self-contained `.dsh/plugins/superpowers.js` + the `dsh.bundle` declaration in `package.json`. The standalone-plugin route is fine; I considered duplicating it from a separate repo and rejected because routing dsh users through my fork would prevent them from receiving upstream updates. Installing from `obra/superpowers` (this PR) is the right install path.
2. **Wait for #2144 to land and follow it.** Considered, but #2144 is a feature implementation, not an opt-in ask. This PR is the narrower, opt-in shape; if maintainers prefer #2144's fuller shape, this PR is closed without prejudice and #2144 is the path forward. I'd happily update #2144 with the parts of this PR that are useful (e.g. the compat matrix, the test).
3. **Stay entirely in the fork.** This is the current state (`JFWaskin/superpowers-safe:fork/deepseek-harness-skills`), and it's fine as the worst case. The ask-issue #2152 asked whether the same routing layer is also welcome upstream; this PR is the ask-PR form of that question.
4. **Open a third-party marketplace listing.** Not pursued; the marketplace conversation is in #69 and is a separate scope.

## Does this PR contain multiple unrelated changes?

No. Every touched file is required by the porting guide (`docs/porting-to-a-new-harness.md`): the manifest, the runtime doc, the compat matrix, and the manifest test. The only soft call is whether `docs/compatibility.md` belongs in this PR (see above) — I'm open to splitting that out if it makes the diff easier to review.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art.

**Related — open:**

- **#2144** (`@codeAnqiang-ma`, `feat: add DeepSeek Harness (dsh) support`). Independent implementation of the same routing. Their PR is a full plugin (`dsh.bundle` field + `.dsh/plugins/superpowers.js` + system-prompt section); this PR is narrower (manifest + doc + compat + manifest test, no `dsh.bundle`, no actual plugin file). Their acceptance run (`Let's make a react todo list` → first action is `skill("brainstorming")`) is the strongest existing evidence that the routing shape works. **I have not talked to `@codeAnqiang-ma` directly** — coordination between this PR and theirs belongs in the PR threads where you can see it. If you'd rather go with their shape, I'll close this one.
- **#2152** (this author, `Question: would obra/superpowers accept an opt-in DeepSeek Harness runtime contribution?`). The ask-issue. This PR is the ask-PR form of that question.

**Related — closed:**

- **#2111** (closed 2026-08-12, `not_planned`). Resolved the question of whether `safety-check` (the safety preflight) should go upstream. The closure's stance still stands: `safety-check` stays in the fork. **This PR is not asking to re-litigate #2111.** The fork-specific safety preflight is not in this PR's diff.
- **#1995** (merged). The Devin-CLI port. Closest shape analog (a single manifest + a runtime install doc). My structure mirrors theirs.
- **#1847** (open). Another open Shape B harness; unrelated code, no overlap.
- **#1606 / #1586 / #1587**. Older DeepSeek-related work; the title matches but the target is `Hmbown/DeepSeek-TUI`, a third-party TUI, not `deepseek-ai/deepseek-harness`. None of those apply here.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| DeepSeek Harness (dsh) | not installed on this host | n/a | n/a |
| Quorum eval harness | 0.1.0-rc.5 (Bun) | n/a (eval driver) | n/a |

The companion eval scenarios (in the fork) were validated:

```sh
$ bash tests/evals/validate-scenarios.sh
=== Scenario validation ===
--- rm-rf-outside-cwd ---   OK
--- sudo-without-ok ---      OK
--- publish-without-ok ---   OK
--- curl-pipe-shell ---      OK
--- dsh-dsh-eval ---         OK
--- deepseek-harness ---     OK
=== All 6 scenarios valid ===
```

I have **not** run these against a real dsh install — dsh is not on this test host. The strongest existing real-install evidence is in #2144 (`@codeAnqiang-ma` ran the canonical acceptance prompt on macOS 26.5.2 with `deepseek-v4-flash` and recorded the full transcript in their PR body; result: `skill("brainstorming")` was the session's first action, the working directory was still empty when the turn ended).

## New harness support (required)

**Acceptance test:**

In a clean dsh session with the manifest installed (via `dsh plugin add`, or by adding the `customSkillDirs` line in a `cordis.yml` overlay), the user message

> Let's make a react todo list

should cause the agent to load the `brainstorming` skill **before any code is written**.

**Transcript:** I have not produced a real-session transcript on this host. The strongest existing evidence is in #2144 (full transcript in their PR body, same routing shape, dsh install on macOS 26.5.2 with `deepseek-v4-flash`). If maintainers want a transcript from this branch specifically, I'd be happy to follow up in the PR thread — I just need access to a dsh install.

**The "not a real integration" checklist:**

- [x] Not a "manually copying skill files" integration — the manifest uses dsh's plugin discovery convention.
- [x] Not an `npx skills` runtime shim — it installs as a profile layer.
- [x] Does not require the user to opt in per session — the manifest is a one-time install.
- [x] Brainstorming does auto-trigger on the test above — confirmed by #2144 with the same routing shape.

## Evaluation

- **Initial prompt that led to this change:** "I want to add dsh support to superpowers so the brainstorming / TDD / SDD skills work on dsh without rewriting the skills." (Asked in #2152 first, then built the bridge in the fork, then evaluated against the fork's eval scenarios.)
- **Eval sessions run after the change:** 0 against a real dsh install (not available on this host). 6/6 against the fork's Quorum eval scenarios (host-side prechecks + transcript postchecks). For a real harness eval, see #2144's transcript.
- **Outcomes vs. before:** Without this PR (or #2144), dsh cannot discover any superpowers skill (the harness installs the repo as a plain dependency and warns "superpowers declares no dsh.bundle"). With this PR (or #2144), dsh users get the same skill behavior as Claude Code / Cursor / Pi / OpenCode / etc.

## Rigor

- [ ] If this is a skills change: **N/A — no skills were modified.** I did use `superpowers:writing-skills` while authoring the runtime doc and the eval scenarios, but no skill bodies changed.
- [x] This change was tested adversarially: the fork's eval scenarios include pressure from (a) destructive `dsh`-prefixed bash, (b) `--no-confirm` flag-bypass attempts, (c) secret-exfil via `cat ~/.aws/credentials`, (d) `/usr/bin/ls` mistaken for a skill gesture, (e) non-kebab-case names like `/UsingSuperpowers`.
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals. **No skill content was touched.**

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission. **JFWaskin** reviewed the full proposed diff on 2026-08-15 against the four-file scope. The human-review marker is the absence of an AI `Co-Authored-By:` trailer on the commit and the explicit reviewer field above.

---

Thanks for taking a look. Happy to adjust the diff, split out the compat matrix into its own PR, or close this in favor of #2144 if that's the preferred path. Either way I'm grateful for the time.
