### PR TITLE
Trace displayed/stored data to its producer before fixing (no downstream masking)

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -85,7 +85,7 @@ your path and complete them in order.
 5. **Report findings** — a recommendation; label anything built as throwaway
 
 **Bounded:**
-1. **Explore project context** — check files, docs, recent commits
+1. **Explore project context** — check files, docs, recent commits. If the request fixes an incorrect displayed/stored value, FIRST trace it to its producer (writer/schema); never design a downstream transformation (formatter/parser) that masks bad data at its source
 2. **Ask clarifying questions** — one at a time, the ones that matter
 3. **Present short design in chat** — approach, files touched, testing
 4. **Get approval** — STOP and wait for an explicit yes; presenting the design and starting in the same breath is skipping the gate

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -117,6 +117,22 @@ You MUST complete each phase before proceeding to the next.
    - Keep tracing up until you find the source
    - Fix at source, not at symptom
 
+6. **Trace Displayed/Stored Data To Its Producer**
+
+   If a WRONG value is displayed or stored (bad label, wrong format, stale field),
+   locate WHO WRITES it (SQL writer, service, seed script) and its schema BEFORE
+   proposing any fix. A display bug is a data bug until proven otherwise.
+
+   NEVER compensate downstream: a UI formatter/parser that masks badly stored
+   data hides the bug instead of fixing it. The complete fix has three parts:
+   1. Fix generation at the producer (single canonical generator)
+   2. Idempotently migrate existing rows (startup migration pattern)
+   3. Align seed/test fixtures with production format
+
+   **Example:** "Mensualité 11" shown in an invoice cart was first "fixed" with
+   a display formatter. Wrong. The real fix: canonical generator used by every
+   producer + idempotent migration of existing rows + delete the band-aid formatter.
+
 ### Phase 2: Pattern Analysis
 
 **Find the pattern before fixing:**
@@ -177,7 +193,9 @@ You MUST complete each phase before proceeding to the next.
    - Use the `superpowers:test-driven-development` skill for writing proper failing tests
 
 2. **Implement Single Fix**
-   - Address the root cause identified
+   - Address the root cause identified — the PRODUCER of the bad data, not a
+     downstream consumer. If existing data is wrong, the fix includes an
+     idempotent migration; seeds/fixtures are aligned with production.
    - ONE change at a time
    - No "while I'm here" improvements
    - No bundled refactoring
@@ -223,6 +241,7 @@ If you catch yourself thinking:
 - "Pattern says X but I'll adapt it differently"
 - "Here are the main problems: [lists fixes without investigation]"
 - Proposing solutions before tracing data flow
+- **"It's just a display issue, a formatter/parser will do"** — masking bad data downstream hides the bug. Trace it to the producer first; fix source + migrate existing rows.
 - **"One more fix attempt" (when already tried 2+)**
 - **Each fix reveals new problem in different place**
 
@@ -252,6 +271,7 @@ If you catch yourself thinking:
 | "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |
 | "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
 | "I see the problem, let me fix it" | Seeing symptoms ≠ understanding root cause. |
+| "A downstream formatter fixes the bad value" | It masks the bug. Find the producer; fix generation + migrate existing data. |
 | "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question pattern, don't fix again. |
 
 ## Quick Reference


### PR DESCRIPTION
## Problem

While debugging a real application, a wrong stored value ("Mensualité 11" — a month *number* baked into a DB label by an old seed script) was surfaced in the UI. The agent's first "fix" was a display formatter that rewrote the label at render time. That masked the bug instead of fixing it: every other consumer of the stored value kept showing bad data.

The root-cause discipline already exists in `systematic-debugging` (Phase 1 / Phase 4), but it didn't trigger because the symptom looked like a *display* concern. Nothing forces tracing a wrong value to its producer before designing or shipping a downstream transformation.

## Changes

**`skills/systematic-debugging/SKILL.md`**
- Phase 1: new step **"6. Trace Displayed/Stored Data To Its Producer"** — locate who writes the value (SQL writer / service / seed) and its schema before proposing any fix; "a display bug is a data bug until proven otherwise"; never compensate downstream; documents the three-part complete fix:
  1. fix generation at the producer (single canonical generator)
  2. idempotently migrate existing rows (startup migration pattern)
  3. align seed/test fixtures with production format
  - includes the real-world case study as an example
- Phase 4: "Implement Single Fix" now states the root cause is the **producer** of the bad data and that fixes include migration when existing rows are wrong
- Red Flags: new bullet — *"It's just a display issue, a formatter/parser will do"*
- Common Rationalizations: matching row for downstream formatters

**`skills/brainstorming/SKILL.md`**
- Bounded path step 1 (Explore project context): if the request fixes an incorrect displayed/stored value, trace it to its producer first — so a downstream-masking design never gets approved in the first place

## Testing

Applied and exercised end-to-end in a production PyQt app: labels regenerated via a single canonical generator (`libelle_mensualite(mois)`), ~60 legacy rows migrated by an idempotent startup migration, seeds aligned, band-aid formatter deleted. Test suite went from 20 failed / 112 passed → 12 failed / 140 passed on a fresh database (8 pre-existing failures fixed as a side effect of cleaning the data contract). The patched skills are also mirrored locally with a re-injection script to survive package updates.