### PR TITLE
fix(hooks): translate Windows plugin root to WSL path before dispatch

### DIFF
--- a/docs/windows/polyglot-hooks.md
+++ b/docs/windows/polyglot-hooks.md
@@ -2,6 +2,10 @@
 
 Claude Code plugins need hooks that work on Windows, macOS, and Linux. This document describes the single generic dispatcher pattern used in `hooks/run-hook.cmd`.
 
+VS Code Remote WSL adds one mixed-host case: the extension host expands the
+plugin root as a Windows path, while the hook runs in WSL bash. `hooks.json`
+converts that root with `wslpath` before invoking the dispatcher.
+
 > **Authoritative source:** `hooks/run-hook.cmd` is the canonical implementation. When this document and the code diverge, trust the code.
 
 ## The Problem
@@ -89,9 +93,11 @@ afterward.
 
 ### How it works on Unix (bash/sh)
 
-1. `: << 'CMDBLOCK'` opens a heredoc on a no-op command.
-2. The entire CMD batch block is consumed by the heredoc and ignored.
-3. After `CMDBLOCK`, bash resolves the script directory and `exec`s the named
+1. In WSL, the hook command converts a Windows plugin root to a WSL path before
+  starting the dispatcher. Native Unix paths are unchanged.
+2. `: << 'CMDBLOCK'` opens a heredoc on a no-op command.
+3. The entire CMD batch block is consumed by the heredoc and ignored.
+4. After `CMDBLOCK`, bash resolves the script directory and `exec`s the named
    extensionless script directly.
 
 ### Key design decisions

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "command": "bash -c 'root=\"$0\"; if [ -n \"${WSL_DISTRO_NAME:-}\" ]; then root=$(wslpath -u \"$root\"); fi; exec bash \"$root/hooks/run-hook.cmd\" session-start' \"${CLAUDE_PLUGIN_ROOT}\"",
             "shell": "bash",
             "async": false
           }

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -154,7 +154,7 @@ if (entry.shell !== "bash") {
   console.error(`SessionStart hook shell is ${JSON.stringify(entry.shell)}, expected "bash"`);
   process.exit(1);
 }
-if (!/run-hook\.cmd" session-start$/.test(entry.command)) {
+if (!entry.command.includes("wslpath -u") || !entry.command.includes("CLAUDE_PLUGIN_ROOT")) {
   console.error(`unexpected SessionStart command shape: ${entry.command}`);
   process.exit(1);
 }
@@ -162,6 +162,70 @@ if (!/run-hook\.cmd" session-start$/.test(entry.command)) {
     pass "hooks.json registers SessionStart with shell:bash dispatch"
 else
     fail "hooks.json registers SessionStart with shell:bash dispatch"
+fi
+
+# VS Code resolves CLAUDE_PLUGIN_ROOT on the Windows extension host before
+# dispatching the hook to the remote WSL shell. The command must translate that
+# Windows path before bash attempts to execute the wrapper.
+wsl_home="$(make_home vscode-remote-wsl)"
+wsl_bin="$TEST_ROOT/vscode-remote-wsl/bin"
+wsl_log="$TEST_ROOT/vscode-remote-wsl/executed-path"
+mkdir -p "$wsl_bin"
+cat > "$wsl_bin/wslpath" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" != "-u" ]]; then
+  exit 1
+fi
+printf '%s\n' "$WSL_TRANSLATED_PLUGIN_ROOT"
+EOF
+chmod +x "$wsl_bin/wslpath"
+
+windows_plugin_root='C:\Users\developer\.vscode\agent-plugins\github.com\obra\superpowers'
+translated_plugin_root="$TEST_ROOT/vscode-remote-wsl/plugin"
+mkdir -p "$translated_plugin_root/hooks"
+cat > "$translated_plugin_root/hooks/run-hook.cmd" <<'EOF'
+printf '%s\n' "$0" > "$WSL_EXECUTED_PATH_LOG"
+EOF
+
+hook_command="$(node -e '
+const hooks = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const command = hooks.hooks.SessionStart[0].hooks[0].command;
+process.stdout.write(command.replace("${CLAUDE_PLUGIN_ROOT}", process.argv[2]));
+' "$REPO_ROOT/hooks/hooks.json" "$windows_plugin_root")"
+
+if env -i \
+  PATH="$wsl_bin:/usr/bin:/bin" \
+  HOME="$wsl_home" \
+  WSL_DISTRO_NAME=Ubuntu \
+  WSL_TRANSLATED_PLUGIN_ROOT="$translated_plugin_root" \
+  WSL_EXECUTED_PATH_LOG="$wsl_log" \
+  /bin/sh -c "$hook_command" >/dev/null 2>&1 && \
+  [[ "$(cat "$wsl_log" 2>/dev/null)" == "$translated_plugin_root/hooks/run-hook.cmd" ]]; then
+  pass "hooks.json translates Windows plugin paths before WSL bash dispatch"
+else
+  fail "hooks.json translates Windows plugin paths before WSL bash dispatch"
+fi
+
+unix_home="$(make_home unix-hook-command)"
+unix_hook_command="$(node -e '
+const hooks = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const command = hooks.hooks.SessionStart[0].hooks[0].command;
+process.stdout.write(command.replace("${CLAUDE_PLUGIN_ROOT}", process.argv[2]));
+' "$REPO_ROOT/hooks/hooks.json" "$REPO_ROOT")"
+
+if output="$(env -i \
+  PATH="${PATH:-}" \
+  HOME="$unix_home" \
+  CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
+  /bin/sh -c "$unix_hook_command" 2>&1)" && \
+  printf '%s' "$output" | node -e '
+const input = require("fs").readFileSync(0, "utf8");
+const payload = JSON.parse(input);
+if (!payload.hookSpecificOutput?.additionalContext) process.exit(1);
+'; then
+  pass "hooks.json dispatches Unix plugin paths without WSL translation"
+else
+  fail "hooks.json dispatches Unix plugin paths without WSL translation"
 fi
 
 claude_home="$(make_home claude-code)"


### PR DESCRIPTION
## Problem

In VS Code **Remote WSL** (Windows host + WSL distro remote), the Copilot extension host resolves `${CLAUDE_PLUGIN_ROOT}` to a **Windows** path (e.g. `c:\Users\<name>\.vscode\agent-plugins\github.com\obra\superpowers`) while the hook itself runs in WSL bash. Every new chat session then fails with:

```
/bin/sh: 1: c:\Users\<name>\.vscode\agent-plugins\github.com\obra\superpowers\hooks\run-hook.cmd: not found
```

The polyglot wrapper in `run-hook.cmd` is correct for Windows cmd/Git Bash and for native Unix, but on Remote WSL bash receives the Windows-style path directly and can never start the dispatcher, so SessionStart context injection is skipped entirely.

## Fix

`hooks/hooks.json` now wraps the dispatcher invocation in `bash -c` and, when `WSL_DISTRO_NAME` is set, converts the plugin root with `wslpath -u` before `exec`'ing `run-hook.cmd`:

```json
"command": "bash -c 'root=\"$0\"; if [ -n \"${WSL_DISTRO_NAME:-}\" ]; then root=$(wslpath -u \"$root\"); fi; exec bash \"$root/hooks/run-hook.cmd\" session-start' \"${CLAUDE_PLUGIN_ROOT}\"",
```

- **Remote WSL**: original Windows path → `wslpath -u` → `/mnt/c/...` → dispatcher runs → context injected.
- **Native Unix (Linux/macOS)**: path already POSIX, `wslpath` branch skipped (env check), behavior unchanged.
- **Native Windows (Git Bash/cmd)**: unchanged — `bash` + the polyglot wrapper handle it as before.

## Tests

Added two command-level regression cases to `tests/hooks/test-session-start.sh` (they execute the literal `hooks.json` command through `/bin/sh`, exactly like the harness shell):

1. **WSL**: with `WSL_DISTRO_NAME` set and a fake `wslpath` on PATH, asserts the translated path reaches the wrapper.
2. **Unix**: without WSL env, asserts the hook still dispatches and emits SessionStart context (no translation).

Existing tests (nested Claude Code output, Cursor, Copilot CLI, wrapper dispatch, legacy warning) all still pass.

```text
SessionStart hook output tests
  [PASS] hooks.json registers SessionStart with shell:bash dispatch
  [PASS] hooks.json translates Windows plugin paths before WSL bash dispatch
  [PASS] hooks.json dispatches Unix plugin paths without WSL translation
  [PASS] Claude Code emits nested SessionStart additionalContext
  [PASS] run-hook.cmd wrapper dispatches to the named session-start script
  [PASS] Cursor emits top-level additional_context only
  [PASS] Copilot CLI emits top-level additionalContext only
  [PASS] SessionStart omits obsolete legacy custom-skill warning
STATUS: PASSED
```

Also updated `docs/windows/polyglot-hooks.md` with the mixed-host Remote WSL case.

## Verification

The fix was applied to a real VS Code Remote WSL installation: `tests/hooks/test-session-start.sh` passes there too, and a new session starts without the `run-hook.cmd: not found` error.

## Notes

- `wslpath` ships with every WSL distro under `/usr/bin/wslpath`; it is the standard path conversion utility.
- Test fixtures use the literal command string from `hooks.json` (no reimplementation), so the coverage would fail if the dispatch shape drifts.