### PR TITLE
fix(hooks): add powershell key so SessionStart works under VS Code Copilot (#2189)

### DIFF
--- a/docs/windows/polyglot-hooks.md
+++ b/docs/windows/polyglot-hooks.md
@@ -51,6 +51,7 @@ hooks/
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "powershell": "& \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
             "shell": "bash",
             "async": false
           }
@@ -62,6 +63,15 @@ hooks/
 ```
 
 The path is quoted because `${CLAUDE_PLUGIN_ROOT}` may contain spaces.
+
+### The `powershell` key
+
+VS Code Copilot runs hook commands through PowerShell regardless of the
+`shell` key (#2189), where a leading quoted path parses as a string expression
+and the trailing bareword is an error ("Unexpected token 'session-start'"). The
+optional `powershell` key gives those hosts the same dispatch with the `&`
+call operator; Claude Code and other harnesses ignore it. Harnesses that run
+the command via `cmd /c`, Git Bash, or a POSIX shell are unaffected.
 
 ## How `run-hook.cmd` Works at a High Level
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -8,7 +8,8 @@
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
             "shell": "bash",
-            "async": false
+            "async": false,
+            "powershell": "& \"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start"
           }
         ]
       }

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -147,6 +147,12 @@ echo "SessionStart hook output tests"
 # Windows dispatches via Git Bash (or fails with an actionable error) instead
 # of PowerShell/cmd.exe, whose parsers break on the quoted command string
 # (PowerShell ParserError; cmd.exe quote-stripping on paths with metacharacters).
+#
+# VS Code Copilot ignores shell:"bash" and runs the `command` string through
+# PowerShell regardless (#2189). The optional `powershell` key supplies a
+# PowerShell-native form of the same dispatch: the `&` call operator makes the
+# quoted plugin-root path parse as a command invocation instead of a string
+# expression followed by the bareword `session-start`.
 if node -e '
 const hooks = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
 const entry = hooks.hooks.SessionStart[0].hooks[0];
@@ -156,6 +162,14 @@ if (entry.shell !== "bash") {
 }
 if (!/run-hook\.cmd" session-start$/.test(entry.command)) {
   console.error(`unexpected SessionStart command shape: ${entry.command}`);
+  process.exit(1);
+}
+if (typeof entry.powershell !== "string") {
+  console.error(`SessionStart hook missing powershell key for VS Code Copilot (#2189)`);
+  process.exit(1);
+}
+if (!/^& "/.test(entry.powershell) || !/run-hook\.cmd" session-start$/.test(entry.powershell)) {
+  console.error(`unexpected SessionStart powershell shape: ${entry.powershell}`);
   process.exit(1);
 }
 ' "$REPO_ROOT/hooks/hooks.json"; then


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | ox-alpha |
| Harness + version | Hermes Agent CLI, macOS (Darwin 26.5.2) |
| All plugins installed | superpowers (local dev clone) |
| Human partner who reviewed this diff | Tugrul Guner (@tugrulguner) — directed the change and reviewed the complete diff before submission |

## What problem are you trying to solve?

Issue #2189: VS Code Copilot executes hook `command` strings through **PowerShell**, not `cmd /c`. The SessionStart hook's command starts with a quoted path, which PowerShell parses as a string expression; the trailing bareword then errors with `Unexpected token 'session-start' in expression or statement`. The hook fails on every session start under Copilot on Windows, so the bootstrap context is never injected.

The existing `shell: "bash"` declaration fixes Claude Code (which honors it) but does not help Copilot, which ignores it. This is a distinct failure mode from #2105 (no variable substitution) and #2091 (backslash paths under WSL): Copilot substitutes `${CLAUDE_PLUGIN_ROOT}` correctly — the parse itself fails.

## What does this PR change?

1. `hooks/hooks.json`: adds a `powershell` key alongside `command`, containing the same dispatch with the PowerShell `&` call operator: `& "${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start`. The call operator makes the quoted path parse as a command invocation rather than a string literal, and `.cmd` dispatch through CMD is transparent.
2. `tests/hooks/test-session-start.sh`: extends the registration-shape check to pin the new key — it now fails if the `powershell` key is missing or doesn't match the expected `& "..." ... session-start` shape.
3. `docs/windows/polyglot-hooks.md`: documents the key and why it exists.

Harnesses that don't read the key (Claude Code, Antigravity, Gemini CLI via `cmd /c`; POSIX shells) are unchanged.

## Is this change appropriate for the core library?

Yes. It fixes the shipped SessionStart hook for every VS Code Copilot user on Windows; no third-party dependencies or project-specific behavior.

## What alternatives did you consider?

- **Dropping the quotes** around the plugin root: breaks installs whose path contains spaces.
- **Changing `shell` to something Copilot-specific**: the issue reporter confirmed Copilot ignores `shell` entirely, and other harnesses depend on `shell: "bash"`.
- **Documenting only a local workaround**: the workaround edits two cache copies that plugin updates overwrite; upstream fix is the durable one.

## Does this PR contain multiple unrelated changes?

No. All three files serve #2189.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2165 (WSL path translation in the `command` string), #2173 (root-level `hooks.json` for Devin). Neither addresses PowerShell parsing under Copilot; both keep the command shape this PR leaves intact.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
| --- | --- | --- | --- |
| bash + node (tests/hooks/test-session-start.sh) | macOS Darwin 26.5.2, node v24 | ox-alpha | n/a |

`bash tests/hooks/test-session-start.sh`: 6/6 PASS after the change. Red evidence: removing the `powershell` key makes the registration-shape test FAIL (`SessionStart hook missing powershell key for VS Code Copilot (#2189)`); restoring it returns 6/6 PASS. `git diff --check` clean. No Windows/Copilot environment was available here; the parse-error mechanism is per the reporter's transcript in #2189 and the `&` fix is exactly as they verified locally.

## New harness support

N/A — no new harness added; existing hook entry made compatible with an existing one.

## Evaluation

- Initial prompt: fix obra/superpowers#2189 by adding the `powershell` key, verifying first that no open PR already covers it.
- Eval sessions after the change: red/green runs of the hook test suite as described above.
- Before: hook registration had no PowerShell-parseable form; Copilot hosts fail at parse time. After: registration pins a valid `&`-prefixed form, guarded by a regression test.

## Rigor

- [ ] Skills change / adversarial pressure testing: N/A — no skill wording touched
- [x] This change was tested adversarially, not just on the happy path (red evidence above; shape assertions reject a malformed value, not just absence)
- [x] No carefully-tuned content modified (Red Flags tables, rationalizations, human-partner language untouched)

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Fixes #2189