### PR TITLE
feat (harness): add Bob harness support

### DIFF
--- a/.bob-plugin/plugin.json
+++ b/.bob-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "superpowers",
+  "displayName": "Superpowers",
+  "description": "Core skills library: TDD, debugging, collaboration patterns, and proven techniques",
+  "version": "6.3.0",
+  "author": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "homepage": "https://github.com/obra/superpowers",
+  "repository": "https://github.com/obra/superpowers",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "tdd",
+    "debugging",
+    "collaboration",
+    "best-practices",
+    "workflows"
+  ]
+}

--- a/.bob-plugin/scripts/install.sh
+++ b/.bob-plugin/scripts/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# .bob-plugin/scripts/install-bob.sh
+#
+# Install Superpowers into IBM Bob.
+#
+# Usage:
+#   bash .bob-plugin/scripts/install-bob.sh            # project-level (.bob/)
+#   bash .bob-plugin/scripts/install-bob.sh --global   # global (~/.bob/)
+#
+# What this does:
+#   1. Copies all skills from skills/ into the target .bob/skills/ directory.
+#   2. Wires the SessionStart hook into .bob/settings.json (creating it if absent).
+#
+# Idempotent: re-running after `git pull` updates existing skill copies and
+# does not double-add the hook stanza.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+GLOBAL=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --global) GLOBAL=1; shift ;;
+        -h|--help)
+            sed -n '/^# Usage:/,/^# What this does:/s/^# \{0,1\}//p' "$0"
+            exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Determine target directories
+# ---------------------------------------------------------------------------
+
+if [[ $GLOBAL -eq 1 ]]; then
+    BOB_DIR="${HOME}/.bob"
+    SETTINGS_FILE="${HOME}/.bob/settings/settings.json"
+    HOOK_COMMAND="${PLUGIN_ROOT}/hooks/session-start-bob"
+    INSTALL_LABEL="global (~/.bob/)"
+else
+    BOB_DIR="${PWD}/.bob"
+    SETTINGS_FILE="${PWD}/.bob/settings.json"
+    HOOK_COMMAND="hooks/session-start-bob"
+    INSTALL_LABEL="project (.bob/)"
+fi
+
+SKILLS_TARGET="${BOB_DIR}/skills"
+
+echo "Installing Superpowers for Bob IDE (${INSTALL_LABEL})..."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 1: Copy skills
+# ---------------------------------------------------------------------------
+
+mkdir -p "${SKILLS_TARGET}"
+
+skill_count=0
+for skill_dir in "${PLUGIN_ROOT}/skills"/*/; do
+    skill_name="$(basename "${skill_dir}")"
+    target="${SKILLS_TARGET}/${skill_name}"
+    rm -rf "${target}"
+    cp -r "${skill_dir}" "${target}"
+    skill_count=$((skill_count + 1))
+done
+
+echo "  Copied ${skill_count} skills to ${SKILLS_TARGET}"
+
+# ---------------------------------------------------------------------------
+# Step 2: Wire the SessionStart hook in settings.json
+# ---------------------------------------------------------------------------
+
+# Ensure the parent directory exists
+mkdir -p "$(dirname "${SETTINGS_FILE}")"
+
+# If the file doesn't exist yet, start with a minimal valid JSON object
+if [[ ! -f "${SETTINGS_FILE}" ]]; then
+    printf '{}\n' > "${SETTINGS_FILE}"
+    echo "  Created ${SETTINGS_FILE}"
+fi
+
+# Idempotency check — skip if the hook command is already present
+if grep -qF "${HOOK_COMMAND}" "${SETTINGS_FILE}" 2>/dev/null; then
+    echo "  Hook already wired in ${SETTINGS_FILE} (no changes)"
+else
+    # Use python3 to merge the hook stanza into existing JSON.
+    # This preserves any settings the user already has.
+    python3 - "${SETTINGS_FILE}" "${HOOK_COMMAND}" <<'PYEOF'
+import json, sys
+
+settings_file = sys.argv[1]
+hook_command  = sys.argv[2]
+
+with open(settings_file, "r") as f:
+    settings = json.load(f)
+
+hook_entry = {
+    "type": "command",
+    "command": f"sh {hook_command}",
+    "timeout": 10
+}
+
+hook_group = {"hooks": [hook_entry]}
+
+settings.setdefault("hooks", {})
+settings["hooks"].setdefault("SessionStart", [])
+settings["hooks"]["SessionStart"].append(hook_group)
+
+with open(settings_file, "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+
+print(f"  Wired SessionStart hook in {settings_file}")
+PYEOF
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Installation complete."
+echo ""
+echo "Smoke check — start a fresh Bob session and ask:"
+echo "  What are your superpowers?"
+echo ""
+echo "Acceptance test — send exactly:"
+echo "  Let's make a react todo list"
+echo "Bob should invoke the 'brainstorming' skill before writing any code."
+echo ""
+echo "To update after 'git pull':"
+echo "  bash .bob-plugin/scripts/install-bob.sh${GLOBAL:+ --global}"

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -7,6 +7,7 @@
     { "path": ".codex-plugin/plugin.json", "field": "version" },
     { "path": ".devin-plugin/plugin.json", "field": "version" },
     { "path": ".kimi-plugin/plugin.json", "field": "version" },
+    { "path": ".bob-plugin/plugin.json", "field": "version" },
     { "path": ".claude-plugin/marketplace.json", "field": "plugins.0.version" },
     { "path": "gemini-extension.json", "field": "version" }
   ],

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [Codex App](#codex-app)
   - [Codex CLI](#codex-cli)
   - [Cursor](#cursor)
+  - [Bob IDE](#ibm-bob)
   - [Devin CLI](#devin-cli)
   - [Factory Droid](#factory-droid)
   - [Gemini CLI](#gemini-cli)
@@ -245,6 +246,23 @@ pi -e /path/to/superpowers
 ```
 
 The Pi package loads the Superpowers skills and a small extension that injects the `using-superpowers` bootstrap at session startup and again after compaction. Pi has native skills, so no compatibility `Skill` tool is required. Subagent and task-list tools remain optional Pi companion packages.
+
+### IBM Bob
+
+IBM Bob has no plugin marketplace. Install by cloning this repository and running
+the install script, which copies skills and wires the bootstrap hook:
+
+```bash
+bash /path/to/superpowers/.bob-plugin/scripts/install.sh
+```
+
+For a global install (all Bob projects):
+
+```bash
+bash /path/to/superpowers/.bob-plugin/scripts/install.sh --global
+```
+
+- Detailed docs: [docs/README.bob.md](docs/README.bob.md)
 
 ### Hermes Agent
 

--- a/docs/README.bob.md
+++ b/docs/README.bob.md
@@ -1,0 +1,132 @@
+# Superpowers for IBM Bob
+
+Complete guide for using [IBM Bob](https://bob.ibm.com/docs/ide).
+
+## Prerequisites
+
+- IBM Bob IDE (any version with `SessionStart` hook support)
+- `bash` and `python3` available in your PATH (used by the install script)
+
+## Installation
+
+Clone this repository and run the install script. Bob has no `bob plugin install` CLI, so installation is handled by a script that copies skills and wires the bootstrap hook for you.
+
+### Project-level install (recommended)
+
+Run from inside your project directory, with the superpowers repo available:
+
+```bash
+git clone https://github.com/obra/superpowers /path/to/superpowers
+cd /your/project
+bash /path/to/superpowers/.bob-plugin/scripts/install.sh
+```
+
+This installs skills into `.bob/skills/` and wires the hook in `.bob/settings.json` — both scoped to your current project.
+
+### Global install
+
+```bash
+bash /path/to/superpowers/.bob-plugin/scripts/install.sh --global
+```
+
+This installs skills into `~/.bob/skills/` and wires the hook in `~/.bob/settings/settings.json` — active across all Bob projects.
+
+## What the script does
+
+1. **Copies skills** from `skills/` into the target `.bob/skills/` directory (one subdirectory per skill). Bob auto-discovers skills from this directory.
+2. **Wires the `SessionStart` hook** into `.bob/settings.json` (project) or `~/.bob/settings/settings.json` (global), creating the file if absent. The hook causes Bob to inject the Superpowers bootstrap into the model context at the start of every session.
+
+The script is **idempotent** — re-running it does not duplicate the hook stanza and simply overwrites existing skill copies with the latest versions.
+
+## Updating
+
+After pulling the latest Superpowers commits, re-run the install script:
+
+```bash
+git -C /path/to/superpowers pull
+bash /path/to/superpowers/.bob-plugin/scripts/install.sh   # or --global
+```
+
+## Smoke check
+
+After installation, start a fresh Bob session and ask:
+
+```
+What are your superpowers?
+```
+
+Bob should respond with knowledge of its available skills.
+
+## Acceptance test
+
+Send exactly this message in a fresh Bob session:
+
+```
+Let's make a react todo list
+```
+
+A working integration triggers the `brainstorming` skill (via `use_skill`) **before any code is written**. If brainstorming does not trigger, the bootstrap is not loading — see Troubleshooting below.
+
+## Manual install
+
+If you prefer not to run the script:
+
+1. **Copy skills:** Copy each subdirectory from `skills/` into `.bob/skills/` (or `~/.bob/skills/` for global):
+
+   ```bash
+   cp -r /path/to/superpowers/skills/* .bob/skills/
+   ```
+
+2. **Wire the hook:** Add the following stanza to `.bob/settings.json` (create the file if absent):
+
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [
+         {
+           "hooks": [
+             {
+               "type": "command",
+               "command": "sh hooks/session-start-bob",
+               "timeout": 10
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+   For a global install, use an absolute path in `command`:
+   ```json
+   "command": "sh /path/to/superpowers/hooks/session-start-bob"
+   ```
+
+   And place the stanza in `~/.bob/settings/settings.json`.
+
+3. Start a fresh Bob session and run the smoke check above.
+
+## Troubleshooting
+
+### Smoke check fails — Bob doesn't know its skills
+
+The bootstrap hook is not loading. Check:
+
+- The hook stanza is present in `.bob/settings.json` or `~/.bob/settings/settings.json`
+- The path in `command` points to the correct `hooks/session-start-bob` script
+- The script is executable: `chmod +x /path/to/superpowers/hooks/session-start-bob`
+- Try running the hook manually to confirm it prints output:
+  ```bash
+  echo '{}' | bash /path/to/superpowers/hooks/session-start-bob
+  ```
+
+### Skills not found after install
+
+- Verify `.bob/skills/` (or `~/.bob/skills/`) contains subdirectories with `SKILL.md` files
+- Re-run the install script: `bash .bob-plugin/scripts/install.sh`
+- Start a fresh Bob session
+
+## Getting Help
+
+- Report issues: https://github.com/obra/superpowers/issues
+- Main documentation: https://github.com/obra/superpowers

--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -792,6 +792,7 @@ Use this as the live index; when in doubt, read the files, not this table.
 | Kimi Code | `.kimi-plugin/plugin.json` | manifest `sessionStart.skill` loads `using-superpowers` | inline `skillInstructions` in manifest | `tests/kimi/` | marketplace or `/plugins install` GitHub URL |
 | OpenCode | `.opencode/plugins/superpowers.js` (declared via root `package.json` `main`) | in-process: `config` hook registers skills dir; `experimental.chat.messages.transform` injects user message | inline in `superpowers.js` | `tests/opencode/` | `opencode.json` plugin git URL |
 | pi | `.pi/extensions/superpowers.ts` | in-process: `resources_discover` registers skills; `context` event injects user message; lifecycle-flag + compaction-aware | `piToolMapping()` inline **and** `references/pi-tools.md` | `tests/pi/` | repo-root `package.json` fields |
+| IBM Bob | `.bob-plugin/plugin.json` + `hooks/hooks-bob.json` (sample) | shell hook → `hooks/session-start-bob` (plain-text stdout, no JSON envelope) | `references/bob-tools.md` | `tests/hooks/` (hook output), `tests/bob/` (manifest + mapping) | `.bob-plugin/scripts/install.sh` (copies skills + wires `settings.json`) |
 
 ## Appendix B — Gotchas that have bitten porters
 

--- a/hooks/hooks-bob.json
+++ b/hooks/hooks-bob.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Sample only — paste the 'hooks' block into .bob/settings.json (project) or ~/.bob/settings/settings.json (global). Bob does not load this file directly. The install script (bob-plugin/install.sh) handles this automatically.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh hooks/session-start-bob",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-start-bob
+++ b/hooks/session-start-bob
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SessionStart hook for superpowers plugin — Bob IDE surface.
+# Bob injects this script's plain-text stdout verbatim into the model context.
+# Unlike other harnesses, Bob does NOT expect JSON output — do NOT use escape_for_json.
+
+set -euo pipefail
+
+# Drain Bob's stdin JSON payload ({"event":"SessionStart","session_id":"..."})
+# before emitting output, to avoid broken-pipe errors.
+cat > /dev/null
+
+# Determine plugin root directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Read using-superpowers content
+using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
+
+# Assemble plain-text context block.
+# Bob injects stdout verbatim — no JSON wrapping, no escaping needed.
+session_context="<EXTREMELY_IMPORTANT>
+You have superpowers.
+
+**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'use_skill' tool:**
+
+${using_superpowers_content}
+</EXTREMELY_IMPORTANT>"
+
+printf '%s\n' "$session_context"
+
+exit 0

--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -44,6 +44,8 @@ DEST_REL="plugins/superpowers"
 # (.DS_Store is intentionally unanchored — Finder creates them everywhere.)
 EXCLUDES=(
   # Dotfiles and infra — top-level only
+  "/.agents/"
+  "/.bob-plugin/"
   "/.claude/"
   "/.claude-plugin/"
   "/.codex/"

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -56,6 +56,7 @@ If your harness appears here, read its reference file for special instructions:
 - Codex: `references/codex-tools.md`
 - Pi: `references/pi-tools.md`
 - Antigravity: `references/antigravity-tools.md`
+- Bob IDE: see `references/bob-tools.md`
 - Hermes Agent: `references/hermes-tools.md`
 
 ## User Instructions

--- a/skills/using-superpowers/references/bob-tools.md
+++ b/skills/using-superpowers/references/bob-tools.md
@@ -1,0 +1,60 @@
+# Bob IDE Tool Mapping
+
+Skills speak in actions ("dispatch a subagent", "create a todo", "read a file"). On IBM Bob IDE these resolve to the tools below.
+
+| Action skills request | Bob IDE equivalent |
+|----------------------|-------------------|
+| Read a file | `read_file` |
+| Create / fully rewrite a file | `write_file` |
+| Edit a file (targeted) | `apply_diff`, `insert_content`, `search_and_replace` |
+| Run a shell command | `execute_command` |
+| Search file contents | `grep` |
+| Find files by name | `glob` |
+| List directory contents | `list_files` |
+| Navigate code symbols | `GetSymbolsOverview`, `FindSymbol`, `FindReferencingSymbols` |
+| Dispatch a subagent (general-purpose) | `spawn_subagent` with `name: "general"` (full tool access) |
+| Dispatch a subagent (read-only research) | `spawn_subagent` with `name: "explore"` |
+| Pass prior conversation context to subagent | Set `fork_context: true` on the `spawn_subagent` call |
+| Multiple parallel dispatches | Multiple `spawn_subagent` calls in the same response |
+| Create / update todos | `update_todo_list` |
+| Invoke a skill | `use_skill` with `skill_name` parameter |
+| Switch mode | `switch_mode` |
+| Structured multi-step work (subtasks) | `start_subtask` |
+| Start a workflow | `start_workflow` |
+| Ask the user a clarifying question | `ask_followup_question` |
+| Web fetch / search | Not natively available — use an MCP server if configured; otherwise treat as degraded |
+
+## Instructions file
+
+When a skill mentions "your instructions file", on Bob IDE this is **`AGENTS.md`**. Bob loads `AGENTS.md` from the workspace root and merges it into the model context alongside any mode-specific instructions.
+
+## Personal skills directory
+
+User-level skills live at **`~/.bob/skills/`**. Project-level skills live at **`.bob/skills/`** within the project root. Bob auto-discovers all `SKILL.md` files in these directories at session start; no explicit registration is required.
+
+## Subagent support
+
+Bob dispatches subagents through the `spawn_subagent` tool.
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `name` | `"general"` | Full tool access — use for implementation tasks |
+| `name` | `"explore"` | Read-only — use for codebase research |
+| `fork_context` | `true` | Passes parent conversation history into the subagent |
+| `description` | string | What the subagent should accomplish — be specific |
+
+Skills dispatch with `Subagent (general-purpose):` and either reference a prompt-template file or supply an inline prompt. On Bob:
+
+| Skill dispatch form | Bob IDE equivalent |
+|---------------------|--------------------|
+| References a `*-prompt.md` template (implementer, task-reviewer, code-reviewer, etc.) | Fill the template, then `spawn_subagent` with `name: "general"` and the filled prompt as `description` |
+| References `superpowers:requesting-code-review`'s `./code-reviewer.md` | `spawn_subagent` with `name: "general"` and the filled review template as `description` |
+| Inline prompt (no template referenced) | `spawn_subagent` with `name: "general"` and your inline prompt as `description` |
+
+### Prompt filling
+
+Skills provide prompt templates with placeholders like `{WHAT_WAS_IMPLEMENTED}` or `[FULL TEXT of task]`. Fill all placeholders before passing the complete prompt to `spawn_subagent`. The prompt template contains the subagent's role, criteria, and expected output — the subagent will follow it.
+
+### Parallel dispatch
+
+Bob supports parallel subagent dispatch. Issue multiple `spawn_subagent` calls in the same response to run independent work in parallel. Keep dependent tasks sequential, but do not serialize independent subagent tasks just to preserve a simpler history.

--- a/tests/bob/run-tests.sh
+++ b/tests/bob/run-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== IBM Bob integration tests ==="
+echo ""
+
+bash "$SCRIPT_DIR/test-bob-plugin-manifest.sh"
+bash "$SCRIPT_DIR/test-bob-tools.sh"
+
+echo ""
+echo "All Bob tests passed."

--- a/tests/bob/test-bob-plugin-manifest.sh
+++ b/tests/bob/test-bob-plugin-manifest.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Validate the IBM Bob plugin manifest.
+# Bob has no plugin-install CLI, so the manifest is a metadata-only file
+# used for version tracking. This test checks it is well-formed, matches
+# the repo version, and is registered in .version-bump.json.
+#
+# CI-safe: does not require Bob to be installed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+MANIFEST="$REPO_ROOT/.bob-plugin/plugin.json"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "test-bob-plugin-manifest: checking IBM Bob plugin manifest"
+
+[ -f "$MANIFEST" ] || fail "manifest missing at $MANIFEST"
+
+python3 - "$MANIFEST" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+repo_root = manifest_path.parents[1]
+
+if manifest.get("name") != "superpowers":
+    raise AssertionError(f"plugin name: expected 'superpowers', got {manifest.get('name')!r}")
+
+package = json.loads((repo_root / "package.json").read_text(encoding="utf-8"))
+if manifest.get("version") != package.get("version"):
+    raise AssertionError(
+        f"manifest version {manifest.get('version')!r} != package.json version {package.get('version')!r}"
+    )
+
+for field in ("description", "license"):
+    if not manifest.get(field):
+        raise AssertionError(f"manifest missing required field: {field!r}")
+
+# Bob manifests are metadata-only — these executable fields are not supported
+unsupported = ["skills", "hooks", "commands", "sessionStart", "contextFileName", "inject"]
+present = sorted(field for field in unsupported if field in manifest)
+if present:
+    raise AssertionError("unsupported Bob manifest fields present: " + ", ".join(present))
+
+version_config = json.loads((repo_root / ".version-bump.json").read_text(encoding="utf-8"))
+entries = version_config.get("files", [])
+if not any(
+    isinstance(e, dict)
+    and e.get("path") == ".bob-plugin/plugin.json"
+    and e.get("field") == "version"
+    for e in entries
+):
+    raise AssertionError(".version-bump.json must update .bob-plugin/plugin.json version")
+
+print("Bob plugin manifest looks good")
+PY
+
+echo "PASS: IBM Bob plugin manifest valid"

--- a/tests/bob/test-bob-tools.sh
+++ b/tests/bob/test-bob-tools.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Validate the IBM Bob tool mapping.
+# Checks that bob-tools.md exists, documents the key Bob-specific tool names,
+# and that SKILL.md's Platform Adaptation section links to it.
+#
+# Mirrors tests/antigravity/test-antigravity-tools.sh.
+# CI-safe: does not require Bob to be installed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+MAPPING="$REPO_ROOT/skills/using-superpowers/references/bob-tools.md"
+SKILL="$REPO_ROOT/skills/using-superpowers/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo "test-bob-tools: checking IBM Bob tool mapping"
+
+# --- Mapping exists ----------------------------------------------------------
+[ -f "$MAPPING" ] || fail "tool mapping missing at $MAPPING"
+
+# --- Core action→tool mappings are documented --------------------------------
+for tool in use_skill spawn_subagent update_todo_list execute_command \
+            read_file write_file apply_diff grep glob; do
+  grep -q "$tool" "$MAPPING" \
+    || fail "mapping does not document the '$tool' tool"
+done
+
+# --- Subagent dispatch documents both named types ----------------------------
+grep -q '"general"' "$MAPPING" \
+  || fail "mapping does not document the 'general' subagent type"
+grep -q '"explore"' "$MAPPING" \
+  || fail "mapping does not document the 'explore' subagent type"
+
+# --- fork_context is documented ----------------------------------------------
+grep -q 'fork_context' "$MAPPING" \
+  || fail "mapping does not document the fork_context parameter"
+
+# --- SKILL.md Platform Adaptation links the mapping --------------------------
+grep -q "bob-tools.md" "$SKILL" \
+  || fail "SKILL.md Platform Adaptation does not reference bob-tools.md"
+
+echo "PASS: IBM Bob tool mapping valid (core tools, subagent dispatch, SKILL.md link)"

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -217,6 +217,48 @@ assert_command_output \
     CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
     bash "$HOOK_UNDER_TEST"
 
+# =============================================================================
+# Bob IDE plain-text output tests
+#
+# Bob's SessionStart hook emits plain text (not JSON). These tests invoke
+# hooks/session-start-bob directly and use inline grep/string checks rather
+# than assert_command_output (which requires JSON output).
+# =============================================================================
+
+BOB_HOOK_UNDER_TEST="$REPO_ROOT/hooks/session-start-bob"
+
+bob_output="$(echo '{"event":"SessionStart","session_id":"test-123"}' | bash "$BOB_HOOK_UNDER_TEST" 2>&1)" || {
+    fail "Bob SessionStart hook exited non-zero"
+    echo "    output: $bob_output" | sed 's/^/      /'
+}
+
+if [[ -n "$bob_output" ]]; then
+    pass "Bob SessionStart hook produces non-empty output"
+else
+    fail "Bob SessionStart hook produces non-empty output"
+fi
+
+if echo "$bob_output" | grep -q "EXTREMELY_IMPORTANT"; then
+    pass "Bob output contains EXTREMELY_IMPORTANT"
+else
+    fail "Bob output contains EXTREMELY_IMPORTANT"
+    echo "    output:" && echo "$bob_output" | sed 's/^/      /'
+fi
+
+if echo "$bob_output" | grep -q "using-superpowers"; then
+    pass "Bob output contains using-superpowers"
+else
+    fail "Bob output contains using-superpowers"
+    echo "    output:" && echo "$bob_output" | sed 's/^/      /'
+fi
+
+if [[ "${bob_output:0:1}" != "{" ]]; then
+    pass "Bob output is plain text (does not start with {)"
+else
+    fail "Bob output is plain text (does not start with {)"
+    echo "    first char was '{' — output is JSON, not plain text"
+fi
+
 if [[ "$FAILURES" -gt 0 ]]; then
     echo "STATUS: FAILED ($FAILURES failure(s))"
     exit 1


### PR DESCRIPTION
<!--
BEFORE SUBMITTING: Read every word of this template. PRs that leave
sections blank, contain multiple unrelated changes, or show no evidence
of human involvement will be closed without review.
-->

> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

## Who is submitting this PR? (required)
<!-- Required. PRs that omit this will be closed. We assume an agent wrote
     this PR — tell us which one and where it ran. We weigh contributions by
     what produced them: content reasoned from documentation is held to a
     different bar than work grounded in a real session. -->

| Field | Value |
|-------|-------|
| Your model + version | The IDE does not expose which model is being used for which tasks |
| Harness + version | IBM Bob 2.0.3 |
| All plugins installed | Superpowers (this repo, branch `bob-harness-v1` |
| Human partner who reviewed this diff | Moisés Mendoza |

## What problem are you trying to solve?
<!-- Describe the specific problem you encountered. If this was a session
     issue, include: what you were doing, what went wrong, the model's
     exact failure mode, and ideally a transcript or session log.

     "Improving" something is not a problem statement. What broke? What
     failed? What was the user experience that motivated this? -->

I want to use Superpowers framework with IBM Bob so I prepared the changes that make superpowers to work with Bob and tested on a small project with 5 features using Golang 1.27 and to be deployed in an OpenShift environment, it worked pretty well.

## What does this PR change?
<!-- 1-3 sentences. What, not why — the "why" belongs above. -->

Adds Shape A (shell-hook) harness support for IBM Bob IDE. A dedicated `hooks/session-start-bob` script injects the `using-superpowers` bootstrap as plain text at session start (Bob's stdout contract, distinct from the JSON envelope other harnesses use). An install script copies skills and wires the `SessionStart` hook into `.bob/settings.json`. A tool mapping in `skills/using-superpowers/references/bob-tools.md` translates the skill action vocabulary to Bob's native tool names.


## Is this change appropriate for the core library?
<!-- Superpowers core contains general-purpose skills and infrastructure
     that benefit all users. Ask yourself:

     - Would this be useful to someone working on a completely different
       kind of project than yours?
     - Is this project-specific, team-specific, or tool-specific?
     - Does this integrate or promote a third-party service?

     If your change is a new skill for a specific domain, workflow tool,
     or third-party integration, it belongs in its own plugin — not here.
     See the plugin development docs for how to publish it separately. -->

If by core library you mean the skills outside `using-superpowers`, no, I'm not proposing any change to skills/core library.

## What alternatives did you consider?
<!-- What other approaches did you try or evaluate before landing on this
     one? Why were they worse? If you didn't consider alternatives, say so
     — but know that's a red flag. -->

**Shape C (instructions-file):** Bob loads `AGENTS.md` at session start, which could carry the bootstrap inline. Rejected because it would require editing the user's own `AGENTS.md` — a direct violation of rule 2 ("never edit the user's files"). The hook approach delivers the bootstrap through a mechanism the user opts into by running the install script.

**Branch in the shared `hooks/session-start`:** Bob sets no env var when running a hook command, so there's no reliable way to detect "I am running inside Bob" inside the shared script. The porting guide explicitly sanctions a dedicated `hooks/session-start-<harness>` script for this case.

**Symlinks instead of copies in the install script:** Rejected because Bob's skill scanner may not follow symlinked directories, global installs with symlinks break if the repo is moved, and copies require no admin rights on Windows.

## Does this PR contain multiple unrelated changes?
<!-- If yes: stop. Split it into separate PRs. Bundled PRs will be closed.
     If you believe the changes are related, explain the dependency. -->

No. All changes are part of a single harness integration: hook script, tool mapping, plugin manifest, install script, documentation, tests, version tracking, and Codex sync excludes. These are the standard set of components every harness port adds — they are not independent changes.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: <!-- #number, #number, or "none found" -->

I did not find any PRs related to Bob

<!-- If a related closed PR exists, explain what's different about your
     approach and why it should succeed where the other didn't. -->

## Environment tested

Please notice that Bob does not allow to select which model you want to use at which time, it auto selects a model in the background and that information is not made public through the IDE or [Documentation](https://bob.ibm.com/docs/ide/faq)

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
|  IBM Bob   |  2.0.3 | not disclosed by Bob | Not disclosed by Bob  |


## New harness support (required if this PR adds a new harness)

<!-- If this PR adds support for a new harness (IDE, CLI tool, agent
     runner), you MUST include a session transcript proving the
     integration actually works.

     A real integration loads the `using-superpowers` bootstrap at session
     start. The bootstrap is what causes skills to auto-trigger. Without
     it, the skills are dead weight — present on disk but never invoked
     at the right moments.

     ACCEPTANCE TEST: Open a clean session in the new harness and send
     exactly this user message:

         Let's make a react todo list

     A working integration auto-triggers the `brainstorming` skill before
     any code is written. Paste the complete transcript below.

     These are NOT real integrations and PRs that ship them will be closed:

     - Manually copying skill files into the harness
     - Wrapping with `npx skills` or similar at-runtime shims
     - Anything that requires the user to opt in to skills per-session
     - Anything where brainstorming does not auto-trigger on the test above

     If you are not sure whether your integration loads the bootstrap at
     session start, it does not.
-->
**Install mechanism note:** Bob has no `bob plugin install` CLI. The install script writes to `.bob/settings.json` (project) or `~/.bob/settings/settings.json `(global). This is the only available mechanism — analogous to `.antigravity-plugin/install.sh`, which the porting guide documents as an acceptable pattern for harnesses with no plugin-install command. The edit is performed by a script the user consciously runs; it does not happen silently during any install step.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
What are your superpowers?
My superpowers come from the specialized skill and methodology framework configured in this workspace:

1. Rigorous Engineering Disciplines & Workflows
using-superpowers: Enforces automatic invocation of relevant development skills and processes before taking action.
test-driven-development: Writing tests before code implementation to ensure correctness and maintainability.
systematic-debugging: Methodical root-cause investigation before applying any fixes.
verification-before-completion: Evidence-based validation (running tests, linters, and typechecks) before declaring tasks complete.
2. Planning, Ideation & Review
brainstorming: Exploring user intent, requirements, and design before starting creative work.
writing-plans & executing-plans: Structured technical specifications broken down into clear, executable steps.
requesting-code-review & receiving-code-review: Thorough code reviews and rigorous feedback assessment.
3. Execution & Isolation
subagent-driven-development & dispatching-parallel-agents: Running parallel and independent subtasks effectively.
using-git-worktrees: Isolating feature work cleanly from the active working directory.
finishing-a-development-branch: Structured integration and merging workflows.
4. Code & Tool Capabilities
Precise AST & Code Navigation: Fast symbol resolution (GetSymbolsOverview, FindSymbol, FindReferencingSymbols).
Targeted Code Modifications: Surgical edits using unified diffs (apply_diff), pattern replacement, and safe insertions.
Analysis & Visualizations: Interactive charts (create_chart), shareable HTML one-pagers (create_html_artifact), Excel processing (read_xlsx), and semantic documentation retrieval (search_bob_docs).

Let's make a react todo list

Using brainstorming to explore requirements and design.

This is an Architectural path task (scaffolding and building a new React application from scratch in this workspace).

Let's explore your requirements first.

What kind of React Todo List application are you looking to build?

A simple client-side React + Vite (TypeScript) app with local storage persistence and basic filtering (All, Active, Completed)
A minimal single-page React app (no bundler/standalone HTML with React CDN or lightweight Vite starter)
A React app with backend API/mock server integration
A full-featured React app with categories/tags, due dates, priority levels, and search
```
<img width="1491" height="885" alt="Screenshot 2026-08-24 at 9 46 22 a m" src="https://github.com/user-attachments/assets/9ce2ec96-9eb6-4843-9536-c15d8ea88e34" />

<img width="1488" height="997" alt="Screenshot 2026-08-24 at 9 46 41 a m" src="https://github.com/user-attachments/assets/e3bee907-73e3-420d-aa5c-f9c91a98becd" />

</details>

## Evaluation
- What was the initial prompt you (or your human partner) used to start
  the session that led to this change?

Human: Nothing, your instructions say, open a fresh session and type "what are your superpowers?"

- How many eval sessions did you run AFTER making the change?

Human: probably 3 or 4 sessions at the moment in 2 different projects

- How did outcomes change compared to before the change?

Human: There was no support for Bob, so this is the first time creating/using a project with Bob + superpowers.

I started a brand new project with the "Let's make a react todo list", Bob came back with questions that I did not answered.

Then I switched to my desired project of creating a Validating Webhook for OpenShift where it should query the signatures from images being deployed in a cluster that should match a given cosign signature, if there is a deviation it should send a notification.  It went through the process: Brainstorm, Writing Plans, Executing Subagent Driven, TDD, Code Review and Finish Branch, the code looks pretty good so far, so the process seems to be working as expected.

<!-- "It works" is not evaluation. Describe the before/after difference
     you observed across multiple sessions. -->

## Rigor

- [x] This is not a skills change — no `SKILL.md` body was modified (only a one-line pointer added to the Platform Adaptation section of `using-superpowers/SKILL.md`, which the porting guide explicitly permits)
- [x] This change was tested adversarially: the hook was verified with a unique-marker token before building the real script; the plain-text stdout contract was confirmed empirically (not assumed from docs); the install script's idempotency was tested by running it twice
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

<!-- If you changed wording in skills that shape agent behavior, show your
     eval methodology and results. These are not prose — they are code. -->

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

<!--
STOP. If the checkbox above is not checked, do not submit this PR.

PRs will be closed without review if they:
- Show no evidence of human involvement
- Contain multiple unrelated changes
- Promote or integrate third-party services or tools
- Submit project-specific or personal configuration as core changes
- Leave required sections blank or use placeholder text
- Modify behavior-shaping content without eval evidence
-->
