### PR TITLE
feat(harness): add Amazon Q Developer CLI support

### DIFF
--- a/.amazonq/cli-agents/superpowers.json
+++ b/.amazonq/cli-agents/superpowers.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/aws/amazon-q-developer-cli/refs/heads/main/schemas/agent-v1.json",
+  "name": "superpowers",
+  "description": "Superpowers skills and workflow bootstrap (obra/superpowers)",
+  "prompt": null,
+  "mcpServers": {},
+  "tools": [
+    "@builtin"
+  ],
+  "toolAliases": {},
+  "allowedTools": [
+    "fs_read",
+    "execute_bash"
+  ],
+  "resources": [],
+  "hooks": {
+    "agentSpawn": [
+      {
+        "command": "AMAZON_Q_AGENT=1 bash \"${HOME}/.superpowers/hooks/session-start\""
+      }
+    ]
+  },
+  "toolsSettings": {}
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Superpowers is a complete software development methodology for your coding agent
 - [Commercial Services](#commercial-services)
 - [Getting Started](#installation)
   - [Claude Code](#claude-code)
+  - [Amazon Q Developer CLI](#amazon-q-developer-cli)
   - [Antigravity](#antigravity)
   - [Codex App](#codex-app)
   - [Codex CLI](#codex-cli)
@@ -88,6 +89,23 @@ agy plugin install https://github.com/obra/superpowers
 
 Antigravity runs the plugin's session-start hook, so Superpowers is active from
 the first message. Reinstall with the same command to update.
+
+### Amazon Q Developer CLI
+
+Clone Superpowers and register the bundled custom agent with Amazon Q:
+
+```bash
+git clone https://github.com/obra/superpowers ~/.superpowers
+mkdir -p .amazonq/cli-agents
+cp ~/.superpowers/.amazonq/cli-agents/superpowers.json .amazonq/cli-agents/
+q chat --agent superpowers
+```
+
+The custom agent's `agentSpawn` hook runs once per session start and injects
+the `using-superpowers` bootstrap as session context, so skills auto-trigger
+from the first message. Update by pulling the clone; the agent JSON references
+it in place. See `skills/using-superpowers/references/amazon-q-tools.md` for
+the tool mapping.
 
 ### Codex App
 

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -35,7 +35,12 @@ session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the 
 #
 # Uses printf instead of heredoc to work around bash 5.3+ heredoc hang.
 # See: https://github.com/obra/superpowers/issues/571
-if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+if [ -n "${AMAZON_Q_AGENT:-}" ]; then
+  # Amazon Q CLI agentSpawn hooks inject raw stdout as fixed session context.
+  # Emit the bootstrap as plain text — no JSON envelope, or the envelope
+  # itself would be injected literally.
+  printf '%s\n' "$session_context" | cat
+elif [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
   # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
   printf '{\n  "additional_context": "%s"\n}\n' "$session_context" | cat
 elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -57,6 +57,7 @@ If your harness appears here, read its reference file for special instructions:
 - Pi: `references/pi-tools.md`
 - Antigravity: `references/antigravity-tools.md`
 - Hermes Agent: `references/hermes-tools.md`
+- Amazon Q Developer CLI: `references/amazon-q-tools.md`
 
 ## User Instructions
 

--- a/skills/using-superpowers/references/amazon-q-tools.md
+++ b/skills/using-superpowers/references/amazon-q-tools.md
@@ -1,0 +1,31 @@
+# Amazon Q Developer CLI (`q`) Tool Mapping
+
+Skills speak in actions ("dispatch a subagent", "create a todo", "read a file"). On Amazon Q Developer CLI these resolve to the tools below.
+
+## Tools
+
+| Action skills request | Amazon Q CLI equivalent |
+|----------------------|------------------------|
+| Read a file | `fs_read` |
+| Create or edit files | `fs_write` |
+| Run a shell command | `execute_bash` |
+| Search / find files | `execute_bash` with `grep`/`find`/`rg` (Q has no dedicated search tool) |
+| Fetch a URL | `execute_bash` with `curl` |
+| Dispatch a subagent (`Subagent (general-purpose):` template) | no built-in subagent tool — see [Subagents](#subagents) |
+| Task tracking ("create a todo", "mark complete") | no built-in todo tool — see [Task lists](#task-lists) |
+
+## Bootstrap
+
+Superpowers reaches Amazon Q CLI sessions through the **superpowers custom agent** (`q chat --agent superpowers`). Its `agentSpawn` hook runs the plugin's session-start script once per session; the script detects `AMAZON_Q_AGENT=1` and emits the bootstrap as plain text, which becomes fixed session context. If you are not running under that agent and no bootstrap is present, fall back to reading the skill directly:
+
+```
+fs_read with path: ~/.superpowers/skills/using-superpowers/SKILL.md
+```
+
+## Subagents
+
+Amazon Q CLI ships no subagent tool. Do not fabricate `Subagent (general-purpose):` calls. Execute sequentially in the current session, or note that subagent capability is not available in this harness.
+
+## Task lists
+
+Amazon Q CLI ships no todo/task tool. Track progress in the plan file's checkboxes or a repo-local `TODO.md`, updated via `fs_write`. Older Superpowers docs may refer to `TodoWrite`; treat that as the task-tracking action above.

--- a/tests/amazon-q/check-envelope.js
+++ b/tests/amazon-q/check-envelope.js
@@ -1,0 +1,11 @@
+let raw = "";
+process.stdin.on("data", c => (raw += c));
+process.stdin.on("end", () => {
+  const d = JSON.parse(raw);
+  if (process.env.WANT === "claude") {
+    process.exit(d.hookSpecificOutput && d.hookSpecificOutput.additionalContext ? 0 : 1);
+  } else if (process.env.WANT === "cursor") {
+    process.exit(d.additional_context ? 0 : 1);
+  }
+  process.exit(1);
+});

--- a/tests/amazon-q/test-integration.sh
+++ b/tests/amazon-q/test-integration.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Registration-shape tests for the Amazon Q Developer CLI integration.
+#
+# Validates, without a live `q` install:
+#   1. The checked-in custom agent manifest parses and wires agentSpawn to
+#      hooks/session-start with AMAZON_Q_AGENT=1.
+#   2. hooks/session-start emits PLAIN TEXT under AMAZON_Q_AGENT=1
+#      (Q injects raw stdout; a JSON envelope would be injected literally)
+#      while every other platform still gets its JSON envelope.
+#   3. The Platform Adaptation list and reference file agree.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+pass() { echo "  [PASS] $1"; }
+fail() { echo "  [FAIL] $1"; FAILURES=$((FAILURES+1)); }
+FAILURES=0
+
+echo "Amazon Q CLI integration tests"
+
+# 1. Custom agent manifest shape
+if node -e '
+const fs = require("fs");
+const agent = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (agent.name !== "superpowers") {
+  console.error(`agent name is ${JSON.stringify(agent.name)}, expected "superpowers"`);
+  process.exit(1);
+}
+const spawn = agent.hooks && agent.hooks.agentSpawn && agent.hooks.agentSpawn[0];
+if (!spawn) {
+  console.error("missing hooks.agentSpawn[0]");
+  process.exit(1);
+}
+if (!/AMAZON_Q_AGENT=1/.test(spawn.command)) {
+  console.error("agentSpawn command must set AMAZON_Q_AGENT=1: " + spawn.command);
+  process.exit(1);
+}
+if (!/hooks\/session-start/.test(spawn.command)) {
+  console.error("agentSpawn command must run hooks/session-start: " + spawn.command);
+  process.exit(1);
+}
+' "$REPO_ROOT/.amazonq/cli-agents/superpowers.json"; then
+    pass "custom agent manifest wires agentSpawn to session-start"
+else
+    fail "custom agent manifest wires agentSpawn to session-start"
+fi
+
+# 2a. Plain-text output under AMAZON_Q_AGENT=1 (must NOT be a JSON envelope)
+out="$(cd "$REPO_ROOT" && AMAZON_Q_AGENT=1 CLAUDE_PLUGIN_ROOT="$REPO_ROOT" bash hooks/session-start)"
+if printf '%s' "$out" | node -e '
+let raw = "";
+process.stdin.on("data", c => raw += c);
+process.stdin.on("end", () => {
+  try { JSON.parse(raw); process.exit(1); }   // JSON = wrong for Q
+  catch { process.exit(0); }                   // not JSON = plain text, correct
+});
+'; then
+    pass "session-start emits plain text under AMAZON_Q_AGENT=1"
+else
+    fail "session-start emits plain text under AMAZON_Q_AGENT=1"
+fi
+
+# 2b. Plain-text output actually contains the bootstrap marker
+if printf '%s' "$out" | grep -q "You have superpowers"; then
+    pass "plain-text output contains the bootstrap block"
+else
+    fail "plain-text output contains the bootstrap block"
+fi
+
+# 2c. Existing platforms keep their JSON envelopes
+if (cd "$REPO_ROOT" && CLAUDE_PLUGIN_ROOT="$REPO_ROOT" bash hooks/session-start \
+    | WANT=claude node "$SCRIPT_DIR/check-envelope.js"); then
+    pass "Claude Code path unchanged (hookSpecificOutput envelope)"
+else
+    fail "Claude Code path unchanged (hookSpecificOutput envelope)"
+fi
+
+if (cd "$REPO_ROOT" && CURSOR_PLUGIN_ROOT="$REPO_ROOT" bash hooks/session-start \
+    | WANT=cursor node "$SCRIPT_DIR/check-envelope.js"); then
+    pass "Cursor path unchanged (additional_context envelope)"
+else
+    fail "Cursor path unchanged (additional_context envelope)"
+fi
+
+# 3. Reference file registered in Platform Adaptation
+if grep -q 'references/amazon-q-tools.md' \
+    "$REPO_ROOT/skills/using-superpowers/SKILL.md" && \
+   [ -f "$REPO_ROOT/skills/using-superpowers/references/amazon-q-tools.md" ]; then
+    pass "amazon-q-tools.md exists and is listed in Platform Adaptation"
+else
+    fail "amazon-q-tools.md exists and is listed in Platform Adaptation"
+fi
+
+if [ "$FAILURES" -eq 0 ]; then
+    echo "STATUS: PASSED"
+    exit 0
+else
+    echo "STATUS: FAILED ($FAILURES failure(s))"
+    exit 1
+fi


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | ox-alpha |
| Harness + version | Hermes Agent CLI, macOS (Darwin 26.5.2) |
| All plugins installed | superpowers (local dev clone) |
| Human partner who reviewed this diff | Tugrul Guner (@tugrulguner) — directed the change and reviewed the complete diff before submission |

## What problem are you trying to solve?

Issue #2194: Amazon Q Developer CLI (`q`) is a major, actively-developed agent CLI with **zero** Superpowers presence — no issues, PRs, or mentions anywhere in the repo (searched open and closed). It is AWS-backed, free-tier, cross-platform, and its **custom agents** feature provides everything the integration bar requires: an `agentSpawn` hook that runs once per session start and injects stdout as fixed session context.

## What does this PR change?

1. `.amazonq/cli-agents/superpowers.json` — checked-in custom agent manifest (schema `agent-v1.json`) whose `agentSpawn` hook runs `hooks/session-start` with `AMAZON_Q_AGENT=1`. No shim, no per-session opt-in.
2. `hooks/session-start` — new first branch keyed on `AMAZON_Q_AGENT`: emits the existing `<EXTREMELY_IMPORTANT>` bootstrap as **plain text**, because Q injects raw stdout; a JSON envelope would be injected literally. Every other platform branch is untouched.
3. `skills/using-superpowers/references/amazon-q-tools.md` — tool mapping following the codex/pi/antigravity/hermes pattern. Maps to Q's built-ins (`fs_read`, `fs_write`, `execute_bash`); Q has no subagent or todo tool, so it uses the Pi-style explicit fallback wording rather than fabricating tool calls.
4. `skills/using-superpowers/SKILL.md` + README — Platform Adaptation entry and install section.
5. `tests/amazon-q/test-integration.sh` (+ helper `check-envelope.js`) — registration-shape tests mirroring the hooks/hermes suites.

Stock skills are untouched except the one-line Platform Adaptation list entry, per the established per-harness reference pattern.

## Is this change appropriate for the core library?

Yes — new harness support, the category where integration surface belongs in core.

## What alternatives did I consider?

- **Resources-only bootstrap** (`resources: ["file://~/.superpowers/skills/..."]`): rejected — resources load skill *files* but not the curated bootstrap wrapper that tells the model how to use them; the hook is what makes skills auto-trigger.
- **MCP server shim**: rejected — runtime shim, explicitly against the rules.
- **JSON envelope for Q**: rejected after checking Q docs/examples — `agentSpawn` output becomes literal context text.

## Does this PR contain multiple unrelated changes?

No. Every file serves Amazon Q CLI harness support (#2194).

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none — #2194 is the first mention of Amazon Q in this repository. Pattern followed: #2025 (Hermes), antigravity/pi references.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
| --- | --- | --- | --- |
| bash + node static suites | macOS Darwin 26.5.2, node v22/v24 | ox-alpha | n/a |

- `bash tests/amazon-q/test-integration.sh`: **6/6 PASS**. Red evidence: with the session-start change stashed, the plain-text assertion fails (STATUS: FAILED); restored, 6/6 pass.
- `bash tests/hooks/test-session-start.sh`: 6/6 PASS — Claude Code/Cursor/Copilot envelopes unchanged.
- `pytest tests/hermes/test_bootstrap.py`: 10 passed (Hermes plugin unaffected).
- Custom agent JSON validated structurally against the documented agent-v1 fields; `git diff --check` clean.

## New harness support (required if this PR adds a new harness)

**Honest disclosure up front:** I do not have an authenticated Amazon Q CLI environment in this workspace, so the live clean-session transcript ("Let's make a react todo list") cannot be included yet. Everything verifiable without credentials is proven: manifest shape, hook wiring, plain-text emission, bootstrap content, non-regression of all other platforms. If maintainers want the live transcript before merge, I'll run the acceptance test on a Q CLI machine and attach it to this PR.

<details>
<summary>Static verification of the acceptance path</summary>

```
$ AMAZON_Q_AGENT=1 bash hooks/session-start | head -c 60
<EXTREMELY_IMPORTANT>
You have superpowers.
...

$ bash tests/amazon-q/test-integration.sh
  [PASS] custom agent manifest wires agentSpawn to session-start
  [PASS] session-start emits plain text under AMAZON_Q_AGENT=1
  [PASS] plain-text output contains the bootstrap block
  [PASS] Claude Code path unchanged (hookSpecificOutput envelope)
  [PASS] Cursor path unchanged (additional_context envelope)
  [PASS] amazon-q-tools.md exists and is listed in Platform Adaptation
STATUS: PASSED
```

The custom agent's agentSpawn command sets exactly the env var the hook checks, and `q chat --agent superpowers` runs agentSpawn once at session start per AWS documentation — the same injection point Claude Code's SessionStart provides elsewhere in this repo.
</details>

## Evaluation

- Initial prompt: identify a major unclaimed harness gap (researched the current agent-CLI landscape against the repo's supported list), file the issue first (#2194), then implement exactly what it proposes.
- Eval runs: static red/green as above; no behavioral eval sessions possible without a live Q environment (disclosed).

## Rigor

- [ ] Skills-change adversarial pressure testing: N/A beyond the one-line platform-list addition; no workflow or rationalization content touched
- [x] Tested adversarially where possible (red evidence; explicit non-regression assertions for every other platform's envelope)
- [x] No carefully-tuned content modified

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Fixes #2194