### PR TITLE
docs: add GitHub Copilot App to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [Devin CLI](#devin-cli)
   - [Factory Droid](#factory-droid)
   - [Gemini CLI](#gemini-cli)
+  - [GitHub Copilot App](#github-copilot-app)
   - [GitHub Copilot CLI](#github-copilot-cli)
   - [Grok Build CLI](#grok-build-cli)
   - [Kimi Code](#kimi-code)
@@ -166,6 +167,12 @@ Superpowers is available via the [official Codex plugin marketplace](https://git
   ```bash
   gemini extensions update superpowers
   ```
+
+### GitHub Copilot App
+
+- In the GitHub Copilot app, click on **Plugins** in the sidebar.
+- Click **+ Install** > **+ Add marketplace** and enter `obra/superpowers-marketplace`.
+- Find `superpowers` in the list and click **Install**.
 
 ### GitHub Copilot CLI
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ Superpowers is available via the [official Codex plugin marketplace](https://git
 
 ### GitHub Copilot App
 
-- In the GitHub Copilot app, click on **Plugins** in the sidebar.
-- Click **+ Install** > **+ Add marketplace** and enter `obra/superpowers-marketplace`.
+- In the GitHub Copilot app, click on **Settings** in the sidebar.
+- Click **Plugins** > **+ Install** > **+ Add marketplace** and enter `obra/superpowers-marketplace`.
 - Find `superpowers` in the list and click **Install**.
 
 ### GitHub Copilot CLI


### PR DESCRIPTION
This PR adds installation instructions for GitHub Copilot App.

Most of the questions from the issue template seem irrelevant for such a change.

I just edited the README through GitHub's website, no AI involved.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Closes #1298
