### PR TITLE
fix(tests): drop -l from brainstorm-server test shell helpers (#2190)

### DIFF
--- a/tests/brainstorm-server/lifecycle.test.js
+++ b/tests/brainstorm-server/lifecycle.test.js
@@ -102,16 +102,16 @@ async function waitForStartedOutput(child, timeoutMs = 5000) {
 }
 
 function makeShellTempDir(prefix) {
-  return execFileSync('bash', ['-lc', `mktemp -d "\${TMPDIR:-/tmp}/${prefix}-XXXXXX"`], { encoding: 'utf8' }).trim();
+  return execFileSync('bash', ['-c', `mktemp -d "\${TMPDIR:-/tmp}/${prefix}-XXXXXX"`], { encoding: 'utf8' }).trim();
 }
 
 function removeShellPath(p) {
-  execFileSync('bash', ['-lc', 'rm -rf "$1"', 'bash', p], { stdio: 'ignore' });
+  execFileSync('bash', ['-c', 'rm -rf "$1"', 'bash', p], { stdio: 'ignore' });
 }
 
 function newestSessionDir(projectDir) {
   const sessionDir = execFileSync('bash', [
-    '-lc',
+    '-c',
     'find "$1/.superpowers/brainstorm" -mindepth 1 -maxdepth 1 -type d -print | sort | tail -1',
     'bash',
     projectDir


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | ox-alpha |
| Harness + version | Hermes Agent CLI, macOS (Darwin 26.5.2) |
| All plugins installed | superpowers (local dev clone) |
| Human partner who reviewed this diff | Tugrul Guner (@tugrulguner) — directed the change and reviewed the complete diff before submission |

## What problem are you trying to solve?

Issue #2190: the three shell helpers in `tests/brainstorm-server/lifecycle.test.js` spawn `bash -lc` — a **login** shell — and capture all stdout. On any machine whose login profile prints to stdout (fastfetch/neofetch banners, motd scripts), the captured output is polluted: `newestSessionDir` returns banner text instead of a path, and the idle-timeout test fails even though nothing is wrong with the server code.

This is the test-suite twin of #292 (`-l` in `run-hook.cmd` breaking Windows startup).

## What does this PR change?

One flag, three spots: `bash -lc` → `bash -c` in `makeShellTempDir`, `removeShellPath`, and `newestSessionDir`. None of them need a login shell — they only run `mktemp`, `rm -rf`, and `find`. No other file in `tests/brainstorm-server/` uses `-l`.

## Is this change appropriate for the core library?

Yes. Test-infrastructure robustness for everyone whose Linux/macOS login profile prints a banner; no behavior or dependency changes.

## What alternatives did you consider?

- **Filtering the captured output**: fragile — you'd have to guess every possible banner shape.
- **Setting `BASH_ENV` / running with a scrubbed HOME**: heavier, still leaves the login-shell dependency in place.
Dropping `-l` removes the failure mode entirely; the commands don't read profile files anyway.

## Does this PR contain multiple unrelated changes?

No. One file, one flag, three occurrences.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found (searched open+closed for "2190" and brainstorm-server test PRs)

## Environment tested

| Harness | Harness version | Model | Model version/ID |
| --- | --- | --- | --- |
| node 22.13.1 + npm ci (tests/brainstorm-server) | macOS Darwin 26.5.2 | ox-alpha | n/a |

Red/green reproduction of the exact reported mechanism:
- Temporarily replaced `~/.bash_profile` with a profile echoing two banner lines.
- Original code: `node lifecycle.test.js` → **12 passed, 1 failed**, with the banner text visible in the captured output.
- Fixed code: **13 passed, 0 failed**, banner still printed by the login profile but never captured.
- Restored the original `~/.bash_profile`; full suite on fixed code: `npm test` → 32/15/3/20/7/33/13/4/7 passed, **0 failures** across all nine suites.

## New harness support

N/A — test-only change.

## Evaluation

- Initial prompt: fix obra/superpowers#2190 after verifying no existing PR covers it.
- Eval runs: red/green as above.
- Before: suite fails on any machine with a banner-printing login profile. After: immune.

## Rigor

- [ ] Skills change: N/A — no skill wording touched
- [x] This change was tested adversarially, not just on the happy path (simulated the reporter's environment rather than trusting the analysis)
- [x] No carefully-tuned content modified

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Fixes #2190