### PR TITLE
fix(sdd): make sdd-workspace's .gitignore create-only, not an unconditional overwrite

### DIFF
--- a/skills/subagent-driven-development/scripts/sdd-workspace
+++ b/skills/subagent-driven-development/scripts/sdd-workspace
@@ -36,5 +36,8 @@ root=$(git rev-parse --show-toplevel)
 base="$root/.superpowers/sdd"
 dir="$base/$slug"
 mkdir -p "$dir"
-printf '*\n' > "$base/.gitignore"
+# Create-only: a repo may commit its own .superpowers/sdd/.gitignore (e.g. to
+# version progress.md ledgers via a negation pattern) — an unconditional
+# overwrite here would silently revert that choice on every invocation.
+[ -e "$base/.gitignore" ] || printf '*\n' > "$base/.gitignore"
 cd "$dir" && pwd


### PR DESCRIPTION
## Problem

`sdd-workspace` runs `printf '*\n' > "$base/.gitignore"` on every invocation (skill setup, every `task-brief`, every `review-package`) with no existence check.

A repo that commits its own `.superpowers/sdd/.gitignore` — for example to negate the wildcard and version `progress.md` ledgers instead of leaving them untracked — gets that choice silently reverted on the very next SDD run, repeatedly, for the life of the plan.

Observed effect in a real repo: the working tree showed `.superpowers/sdd/.gitignore` modified with no agent having touched it. The `progress.md` of that run was also lost separately (the "Finish" step's `rm -rf` of the workspace ran before the conflict was noticed), which is a related but distinct issue — this PR only addresses the `.gitignore` overwrite.

## Fix

Make the write create-only:

```diff
-printf '*\n' > "$base/.gitignore"
+[ -e "$base/.gitignore" ] || printf '*\n' > "$base/.gitignore"
```

The script's own header comment already states the intent — keep every plan's workspace out of `git status` and out of accidental commits "without modifying any tracked file." An unconditional overwrite violates that stated intent whenever the file is already tracked. Create-only satisfies the same intent (the file always ends up existing) while leaving a deliberately customized `.gitignore` untouched.

## Verification

Manually verified in a temp repo:
- With a pre-existing custom `.superpowers/sdd/.gitignore`: content survives an `sdd-workspace` run unchanged.
- With no `.gitignore` present: the default `*` is still created, same as before.

`bash -n` passes; no test harness change needed since this is a one-line behavioral guard with no new inputs/outputs.

## Note

`fix/sdd-workspace-ownership` also touches this script for an unrelated issue (workspace slug collisions between plans). No overlap in the change itself; whichever merges second will need a small rebase.