### PR TITLE
fix(sdd): stop task-brief swallowing letter-suffixed sub-tasks    (#2175)

### DIFF
--- a/skills/subagent-driven-development/scripts/task-brief
+++ b/skills/subagent-driven-development/scripts/task-brief
@@ -28,7 +28,7 @@ fi
 awk -v n="$n" '
   /^```/ { infence = !infence }
   !infence && /^#+[ \t]+Task[ \t]+[0-9]+/ {
-    intask = ($0 ~ ("^#+[ \t]+Task[ \t]+" n "([^0-9]|$)"))
+    intask = ($0 ~ ("^#+[ \t]+Task[ \t]+" n "([^0-9A-Za-z]|$)"))
   }
   intask { print }
 ' "$plan" > "$out"


### PR DESCRIPTION
## Who is submitting this PR? (required)                          
                                                                       
| Field | Value |                                                 
|-------|-------|                                                 
| Your model + version | Kimi K3 (Moonshot AI) |                  
| Harness + version | Kimi Code CLI 0.36.1 |                      
| All plugins installed | Superpowers skills; Comet workflow      
skills; GitNexus skills; OpenSpec skills |                          
| Human partner who reviewed this diff | jwang513 |               
                                                                       
## What problem are you trying to solve?                          
                                                                       
Fixes #2175. In                                                   
`skills/subagent-driven-development/scripts/task-brief`, the        
awk terminator regex is `([^0-9]|$)` after the task number. With a plan that                                                           
has sub-tasks (`### Task 6` followed by `### Task 6b`), extracting Task 6                                                              
folds all of Task 6b into the brief, because `b` is not a digit.  Seen with                                                           
plugin 6.3.0 on 2026-08-18.                                       
                                                                       
Reproduction: given a plan with `### Task 6` / `### Task 6b` /  `### Task 7`                                                       
headings, `task-brief plan.md 6` yields a 6-line brief containing Task 6b's                                                           
full body. After the fix it yields only Task 6's 3 lines, and `task-brief plan.md 6b` still extracts Task 6b correctly.         
                                                                       
## What does this PR change?                                      
                                                                       
One character class in the awk terminator: `([^0-9]|$)` → `([^0-9A-Za-z]|$)`,                                                 
so a letter-suffixed heading (`Task 6b`) terminates the previous task instead                                                       
of being treated as its continuation.                             
                                                                       
## Is this change appropriate for the core library?               
                                                                       
Yes — it fixes incorrect extraction in an existing core SDD helper script.                                                             
No new dependencies, no behavior change beyond the bug fix.       
                                                                       
## What alternatives did you consider?                            
                                                                       
Rejecting only lowercase letters after the number; rejected because task                                                        
suffixes could reasonably be uppercase too (`6B`), and `[0-9A-Za-z]` matches                                               
the task-number grammar the script already implies.               
                                                                       
## Does this PR contain multiple unrelated changes?               
                                                                       
No. Single-line fix.                                              
                                                                       
## Existing PRs                                                   
- [x] I have reviewed all open AND closed PRs for duplicates or prior art                                                           
- Related PRs: none found (searched task-brief and SDD-related  PRs; #1772,                                                        
- #1905, #2014 touch task-brief paths/overwrite behavior, not this regex)                                                              
                                                                       
## Environment tested                                             
                                                                       
| Harness | Harness version | Model | Model version/ID |          
|---------|-----------------|-------|------------------|          
| Kimi Code CLI (Git Bash on Windows) | 0.36.1 | Kimi | K3 |      
                                                                       
                                           
                                                                       
## Evaluation                                                     
                                                                       
- Initial prompt: reproduce and fix obra/superpowers#2175         
- Verified before/after with plans containing `Task 6` + `Task 6b`
   (letter suffix), `Task 1` + `Task 10` (numeric boundary), and a missing task number (still exits 3 with the expected error).                 
- Before: Task 6's brief includes Task 6b's full body. After: each task extracts exactly its own body; numeric boundaries, suffix       extraction, and error handling unchanged.                                       
                                                                       
## Rigor                                                          
                                                                       
- [x] This change was tested adversarially, not just on the happy path                                                                
(letter suffixes, multi-digit numeric boundaries, missing task number; the fenced-code-block guard is untouched)                   
                                                                       
## Human review                                                   
- [x] A human has reviewed the COMPLETE proposed diff before submission