### PR TITLE
fix: harden TDD/SDD/writing-plans against NameError, accidental deletes, uncommitted work

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -152,6 +152,8 @@ a ledger file, not only in todos.
   trust the ledger and `git log` over your own recollection.
 - `git clean -fdx` will destroy the workspace (it's git-ignored scratch); if
   that happens, recover from `git log`.
+- **NEVER run `git clean -fdx`, `rm -rf <repo-root>`, or `git rm` on tracked files without explicit human confirmation.** A clean can silently delete `AGENTS.md`, `README.md`, `pyproject.toml`, `config/*.yaml`, and other critical files that are git-tracked but easy to overlook. The cost of one accidental delete (even if recoverable from git) is higher than the convenience of a clean. When a subagent or step suggests it, STOP and ask your human partner.
+- **Protected files — never delete or overwrite without confirmation:** `AGENTS.md`, `README.md`, `LICENSE`, `pyproject.toml`, `setup.py`, `package.json`, `config/*.yaml`, `config/*.json`, `.env` (and any `.env.*`). If a task seems to require touching one of these, surface it to your human partner first.
 
 Read the plan once, note its context and Global Constraints, and create a
 todo per task. If the plan names a Spec, read that too: the spec is the

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -292,6 +292,8 @@ Before marking work complete:
 - [ ] Output pristine (no errors, warnings)
 - [ ] Tests use real code (mocks only if unavoidable)
 - [ ] Edge cases and errors covered
+- [ ] **FULL SUITE PASSES BEFORE DECLARING DONE** — run the project's complete test command (e.g. `pytest`, `npm test`) on the WHOLE tree, not just the file you edited. A test that passes in isolation can still `NameError` on an undefined symbol when the full suite imports the module. If any test fails with `NameError`/`ImportError`/`undefined`, fix it NOW — do not declare done.
+- [ ] **No undefined symbols in any test** — every name referenced in a test (logger, fixtures, helpers) must be imported or defined in that test's scope.
 
 Can't check all boxes? You skipped TDD. Start over.
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -126,6 +126,8 @@ Expected: PASS
 git add tests/path/test.py src/path/file.py
 git commit -m "feat: add specific feature"
 ```
+
+**MANDATORY:** A plan is not done until it is committed. After the final task's tests pass, stage the feature files and commit. Do not leave the working tree with uncommitted feature work — an uncommitted branch is fragile (a crash, a clean, or a context reset loses the work). If `git status` still shows modified/untracked feature files after you believe you are done, you are NOT done — commit them (or explicitly tell your human partner why you are leaving them uncommitted).
 ````
 
 ## No Placeholders


### PR DESCRIPTION
## Summary
Hardens three superpowers skills after a real TDD session produced fragile output:

- **test-driven-development**: require running the FULL test suite (not just the edited file) before declaring done; flag undefined symbols in any test. Prevents NameError/ImportError slipping through when a test passes in isolation but fails in the full import tree.
- **subagent-driven-development**: change git clean -fdx / rm -rf from warn to NEVER without explicit human confirmation; add a Protected-files list (AGENTS.md, README, LICENSE, pyproject.toml, config/*.yaml, .env) that must not be deleted/overwritten without confirmation.
- **writing-plans**: make the commit step MANDATORY — a plan is not done until committed; warn that uncommitted feature work is fragile.

## Verification
Re-ran a full superpowers TDD session (breakeven stop feature on a real repo): 166 passed, AGENTS.md preserved, work committed — vs. the prior session which left 3 failing tests, deleted AGENTS.md, and left work uncommitted.

## Files changed
- skills/test-driven-development/SKILL.md
- skills/subagent-driven-development/SKILL.md
- skills/writing-plans/SKILL.md