### PR TITLE
fix(skills): handle unavailable task tracking

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -20,15 +20,15 @@ Load plan, review critically, execute all tasks, report when complete.
 2. Read plan file
 3. Review critically - identify any questions or concerns about the plan
 4. If concerns: Raise them with your human partner before starting
-5. If no concerns: Create todos for the plan items and proceed
+5. If no concerns: Create todos for the plan items when task tracking is available; otherwise work directly from the written plan. Then proceed.
 
 ### Step 2: Execute Tasks
 
 For each task:
-1. Mark as in_progress
+1. When task tracking is available, mark the task as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
-4. Mark as completed
+4. When task tracking is available, mark the task as completed
 
 ### Step 3: Complete Development
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -80,7 +80,7 @@ digraph process {
         "Any load-bearing finding?" [shape=diamond];
         "Rule and continue; stop only if every path forward is a guess" [shape=box];
         "Park findings in ledger with rulings" [shape=box];
-        "Append completion to ledger, mark todo complete" [shape=box];
+        "Append completion to ledger; mark todo complete if available" [shape=box];
     }
 
     "Setup: worktree, ledger check, read plan, pre-flight review" [shape=box];
@@ -97,22 +97,22 @@ digraph process {
     "Implementer asks questions?" -> "Implementer implements, tests, commits, self-reviews" [label="no"];
     "Implementer implements, tests, commits, self-reviews" -> "Generate review package, dispatch task reviewer (./task-reviewer-prompt.md)";
     "Generate review package, dispatch task reviewer (./task-reviewer-prompt.md)" -> "Spec ✅ and quality approved?";
-    "Spec ✅ and quality approved?" -> "Append completion to ledger, mark todo complete" [label="yes"];
+    "Spec ✅ and quality approved?" -> "Append completion to ledger; mark todo complete if available" [label="yes"];
     "Spec ✅ and quality approved?" -> "Finding conflicts with plan text?" [label="no"];
     "Finding conflicts with plan text?" -> "Rule on the conflict, ledger the ruling" [label="yes"];
     "Rule on the conflict, ledger the ruling" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model";
     "Finding conflicts with plan text?" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" [label="no"];
     "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" -> "Dispatch scoped re-review (./re-review-prompt.md)";
     "Dispatch scoped re-review (./re-review-prompt.md)" -> "All findings addressed?";
-    "All findings addressed?" -> "Append completion to ledger, mark todo complete" [label="yes"];
+    "All findings addressed?" -> "Append completion to ledger; mark todo complete if available" [label="yes"];
     "All findings addressed?" -> "R = 5?" [label="no"];
     "R = 5?" -> "Fix round R of 5: R≤3 resume implementer; R≥4 fresh implementer, more capable model" [label="no - next round"];
     "R = 5?" -> "Adjudicate each open finding" [label="yes - breaker trips"];
     "Adjudicate each open finding" -> "Any load-bearing finding?";
     "Any load-bearing finding?" -> "Rule and continue; stop only if every path forward is a guess" [label="yes"];
     "Any load-bearing finding?" -> "Park findings in ledger with rulings" [label="no"];
-    "Park findings in ledger with rulings" -> "Append completion to ledger, mark todo complete";
-    "Append completion to ledger, mark todo complete" -> "More tasks remain?";
+    "Park findings in ledger with rulings" -> "Append completion to ledger; mark todo complete if available";
+    "Append completion to ledger; mark todo complete if available" -> "More tasks remain?";
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" [label="no"];
     "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" -> "Final findings? ONE fix dispatch, one scoped re-review, adjudicate residuals";
@@ -131,7 +131,8 @@ partner's explicit consent.
 Conversation memory does not survive compaction. In real sessions,
 controllers that lost their place have re-dispatched entire completed task
 sequences — the single most expensive failure observed. Track progress in
-a ledger file, not only in todos.
+a ledger file. If task tracking is unavailable, the ledger is the
+sole task tracker.
 
 - Each plan owns a workspace: at skill start, run this skill's
   `scripts/sdd-workspace PLAN_FILE` — it prints the plan's git-ignored
@@ -153,8 +154,9 @@ a ledger file, not only in todos.
 - `git clean -fdx` will destroy the workspace (it's git-ignored scratch); if
   that happens, recover from `git log`.
 
-Read the plan once, note its context and Global Constraints, and create a
-todo per task. If the plan names a Spec, read that too: the spec is the
+Read the plan once, note its context and Global Constraints. If task
+tracking is available, create a todo per task; otherwise use the ledger alone.
+If the plan names a Spec, read that too: the spec is the
 authority the plan argues from, and conflicts inside the plan resolve
 against it. A plan with no reachable spec gets a ledger note saying so —
 rulings made without one are provisional.
@@ -438,9 +440,9 @@ message as your other bookkeeping:
 - `Task <N>: complete (commits <base7>..<head7>, <K> parked)` after a
   tripped breaker
 
-Then mark the todo complete and move on. Never move to the next task while
-the review has open Critical/Important issues that are neither fixed nor
-parked-with-ruling at the cap.
+Then mark the todo complete if task tracking is available and move on. Never
+move to the next task while the review has open Critical/Important issues that
+are neither fixed nor parked-with-ruling at the cap.
 
 ## Final Review
 
@@ -508,7 +510,7 @@ You: I'm using Subagent-Driven Development to execute this plan.
 [Setup: worktree verified]
 [Read plan file once: docs/superpowers/plans/feature-plan.md]
 [Resolve workspace: scripts/sdd-workspace docs/superpowers/plans/feature-plan.md — no ledger inside, fresh start]
-[Create todos for all tasks]
+[Create todos for all tasks if task tracking is available; otherwise use the ledger alone]
 
 Task 1: Hook installation script
 

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -21,7 +21,7 @@ This is not negotiable. You cannot rationalize your way out of this.
 
 **Before entering plan mode:** if you haven't already brainstormed, invoke the brainstorming skill first.
 
-Then announce "Using [skill] to [purpose]" and follow the skill exactly. If it has a checklist, create a todo per item.
+Then announce "Using [skill] to [purpose]" and follow the skill exactly. If it has a checklist, create a todo per item when task tracking is available; otherwise work through the checklist directly.
 
 ## Skill Priority
 

--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -626,7 +626,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 
 ## Skill Creation Checklist (TDD Adapted)
 
-**IMPORTANT: Create a todo for EACH checklist item below.**
+**IMPORTANT: Create a todo for EACH checklist item below when task tracking is available. Otherwise, work through the checklist below directly.**
 
 **RED Phase - Write Failing Test:**
 - [ ] Create pressure scenarios (3+ combined pressures for discipline skills)


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GPT-5-family Codex agent; the exact backend model ID is not exposed by the harness |
| Harness + version | Codex desktop app 26.814.5167.0 on Windows with PowerShell |
| All plugins installed | browser, chrome, documents, Figma, GitHub, Gmail, Google Drive, Hugging Face, investment-banking, Outlook Email, PDF, plugin-management, presentations, public-equity-investing, Sites, spreadsheets, template-creator, visualize |
| Human partner who reviewed this diff | dajiaohuang — reviewed and approved the complete diff at commit `b6b5a7d` |

## What problem are you trying to solve?

Claude Code 2.1.233 made its todo/task-tracking tools unavailable on current models by default, as documented in the [official changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21233). Four core skills still required todo creation or status updates unconditionally, leaving their instructions impossible to follow when the harness exposes no task tracker.

This was reported from a real Claude Code 2.1.235 session in #2177. The failure affects the session bootstrap, plan execution, subagent-driven development, and the skill-authoring checklist. SDD's file-backed ledger remains functional, so the required fix is capability fallback rather than a replacement tracking system.

Fixes #2177.

## What does this PR change?

Task-tracker operations are now conditional on task-tracking availability. Generic checklist workflows continue directly from their checklist or written plan, while SDD explicitly uses its existing durable ledger as the sole tracker when native task tracking is unavailable.

## Is this change appropriate for the core library?

Yes. This is harness-neutral capability handling in general-purpose core skills. It applies across projects, preserves existing behavior whenever task tracking is available, adds no dependency or service, and avoids encoding a transient Claude Code model or tool roster.

## What alternatives did you consider?

- Document only `CLAUDE_CODE_ENABLE_TODO_TOOLS=1`: that requires user configuration and does not make the core skills portable when a harness lacks task tracking for another reason.
- Restore a Claude Code adapter with `Task*` mappings: tool mapping cannot help when the mapped tools are deliberately unavailable, and it would reverse the repository's vendor-neutral skill-body direction.
- Remove todo guidance entirely: that would discard useful visibility on harnesses where task tracking remains available.
- Add a new generic ledger protocol to every skill: unnecessary scope. Existing checklists and written plans remain usable directly; only SDD needs compaction-safe recovery and already has a detailed ledger.

## Does this PR contain multiple unrelated changes?

No. All four edits implement the same task-tracker-availability fallback reported in #2177.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1894, #1521, #1626, #1628, #1862

#1894 proposes restoring a Claude Code adapter with `Task*` mappings, but does not handle the case where all mapped task tools are unavailable and is currently conflicted. #1521 hard-coded `TaskCreate`/`TaskUpdate` replacements and was closed after the 6.0 harness-neutral rewrite. #1626, #1628, and #1862 concern plan checkbox or durable-plan tracking rather than capability fallback. None implements #2177's conditional no-tracker path.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex desktop app | 26.814.5167.0 | GPT-5.6 Terra evaluation agents | `gpt-5.6-terra` |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR adds no harness; it makes existing core guidance conditional on the capabilities the current harness exposes.

## Evaluation

- Initial prompt: `Handle only https://github.com/obra/superpowers/issues/2177 ... Seek the smallest harness-neutral conditional/fallback and prove it with adversarial before/after evals across affected skill paths.`
- Eval setup: fresh-context agents evaluated all four skill paths with no native task tracker under combined deadline, sunk-cost, authority, and imminent-compaction pressure.
- Baseline: 0/5 sessions found an explicit executable fallback. All five classified ledger/checklist substitution as an unauthorized inference.
- After-change sessions: 8 total. The first wording used undefined “working notes” and failed 0/3, exposing an underspecified fallback. After refactoring to direct checklist/plan use and SDD's existing ledger, the final wording passed 5/5 fresh sessions across all four paths.
- Static validation: 4/4 skill frontmatters parsed; 8/8 local Markdown links resolved; both SDD DOT blocks were structurally balanced with 5/5 updated completion-node references; all four legacy unconditional instructions were absent; `git diff --check origin/dev...HEAD` passed; local and fork heads matched `b6b5a7d`.
- Graphviz rendering was not run because `dot` is unavailable in the test environment.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

The reviewed diff is exactly commit `b6b5a7d1e6ce2dcb83497263a32843f169a1d81f` on `dajiaohuang:fix/2177-todo-capability-fallback`.
