### PR TITLE
Add skeleton-first planning as a selectable alternative to task-by-task plans

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -195,6 +195,10 @@ Use the least powerful model that can handle each role to conserve cost and incr
 
 **Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.
 
+When a task carries a **Tier:** field, follow it — the planner already
+ruled: mechanical → the cheapest available model; judgment → a standard
+model. Do not re-litigate the tier at dispatch.
+
 **Integration and judgment tasks** (multi-file coordination, pattern matching, debugging): use a standard model.
 
 **Architecture and design tasks**: use the most capable available model.
@@ -216,7 +220,10 @@ most expensive — which silently defeats this section.
 **Turn count beats token price.** Wall-clock and context cost scale with how
 many turns a subagent takes, and the cheapest models routinely take 2-3× the
 turns on multi-step work — costing more overall. Use a mid-tier model as the
-floor for reviewers and for implementers working from prose descriptions.
+floor for reviewers and for implementers working from task contracts or
+prose descriptions — unless the task's Tier line says mechanical: the
+planner has already ruled the deliverable fully specified, so treat a
+mechanical-tier contract like spelled-out content.
 When the task's plan text contains the complete code to write, the
 implementation is transcription plus testing: use the cheapest tier for
 that implementer. Single-file mechanical fixes also take the cheapest tier.

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -173,6 +173,14 @@ its own text agrees with itself — the tests it specifies against the code it
 specifies, the files it creates against the files it later touches. "The scan
 is clean" without those rows is not a scan you ran.
 
+**When the plan's header declares `Plan shape: skeleton-first`,** the
+table gets a final section: the DISPATCH PLAN — group the pending tasks
+into waves. Tasks in the same wave are mutually file-disjoint and consume
+no interface still under construction — dispatch each wave's implementers
+concurrently, one worktree per task, and integrate before the next wave;
+tasks that fail those conditions serialize. On a skeleton-first plan, a
+scan without a dispatch plan is not a scan you ran.
+
 Write the table to the ledger. Rule on everything you find before execution
 begins — each finding against the plan text that mandates it — and record
 each ruling in the ledger. If the scan is clean, proceed without comment.
@@ -259,7 +267,13 @@ and fix-round diffs need it.
   know; (4) your resolution of any ambiguity you noticed in the brief;
   (5) the report-file path and report contract. Exact values (numbers,
   magic strings, signatures, test cases) appear only in the brief. Never
-  make a subagent read the whole plan file.
+  make a subagent read the whole plan file. When the brief is a contract
+  (goal, success criteria, interfaces) rather than written-out code, item
+  (3) also carries the elaboration the contract leaves to dispatch time:
+  the interfaces as actually built by completed tasks, environment facts
+  and discoveries from earlier reports, and any amendment rulings. There
+  the success criteria name the cases the tests must cover, and the
+  implementer designs its own code and tests within the contract.
 - **Report file:** name the implementer's report file after the brief
   (brief `…/task-N-brief.md` → report `…/task-N-report.md`) and put it in
   the dispatch prompt. The implementer writes the full report there and
@@ -280,6 +294,26 @@ and fix-round diffs need it.
 - Record the implementer's agent identity from the dispatch result —
   fix-loop rounds 1-3 resume this agent.
 - Never dispatch multiple implementation subagents in parallel (conflicts).
+  The one exception is a skeleton-first plan whose dispatch plan shows two
+  or more pending tasks mutually file-disjoint with none consuming an
+  interface still under construction. Dispatch those implementers
+  concurrently, each in its own worktree:
+  - Record the integration base commit in the ledger before the first
+    concurrent dispatch.
+  - Create one worktree per concurrent task off that base
+    (`git worktree add <repo-root>/.worktrees/task-<N> -b task-<N>
+    <base>`); each dispatch's `Work from:` is its own worktree, and its
+    BASE is that worktree's HEAD.
+  - Review each task's diff as usual when it reports. Integrate reviewed
+    branches in plan order: merge each into the integration branch
+    (`git merge --no-ff task-<N>`), and run that task's verification
+    commands after each merge.
+  - A merge conflict or post-merge verification failure is that task's
+    fix-loop round 1: rebase the task branch onto the current
+    integration head in its worktree, then resume its implementer
+    there. Never resolve conflicts yourself.
+  - Remove each worktree (`git worktree remove`) once its branch is
+    integrated, and record the integrated range in the ledger as usual.
 
 Template: [implementer-prompt.md](implementer-prompt.md)
 
@@ -437,6 +471,16 @@ message as your other bookkeeping:
 - `Task <N>: complete (commits <base7>..<head7>, review clean)`
 - `Task <N>: complete (commits <base7>..<head7>, <K> parked)` after a
   tripped breaker
+
+**On a skeleton-first plan,** write one plan-check line with the
+completion line. Re-read the remaining tasks against what this task
+actually established — interfaces as built, environment facts,
+discoveries in the report — and append either `Plan holds` or
+`Amendment: Task <M>: <what changes and why>` to the ledger. An
+amendment is plan authority applied at the plan layer: from then on the
+amended text IS the plan's text, and it rides into every affected task's
+dispatch under item (3). Never dispatch a task whose brief a completed
+task's report has already invalidated.
 
 Then mark the todo complete and move on. Never move to the next task while
 the review has open Critical/Important issues that are neither fixed nor

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -5,8 +5,11 @@ Use this template when dispatching an implementer subagent.
 ```
 Subagent (general-purpose):
   description: "Implement Task N: [task name]"
-  model: [MODEL — REQUIRED: choose per SKILL.md Model Selection; an omitted
-         model silently inherits the session's most expensive one]
+  model: [MODEL — REQUIRED: when the brief carries a Tier line, set from it:
+         mechanical → the cheapest model the subagent tool offers; judgment →
+         a standard mid-tier model. Otherwise choose per SKILL.md Model
+         Selection. An omitted model silently inherits the session's most
+         expensive one]
   prompt: |
     You are implementing Task N: [task name]
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -22,6 +22,30 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
 
+## Two Plan Shapes
+
+Before mapping files, classify the plan's shape and say the
+classification out loud — "this composes three subsystems, so I'll plan
+it skeleton-first" — so your human partner can override it:
+
+- **Task-by-task (default)** — tasks build the feature a component at a
+  time, each step carrying the actual content the engineer needs. Use it
+  for changes to code that already exists, for a spec that touches one
+  subsystem, and whenever the alternative's conditions do not clearly
+  hold. The rest of this skill describes this shape.
+- **Skeleton-first (alternative)** — Task 1 is the thinnest end-to-end
+  slice through every subsystem the spec composes; later tasks widen it
+  one component at a time, each from a contract rather than written-out
+  code. Use it when the spec composes more than one subsystem AND a
+  running end-to-end slice early is worth a longer total build. Read
+  [skeleton-first-plans.md](skeleton-first-plans.md) before writing one
+  — it adds one line to the plan header and replaces this skill's task
+  granularity, task template, and plan-failure list.
+
+When in doubt, plan task-by-task. Skeleton-first buys an earlier running
+system and pays for it in total wall clock; it is a trade, not an
+upgrade.
+
 ## File Structure
 
 Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.

--- a/skills/writing-plans/skeleton-first-plans.md
+++ b/skills/writing-plans/skeleton-first-plans.md
@@ -1,0 +1,131 @@
+# Skeleton-First Plans
+
+The alternative plan shape from writing-plans' Two Plan Shapes router.
+Each section below replaces the same-named section of
+[SKILL.md](SKILL.md); everything SKILL.md says that is not named here
+still binds — Scope Check, File Structure, Task Right-Sizing, the plan
+header, Self-Review, and the Execution Handoff.
+
+## Overview
+
+Write a plan that carries the decisions, not the keystrokes:
+decomposition, file structure, interfaces, constraints, and a precise
+contract per task. Assume the engineer is skilled and designs their own
+code and tests from a precise contract, but knows nothing about our
+codebase, toolset, or problem domain — every name, path, constraint, and
+behavior they must match is stated explicitly. DRY. YAGNI. TDD.
+Frequent commits.
+
+## When This Shape Fits
+
+Use it when the spec composes more than one subsystem and a running
+end-to-end slice early is worth a longer total build: the value arrives
+as soon as real input reaches real output, and every later task widens
+something that already runs.
+
+Do not use it for a change to one subsystem, or when the whole point is
+to land the finished thing as fast as possible. This shape spends its
+first task on a slice that does almost nothing, and it spends planning
+effort on contracts and interfaces the task-by-task shape gets for free
+by writing the code out.
+
+## Plan Document Header
+
+The header is SKILL.md's, plus one line directly under the **Goal:**
+line, which is how executors know which shape they are running:
+
+```markdown
+**Plan shape:** skeleton-first
+```
+
+## Walking Skeleton First
+
+Task 1 builds the thinnest end-to-end slice through every subsystem the
+spec composes — real input to real output — before any task deepens a
+single layer; later tasks widen the skeleton.
+
+The test of a skeleton is that it runs. A first task that builds the
+data loader, the schema, or the config layer is a foundation, not a
+skeleton: nothing runs until something above it exists. A skeleton
+reaches the output — thinly, with one real case — through every
+subsystem the spec names.
+
+## Task Contracts, Not Task Scripts
+
+A task states WHAT must exist when it is done, precisely enough that a
+skilled engineer can build it without asking you anything, without
+prescribing HOW:
+
+- **Goal:** one short paragraph naming the deliverable and its role in
+  the feature.
+- **Success criteria:** concrete, checkable behaviors — exact commands
+  to run and what they must show, the cases tests must cover (including
+  failure cases), constraints that bind the implementation.
+- **Notes:** what the engineer needs and cannot discover alone — spec
+  sections to read, files worth reading first, known pitfalls.
+
+The Interfaces block carries the exact names, signatures, and types;
+the success criteria carry the behaviors; the engineer supplies the
+code and the test design. TDD and frequent commits remain required.
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+**Interfaces:**
+- Consumes: [what this task uses from earlier tasks — exact signatures]
+- Produces: [what later tasks rely on — exact function names, parameter
+  and return types. A task's implementer sees only their own task; this
+  block is how they learn the names and types neighboring tasks use.]
+
+**Goal:** [one paragraph — the deliverable and its role in the feature]
+
+**Success criteria:**
+- Run: `pytest tests/exact/path/to/test.py -v` — all tests pass; tests
+  cover [the specific behaviors and failure cases, named concretely]
+- [observable behavior the deliverable must exhibit, with the exact
+  command or input/output that demonstrates it]
+- [constraint that binds the implementation, copied from the spec]
+
+**Notes:** [spec sections to read; files to read first; known pitfalls]
+
+**Tier:** mechanical | judgment. Mechanical = the deliverable is fully
+specified by Files + Interfaces + success criteria above (most tasks in
+a well-specified plan are mechanical); judgment = multi-file
+coordination, debugging, or real design latitude remains. The
+implementer's model follows this field — mark it deliberately.
+
+**Commit:** one commit ending the task; message named here.
+````
+
+## No Vague Contracts
+
+Every contract must be checkable by someone who did not write it. These
+are **plan failures** — never write them:
+- "TBD", "TODO", "implement later", "fill in details"
+- Goals naming activity instead of a deliverable ("improve error handling")
+- Success criteria with no observable check ("works correctly", "handles edge cases")
+- Interfaces blocks omitting a name, signature, or type another task consumes
+- "Similar to Task N" (state this task's own contract in full — the engineer may be reading tasks out of order)
+- References to types, functions, or methods not defined in any task's Interfaces block
+
+## Self-Review
+
+Run SKILL.md's Self-Review checklist, reading step 2 against "No Vague
+Contracts" above rather than "No Placeholders".
+
+## Red Flags
+
+| Thought | Reality |
+|---------|---------|
+| "Task 1 is the data loader — that's the foundation" | A foundation is a layer. The skeleton runs real input to real output through every subsystem the spec names, thinly. |
+| "The skeleton can return a hardcoded value for now" | It may be thin, but the path must be real: real input, real wiring, real output. A hardcoded response tests nothing end to end. |
+| "A contract without the code is vague" | Vague is an uncheckable success criterion. Exact names, exact commands, exact expected output — no code. |
+| "I'll write the test code into the task to be safe" | The success criteria name the cases; the implementer designs the tests. Written-out tests are the task-by-task shape. |
+| "Skeleton-first is the better shape, so I'll use it here" | It costs total wall clock. Without more than one subsystem and a reason to want an early running slice, plan task-by-task. |


### PR DESCRIPTION
> ## ⚠️ UNREVIEWED AGENTIC OUTPUT — DO NOT MERGE
>
> **This PR is agentic slop. No human has reviewed it.**
>
> Every line of the diff, this description, and the numbers quoted in it
> were produced by an autonomous agent campaign. Jesse has not read the
> diff. The wording was never validated by `writing-skills` micro-tests,
> and no session has ever run this exact text — the measurements come
> from a research arm that rewrote `writing-plans` in place, while this
> PR restructures the same ideas as a selectable path. By the campaign's
> own shipping rule that makes this text **unqualified**.
>
> It is published as a draft so a human can decide whether any of it is
> worth keeping. Treat every claim below as a lead to verify, not a
> finding to trust.

---

Adds **skeleton-first** as a second, selectable plan shape in `writing-plans`, plus the `subagent-driven-development` clauses needed to execute one. Nothing about the current flow changes: task-by-task planning stays the default, its guidance is byte-identical, and every new SDD clause is gated on a plan explicitly declaring `Plan shape: skeleton-first`. The case for it is narrow and specific — **better artifacts, slower builds**: on a blind two-judge panel this shape scored 5.0/5 with zero major defects in 4 of 4 reps, against a control that scored 4.0 median and shipped real major defects in 2 of 5 reps. It pays for that with roughly 72% more wall clock on the larger fixture. This is the shippable half of an autonomous research campaign (~110 agent sessions, $2,500 budget) that set out to *replace* `writing-plans` + SDD and did not earn a replacement — it earned an option.

> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

**Draft status is deliberate.** Jesse has not reviewed this diff, and the campaign's own standing rule is that a quorum battery of the *exact shipped text* is the only ship gate — that battery has not run on this text. Do not merge on the evidence below alone.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 5 (`us.anthropic.claude-opus-5[1m]`) wrote this PR. The research it reports was run by agent sessions orchestrated on Opus 5 (`us.anthropic.claude-opus-5`, Bedrock), with Sonnet 5 / Haiku 4.5 subagents; the blind judge panel ran `claude-opus-4-8` via Bedrock. Elicitation checks on this PR's exact text ran on Fable 5 (`us.anthropic.claude-fable-5[1m]`), the host's configured default for `claude -p`. |
| Harness + version | Claude Code CLI 2.1.227 (this session and the elicitation checks). The campaign sessions ran headless Claude Code driven by a bespoke autoresearch harness (staged `HOME`, `--plugin-dir` per arm); the Claude Code version used during the campaign is not recorded in the log, so I will not state one. |
| All plugins installed | Enabled: `agent-sdk-dev`, `claude-code-setup`, `claude-session-driver`, `code-simplifier`, `context7`, `elements-of-style`, `episodic-memory`, `frontend-design`, `gopls-lsp`, `linear`, `mcp-server-dev`, `plugin-dev`, `primeradiant-ops`, `release-radar`, `superpowers-chrome`, `superpowers-developing-for-claude-code`, `superpowers-lab`. Disabled: `double-shot-latte`, `hookify`, `rust-analyzer-lsp`, `swift-lsp`, and **both installed copies of `superpowers` itself** — so the elicitation checks loaded only this branch via `--plugin-dir`, with no competing installed copy. |
| Human partner who reviewed this diff | **Not yet — Jesse (@obra) is the human partner and has not reviewed it.** That is why this is a draft. It must not be merged or marked ready until he has read the complete diff. |

## What problem are you trying to solve?

Two things the current flow does, observed across ~110 measured sessions on real fixtures.

**1. The artifacts carry avoidable defects.** On the `ws-parallel-lattice` fixture, judged blind by an adversarial two-judge panel against the fixture spec with all process evidence stripped, the current flow scored **4.0 median overall with real major defects in 2 of 5 reps**. The composed skeleton-first arm scored **5.0 with zero majors in every rep** — 4/4 for the arm in this PR, and 7 consecutive zero-major sessions across it and its direct parent. Against a control that ships majors 40% of the time, this is the campaign's cleanest and most-replicated result, and it is the whole reason this PR exists.

**2. Nothing runs until near the end.** Under the current shape agents plan layer-by-layer: 5/5 control sessions titled Task 1 as a bottom layer ("Core reader") and 0/5 built an end-to-end slice first. A skeleton-alive walker (earliest commit where the CLI actually runs on real data) put control at ordinal 0.75–0.90 of its commit history; on the larger fixture control's first running end-to-end system arrived at 26.0–32.4 min. Nothing is demoable or integration-tested until the build is nearly finished.

Neither is a bug. The current shape optimizes for landing the finished thing fastest, and it does that well — it is still the right default. Some specs want the other trade, and today there is no way to ask for it.

**What this is not.** The campaign's founding hypothesis was that skeleton-first ordering prevents *compounding errors* from a wrong early assumption. **That hypothesis is dead for this model class and I am not claiming it.** The pre-registered trap battery returned INCONCLUSIVE-BY-UNIFORM-DISCOVERY: all 16/16 sessions, control included, opened the real SQLite artifact and named the hidden schema drift ("row 1811") within ~1 minute of session start. Opus-class agents probe the data before planning no matter which process you hand them.

## What does this PR change?

A plan-shape router in `writing-plans` (classify, announce, human overrides, default on doubt — the idiom of `brainstorming`'s Three Paths), the alternative shape's full text in a sibling reference file, and four SDD clauses that only fire for a plan declaring that shape.

| File | +/− | What |
|---|---|---|
| `skills/writing-plans/SKILL.md` | +24/−0 | New `## Two Plan Shapes` section after Scope Check. Task-by-task is named the default and the rest of the skill is explicitly its description; skeleton-first is named the alternative with its use conditions and a link out. Tie-break: "When in doubt, plan task-by-task… it is a trade, not an upgrade." **No existing line is touched.** |
| `skills/writing-plans/skeleton-first-plans.md` | +131 (new) | The alternative shape: when it fits and when it does not, the one added header line (`**Plan shape:** skeleton-first`), walking-skeleton ordering, task contracts instead of task scripts, the contract task template (adds `Goal` / `Success criteria` / `Notes` / `Tier` / `Commit`), a "No Vague Contracts" plan-failure list, and a Red Flags table. Sibling-file progressive disclosure, matching `implementer-prompt.md` / `writing-good-tests.md` / `visual-companion.md`. |
| `skills/subagent-driven-development/SKILL.md` | +53/−2 | Four gated additions, each at a moment the controller already attends to: (a) the pre-flight scan ends with a **dispatch plan** grouping pending tasks into waves of mutually file-disjoint tasks; (b) the `Never dispatch multiple implementation subagents in parallel` bullet keeps its unqualified rule and gains **one exception** — a skeleton-first plan's file-disjoint tasks — with the worktree-per-task integration protocol that makes it safe; (c) at task completion, a **plan-check line** (`Plan holds` / `Amendment: Task <M>: …`), where an amendment becomes the plan's text; (d) Model Selection **follows a declared `Tier:`** field, and an explicit `mechanical` ruling overrides the mid-tier contract floor. The 2 changed lines are extensions of existing sentences, not removals. |
| `skills/subagent-driven-development/implementer-prompt.md` | +5/−2 | The model slot reads the brief's `Tier` line at fill time; with no `Tier` line it falls through to the existing Model Selection guidance verbatim. |

## Is this change appropriate for the core library?

Yes. It is a general-purpose planning shape — "build the thinnest end-to-end slice first, then widen it" is domain-, language- and tool-agnostic, and the fixtures it was measured on (a five-analyzer lattice, a SQLite metrics pipeline) are unrelated to any project of mine. It adds no dependency, no third-party service, and no scripts. It touches only the two skills that own plan shape and plan execution, and it is inert for every plan that does not opt in.

The one judgment call worth flagging: this is **new behavior-shaping surface area** in two carefully-tuned skills. If the maintainers' view is that `writing-plans` should have exactly one shape, that is a legitimate reason to close this, and the evidence below does not overturn it.

## What alternatives did you consider?

1. **Replace the default** — what the campaign was chartered to do, and what it *failed* to justify. No arm beat control on completion; the shape in this PR is substantially slower. Rejected on its own evidence.
2. **Ship the measured arm text verbatim.** The research branch (`ws/cd3`) rewrites `writing-plans`' Overview, deletes `Bite-Sized Task Granularity`, and replaces the task template and `No Placeholders` outright. That *is* a default replacement. Rejected; the same clauses are re-homed behind a router instead, which is why the shipped text is not byte-identical to the measured text (see Limitations).
3. **Ship the faster variants instead** (`ws/cd4`, `ws/cd7`). Rejected on measured quality — see "The speed levers this PR deliberately excludes" below. This PR takes the quality-first point on the frontier, because quality is the only axis where this shape beats the default.
4. **A separate `skeleton-first-planning` skill.** Rejected: it would duplicate Scope Check, File Structure, Task Right-Sizing, the plan header, Self-Review and the Execution Handoff, and it splits the choice across two skill descriptions where a router keeps it at one decision point. The repo's existing idiom for two ways to do one job is an in-skill path router (`brainstorming`'s Three Paths) or a numbered handoff (`writing-plans`' own Execution Handoff).
5. **Ship the cheap-orchestrator machinery** (`cd12`/`cd13`: portable bash plan-lint, an acceptance gate, integrity clauses). That is a **separate PR**, deliberately out of scope here.
6. **Ungate the plan-check line for all plans.** It was measured standalone (trap: 34.5 min, 4/4 complete) and is arguably good for task-by-task plans too. Deferred: it would change default behavior, so it deserves its own PR and its own evidence.

## Does this PR contain multiple unrelated changes?

No — one feature across three commits, related by dependency. Commit 1 adds the plan shape; commits 2 and 3 add the SDD support without which a skeleton-first plan cannot be executed as designed (the dispatch plan and the `Tier` field are both written by commit 1's template and read by commits 2–3). Splitting them would land a plan shape the executor ignores.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1978, #1534, #970, #1524, #1898, #1141

No duplicate exists. The closest prior art, and how this differs:

- **#1978 (open) — hierarchical plan mode for complex plans.** Same *pattern* (writing-plans gains a second mode selected by a threshold), different axis: #1978 changes plan *file layout* at 8+ tasks; this changes plan *ordering and task form*. Compatible, not overlapping.
- **#1534 (open) — allow parallel dispatch with worktree isolation.** Direct overlap on the `Never dispatch multiple implementation subagents in parallel` rule. #1534 narrows the rule for any file-independent tasks; this PR keeps the rule unqualified and opens the exception **only** inside a skeleton-first plan whose pre-flight scan has proven disjointness. Relevant measured caveat for both PRs: across four escalating arm texts, orchestrators issued **0 multi-dispatch messages in 41 dispatch-carrying messages**, and the one genuine 4-way concurrent dispatch the campaign ever observed then integrated serially and finished *slower*. If #1534 lands first, this PR should be rebased onto it and the exception paragraph collapsed into #1534's wording.
- **#970 (open) — parallel suitability check at plan handoff** and **#1524 (open) — propose parallel execution tracks by default.** Both add per-task dependency/scope metadata to decide parallelism. This PR's dispatch plan is computed by the executor from the scan it already runs, not declared by the planner, and it is explicitly not parallel-first. If #970 lands, its `Depends on` / `Write Scope` fields would be a better source for the waves than a re-derived scan.
- **#1898 (open) — planning alternatives and pre-mortems.** Adjacent: alternatives *within* a plan, not alternative plan shapes.
- **#1141 (closed) — enforce vertical tracer bullets in TDD.** The nearest conceptual ancestor (vertical slice over horizontal layers), closed without comment. Two differences: it made tracer bullets *mandatory* inside the TDD skill; this makes the equivalent ordering *selectable* at plan time, and it arrives with session-scale outcome evidence rather than a rationale.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (elicitation checks on this branch's exact text, `--plugin-dir`) | 2.1.227 | Fable 5 | `us.anthropic.claude-fable-5[1m]` |
| Claude Code, headless, via the campaign's autoresearch harness (measured the `ws/cd3` research text, not this branch's text) | not recorded in the log | Opus 5 orchestrator; Sonnet 5 / Haiku 4.5 subagents | `us.anthropic.claude-opus-5` (Bedrock) |
| Claude Code, headless (blind judge panel + adjudicator) | not recorded in the log | Opus 4.8 | `claude-opus-4-8` (Bedrock) |

Not tested on Codex, Gemini, or any other harness — see Limitations.

## New harness support (required if this PR adds a new harness)

Not applicable — this PR adds no harness support. No new-harness transcript is owed.

## Evaluation

**What was the initial prompt that led to this change?** Not a single prompt — a chartered campaign. Jesse opened it by asking whether, now that orchestrating models are more capable, the planning process could look more *agile*: build a walking skeleton first, then widen it, possibly with subagents in parallel worktrees — explicitly as a candidate **replacement** for `writing-plans` + SDD, with a $2,500 budget and pre-registered, blind-judged, append-only-corrected experiments. Verbatim directives recorded in the log that steered it include: *"before we do full quorum runs, I want to understand the code quality, wall clock, and cost differences between walking-skeleton and traditional"*; *"rather than doing big quorum runs, let's use a tight autoresearch loop with hypotheses and micro-evals"*; and *"figure out how you could do quick pruning of obvious failures."*

**How many eval sessions ran after the change?** ~110 agent sessions across 15 pre-registered experiments; ~70 artifacts blind-judged. Directly load-bearing for this PR: the arm this ships (`ws/cd3`) at **n=4** on the lattice fixture and **n=2** on the trap fixture, against control at **n=5** (lattice) and **n=4** (trap), plus its lineage (`l1`, `l4`, `full2` at n=3–4 each) and the two rejected speed variants (`cd4`, `cd7` at n=2–4). Separately, **5 elicitation checks on this branch's exact text** (results at the end of this section).

**How did outcomes change?** Better artifacts, substantially slower builds, modestly cheaper on the larger fixture. In detail:

### Evidence

Fixtures: **lattice** = `ws-parallel-lattice`, five file-disjoint analyzers over a shared core (the smaller build). **trap** = `p3-compounding-trap`, a metrics pipeline over a shipped SQLite DB with hidden schema drift (the larger build). Completion on the trap fixture is the scenario-owned external `accept.sh` **v3** bar, which demands spec-forced values from *every* feature (834 windows, 157 anomaly flags, a 50,001-line export, six summary counts). Quality = blind two-judge adversarial panel + adjudicator, artifacts packed with all process evidence stripped. Dollars = published list rates × 1.1 AWS Bedrock regional premium, orchestrator **and** every subagent priced at its own tier, whole-session medians.

**Quality — the case for this change (lattice fixture, blind panel):**

| Cell | Overall | Majors | n |
|---|---|---|---|
| control (current flow) | **4.0** median | majors in **2 of 5** reps | 5 |
| `full2` (this arm's direct parent) | **5.0** every rep | 0 in 3/3 | 3 |
| **`cd3` — this PR** | **5.0** every rep | **0 in 4/4** | 4 |
| `full2` + `cd3` pooled | 5.0 | 0 majors, 7 consecutive sessions | 7 |
| control, trap fixture | **never judged** | — | — |

**Completion — trap fixture, v3 spec-complete time-to-green (medians):**

| Arm | Median | Complete | n |
|---|---|---|---|
| control (current flow) | **32.4 min** | 4/4 | **4** |
| `l1` skeleton ordering only | 37.7 min | 4/4 | 4 |
| `l4` re-plan gate only | 34.5 min | 4/4 | 4 |
| `full2` all four levers | 49.2 min | 4/4 | 4 |
| **`cd3` — this PR** | **55.8 min** | 2/2 | **2** |

Stated plainly, both halves: this shape is **~72% slower than control on the larger fixture**, and it is measured on **half the reps the control is** (n=2 vs n=4). No arm in the campaign beat control on completion.

**Completion — lattice fixture, time-to-green (medians):**

| Arm | Median | Green | n |
|---|---|---|---|
| control | 27.1 min | 5/5 | 5 |
| `full2` | 45.6 min | 3/3 | 3 |
| **`cd3` — this PR** | **32.0 min** | **4/4** | 4 |

On the smaller fixture the gap narrows to **+18% over control**, and `cd3` is 30% faster than the parent arm it replaced — that speedup is why `cd3` became the campaign's keeper. The log records explicitly that this lattice speedup **does not transfer** to the larger fixture.

**Cost (whole-session medians, orchestrator + all subagents):**

| Arm | trap $/build | lattice $/build |
|---|---|---|
| control | **$58.94** (n=4) | **$22.90** (n=5) |
| **`cd3` — this PR** | **$51.58** (n=2) | $26.31 (n=4) |
| `cd4` (rejected) | $62.74 (n=4) | $50.68 |
| `cd7` (rejected) | $61.58 (n=4) | $42.99 |

`cd3` is about **12% cheaper than control on the larger fixture** and about 15% dearer on the smaller one. Two bar-hygiene notes: the $51.58 figure was computed from the same two runs whose *v2*-measured time was 48.2 min, not the 55.8 min v3 figure above — the dollars are usage-based and stand under v3, but do not pair "$51.58" with "48.2 min" as if 48.2 were the completion number. And the lattice whole-session totals include post-completion polishing under the deadline, a caveat the log records for every arm.

**Early capability (trap fixture, shallow "is anything alive?" bar — suite green + CLI runs).** `full2`, this arm's direct parent, reached a running end-to-end system at **8.6–11.0 min** and `l1` at **11.8–23.2 min**, against control's **26.0–32.4 min** — roughly 2.5× sooner, then the remaining time goes into filling it in. This was measured on `full2` and `l1`, **not on `cd3` itself**, and on a shallower bar than the completion table above; I am not merging the two bars.

**Mechanism caveat on the `Tier` clauses, recorded rather than spun.** `cd3`'s win is *not* cleanly attributable to cheap-model routing, which is what the edit was designed to produce: cheap-tier engagement was sporadic in vivo (6/16 dispatches in one rep, 0/13 in another), and the fastest reps included a rep with zero cheap dispatches. The speedup tracked dispatch count and decomposition leanness instead. The mid-tier floor's own empirical claim ("cheap models take 2-3× the turns and cost more overall") remains **unruled** — engagement was too sporadic to discriminate it. The clauses are kept for their measured whole-arm effect, not their original rationale.

### The speed levers this PR deliberately excludes

The campaign built and measured two further arms on top of this one, and this PR drops both. That is a deliberate choice at a mapped frontier, not an untested omission:

- **`cd4` — "the skeleton owns every integration point"** (the skeleton stubs every planned component so widening tasks are file-disjoint by construction). Trap v3: 42.0 min, but only **2/4 reps ever fully completed**. Lattice judges 5.0/0 and **4.5/1 — one major in one rep**. Trap cost $62.74, above control.
- **`cd7` — `cd4` plus ready-set scheduling** (dispatch whatever is unblocked, no wave barriers). The fastest composed arm that still completes: trap v3 38.4 min at 4/4, and its trap artifacts judged 5.0/0 in 4/4. But on the lattice fixture it judged **4.0/0, 4.5/0, 4.0/1 — a quality-floor breach, confirmed by the protocol's own repeat rep.** The campaign's keeper pointer therefore **never moved to `cd7`**; it is recorded as "the big-fixture arm of record, quality-flagged on small fixtures."

**A retracted number, flagged because it is the one most likely to be quoted at me.** `cd7`'s headline result was once "18.0 min, −42% vs control, target met." That was **retracted**: the `accept.sh` v2 bar it was measured against turned out to print all six of its ground-truth counts inside the *summary* feature alone, so one real feature plus five stubs passed it. On the honest v3 bar `cd7` is 38.4 min. Jesse's stated targets of ≥25% and 50% faster than control were **not met by any arm** on the honest bar.

The campaign's own recorded reading, which is why this PR ships the slow arm: *"the 5.0-sweep quality signature of cd3/full2 partly LIVED IN THE SLACK the speed levers remove… Speed and the immaculate signature are different points on one frontier, not one arm's property."* The frontier was mapped; this PR takes the quality-first point on it, because quality is the only axis where this shape beats the default.

### What this does not buy

- **No completion win.** ~72% slower than control on the larger fixture (55.8 vs 32.4 min), +18% on the smaller one (32.0 vs 27.1 min).
- **No trap-avoidance win.** The compounding-error hypothesis is dead for this model class (16/16 sessions, control included, found the hidden drift in ~1 minute).
- **No reliable parallelism win.** The dispatch plan's measured effect was mostly on decomposition and orchestrator sequencing, not implementer concurrency: orchestrators issued 0 multi-dispatch messages in 41 dispatch-carrying messages across four escalating arm texts, and the single 4-way overlap ever observed integrated its branches serially and finished slower. The worktree protocol here is correctness scaffolding for a path that engages rarely at this task size.
- **A modest cost win only, and only on the larger fixture** (−12% trap, +15% lattice). The real cost reductions this campaign found live in the `cd12`/`cd13` machinery that is *not* in this PR.

### Limitations and retractions

**Different fixtures carry different claims.** The judged control-vs-treatment head-to-head is on the **lattice** fixture; completion and cost are on the **trap** fixture. **The control's trap artifacts were never judged**, so there is *no like-for-like quality number on the larger fixture*. The log carries that as a registered, unrun item, not an oversight.

**Thin denominators.** The quality claim is n=4 (pooled n=7 with the parent arm) against control's n=5. The trap completion and cost claims are **n=2 against control's n=4**. Nothing here is a variance claim.

**The shipped text is not the measured text.** Every number above was produced by `ws/cd3` @ `8a9e88d`, which rewrites `writing-plans` in place. This PR re-homes the same clauses behind a router and gates the SDD side on a declared plan shape. The behavioral clauses are carried across substantially verbatim, but no measured session ever ran *this* arrangement. By the campaign's own standing rule — a quorum battery of the exact shipped text is the only ship gate — this text is unqualified. That is the main reason it is a draft.

**Scope.** Single scenario family, one harness for every shipped claim. A second harness (Codex) took up the **plan-side** levers only: contract-shaped tasks elicited 100% on both harnesses, but the SDD execution-side levers never engaged on Codex's stock native-skills route (0/3 for parallel dispatch, 1/3 for the plan-check line). If this lands, expect the `writing-plans` half to work on Codex and the SDD half not to. Gemini, Cursor and the rest are untested.

**Instrument retractions — the campaign was wrong three times, and each time the instrument was the culprit:**

1. **Agent-authored acceptance bars.** An early verdict reported that the composed arm completed only 1/4 builds within deadline — a completion risk. **Retracted.** The trap fixture shipped no acceptance script, so the harness had been grading each session against whatever acceptance script *that session wrote for itself*: a rep-varying, arm-correlated bar that skeleton arms made stricter and then polished toward until the deadline. A scenario-owned `accept.sh` re-walked every cell; every arm completed well inside the deadline. Standing rule: agent-authored checks are an outcome to grade, never an instrument to measure with.
2. **File-presence bars defeated by stub-first skeletons.** `accept.sh` v1 checked that module files *existed*. `cd4`'s skeleton creates every planned component as a registered stub, so two reps "completed" in ~11 minutes against a vacuous truth. v2 required ground-truth values from the shipped database to appear in CLI output.
3. **Summary-only ground truth.** Under v2, `cd7` measured a −42% wall-clock win at n=4 and the 25% target was declared met. **Retracted** (detail above). v3 demands spec-forced values from every feature. On v3, no arm beats control. **The standing rule from three strikes: a completion bar is valid only after it fails a *one-real-feature* near-miss, not just an all-stubs near-miss — because arms evolve toward whatever the bar rewards, so the near-miss family has to evolve with them.**

A fourth correction is load-bearing for the cost table: token accounting originally summed the orchestrator transcript only, and subagent consumption — living in separate transcript files — turned out to be roughly 4× larger. Every prior token claim was re-scoped and split by model tier, which is the only reason per-build dollars can be priced honestly at all.

**Lever interaction worth stating plainly.** Skeleton-first ordering and parallel dispatch **compete rather than compose**. Skeleton ordering reshapes decomposition so widening wires each feature into the shared entry point task by task — which consumes exactly the file-disjointness parallel dispatch needs. When the composed arm's pre-flight scan ruled "fully sequential — every task modifies the shared CLI, no two tasks file-disjoint," it was *correct*, and zero concurrent dispatches was the right answer rather than a failure. Expect the dispatch plan in this PR to rule "serialize" often on single-artifact specs. (The `cd4` lever exists precisely to give that disjointness back by construction — and it is excluded here for the quality reasons above.)

### How it was measured

Outcome-first, pre-registered, and adversarial. The metric of record is a blind two-judge panel: two adversarial frontier-model judges score each final artifact against the fixture spec (coverage, defects, code quality, test quality) with all process artifacts stripped, plus an adjudicator on disagreement — and the panel only counted after passing an instrument-validation gate requiring it to score a known-good reference correctly *and* catch a near-miss (the reference with three seeded, end-to-end-invisible defects; it scored 4.0 and 2.0 respectively and named all three seeded defects). Its validity was later demonstrated on a real wrong build, not a seeded one: it caught a session that silently truncated 96% of its input data (48,190 of 50,000 rows) after that build's 78 passing tests, its reviewer, and its own completion gate had all certified it. Completion is a scenario-owned external bar the arms cannot author or influence. Everything ran against a dated, append-only hypothesis log that serves as the grading contract, with pre-registered INCONCLUSIVE gates evaluated before verdicts, locked denominators, and no cherry-picking — the log's own tally at the point these results closed was 12 dated corrections and 2 full retractions.

### Elicitation checks on this branch's exact text

Five headless `claude -p` probes against `--plugin-dir` pointing at this branch (Fable 5; superpowers disabled on the host, so no competing copy). These are a smoke check that the router routes, **not** an eval — n=1 per prompt, and the runs inherit the host's user-level `CLAUDE.md`.

| Probe | Result |
|---|---|
| Five-subsystem CLI spec: which shape? | Classified **skeleton-first**, announced it as overridable, cited the trade, and quoted the header line exactly. |
| `--verbose` flag on an existing working CLI: which shape? | Classified **task-by-task**, quoting the default's own condition — and described the default's content correctly (bite-sized TDD steps with actual test and implementation code, No Placeholders), confirming the default path is untouched. |
| Plan with **no** shape declaration, Tasks 3 and 4 file-disjoint: dispatch in parallel? | **"No."** Quoted the preserved unqualified rule plus the gate: "file-disjointness alone isn't enough." |
| Skeleton-first: header line, task fields, written-out test code? | `**Plan shape:** skeleton-first`; Files / Interfaces / Goal / Success criteria / Notes / Tier / Commit; "No — the implementer designs the tests," citing the red flag. |
| Skeleton-first plan where every widening task modifies the same shared CLI file? | Named the DISPATCH PLAN requirement, then correctly ruled **serialize** — "they fail the file-disjoint condition… no concurrent implementers or per-task worktrees" — reaching the campaign's observed-correct answer from the arm's own wording. |

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

**Both unchecked boxes are honest, and here is exactly what is missing.** The `cd3`-lineage text was developed and validated by *session-scale outcome measurement* — blind judges, an external completion bar, pre-registered endpoints — not by `writing-skills`' wording protocol. That protocol (Match-the-Form, then micro-test each clause with n=5 fresh-context samples against a no-guidance control, reading every response by hand) was adopted later in the same campaign for a different arm family and is documented to work well; it was never applied to these clauses. Likewise, adversarial *pressure* testing in the `writing-skills` sense — prompts engineered to make an agent rationalize its way out of the rule — was not run against this text. What was run adversarially is the *grading*: an adversarial judge panel hunting defects in blind artifacts, and an instrument history in which the arms repeatedly defeated the measurement and the measurement had to be hardened three times.

**What I changed in tuned content, precisely, so a reviewer can check it in one pass.** Four lines in SDD are modified rather than added; all four extend an existing sentence, none removes guidance:

1. The mid-tier-floor sentence gains "task contracts or" and the gated `Tier: mechanical` override.
2. The dispatch item-(3) sentence gains a following sentence about contract briefs (needed because "test cases appear only in the brief" is false when the brief is a contract).
3. The `Never dispatch multiple implementation subagents in parallel (conflicts).` bullet keeps that sentence verbatim and gains a gated exception beneath it.
4. `implementer-prompt.md`'s model slot gains the `Tier` route ahead of the existing fall-through.

No Red Flags table, rationalization list, or "human partner" phrasing was touched. `writing-plans`' existing text has **zero** modified or deleted lines.

**Repo checks run.** `tests/shell-lint` passes (8/8); `scripts/lint-shell.sh` reports no shell files (this PR adds none). `tests/writing-skills/test-render-graphs.sh` fails 5/8 identically on a clean `origin/dev` checkout on this host because `graphviz` is not installed — pre-existing and unrelated; this PR adds no diagrams. `tests/claude-code/*` are live LLM behavior tests whose helper invokes the ambient `claude` with no `--plugin-dir`, so they exercise the host's installed plugin rather than a branch; I ran the equivalent probes against this branch explicitly instead (table above).

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

**Not yet.** This is a draft opened so Jesse (@obra) can read the complete diff and the numbers together, including the ones that argue against merging: no completion win, a ~72% wall-clock premium on the larger fixture, and n=2 on that fixture against the control's n=4. Please do not mark it ready for review or merge it until he has.

---

The full research record — the dated hypothesis log that is the grading contract of record, with every verdict, correction and retraction; the arm manifest with SHA-pinned branches; and the per-battery raw results — lives in a private repository outside this project. Every number in this PR is traceable to it, and it can be shared on request.

