### PR TITLE
fix(codex): derive spawns from live capabilities

### DIFF
--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -16,11 +16,15 @@ disagree.
 
 - **Spawning:** give children a clean context with
   `spawn_agent {fork_turns: "none"}`; the default `"all"` copies your
-  entire transcript into the child. On Codex 0.145+, role files under
-  `~/.codex/agents/` attach to isolated forks via `agent_type`.
-  Full-history forks accept `model` and `reasoning_effort` overrides
-  (only `agent_type` is refused there) — isolated forks are the SDD
-  default for context hygiene, not because overrides require them.
+  entire transcript into the child. Under MultiAgent V2 on Codex
+  0.148+, role files under `~/.codex/agents/` attach via `agent_type`
+  regardless of how much parent history is inherited. In Codex
+  0.149.1's live V2 contract, full-history forks (`fork_turns: "all"` or
+  omitted) inherit the parent model and reasoning effort by default and
+  do not accept per-call `model` or `reasoning_effort` overrides. To
+  select either explicitly, use `fork_turns: "none"` or a positive
+  integer string. Isolated forks remain the SDD default for context
+  hygiene.
 - **Fix rounds:** resume the implementer with `followup_task` — it
   delivers your message, triggers a turn, and transparently reloads a
   child the harness evicted. Never dispatch a fresh implementer on the
@@ -61,22 +65,32 @@ two-thirds of all wait calls were short polls that timed out.
 
 ## Model routing on spawns
 
-Every `spawn_agent` you issue — including when you are yourself a
-spawned child running a fan-out — sets `model` AND `reasoning_effort`
-explicitly, per the Model Selection rules of the skill you are
-executing. Setting `model` alone is a trap: the child's effort
-silently resets to that model's default, not to yours.
+Whenever a `spawn_agent` explicitly selects a model — including when
+you are yourself a spawned child running a fan-out — set `model` AND
+`reasoning_effort`, per the Model Selection rules of the skill you are
+executing. Setting `model` alone is a trap: the child's effort silently
+resets to that model's default, not to yours, unless a machine-level
+subagent-effort default or selected role supplies different routing.
+Under the verified Codex 0.149.1 live V2 contract, model and effort
+overrides in the call require `fork_turns: "none"` or a positive integer
+string; full-history calls must omit both. Without machine-level
+subagent defaults or role-specific routing, those full-history children
+inherit the parent's routing.
 
-Ask your human partner to add a machine-level backstop to
-`~/.codex/config.toml` so any spawn that slips through still routes to
-a deliberate tier instead of silently inheriting the session's most
-expensive model:
+If otherwise-unrouted children should use a deliberate default tier
+instead of silently inheriting the session's model, ask your human
+partner to add this to `~/.codex/config.toml`:
 
 ```toml
 [agents]
 default_subagent_model = "<a mid-tier model from your spawn allowlist>"
 default_subagent_reasoning_effort = "medium"
 ```
+
+These defaults also apply when a full-history call omits `model` and
+`reasoning_effort`, although a selected role can replace them. When a
+full-history child must truly inherit the parent's model and effort, do
+not set these defaults or select a role that changes routing.
 
 ## Environment Detection
 

--- a/skills/using-superpowers/references/codex-tools.md
+++ b/skills/using-superpowers/references/codex-tools.md
@@ -9,36 +9,53 @@ multi_agent = true
 
 This enables the multi-agent tools that skills like
 `dispatching-parallel-agents` and `subagent-driven-development` use.
-Which tools you get depends on the multi-agent version your model
-preset selects (current presets run V2; older ones run V1). Trust your
-actual tool list over any table — including this one — when they
-disagree.
+The exact multi-agent contract can depend on the current model preset
+and configuration. Trust the live tool declaration and current-session
+usage hints over version numbers, old sessions, and this reference.
+`codex --version` alone is not capability detection.
 
-- **Spawning:** give children a clean context with
-  `spawn_agent {fork_turns: "none"}`; the default `"all"` copies your
-  entire transcript into the child. Under MultiAgent V2 on Codex
-  0.148+, role files under `~/.codex/agents/` attach via `agent_type`
-  regardless of how much parent history is inherited. In Codex
-  0.149.1's live V2 contract, full-history forks (`fork_turns: "all"` or
-  omitted) inherit the parent model and reasoning effort by default and
-  do not accept per-call `model` or `reasoning_effort` overrides. To
-  select either explicitly, use `fork_turns: "none"` or a positive
-  integer string. Isolated forks remain the SDD default for context
-  hygiene.
-- **Fix rounds:** resume the implementer with `followup_task` — it
-  delivers your message, triggers a turn, and transparently reloads a
-  child the harness evicted. Never dispatch a fresh implementer on the
-  theory that a spawned agent cannot be messaged again; on V2 it
-  always can.
-- **Lifecycle:** V2 has no `close_agent`. Finished children are
-  evicted automatically when slots are needed; leaving them unclosed
-  costs nothing. Only V1 sessions have `close_agent` — there, close
-  reviewers when their review returns, and close each implementer
-  after its task's review passes.
+- **Spawning:** prefer a clean context with the no-history form exposed
+  by the live spawn tool (for example, `fork_turns: "none"` when that
+  value is listed). If no context control is exposed, follow the tool's
+  fixed semantics and the unavailable-mode rule below.
+  Use partial or full-history forks only when the task needs inherited
+  context, then add role and routing fields only when the live contract
+  permits that combination. Isolated forks remain the SDD default for
+  context hygiene.
+- **Fix rounds:** when the live tools expose `followup_task` with
+  turn-triggering or reload behavior, use it to resume the implementer.
+  Do not dispatch a replacement merely because a child is no longer
+  resident; follow the live tool description for resumption behavior.
+- **Lifecycle:** use only the lifecycle controls in the live tool list.
+  Do not invent `close_agent` when it is absent. When it is exposed,
+  follow its current description and close completed agents at the
+  documented point.
 - **Model names:** never copy a model name from a skill, table, or old
   session into `spawn_agent` without checking it against your current
-  spawn allowlist — V2 accepts only V2-capable presets and hard-errors
-  on the rest.
+  spawn allowlist. Unlisted names may hard-error.
+
+## Constructing spawns from live capabilities
+
+Before every spawn, read the live `spawn_agent` fields and values plus
+any current-session usage hint and selected-role constraints. The tool
+declaration says which fields exist; the hints and role descriptions
+may impose stricter cross-field rules. Never invent an absent field or
+override a declared fixed role setting.
+
+| Requirement | Call shape |
+|---|---|
+| Clean context | If exposed, use the live no-history form. Add role/model/effort only if exposed and compatible. Otherwise apply the unavailable-mode rule. |
+| Limited recent context | Use a positive turn count only if the live fork field supports it. Choose the actual bounded count needed; never use a guessed huge number as a surrogate for full history. Otherwise apply the unavailable-mode rule. |
+| Full history | If exposed, use the live full-history form. Add `agent_type`, `model`, or `reasoning_effort` only if the live contract explicitly permits each with full history. Otherwise apply the unavailable-mode rule. |
+| Full history plus an incompatible role or routing override | One call cannot satisfy both requirements. Keep full history and omit the incompatible override, or use a clean/partial fork and put the required context in the exposed task-instruction field (`message` in the current contract). Use partial history only when the needed bounded turn count is known; otherwise use a clean fork with self-contained instructions. Follow the task's stated priority; if none is stated, ask rather than silently changing it. |
+| Requested context mode unavailable | Use only the exposed or fixed context semantics. Put needed context in the exposed task-instruction field (`message` in the current contract) when self-contained instructions preserve the requirements. If the available mode would violate a required isolation or inheritance boundary, follow the task's stated priority; if none is stated, ask. |
+
+Only treat a rejection as newer capability evidence when the error
+explicitly identifies an unsupported field, value, or cross-field
+combination. Rebuild that payload instead of retrying it or inferring a
+rule from the version string. Slot exhaustion, task-name errors, and
+other operational failures are not capability evidence; handle them by
+their own documented semantics.
 
 ## Waiting on children
 
@@ -65,21 +82,19 @@ two-thirds of all wait calls were short polls that timed out.
 
 ## Model routing on spawns
 
-Whenever a `spawn_agent` explicitly selects a model — including when
-you are yourself a spawned child running a fan-out — set `model` AND
-`reasoning_effort`, per the Model Selection rules of the skill you are
-executing. Setting `model` alone is a trap: the child's effort silently
-resets to that model's default, not to yours, unless a machine-level
-subagent-effort default or selected role supplies different routing.
-Under the verified Codex 0.149.1 live V2 contract, model and effort
-overrides in the call require `fork_turns: "none"` or a positive integer
-string; full-history calls must omit both. Without machine-level
-subagent defaults or role-specific routing, those full-history children
-inherit the parent's routing.
+When the live contract permits explicit model routing — including from
+a spawned child running a fan-out — choose a model from its current
+allowlist. If `reasoning_effort` is exposed, not fixed by the selected
+role, and permitted with that model by the live cross-field rules, set
+it explicitly with `model`; do not assume an omitted effort inherits
+yours. If any of those conditions fails, omit the conflicting override
+and follow the declared effective route.
+This Codex-specific rule overrides generic skill text or spawn templates
+that require an explicit model on every call.
 
-If otherwise-unrouted children should use a deliberate default tier
-instead of silently inheriting the session's model, ask your human
-partner to add this to `~/.codex/config.toml`:
+If the current Codex config reference still exposes these keys and
+otherwise-unrouted children should use a deliberate default tier, ask
+your human partner to add this to `~/.codex/config.toml`:
 
 ```toml
 [agents]
@@ -87,10 +102,11 @@ default_subagent_model = "<a mid-tier model from your spawn allowlist>"
 default_subagent_reasoning_effort = "medium"
 ```
 
-These defaults also apply when a full-history call omits `model` and
-`reasoning_effort`, although a selected role can replace them. When a
-full-history child must truly inherit the parent's model and effort, do
-not set these defaults or select a role that changes routing.
+Machine defaults may affect calls that omit routing, and a selected
+role may replace them. Confirm precedence against the current config
+and role descriptions. When a child must truly inherit the parent's
+model and effort, do not configure child-routing defaults or select a
+role that changes routing.
 
 ## Environment Detection
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | OpenAI Codex GPT-5 (the exact model snapshot is not exposed to this session) |
| Harness + version | Codex CLI 0.149.1, API-orchestrated coding session |
| All plugins installed | Superpowers 6.3.0; Codex Security 0.1.22; Plugin Management 0.1.0 |
| Human partner who reviewed this diff | GitHub user `smtmfft`; reviewed the complete updated diff in-session and explicitly approved the PR update |

## What problem are you trying to solve?

The Codex reference encoded a moving spawn contract as fixed version-specific rules. The original text said full-history forks accept per-call `model` and `reasoning_effort` overrides but refuse `agent_type`; the currently observed contract has the opposite cross-field restriction. Either snapshot can become stale again as Codex changes.

The effective contract is exposed by the current session: the live `spawn_agent` fields and allowlists, current-session cross-field usage hints, and selected-role constraints. Depending on the preset and configuration, those capabilities can differ even when the CLI version string is the same. Following a version-pinned reference can therefore produce rejected calls, omit supported fields, or force an agent to guess an invalid compatibility path.

## What does this PR change?

It updates `skills/using-superpowers/references/codex-tools.md` to:

- construct spawn payloads from the live schema, session hints, role constraints, and allowlists instead of a Codex version table;
- handle clean, bounded, full-history, fixed-context, and unavailable-context modes without inventing fields or using a guessed huge turn count;
- resolve incompatible context, role, and routing requirements explicitly, preserving task priorities or asking when no valid call can satisfy them;
- distinguish explicit capability errors from operational failures such as slot exhaustion or task-name rejection;
- make model/effort routing conditional on the live cross-field contract and override generic templates that demand unsupported fields;
- make adjacent resumption, lifecycle, model-name, and config-default guidance capability-driven.

## Is this change appropriate for the core library?

Yes. This is a factual correction to the core Codex runtime reference used by every Superpowers installation on that harness. It adds no dependency, local compatibility layer, or machine-specific configuration.

## What alternatives did you consider?

- **Patch the installed plugin cache locally.** Rejected because the cache is managed generated state and would be overwritten by reinstall/update.
- **Switch on `codex --version`.** Rejected because the live surface can also depend on preset, configuration, role, and session-provided cross-field constraints. A version branch would merely move the next stale boundary.
- **Hard-code the currently observed 0.149.1 contract.** Rejected because it fixes today's mismatch but fails the next time a compatible combination changes.
- **Delete the model-routing section.** Rejected because allowlists, role-fixed routing, and config precedence remain useful when stated conditionally.

## Does this PR contain multiple unrelated changes?

No. It changes one reference file and only the statements directly affected by the fork-routing contract.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2060, #2062, #2088

Searches covered open and closed PRs containing `fork_turns`, `full-history`, `agent_type`, and `reasoning_effort`. #2060 and #2062 introduced the older source-verified behavior this PR updates. #2088 also touches `codex-tools.md`, but only for post-compaction re-grounding and does not change fork parameter compatibility.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI | 0.149.1 | OpenAI Codex GPT-5 | Exact snapshot not exposed |

Source boundaries were cross-checked against the tagged Codex 0.147, 0.148, and 0.149.1 MultiAgent handlers. The actual 0.149.1 tool surface was inspected and a real full-history `reviewer` role spawn succeeded. These versions are reproduction evidence only; they are not used as the runtime decision mechanism.

Validation run:

```text
skill-creator quick_validate skills/using-superpowers
git diff --check
bash tests/codex/test-marketplace-manifest.sh
env TZ=UTC bash tests/codex/test-package-codex-plugin.sh
```

All passed. The package suite was run in a full clone carrying byte-identical changed file content and finished with `All Codex package archive tests passed` and exit code 0.

## New harness support (required if this PR adds a new harness)

Not applicable. Codex is already supported; this PR only corrects its existing reference.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```text
Not applicable: this PR does not add a harness or change session startup.
```

</details>

## Evaluation

The initial user request was to self-check the newly installed agents and plugins, especially whether Superpowers worked correctly. The audit found this reference/live-contract mismatch, and the user requested an upstream fix rather than a local cache patch.

### RED: version-scoped reference

Three fresh isolated sessions exercised synthetic contracts against the version-scoped draft:

1. The current-like contract served as the control and could construct the expected payload.
2. A future contract that permits role, model, and effort together with full history had to ignore the hard-coded prohibition to make a valid call.
3. A reversed contract that permits full-history routing but not a role guessed a huge positive turn count to approximate full history when asked for a reviewer, because the reference had no safe incompatibility path.

### Runtime probe

A real `fork_turns: "all"` plus `agent_type: "reviewer"` spawn succeeded under Codex CLI 0.149.1. The child reported the independent adversarial reviewer instructions, confirming that the role was applied rather than merely accepted syntactically.

### GREEN and pressure testing

**Eval sessions run AFTER the capability-driven change: 5 fresh isolated sessions, with follow-up rechecks after review fixes.** The final A-I matrix covered:

- legacy `fork_context` with no role field;
- the current-like full-history-role and partial-routing combinations;
- the reversed full-history-routing/no-role combination;
- a future contract where every field is compatible with every fork mode;
- fixed clean and fixed full-history contracts with no context-control field;
- slot exhaustion versus an explicit unsupported cross-field error;
- a future task-instruction field renamed from `message` to `prompt`;
- exposed model and effort fields whose live cross-field rules forbid pairing them.

Pressure testing and independent review drove hardening for unavailable context modes, operational-error classification, generic template precedence, renamed task fields, and model/effort compatibility. The same reviewer re-read every fix and returned `Ready to merge: Yes` with no unresolved findings.

Dedicated dollar cost was not exposed by the harness.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

No Red Flags table or rationalization list was changed. One existing human-partner configuration sentence was made conditional; its terminology and intent were preserved, and the routing/config path was included in the evals.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

The complete updated one-file diff was shown in-session. The human partner explicitly approved it before the commit, push, and PR-update steps were performed.
