### PR TITLE
Add ZCode harness support

### DIFF
--- a/.version-bump.json
+++ b/.version-bump.json
@@ -7,6 +7,7 @@
     { "path": ".codex-plugin/plugin.json", "field": "version" },
     { "path": ".devin-plugin/plugin.json", "field": "version" },
     { "path": ".kimi-plugin/plugin.json", "field": "version" },
+    { "path": ".zcode-plugin/plugin.json", "field": "version" },
     { "path": ".claude-plugin/marketplace.json", "field": "plugins.0.version" },
     { "path": "gemini-extension.json", "field": "version" }
   ],

--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "superpowers",
+  "version": "6.3.0",
+  "description": "An agentic skills framework and software development methodology.",
+  "author": {
+    "name": "Jesse Vincent",
+    "email": "jesse@fsck.com"
+  },
+  "homepage": "https://github.com/obra/superpowers",
+  "repository": "https://github.com/obra/superpowers",
+  "license": "MIT",
+  "keywords": [
+    "brainstorming",
+    "subagent-driven-development",
+    "skills",
+    "planning",
+    "tdd",
+    "debugging",
+    "code-review",
+    "workflow"
+  ],
+  "skills": "skills",
+  "hooks": "./hooks/hooks-zcode.json"
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [OpenCode](#opencode)
   - [Pi](#pi)
   - [Hermes Agent](#hermes-agent)
+  - [ZCode](#zcode)
 - [The Basic Workflow](#the-basic-workflow)
 - [Community](#community)
 - [What's Inside](#whats-inside)
@@ -257,6 +258,22 @@ hermes plugins install obra/superpowers --enable
 Restart any active Hermes sessions after installing. Note: Hermes has no
 post-compaction hook, so a very long session that compacts over its first
 turn loses the bootstrap — start a fresh session if skills stop triggering.
+
+### ZCode
+
+Superpowers ships as a first-class ZCode plugin with skills and a
+session-start hook.
+
+- In ZCode, open `Settings` > `Plugins`, add this repository as a marketplace
+  source, and install Superpowers:
+
+  ```text
+  https://github.com/obra/superpowers
+  ```
+
+- Restart ZCode after installing so the session-start hook takes effect.
+
+- Detailed docs: [docs/README.zcode.md](docs/README.zcode.md)
 
 ## The Basic Workflow
 

--- a/docs/README.zcode.md
+++ b/docs/README.zcode.md
@@ -1,0 +1,77 @@
+# Superpowers for ZCode
+
+Superpowers ships as a first-class ZCode plugin: the full skills library plus
+a session-start hook that injects the `using-superpowers` bootstrap into every
+new session — no per-session opt-in.
+
+## Install
+
+1. Open ZCode.
+2. Go to `Settings` > `Plugins`.
+3. Add a marketplace source and point it at this repository:
+
+   ```text
+   https://github.com/obra/superpowers
+   ```
+
+4. Install the Superpowers plugin and restart ZCode.
+
+## How it works
+
+- `.zcode-plugin/plugin.json` declares the plugin: identity metadata, the
+  bundled `skills/` directory, and the hook config at
+  `hooks/hooks-zcode.json`.
+- The hook runs on every `SessionStart` event. It dispatches through the
+  shared cross-platform polyglot wrapper (`hooks/run-hook.cmd`) into
+  `hooks/session-start`, which prints ZCode's native JSON shape:
+
+  ```json
+  {"hookEventName": "SessionStart", "additionalContext": "<bootstrap>"}
+  ```
+
+- ZCode merges that context before the first model request, so skills exist,
+  are discoverable, and auto-trigger by their descriptions. Skills use
+  ZCode's native skill system; subagents map to ZCode's built-in agent types.
+
+## Requirements
+
+- **Windows:** Git Bash must be installed (the standard Git for Windows
+  location or `bash` on `PATH`). Without it the hook exits silently — ZCode
+  still works, but sessions don't get the bootstrap injected.
+- **Linux/macOS:** no extra requirements; `bash` is used directly.
+
+## Verify it works
+
+1. Start a new session and ask:
+
+   > What are your superpowers?
+
+   The agent should describe its skills. If not, the bootstrap isn't loading
+   — see Troubleshooting.
+
+2. In a clean workspace, send exactly:
+
+   > Let's make a react todo list
+
+   A working install triggers the `brainstorming` skill *before* any code is
+   written.
+
+## Local development
+
+To test a checkout of this repository instead of a published build, add the
+local directory itself as the marketplace source in `Settings` > `Plugins`,
+then reinstall and restart after each change — the bootstrap loads at startup,
+so changes don't apply to already-running sessions.
+
+## Troubleshooting
+
+- **Skills never trigger / agent doesn't know its superpowers:** confirm the
+  plugin is enabled in `Settings` > `Plugins`, check that the Superpowers
+  SessionStart hook appears in the hooks settings, and verify bash is
+  reachable (see Requirements).
+- **Hook shows an error in Settings:** make sure nothing modified
+  `hooks/hooks-zcode.json`; reinstalling the plugin restores it.
+- **Still stuck:** open an issue at
+  [obra/superpowers/issues](https://github.com/obra/superpowers/issues) with
+  your ZCode version, OS, and the output of asking "What are your
+  superpowers?".

--- a/docs/superpowers/specs/2026-08-22-zcode-harness-support-design.md
+++ b/docs/superpowers/specs/2026-08-22-zcode-harness-support-design.md
@@ -50,6 +50,11 @@ guide ("when this guide and the code disagree, the code wins"):
 8. **Subagents:** built-in agent types include literally `general-purpose`
    and `Explore`. Skills system: native (`skillsService`; personal dir
    `~/.zcode/skills/`, plugin-contributed `skills/` dirs).
+9. **Tool surface (live probe):** `Read`, `Write`, `Edit`, `Bash`,
+   `WebFetch`, `WebSearch`, `TodoWrite`/`TodoRead`, `Skill`,
+   `AskUserQuestion` match Claude vocabulary; deltas are subagent dispatch
+   via an `Agent` tool and **no dedicated Grep/Glob tools** (content/name
+   search rides `Bash`). A mapping file is therefore required.
 
 ## Design
 
@@ -77,7 +82,7 @@ ZCode new session (SessionStart)
 | 1 | `.zcode-plugin/plugin.json` | NEW | First-class manifest: identity fields + `"skills": "skills"` + `"hooks": "./hooks/hooks-zcode.json"`. Declaring hooks explicitly is mandatory here (see finding 4): standard-path autoload would feed our Claude-format `hooks.json` into ZCode's strict `events:` schema and fail |
 | 2 | `hooks/hooks-zcode.json` | NEW | ZCode schema: `{"events":{"SessionStart":[{"hooks":[{"type":"command","command":"\"${ZCODE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start","shell":"bash","async":false}]}]}}` |
 | 3 | `hooks/session-start` | EDIT | New `elif [ -n "${ZCODE_PLUGIN_ROOT:-}" ]` branch placed BEFORE the `CLAUDE_PLUGIN_ROOT` branch, emitting the native top-level shape. Native-first beats compat-path reliance (survives compat-var removal; independently testable) |
-| 4 | Tool mapping | NONE (expected) | Subagent types are literally `general-purpose`/`Explore`; skill system is native; file/shell tools assumed Claude-like — verify live during acceptance run. Ship `references/zcode-tools.md` only if probes show deltas (then also one Platform Adaptation pointer line — the only permitted SKILL.md edit) |
+| 4 | `skills/using-superpowers/references/zcode-tools.md` | NEW | Live probe showed two deltas: subagent dispatch is the `Agent` tool (types `general-purpose`/`Explore`), and there is no dedicated Grep/Glob (search rides `Bash`). Standard-shape mapping file + the one sanctioned pointer line in SKILL.md's Platform Adaptation list |
 | 5 | `tests/zcode/` | NEW | `run-tests.sh` + manifest validity test (fields, version-bump registration, no stale references) + hook-shape test (with `ZCODE_PLUGIN_ROOT` set: valid JSON, top-level `hookEventName=="SessionStart"`, non-empty `additionalContext` containing the bootstrap, NO `additional_context`, NO nested `hookSpecificOutput`) |
 | 6 | `.version-bump.json` | EDIT | Register `.zcode-plugin/plugin.json` → `version` (unregistered manifests ship stale) |
 | 7 | `scripts/sync-to-codex-plugin.sh` | EDIT | Add `"/.zcode-plugin/"` to EXCLUDES so the dotdir doesn't leak into the Codex distribution |

--- a/docs/superpowers/specs/2026-08-22-zcode-harness-support-design.md
+++ b/docs/superpowers/specs/2026-08-22-zcode-harness-support-design.md
@@ -1,0 +1,130 @@
+# ZCode Harness Support Design
+
+**Date:** 2026-08-22
+**Status:** Approved (Approach B — first-class integration)
+**Harness:** ZCode Desktop 3.8.1 (Z.ai, Electron; Linux x86_64 verified locally)
+
+## Problem
+
+Superpowers supports 14 harnesses but not ZCode, so ZCode users get no
+session-start bootstrap: the skills sit on disk and never trigger. We add
+ZCode as a supported harness following `docs/porting-to-a-new-harness.md`,
+mirroring the Cursor row (Shape A shell-hook, Claude-compatible tool surface).
+
+Success criterion: merged upstream PR against `dev`, with the acceptance-test
+transcript (`Let's make a react todo list` auto-triggers brainstorming).
+
+## Empirical contract (verified from installed ZCode 3.8.1 binaries)
+
+Derived by extracting `/opt/ZCode/resources/app.asar` and grepping the agent
+runtime (`resources/glm/zcode.cjs`) — the authoritative source per the porting
+guide ("when this guide and the code disagree, the code wins"):
+
+1. **Manifest discovery order:** `.zcode-plugin/plugin.json` →
+   `.claude-plugin/plugin.json` → `.codex-plugin/plugin.json`. A first-class
+   `.zcode-plugin/` directory exists.
+2. **Official manifest fields** (document-skills plugin): `name`, `version`,
+   `description`, `description_i18n`, `author`, `license`,
+   `"skills": "skills"` (bare relative dir, no `./` prefix).
+3. **Hook events:** `SessionStart`, `UserPromptSubmit`, `PreToolUse`,
+   `PermissionRequest`, `PostToolUse`, `PostToolUseFailure`, `Stop`.
+4. **Plugin hook config schema is NOT Claude-compatible.** Top-level key is
+   `events:` (strict), entries are `{matcher?, hooks:[...]}`; hook types are
+   `command` (`command`, `shell: true|string`, `async`, `timeout`) and
+   `process` (`command`, `args[]`). Claude's `{hooks:{...}}` shape fails this
+   strict schema — the shared `hooks/hooks.json` cannot ride standard-path
+   autoload; ZCode needs its own declared hooks file.
+5. **Env vars:** hook/custom-command processes receive BOTH
+   `ZCODE_PLUGIN_ROOT` and `CLAUDE_PLUGIN_ROOT` (same value), plus
+   `*_PLUGIN_DATA`, `*_PROJECT_DIR`, session IDs. `${CLAUDE_PLUGIN_ROOT}` /
+   `${ZCODE_PLUGIN_ROOT}` in command strings are expanded by ZCode itself.
+6. **stdin:** Claude Code-compatible JSON (`hook_event_name`, `session_id`,
+   `transcript_path`, `tool_name`…).
+7. **stdout:** parsed once as JSON; ALL of these are consumed for
+   SessionStart: top-level `additionalContext`, top-level
+   `additional_context`, and nested
+   `hookSpecificOutput.{hookEventName,additionalContext}` — the nested form is
+   validated (`hookEventName` must equal the firing event) then merged. Our
+   existing Claude branch output therefore parses on ZCode today, but via the
+   compat path only.
+8. **Subagents:** built-in agent types include literally `general-purpose`
+   and `Explore`. Skills system: native (`skillsService`; personal dir
+   `~/.zcode/skills/`, plugin-contributed `skills/` dirs).
+
+## Design
+
+Shape A shell-hook port. Skills discovery via manifest; bootstrap via
+plugin-declared ZCode-format hook file running the existing polyglot chain;
+one new env-var branch in `hooks/session-start` emitting ZCode's native
+top-level shape, ordered **before** the Claude branch (shadowing rule: ZCode
+sets `CLAUDE_PLUGIN_ROOT` too).
+
+### Data flow
+
+```
+ZCode new session (SessionStart)
+  → runs plugin hook (declared in .zcode-plugin/plugin.json)
+    → hooks/hooks-zcode.json entry → run-hook.cmd polyglot → bash hooks/session-start
+      → detects ZCODE_PLUGIN_ROOT → prints {"hookEventName":"SessionStart","additionalContext":"<bootstrap>"}
+  → ZCode merges additionalContext into model context
+  → model knows it has superpowers; skills auto-trigger by description
+```
+
+### Files
+
+| # | File | Change | Why |
+|---|------|--------|-----|
+| 1 | `.zcode-plugin/plugin.json` | NEW | First-class manifest: identity fields + `"skills": "skills"` + `"hooks": "./hooks/hooks-zcode.json"`. Declaring hooks explicitly is mandatory here (see finding 4): standard-path autoload would feed our Claude-format `hooks.json` into ZCode's strict `events:` schema and fail |
+| 2 | `hooks/hooks-zcode.json` | NEW | ZCode schema: `{"events":{"SessionStart":[{"hooks":[{"type":"command","command":"\"${ZCODE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start","shell":"bash","async":false}]}]}}` |
+| 3 | `hooks/session-start` | EDIT | New `elif [ -n "${ZCODE_PLUGIN_ROOT:-}" ]` branch placed BEFORE the `CLAUDE_PLUGIN_ROOT` branch, emitting the native top-level shape. Native-first beats compat-path reliance (survives compat-var removal; independently testable) |
+| 4 | Tool mapping | NONE (expected) | Subagent types are literally `general-purpose`/`Explore`; skill system is native; file/shell tools assumed Claude-like — verify live during acceptance run. Ship `references/zcode-tools.md` only if probes show deltas (then also one Platform Adaptation pointer line — the only permitted SKILL.md edit) |
+| 5 | `tests/zcode/` | NEW | `run-tests.sh` + manifest validity test (fields, version-bump registration, no stale references) + hook-shape test (with `ZCODE_PLUGIN_ROOT` set: valid JSON, top-level `hookEventName=="SessionStart"`, non-empty `additionalContext` containing the bootstrap, NO `additional_context`, NO nested `hookSpecificOutput`) |
+| 6 | `.version-bump.json` | EDIT | Register `.zcode-plugin/plugin.json` → `version` (unregistered manifests ship stale) |
+| 7 | `scripts/sync-to-codex-plugin.sh` | EDIT | Add `"/.zcode-plugin/"` to EXCLUDES so the dotdir doesn't leak into the Codex distribution |
+| 8 | `README.md` | EDIT | ZCode install section matching existing per-harness sections |
+| 9 | `docs/README.zcode.md` | NEW | Install/troubleshooting details |
+
+### Error handling
+
+- **No bash (Windows without Git Bash):** `run-hook.cmd` exits 0 silently —
+  same degradation as Claude Code/Cursor today; `$`-style invocation of
+  discovered skills still works, bootstrap injection doesn't.
+- **Wrong event name:** impossible for the new branch (literal
+  `SessionStart`); ZCode hard-fails mismatches loudly rather than silently.
+- **Compaction:** ZCode fires `SessionStart` per its own lifecycle; no
+  compaction-specific handling needed beyond what the shared script already
+  does (stateless re-runs).
+- **Double injection:** impossible — the branch emits exactly one field set;
+  tests assert absence of the other shapes.
+
+## Verification ladder
+
+1. `tests/zcode/run-tests.sh` green; existing `tests/hooks/`,
+   `tests/kimi/` unaffected; `scripts/bump-version.sh --check` clean.
+2. Local install into ZCode from the checkout (marketplace/local-dir path;
+   confirm which the UI offers).
+3. Smoke: new session → *"What are your superpowers?"* → describes skills.
+4. **Acceptance test:** clean workspace, exact prompt
+   `Let's make a react todo list` → brainstorming triggers before any code;
+   capture transcript ×2–3 (this is the PR's required evidence).
+5. Capability probe: ask the model to enumerate its tools; compare against
+   Claude Code vocabulary → decide zcode-tools.md yes/no.
+6. Regression: `tests/hooks/test-session-start.sh` still green (Claude/
+   Cursor/Copilot shapes unchanged).
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `"shell": "bash"` unavailable on some Windows installs | Same silent-exit fallback as every other Shape A harness; documented |
+| Manifest `skills` path format drifts between ZCode versions | Copied verbatim from official bundled plugin; acceptance test catches regressions |
+| Marketplace git-URL install flow differs from assumption | Verified hands-on during verification step 2 before writing docs claims |
+| Maintainer wants minimal diff (rely on compat var, zero hook change) | Fallback is deleting the new branch — additive, trivially negotiable in review |
+
+## Contribution process (PR gates from CLAUDE.md / PR template)
+
+Target `dev`. Fill every template section: disclosure table (model/harness/
+plugins), problem statement, alternatives, environment-tested table,
+acceptance transcript in `<details>`, eval section, human-reviewed-diff
+checkbox (the human partner reviews the complete diff before submission).
+One PR, no bundled unrelated changes.

--- a/hooks/hooks-zcode.json
+++ b/hooks/hooks-zcode.json
@@ -1,0 +1,16 @@
+{
+  "events": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${ZCODE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "shell": "bash",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -28,6 +28,7 @@ session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the 
 
 # Output context injection as JSON.
 # Cursor hooks expect additional_context (snake_case).
+# ZCode expects hookEventName + additionalContext at the top level.
 # Claude Code hooks expect hookSpecificOutput.additionalContext (nested).
 # Copilot CLI (v1.0.11+) and others expect additionalContext (top-level, SDK standard).
 # Claude Code reads BOTH additional_context and hookSpecificOutput without
@@ -38,6 +39,11 @@ session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the 
 if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
   # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
   printf '{\n  "additional_context": "%s"\n}\n' "$session_context" | cat
+elif [ -n "${ZCODE_PLUGIN_ROOT:-}" ]; then
+  # ZCode sets ZCODE_PLUGIN_ROOT and also CLAUDE_PLUGIN_ROOT as a compat
+  # alias, so this branch must run before the Claude Code branch. ZCode's
+  # native SessionStart shape is top-level hookEventName + additionalContext.
+  printf '{\n  "hookEventName": "SessionStart",\n  "additionalContext": "%s"\n}\n' "$session_context" | cat
 elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
   # Claude Code sets CLAUDE_PLUGIN_ROOT without COPILOT_CLI
   printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context" | cat

--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -60,6 +60,7 @@ EXCLUDES=(
   "/.pre-commit-config.yaml"
   "/.version-bump.json"
   "/.worktrees/"
+  "/.zcode-plugin/"
   ".DS_Store"
 
   # Root ceremony files

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -57,6 +57,7 @@ If your harness appears here, read its reference file for special instructions:
 - Pi: `references/pi-tools.md`
 - Antigravity: `references/antigravity-tools.md`
 - Hermes Agent: `references/hermes-tools.md`
+- ZCode: `references/zcode-tools.md`
 
 ## User Instructions
 

--- a/skills/using-superpowers/references/zcode-tools.md
+++ b/skills/using-superpowers/references/zcode-tools.md
@@ -1,0 +1,30 @@
+# ZCode Tool Mapping
+
+Skills speak in actions ("dispatch a subagent", "create a todo", "read a file"). On ZCode these resolve to the tools below.
+
+| Action | Tool |
+|--------|------|
+| Read a file | `Read` |
+| Create a file | `Write` |
+| Edit a file | `Edit` |
+| Run a shell command | `Bash` |
+| Search file contents | `Bash` with `grep`/`rg` — ZCode has no dedicated Grep tool |
+| Find files by name | `Bash` with `find`/`fd` — ZCode has no dedicated Glob tool |
+| Fetch a URL | `WebFetch` |
+| Web search | `WebSearch` |
+| Dispatch a subagent | `Agent` |
+| Create / update todos | `TodoWrite` (read back with `TodoRead`) |
+| Invoke a skill | `Skill` |
+| Ask your human partner a question | `AskUserQuestion` |
+
+## Subagent dispatch
+
+Skills that say "dispatch a subagent" or "Task tool (general-purpose)" call ZCode's `Agent` tool. Use `general-purpose` for implementer/reviewer-style work and `Explore` for read-only codebase investigation. Do not invent other agent types; if `Agent` is unavailable, do the work inline and say so.
+
+## Task tracking
+
+`TodoWrite`/`TodoRead` already match the names skills use — no translation needed.
+
+## Skills
+
+Invoke skills with the native `Skill` tool.

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -100,6 +100,20 @@ if (shape === "nested") {
     fail("cursor output included additionalContext");
   }
   context = payload.additional_context;
+} else if (shape === "zcode") {
+  if (payload.hookEventName !== "SessionStart") {
+    fail(`unexpected or missing hookEventName: ${payload.hookEventName}`);
+  }
+  if (!hasOwn(payload, "additionalContext")) {
+    fail("zcode output missing top-level additionalContext");
+  }
+  if (hasOwn(payload, "hookSpecificOutput")) {
+    fail("zcode output included nested hookSpecificOutput");
+  }
+  if (hasOwn(payload, "additional_context")) {
+    fail("zcode output included snake_case additional_context");
+  }
+  context = payload.additionalContext;
 } else if (shape === "sdk") {
   if (hasOwn(payload, "hookSpecificOutput")) {
     fail("sdk output included hookSpecificOutput");
@@ -192,6 +206,17 @@ assert_command_output \
     "" \
     "$cursor_home" \
     CURSOR_PLUGIN_ROOT="$REPO_ROOT" \
+    CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
+    bash "$HOOK_UNDER_TEST"
+
+zcode_home="$(make_home zcode)"
+assert_command_output \
+    "ZCode emits native top-level additionalContext" \
+    "zcode" \
+    "" \
+    "" \
+    "$zcode_home" \
+    ZCODE_PLUGIN_ROOT="$REPO_ROOT" \
     CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
     bash "$HOOK_UNDER_TEST"
 

--- a/tests/zcode/run-tests.sh
+++ b/tests/zcode/run-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+bash "$SCRIPT_DIR/test-plugin-manifest.sh"

--- a/tests/zcode/test-plugin-manifest.sh
+++ b/tests/zcode/test-plugin-manifest.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MANIFEST="$REPO_ROOT/.zcode-plugin/plugin.json"
+HOOKS_CONFIG="$REPO_ROOT/hooks/hooks-zcode.json"
+SESSION_START="$REPO_ROOT/hooks/session-start"
+
+python3 - "$MANIFEST" "$HOOKS_CONFIG" "$SESSION_START" "$REPO_ROOT/.version-bump.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+hooks_config_path = Path(sys.argv[2])
+session_start_path = Path(sys.argv[3])
+version_bump_path = Path(sys.argv[4])
+
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+assert_equal(manifest.get("name"), "superpowers", "plugin name")
+assert_equal(manifest.get("skills"), "skills", "skills path")
+assert_equal(
+    manifest.get("hooks"), "./hooks/hooks-zcode.json", "declared hooks path"
+)
+
+# ZCode's plugin hook schema uses a top-level `events` key with strict
+# parsing, so the shared Claude-format hooks/hooks.json cannot be reused.
+hooks_config = json.loads(hooks_config_path.read_text(encoding="utf-8"))
+events = hooks_config.get("events")
+if not isinstance(events, dict) or "hooks" in hooks_config:
+    raise AssertionError("hooks-zcode.json must use ZCode's top-level events schema")
+entries = events.get("SessionStart")
+if not isinstance(entries, list) or not entries:
+    raise AssertionError("hooks-zcode.json missing SessionStart entry")
+hook = entries[0].get("hooks", [])[0]
+assert_equal(hook.get("type"), "command", "hook type")
+assert_equal(hook.get("shell"), "bash", "hook shell")
+assert_equal(hook.get("async"), False, "hook async")
+command = hook.get("command", "")
+if "${ZCODE_PLUGIN_ROOT}" not in command:
+    raise AssertionError("hook command must reference ${ZCODE_PLUGIN_ROOT}")
+if not command.endswith('run-hook.cmd" session-start'):
+    raise AssertionError(f"unexpected hook command shape: {command}")
+
+# The ZCode branch must precede the Claude Code branch: ZCode sets both
+# ZCODE_PLUGIN_ROOT and CLAUDE_PLUGIN_ROOT (compat alias), and the Claude
+# branch would otherwise shadow it.
+script = session_start_path.read_text(encoding="utf-8")
+zcode_pos = script.find('elif [ -n "${ZCODE_PLUGIN_ROOT:-}" ]')
+claude_pos = script.find('elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]')
+if zcode_pos == -1 or claude_pos == -1:
+    raise AssertionError("session-start is missing the ZCode branch")
+if zcode_pos > claude_pos:
+    raise AssertionError(
+        "ZCode branch must run before the Claude Code branch "
+        "(ZCode sets CLAUDE_PLUGIN_ROOT too)"
+    )
+for shape in ("hookEventName", "additionalContext"):
+    segment = script[zcode_pos:claude_pos]
+    if shape not in segment:
+        raise AssertionError(f"ZCode branch must emit top-level {shape}")
+
+version_config = json.loads(version_bump_path.read_text(encoding="utf-8"))
+version_entries = version_config.get("files")
+if not isinstance(version_entries, list):
+    raise AssertionError(".version-bump.json must contain files list")
+if not any(
+    entry.get("path") == ".zcode-plugin/plugin.json" and entry.get("field") == "version"
+    for entry in version_entries
+    if isinstance(entry, dict)
+):
+    raise AssertionError(
+        ".version-bump.json must update .zcode-plugin/plugin.json version"
+    )
+
+print("ZCode plugin manifest looks good")
+PY

--- a/tests/zcode/test-plugin-manifest.sh
+++ b/tests/zcode/test-plugin-manifest.sh
@@ -38,7 +38,12 @@ if not isinstance(events, dict) or "hooks" in hooks_config:
 entries = events.get("SessionStart")
 if not isinstance(entries, list) or not entries:
     raise AssertionError("hooks-zcode.json missing SessionStart entry")
-hook = entries[0].get("hooks", [])[0]
+
+hooks = entries[0].get("hooks")
+if not isinstance(hooks, list) or not hooks:
+    raise AssertionError("hooks-zcode.json SessionStart entry must contain a non-empty hooks list")
+
+hook = hooks[0]
 assert_equal(hook.get("type"), "command", "hook type")
 assert_equal(hook.get("shell"), "bash", "hook shell")
 assert_equal(hook.get("async"), False, "hook async")

--- a/tests/zcode/test-plugin-manifest.sh
+++ b/tests/zcode/test-plugin-manifest.sh
@@ -79,5 +79,22 @@ if not any(
         ".version-bump.json must update .zcode-plugin/plugin.json version"
     )
 
+# Tool mapping: ZCode's surface is mostly Claude-compatible but dispatches
+# subagents via `Agent` and has no dedicated Grep/Glob tools.
+tools_mapping = (manifest_path.parents[1] / "skills/using-superpowers/references/zcode-tools.md").read_text(
+    encoding="utf-8"
+)
+for token in ("ZCode Tool Mapping", "`Agent`", "`TodoWrite`", "`Skill`", "no dedicated Grep"):
+    if token not in tools_mapping:
+        raise AssertionError(f"zcode-tools.md missing expected content: {token!r}")
+
+skill_md = (manifest_path.parents[1] / "skills/using-superpowers/SKILL.md").read_text(
+    encoding="utf-8"
+)
+if "- ZCode: `references/zcode-tools.md`" not in skill_md:
+    raise AssertionError(
+        "SKILL.md Platform Adaptation list must point at references/zcode-tools.md"
+    )
+
 print("ZCode plugin manifest looks good")
 PY


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | ox-alpha (agent authored the port), GLM-5.3 (model used for live acceptance testing inside ZCode) |
| Harness + version | Authored in OpenCode; target harness ZCode Desktop 3.8.1 (Z.ai, Linux x86_64) |
| All plugins installed | superpowers (this branch, local-checkout install), document-skills/browser-use/skill-creator/zcode-guide (zcode-plugins-official), personal `~/.zcode/skills` |
| Human partner who reviewed this diff | Shivansh Sharma (@shivansh7102003) |

## What problem are you trying to solve?

ZCode is my daily coding agent, and none of its sessions get Superpowers.
Installing upstream leaves the skills inert: ZCode discovers plugins via
`.zcode-plugin/plugin.json` (falling back to `.claude-plugin/` /
`.codex-plugin/`), and its plugin hook config uses a strict top-level
`events:` schema that Claude-format `hooks/hooks.json` fails to parse. Result:
no SessionStart hook fires, the `using-superpowers` bootstrap never reaches
the model, and asking the agent "what are your superpowers?" returns an
improvised answer from unrelated personal skills instead of the methodology.

## What does this PR change?

Adds a first-class ZCode port following `docs/porting-to-a-new-harness.md`
(Shape A shell-hook): `.zcode-plugin/plugin.json` manifest, a ZCode-schema
`hooks/hooks-zcode.json`, a `ZCODE_PLUGIN_ROOT` branch in
`hooks/session-start` emitting ZCode's native top-level
`{hookEventName, additionalContext}` shape ahead of the Claude branch (ZCode
sets both env vars), a `references/zcode-tools.md` mapping (live probe: `Agent`
subagent tool, no dedicated Grep/Glob) plus its one sanctioned Platform
Adaptation pointer line, tests, version-bump registration, Codex-sync exclude,
and install docs.

## Is this change appropriate for the core library?

Yes — new-harness support is the documented carve-out for third-party
integration. This mirrors the 14 existing per-harness ports; nothing here is
project- or team-specific.

## What alternatives did you consider?

1. **Documentation-only compat bet**: rely on ZCode's `CLAUDE_PLUGIN_ROOT`
   alias so the existing nested-output branch parses. Rejected as primary:
   fragile against compat-var removal, ships no explicit manifest/hooks wiring,
   and the shared `hooks/hooks.json` still fails ZCode's strict schema — so it
   wouldn't even fire. The native branch keeps the compat path as fallback.
2. **Standalone `superpowers-zcode` wrapper repo**: against contributor rules
   (wrappers get closed) and duplicates maintenance.
3. **Manifest-only, no new branch**: would force ZCode through the compat
   output shape forever and can't be asserted by shape-specific tests.

## Does this PR contain multiple unrelated changes?

No. Every non-manifest line (tests, version-bump entry, sync exclude, docs)
exists solely to support the ZCode port.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found (searched open + closed for "zcode")

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| ZCode Desktop | 3.8.1 | GLM-5.3 | glm-5.3 |

## New harness support (required if this PR adds a new harness)

<details>
<summary>Clean-session transcript #1 for "Let's make a react todo list"</summary>

```
[User] Let's make a react todo list

[ZCode agent] Working for 1m 10s

Thought for 5 seconds

Using brainstorming skill to help plan this React todo list project.

Ran skill: brainstorming

This looks like an architectural request — a new React project from
scratch. Let me explore the workspace first, then we'll design this
together.

( brainstorming questions follow — no code or scaffolding occurs before
  the design dialogue )
```

</details>

## Evaluation

- Initial prompt that led to this change: "this supports many IDEs/CLI agents
  but not ZCode — research how to add it" (human partner's real gap).
- Eval sessions AFTER the change: 4 (bootstrap smoke check ×2, acceptance test
  in two separate clean workspaces).
- Before: zero skill triggering in any ZCode session; the model had no
  knowledge of Superpowers at all. After: every new session receives the
  `using-superpowers` bootstrap, and the exact acceptance prompt auto-triggers
  `brainstorming` before any code is written, repeatably across workspaces.
- Automated checks: `tests/zcode/run-tests.sh`, extended
  `tests/hooks/test-session-start.sh` (7/7 pass incl. new ZCode shape +
  precedence case), `tests/kimi/`, `tests/devin/` regressions green;
  `scripts/bump-version.sh --check` consistent (jq path).

## Rigor

- [x] N/A — not a skills change: no `skills/*/SKILL.md` bodies are modified.
      The only skill-adjacent surface is infrastructure (manifest/hook/tests).
- [x] This change was tested adversarially, not just on the happy path —
      wrong-prompt variants, uninstalled-plugin state, and both-env-vars-set
      precedence were all exercised before landing the final wiring.
- [x] I did not modify carefully-tuned content (Red Flags tables,
      rationalizations, "human partner" language).

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission
