### PR TITLE
fix: detect Python package manager before poetry install in worktrees

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -111,8 +111,13 @@ if [ -f package.json ]; then npm install; fi
 if [ -f Cargo.toml ]; then cargo build; fi
 
 # Python
-if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-if [ -f pyproject.toml ]; then poetry install; fi
+if [ -f uv.lock ]; then
+  uv sync
+elif [ -f poetry.lock ] || grep -q '\[tool\.poetry\]' pyproject.toml 2>/dev/null; then
+  poetry install
+elif [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi
 
 # Go
 if [ -f go.mod ]; then go mod download; fi


### PR DESCRIPTION
> **This PR MUST target the `dev` branch, not `main`.** `main` is the
> released branch; active work lands on `dev` first. PRs opened against
> `main` will be asked to retarget `dev` before review.

Addresses #1108. Hatch/pdm/setuptools-only `pyproject.toml` and lockless uv still no-op, so this does not `Closes` the issue. A `dev` merge also will not auto-close it (default branch is `main`).

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Cursor Grok 4.6 |
| Harness + version | Cursor 3.17.8 |
| All plugins installed | No marketplace plugins. Superpowers not installed. Cursor built-in skills + gstack + frontend-design; MCP browser + Atlassian. |
| Human partner who reviewed this diff | szsunyuan |

## What problem are you trying to solve?

#1108: `using-git-worktrees` Step 2 runs `poetry install` for every `pyproject.toml`. Most modern Python projects use that file without Poetry (`uv`, hatch, pdm, setuptools, pip). On those trees the setup step fails (no Poetry) or installs the wrong environment. The reporter named the snippet; on `upstream/dev` (`fd02874`) it is still:

```
if [ -f pyproject.toml ]; then poetry install; fi
```

obra confirmed the bug is real when closing #1109 and invited a single scoped `dev` PR that completes this template.

## What does this PR change?

Gates the Python setup snippet only. `uv.lock` → `uv sync`. `poetry install` only when `poetry.lock` exists or `pyproject.toml` contains `[tool.poetry]`. Otherwise `requirements.txt` as before. Bare hatch/pdm/setuptools `pyproject.toml` is left alone.

## Is this change appropriate for the core library?

Yes. Every worktree setup on a Python repo hits this snippet. It does not add a dependency, a skill, or a third-party tool.

## What alternatives did you consider?

- Copy #1109 including `pip install -e .` for leftover `pyproject.toml` — rejected; that picks a package manager for hatch/pdm/setuptools.
- Copy #1106 (`uv.lock` / `poetry.lock` only) — rejected; misses a Poetry project that has `[tool.poetry]` but no committed lockfile.
- Take #1562’s Node lockfile rewrite in the same PR — rejected; different family, same file.
- A new grep test or `writing-skills` pressure sessions — rejected; #1593 died on a decorative grep test; Superpowers is not installed here and this is a setup-command gate, not Red Flags / walk-order.

## Does this PR contain multiple unrelated changes?

No. One Python block in one skill.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1106, #1562, #1109, #934

#1106 is still open against `main` and switches to lockfiles only (incomplete template). #1562 is still open against `main`, mostly Node lockfiles, and still does `elif pyproject.toml → poetry install`. #1109 implemented a broader detector including `pip install -e .` but was closed for process: wrong base (`main`), no official template, no identity table, no prior-art search, and a same-second scripted “review”; obra said the bug is real, #1108 stays open, and a single scoped `dev` PR that completes the template is welcome. #934 is a closed, unmerged Codex-worktree rewrite of the same skill (including a uv preference) against `main`; it is not this poetry-on-every-`pyproject.toml` slice. This PR targets `dev`, fills the template, discloses the authoring environment, changes only the Python block, and does not add `pip install -e .` or the Node rewrite.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Cursor | 3.17.8 | Grok 4.6 | Cursor Grok 4.6 |

Proof is `grep` of the snippet on `upstream/dev` (`fd02874`), not a live Superpowers session. Existing `tests/claude-code/test-worktree-path-policy.sh` still passes.

## New harness support (required if this PR adds a new harness)

Not applicable. This PR does not add support for a new harness.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

Not applicable: this PR does not add harness support.

</details>

## Evaluation

- What was the initial prompt you (or your human partner) used to start the session that led to this change?
  Triage of obra/superpowers for a next community PR; #1108 after claim-check against #1106 / #1562 / #1109.
- How many eval sessions did you run AFTER making the change?
  0 skill-behavior evals. Superpowers is not installed; `evals/` is not cloned.
- How did outcomes change compared to before the change?
  Before: any `pyproject.toml` ran `poetry install`. After: Poetry is lock-or-`[tool.poetry]` gated; `uv.lock` uses `uv sync`. We did not re-run Superpowers.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

This is the invited setup-snippet guard, not Red Flags / “human partner” / walk-order. Checking the first two boxes would be a lie.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission