### PR TITLE
fix: add hooks.json at plugin root for Devin CLI/Desktop SessionStart bootstrap

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -1,0 +1,15 @@
+{
+  "SessionStart": [
+    {
+      "matcher": "startup|clear|compact",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+          "shell": "bash",
+          "async": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GLM-5.2 High |
| Harness + version | Devin CLI 3000.4.25 (Windows 10, PowerShell) |
| All plugins installed | superpowers v6.3.0 (from this fork branch) |
| Human partner who reviewed this diff | Mkiv001-1 (approved the complete diff before submission) |

## What problem are you trying to solve?

After installing superpowers via `devin plugins install obra/superpowers`, the plugin loads (skills=14, rules=1) but **SessionStart hook never fires** — `hooks=0` in the logs. Without the SessionStart hook, the `using-superpowers` bootstrap is not injected into the session context, so skills never auto-trigger. The user has to manually invoke `/superpowers:using-superpowers` or the agent has to guess that skills exist.

This was hit in a real session on Windows 10 with Devin CLI 3000.4.25 / Devin Desktop (Windsurf). The user installed the plugin, verified `devin plugins list` showed `superpowers v6.3.0`, but skills did not auto-trigger on subsequent sessions.

**Root cause:** Devin reads `hooks.json` only from the **plugin root** (per docs `extensibility/plugins/overview.mdx:63`: "a `hooks.json` at the plugin root registers lifecycle hooks"). Superpowers ships its hooks at `hooks/hooks.json` (Claude Code format with `"hooks": { ... }` wrapper). Devin does not look in subdirectories for hooks files, and the `.devin-plugin/plugin.json` manifest has no `hooks` field (Devin docs only document `skills` and `mcpServers` manifest fields for asset path overrides).

**Log evidence (Devin CLI 3000.4.25, Windows):**

Before fix (hooks/hooks.json only, not at root):
`
WARN config_importers::importers::hooks: Failed to parse hooks file
  ...6.3.0\hooks.json: unknown variant hooks, expected one of PreToolUse,
  PostToolUse, UserPromptSubmit, Stop, PostCompaction, SessionStart,
  SessionEnd, PermissionRequest at line 2 column 9
INFO plugin::activate: plugins discovery: active_plugins=1 skills=14 hooks=0 rules=1
`

After fix (hooks.json at root, flat format):
`
INFO plugin::activate: plugins discovery: active_plugins=1 skills=14 hooks=1 rules=1
`

The hook fires, `run-hook.cmd` finds Git Bash on Windows, executes `session-start`, and injects the `using-superpowers` bootstrap via `hookSpecificOutput.additionalContext`.

## What does this PR change?

Adds a `hooks.json` file at the plugin root with the flat Devin hooks format (event keys at top level, no `"hooks"` wrapper). The hook content is identical to `hooks/hooks.json` — same SessionStart matcher (`startup|clear|compact`), same command (`run-hook.cmd session-start`), same `\` expansion (which Devin also supports per docs `plugins/overview.mdx:88-89`).

## Is this change appropriate for the core library?

Yes. This fixes the Devin integration that PR #1995 added. Without this, the Devin integration is incomplete — skills are installed but the bootstrap never loads, which the CLAUDE.md explicitly calls out as "not a real integration": "A real integration loads the `using-superpowers` bootstrap at session start. The bootstrap is what causes skills to auto-trigger at the right moments. Without it, the skills are dead weight."

This benefits every Devin CLI/Desktop user on any project, not a specific domain or team.

## What alternatives did you consider?

1. **Add a `hooks` field to `.devin-plugin/plugin.json`** pointing to `./hooks/hooks.json` — rejected because Devin docs only document `skills` and `mcpServers` as manifest path-override fields. There is no `hooks` manifest field in the Devin plugin format.

2. **Move `hooks/hooks.json` to root and update Claude Code to read from root** — rejected because Claude Code expects `hooks/hooks.json` in the subdirectory; moving it would break the Claude Code integration.

3. **Symlink from root to `hooks/hooks.json`** — rejected because the existing `hooks/hooks.json` uses Claude Code format (with `"hooks": { ... }` wrapper), which Devin rejects. Devin's standalone hooks format is flat (no wrapper), per docs `hooks/overview.mdx:211-213`: "In `.devin/hooks.v1.json`, the hooks object is the entire file (no wrapper key needed)." A symlink would carry the wrong format.

4. **Duplicate the file at root with Devin format** (this PR) — minimal, no impact on other harnesses, each harness gets its hooks in the format it expects.

## Does this PR contain multiple unrelated changes?

No. One file, one purpose.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1995 (merged — added `.devin-plugin/plugin.json` manifest for Devin CLI but did not add `hooks.json` at root)

No prior PR addresses the missing root-level `hooks.json` for Devin.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Devin CLI / Devin Desktop (Windsurf) | 3000.4.25 | GLM-5.2 High | glm-5-2 |

## New harness support

Not applicable — Devin is already a supported harness (PR #1995). This PR fixes a gap in that existing integration: the SessionStart hook was not being loaded because `hooks.json` was not at the plugin root.

## Evaluation

- Initial prompt: user asked to install the superpowers plugin from `https://github.com/obra/superpowers` for Devin CLI and IDE
- After installing, `devin plugins list` showed `superpowers v6.3.0` but skills did not auto-trigger in new sessions
- Investigated logs: `hooks=0` and parse errors pointing to the missing root-level `hooks.json`
- Applied fix locally, restarted Devin, verified `hooks=1` in logs across 5 consecutive session activations (18:51-18:52 UTC)
- Verified hook execution: `run-hook.cmd` finds Git Bash on Windows, `session-start` script outputs valid JSON with `hookSpecificOutput.additionalContext` containing the full `using-superpowers/SKILL.md` content

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path — tested on Windows 10 with PowerShell, verified hook fires across multiple session restarts, verified error logs before and after
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

The complete diff (one new file, 15 lines) was shown to the human partner (Mkiv001-1) who gave explicit approval before this PR was submitted.

Generated with [Devin](https://devin.ai)