### PR TITLE
fix(skills): require explicit model on subagent dispatches outside SDD (#2034)

### DIFF
--- a/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -9,6 +9,9 @@ Use this template when dispatching a spec document reviewer subagent.
 ```
 Subagent (general-purpose):
   description: "Review spec document"
+  model: [MODEL — REQUIRED: choose per subagent-driven-development SKILL.md
+         Model Selection; an omitted model silently inherits the session's
+         most expensive one]
   prompt: |
     You are a spec document reviewer. Verify this spec is complete and ready for planning.
 

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -74,6 +74,11 @@ Subagent (general-purpose): "Fix tool-approval-race-conditions.test.ts failures"
 # All three run concurrently.
 ```
 
+Specify the model explicitly on each dispatch — an omitted model silently
+inherits your session's model, often the most capable and most expensive.
+Choose per subagent-driven-development's Model Selection section: mechanical
+single-file fixes take a cheap tier; multi-file integration work takes more.
+
 Multiple dispatch calls in one response = parallel execution. One per response = sequential.
 
 ### 4. Review and Integrate

--- a/skills/requesting-code-review/code-reviewer.md
+++ b/skills/requesting-code-review/code-reviewer.md
@@ -7,6 +7,9 @@ Use this template when dispatching a code reviewer subagent.
 ```
 Subagent (general-purpose):
   description: "Review code changes"
+  model: [MODEL — REQUIRED: choose per subagent-driven-development SKILL.md
+         Model Selection; an omitted model silently inherits the session's
+         most expensive one]
   prompt: |
     You are a Senior Code Reviewer with expertise in software architecture,
     design patterns, and best practices. Your job is to review completed work

--- a/skills/writing-plans/plan-document-reviewer-prompt.md
+++ b/skills/writing-plans/plan-document-reviewer-prompt.md
@@ -9,6 +9,9 @@ Use this template when dispatching a plan document reviewer subagent.
 ```
 Subagent (general-purpose):
   description: "Review plan document"
+  model: [MODEL — REQUIRED: choose per subagent-driven-development SKILL.md
+         Model Selection; an omitted model silently inherits the session's
+         most expensive one]
   prompt: |
     You are a plan document reviewer. Verify this plan is complete and ready for implementation.
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | ox-alpha |
| Harness + version | Hermes Agent CLI, macOS (Darwin 26.5.2) |
| All plugins installed | superpowers (local dev clone) |
| Human partner who reviewed this diff | Tugrul Guner (@tugrulguner) — directed the change and reviewed the complete diff before submission |

## What problem are you trying to solve?

Issue #2034: SDD treats the subagent model as a required explicit choice ("an omitted model silently inherits your session's model — often the most capable and most expensive"), but every other dispatch site in the repo has no `model:` field or model guidance at all, so those dispatches silently do exactly what SDD's guidance warns against.

`requesting-code-review` is the sharpest case: SDD mandates it after every task, so a run that carefully pins cheap implementer models then dispatches its code reviewer at full session model. The issue also notes two compounding platform changes: Claude Code 2.1.219 raised nested spawn depth 1→3, and Opus 5 delegates more readily than 4.8.

I verified each claim against current `main` before implementing: all four dispatch sites listed in the issue still lack model fields; SDD's templates (`implementer-prompt.md`, `task-reviewer-prompt.md`) both carry the required placeholder.

## What does this PR change?

1. Adds SDD's exact required-model placeholder to three reviewer prompt templates:
   - `requesting-code-review/code-reviewer.md`
   - `brainstorming/spec-document-reviewer-prompt.md`
   - `writing-plans/plan-document-reviewer-prompt.md`
2. Adds a short paragraph after the parallel-dispatch example in `dispatching-parallel-agents/SKILL.md` pointing at SDD's Model Selection section.

No behavior-shaping content touched: no Red Flags tables, no rationalizations, no workflow steps added or removed — only template placeholders and one cost-hygiene pointer, exactly as #2034 proposes.

## Is this change appropriate for the core library?

Yes — cross-skill consistency fix in general-purpose dispatch infrastructure; no third-party dependencies.

## What alternatives did I consider?

- **Duplicating the full Model Selection section** into each skill: rejected — maintenance drift; a pointer plus the required placeholder matches how SDD's own prompts reference it.
- **Only fixing requesting-code-review**: rejected — brainstorming/spec review and writing-plans/plan review have the identical gap, and dispatching-parallel-agents fans out widest with zero guidance.

## Does this PR contain multiple unrelated changes?

No. All four edits are the single change requested by #2034 (extend SDD's model discipline to the other dispatch sites).

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for #2034 (searched open+closed). Adjacent-but-different: #1744/#1717/#1716 (cost tiering inside SDD) and #1747 (effort dimension) — both operate within SDD; this PR covers the sites *outside* SDD, which none of them touch.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
| --- | --- | --- | --- |
| bash (tests/claude-code/test-subagent-driven-development.sh) | macOS Darwin 26.5.2 | ox-alpha | n/a |

- Placeholder present in all 3 reviewer templates (grep-verified); frontmatter of the edited SKILL.md intact.
- `tests/claude-code/test-subagent-driven-development.sh`: PASS/FAIL verdicts byte-identical before and after my diff (the single pre-existing FAIL on clean `main`, "Read at beginning", reproduces identically with my changes — not caused by this PR).
- `git diff --check` clean; 4 files changed, 14 insertions(+), 0 deletions(-).

## New harness support

N/A — no harness added.

## Evaluation

- Initial prompt: find an unclaimed issue consistent with #2034's proposal, verify claims against current main, implement exactly the suggested fix.
- Eval runs: static verification as above. This change adds template placeholders mirroring existing shipped wording, so no behavioral eval sessions were run beyond the regression suite.

## Rigor

- [ ] Skills-change adversarial pressure testing: partially applicable — this touches skill files but only mechanical template fields and one pointer sentence, no workflow or rationalization content
- [x] Tested against clean-main baseline (verdict-diff proof above)
- [x] No carefully-tuned content modified

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Fixes #2034