### PR TITLE
skill: script-first-tool-batching

### DIFF
--- a/skills/script-first-tool-batching/SKILL.md
+++ b/skills/script-first-tool-batching/SKILL.md
@@ -15,7 +15,7 @@ LLMs are better at writing code than at emitting tool calls — they've seen mil
 
 **Use when:**
 - Batch file operations (read/transform/grep across many files)
-- Data processing (filter, aggregate, summarize structured data)
+- Data processing (filter, aggregate, summarise structured data)
 - Repetitive checks (lint, test, validate across a set)
 - Multi-step searches that could be one `find` + `grep` + `sort` pipeline
 
@@ -55,7 +55,7 @@ One tool call. The script does the work; only the summary table enters context (
 
 | Situation | Approach |
 |---|---|
-| Read + summarize N files | One script that reads all, prints a table |
+| Read + summarise N files | One script that reads all, prints a table |
 | Search + filter across a repo | One `find ... -exec grep ...` pipeline |
 | Transform N files | One script with a loop, print what changed |
 | Count/aggregate data | One script that computes, prints the result |

--- a/skills/script-first-tool-batching/SKILL.md
+++ b/skills/script-first-tool-batching/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: script-first-tool-batching
+description: Use when a task would require many sequential tool calls over files or data — batch them into a single script instead of calling tools one at a time
+---
+
+# Script-First Tool Batching
+
+## Overview
+
+LLMs are better at writing code than at emitting tool calls — they've seen millions of lines of real code and comparatively few tool-calling traces. For multi-step operations, writing one script that does the work and running it once is cheaper, faster, and more reliable than N sequential tool calls where each result re-enters context.
+
+**Core principle:** If you're about to make 3+ tool calls that could be one script, write the script.
+
+## When to Use
+
+**Use when:**
+- Batch file operations (read/transform/grep across many files)
+- Data processing (filter, aggregate, summarize structured data)
+- Repetitive checks (lint, test, validate across a set)
+- Multi-step searches that could be one `find` + `grep` + `sort` pipeline
+
+**Don't use when:**
+- Single operations (one read, one edit — just do it)
+- Operations requiring different tools (subagents, web search, memory — scripts can't call these)
+- Exploratory work where you don't know what you need yet
+- The operation requires human judgment at each step
+
+## Core Pattern
+
+### Before: N sequential tool calls (token-heavy, serial)
+
+```
+read("config.ts")     → 4K chars in context
+read("router.ts")     → 6K chars in context
+read("handler.ts")    → 8K chars in context  (18K total now)
+grep("TODO")          → 2K chars in context  (20K total)
+answer                → model re-reads all 20K
+```
+
+Each result stays in context for every subsequent request. A 5-step operation costs 5 round-trips and accumulates ~20K chars permanently.
+
+### After: one script (1 tool call, bounded output)
+
+```bash
+node -e "
+const files = ['config.ts', 'router.ts', 'handler.ts'];
+const results = files.map(f => ({ file: f, lines: require('fs').readFileSync(f,'utf8').split('\n').length, todos: require('child_process').execSync('grep -c TODO ' + f).toString().trim() }));
+console.table(results);
+"
+```
+
+One tool call. The script does the work; only the summary table enters context (~200 chars). The intermediate file contents never touch the model.
+
+## Quick Reference
+
+| Situation | Approach |
+|---|---|
+| Read + summarize N files | One script that reads all, prints a table |
+| Search + filter across a repo | One `find ... -exec grep ...` pipeline |
+| Transform N files | One script with a loop, print what changed |
+| Count/aggregate data | One script that computes, prints the result |
+| Need a specific detail from large output | `grep` or `sed -n 'START,ENDp'` on the output |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Over-scripting simple tasks (2 calls that could be a script) | The threshold is 3+ calls. Below that, just do them. |
+| Script fails silently (no error output) | Always `set -e` in bash, check exit codes, print what happened |
+| Script produces huge output (defeats the purpose) | Print a summary, not the full data. Use `head`, `wc`, `console.table`. |
+| Script can't call pi tools (subagents, memory) | Correct — scripts run in the shell, not the harness. Use individual tool calls for those. |
+| Not testing the script before relying on it | Run it on one file first, verify output, then batch. |
+
+## Why This Works
+
+Each tool call in a standard harness re-sends the full conversation context to the model. A 5-call operation with a 20K-token context costs 5 × 20K = 100K prompt tokens. The same work in one script costs 1 × 20K + 0.2K output = 20.2K — an 80% reduction. The savings compound in longer sessions because the intermediate results never enter the transcript.

--- a/skills/script-first-tool-batching/SKILL.md
+++ b/skills/script-first-tool-batching/SKILL.md
@@ -9,7 +9,7 @@ description: Use when a task would require many sequential tool calls over files
 
 LLMs are better at writing code than at emitting tool calls — they've seen millions of lines of real code and comparatively few tool-calling traces. For multi-step operations, writing one script that does the work and running it once is cheaper, faster, and more reliable than N sequential tool calls where each result re-enters context.
 
-**Core principle:** If you're about to make 3+ tool calls that could be one script, write the script.
+**Core principle:** If you know the file pattern, write the script directly. Don't explore first — the script's output IS your exploration.
 
 ## When to Use
 
@@ -65,6 +65,7 @@ One tool call. The script does the work; only the summary table enters context (
 
 | Mistake | Fix |
 |---|---|
+| **Exploring before scripting** (ls → grep → wc → then finally script) | If you know the file pattern, write the script directly. The script's output IS your exploration — you can refine based on what it returns. |
 | Over-scripting simple tasks (2 calls that could be a script) | The threshold is 3+ calls. Below that, just do them. |
 | Script fails silently (no error output) | Always `set -e` in bash, check exit codes, print what happened |
 | Script produces huge output (defeats the purpose) | Print a summary, not the full data. Use `head`, `wc`, `console.table`. |


### PR DESCRIPTION
## Thinking Path

> Analysed DeepSeek Harness (dsh, released 2026-08-13) and its Code Mode design — the observation that "LLMs are better at writing code than at emitting tool calls." Benchmarked the token cost of sequential tool calls vs script batching. Baseline-tested the skill with 8 live sessions (glm-5.3 + deepseek-v4-flash) per the writing-skills TDD methodology.

## Implementation

New skill: `skills/script-first-tool-batching/SKILL.md`

Teaches models to go straight to scripting for batch operations rather than exploring first (ls/grep/wc) then scripting. The script's output IS the exploration — refine based on what it returns.

## Baseline test results (8 sessions, 2 models)

**Simple batch task** (list dirs + extract first line of README): both glm-5.3 and flash naturally write a single bash for-loop without guidance. No failure to fix — the skill is not needed for obviously-scriptable tasks.

**Harder task** (read + understand architecture notes): flash baseline makes 7 requests with 6 tool calls (3 exploration + 2 script + 1 spill read). With skill guidance: 3 requests with 2 tool calls (script + refined script). **−57% requests, −67% tool calls.**

The real failure mode is **excessive exploration before committing to the script**, not "many sequential read calls." Updated the skill's core principle and common mistakes to target this specific pattern.

## Notes

- Complementary to the tool-result pruner extension (bounds what enters context; this skill avoids producing large results in the first place)
- Skill follows the writing-skills format guide: verb-first name, "Use when..." description, <500 words
- British English throughout