### PR TITLE
fix: add default export for OpenCode plugin loader

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -137,3 +137,9 @@ ${toolMapping}
     }
   };
 };
+
+// Default export required by OpenCode's plugin loader.
+// The loader iterates Object.values() and expects a callable default export.
+// Without this, the plugin fails silently when other plugins (e.g. omo-meta-governor)
+// are also registered, because the loader never finds a valid plugin function.
+export default SuperpowersPlugin;


### PR DESCRIPTION
OpenCode plugin loader iterates Object.values() and expects a callable default export. Without this, superpowers fails silently when other plugins (e.g. omo-meta-governor) are registered.

Added: export default SuperpowersPlugin

Repro: Add both superpowers and omo-meta-governor to opencode.jsonc plugin array. Superpowers bootstrap stops being injected.