### PR TITLE
fix(opencode): skip controller bootstrap in task subagent sessions (#2160)

### DIFF
--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -68,23 +68,56 @@ let _bootstrapCache = undefined; // undefined = not yet loaded, null = file miss
 // agent step) pays only one client roundtrip per session.
 const _childSessionCache = new Map();
 
+// sessionIDs whose lookup failure has already been logged. Failed lookups are
+// deliberately not cached (so they can recover), which means the hook retries
+// every step; without this guard a persistently failing session would log an
+// error on every single step.
+const _lookupFailureLogged = new Set();
+
+const logLookupFailure = (sessionID, reason) => {
+  if (_lookupFailureLogged.has(sessionID)) return;
+  _lookupFailureLogged.add(sessionID);
+  console.error('[superpowers] session lookup failed, treating session as top-level:', reason);
+};
+
 const isChildSession = async (fetchSession, sessionID) => {
   if (!sessionID) return false; // unknown session: keep current behavior
   if (_childSessionCache.has(sessionID)) return _childSessionCache.get(sessionID);
 
-  let isChild = false;
+  let result;
   try {
-    const result = await fetchSession(sessionID);
-    // The V1 SDK returns { data: Session } rather than the record itself.
-    const session = result && typeof result === 'object' && result.data && typeof result.data === 'object' && !('parentID' in result)
-      ? result.data
-      : result;
-    isChild = Boolean(session && typeof session === 'object' && session.parentID);
+    result = await fetchSession(sessionID);
   } catch (err) {
     // Fail open: on lookup errors keep injecting (previous behavior) and do
     // not cache, so a transient failure can recover on the next step.
-    console.error('[superpowers] session lookup failed, treating session as top-level:', err);
+    logLookupFailure(sessionID, err);
     return false;
+  }
+
+  // The V1 SDK only throws on non-2xx when called with { throwOnError: true }
+  // (sdk error-interceptor.ts); without it an error resolves as
+  // { data: undefined, error, response } and never reaches the catch above.
+  // Treat that shape as a lookup failure too and never cache it — otherwise
+  // one transient error would pin a child session as top-level for its whole
+  // life and re-inject the controller bootstrap every step (#2160).
+  if (!result || (typeof result === 'object' && result.error)) {
+    logLookupFailure(sessionID, result && result.error ? result.error : result);
+    return false;
+  }
+
+  // The V1 SDK returns { data: Session }; V2's ctx returns the record itself.
+  // Prefer .data whenever it is a non-null object — Session records have no
+  // `data` field, so the shapes stay unambiguous even if the envelope happens
+  // to carry its own parentID key.
+  const session = result && typeof result === 'object' && result.data && typeof result.data === 'object'
+    ? result.data
+    : result;
+  const isChild = Boolean(session && typeof session === 'object' && session.parentID);
+
+  if (isChild) {
+    // One-time visibility: a missing bootstrap in a subagent session should
+    // be explainable from the logs instead of failing silently.
+    console.log('[superpowers] skipping controller bootstrap for task subagent session:', sessionID);
   }
   _childSessionCache.set(sessionID, isChild);
   return isChild;
@@ -175,7 +208,10 @@ ${toolMapping}
       // 1.18.x bundle: trigger(..., {}, {messages})), so take the sessionID
       // from the message record itself.
       if (client && await isChildSession(
-        (id) => client.session.get({ path: { id } }),
+        // throwOnError makes the SDK throw on non-2xx so HTTP errors reach
+        // the catch path; isChildSession's result.error check still covers
+        // versions/callers that ignore the flag.
+        (id) => client.session.get({ path: { id } }, { throwOnError: true }),
         firstUser.info.sessionID,
       )) return;
 

--- a/.opencode/plugins/superpowers.js
+++ b/.opencode/plugins/superpowers.js
@@ -52,6 +52,44 @@ const normalizePath = (p, homeDir) => {
 // every agent step.  See #1202 for the full analysis.
 let _bootstrapCache = undefined; // undefined = not yet loaded, null = file missing
 
+// --- Task-subagent (child session) detection --------------------------------
+//
+// #2160: the bootstrap drives controller workflows (brainstorming, planning,
+// approval cycles). Injecting it into task subagent sessions makes workers
+// restart design/approval cycles for work the parent already authorised; the
+// <SUBAGENT-STOP> note inside the bootstrap relies on model compliance, which
+// is not reliable. Detect child sessions structurally instead: OpenCode task
+// sessions are created with a parentID, so when the session carrying the
+// message has a parentID we skip bootstrap injection. Skills stay registered
+// for every session — workers keep explicit access to execution skills.
+
+// sessionID -> is-child decision. parentID never changes for a session, so
+// the result is cached for life and the injection hook (which fires on every
+// agent step) pays only one client roundtrip per session.
+const _childSessionCache = new Map();
+
+const isChildSession = async (fetchSession, sessionID) => {
+  if (!sessionID) return false; // unknown session: keep current behavior
+  if (_childSessionCache.has(sessionID)) return _childSessionCache.get(sessionID);
+
+  let isChild = false;
+  try {
+    const result = await fetchSession(sessionID);
+    // The V1 SDK returns { data: Session } rather than the record itself.
+    const session = result && typeof result === 'object' && result.data && typeof result.data === 'object' && !('parentID' in result)
+      ? result.data
+      : result;
+    isChild = Boolean(session && typeof session === 'object' && session.parentID);
+  } catch (err) {
+    // Fail open: on lookup errors keep injecting (previous behavior) and do
+    // not cache, so a transient failure can recover on the next step.
+    console.error('[superpowers] session lookup failed, treating session as top-level:', err);
+    return false;
+  }
+  _childSessionCache.set(sessionID, isChild);
+  return isChild;
+};
+
 export const SuperpowersPlugin = async ({ client, directory }) => {
   const homeDir = os.homedir();
   const superpowersSkillsDir = path.resolve(__dirname, '../../skills');
@@ -131,6 +169,15 @@ ${toolMapping}
       // This prevents double injection when OpenCode passes an already
       // transformed in-memory message array through the hook again.
       if (firstUser.parts.some(p => p.type === 'text' && p.text.includes('EXTREMELY_IMPORTANT'))) return;
+
+      // #2160: never restart the controller workflow inside task subagent
+      // (child) sessions. V1 passes no input to this hook (verified in the
+      // 1.18.x bundle: trigger(..., {}, {messages})), so take the sessionID
+      // from the message record itself.
+      if (client && await isChildSession(
+        (id) => client.session.get({ path: { id } }),
+        firstUser.info.sessionID,
+      )) return;
 
       const ref = firstUser.parts[0];
       firstUser.parts.unshift({ ...ref, type: 'text', text: bootstrap });

--- a/tests/opencode/run-tests.sh
+++ b/tests/opencode/run-tests.sh
@@ -45,6 +45,7 @@ while [[ $# -gt 0 ]]; do
             echo "Tests:"
             echo "  test-plugin-loading.sh  Verify plugin installation and structure"
             echo "  test-bootstrap-caching.sh  Verify bootstrap content caching"
+            echo "  test-child-session-gate.sh  Verify child session bootstrap gating (#2160)"
             echo "  test-tools.sh           Test use_skill and find_skills tools (integration)"
             echo "  test-priority.sh        Test skill priority resolution (integration)"
             exit 0
@@ -61,6 +62,7 @@ done
 tests=(
     "test-plugin-loading.sh"
     "test-bootstrap-caching.sh"
+    "test-child-session-gate.sh"
 )
 
 # Integration tests (require OpenCode)

--- a/tests/opencode/test-child-session-gate.mjs
+++ b/tests/opencode/test-child-session-gate.mjs
@@ -1,0 +1,267 @@
+import { pathToFileURL } from 'url';
+
+// Test: Child session gate (#2160)
+//
+// Drives the plugin's experimental.chat.messages.transform with a mock
+// client to verify the #2160 child-session gate:
+//   - child sessions (parentID set) never receive the controller bootstrap
+//   - top-level sessions and degenerate shapes still receive it
+//   - lookup failures fail open, are NOT cached, and recover next step
+//   - session.get is called with { throwOnError: true }
+//   - skip/error decisions are logged exactly once per session
+//
+// Usage: node test-child-session-gate.mjs PLUGIN_PATH CASE_NAME
+
+const [, , pluginPath, caseName] = process.argv;
+
+const cases = {
+  'skip-child-envelope': skipChildEnvelope,
+  'inject-top-level-envelope': injectTopLevelEnvelope,
+  'skip-child-bare-record': skipChildBareRecord,
+  'skip-child-envelope-parentid-key': skipChildEnvelopeParentIDKey,
+  'error-tuple-fail-open-uncached': errorTupleFailOpenUncached,
+  'throw-fail-open-uncached': throwFailOpenUncached,
+  'transient-error-recovers': transientErrorRecovers,
+  'degenerate-shapes-inject': degenerateShapesInject,
+};
+
+if (!pluginPath || !cases[caseName]) {
+  console.error(`Usage: node test-child-session-gate.mjs PLUGIN_PATH ${Object.keys(cases).join('|')}`);
+  process.exit(2);
+}
+
+// Capture plugin console output ([superpowers] lines) instead of printing it.
+const capturedLogs = [];
+const capturedErrors = [];
+const originalLog = console.log;
+const originalError = console.error;
+console.log = (...args) => capturedLogs.push(args.map(String).join(' '));
+console.error = (...args) => capturedErrors.push(args.map(String).join(' '));
+
+const failures = [];
+const superpowersLines = () => [...capturedLogs, ...capturedErrors]
+  .filter((line) => line.includes('[superpowers]'));
+const skipLogs = () => superpowersLines().filter((line) => line.includes('skipping'));
+const errorLogs = () => superpowersLines().filter((line) => line.includes('lookup failed'));
+
+try {
+  await cases[caseName]();
+} catch (err) {
+  failures.push(`unexpected exception: ${err && err.stack ? err.stack : String(err)}`);
+} finally {
+  console.log = originalLog;
+  console.error = originalError;
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) console.error(`FAIL: ${failure}`);
+  process.exit(1);
+}
+
+console.log(`PASS: ${caseName}`);
+
+// --- helpers -----------------------------------------------------------------
+
+function makeClient(respond) {
+  const calls = [];
+  const client = {
+    session: {
+      get: async (arg, opts) => {
+        const id = arg && arg.path && arg.path.id;
+        calls.push({ id, opts });
+        const shaped = respond(id, calls.length);
+        if (shaped && shaped.__throw) throw shaped.__throw;
+        return shaped;
+      },
+    },
+  };
+  return { client, calls };
+}
+
+function makeOutput(sessionID, text) {
+  return {
+    messages: [{
+      info: { role: 'user', sessionID },
+      parts: [{ type: 'text', text }],
+    }],
+  };
+}
+
+function countBootstrapParts(output) {
+  return output.messages[0].parts.filter(
+    (part) => part.type === 'text' && part.text.includes('EXTREMELY_IMPORTANT'),
+  ).length;
+}
+
+function expect(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+async function loadPlugin(client) {
+  const mod = await import(pathToFileURL(pluginPath).href);
+  const plugin = await mod.SuperpowersPlugin({ client, directory: '.' });
+  return plugin['experimental.chat.messages.transform'];
+}
+
+function expectThrowOnError(calls, caseLabel) {
+  const without = calls.filter((call) => !(call.opts && call.opts.throwOnError === true));
+  expect(
+    without.length === 0,
+    `${caseLabel}: expected every session.get call to pass { throwOnError: true }, ${without.length} call(s) did not`,
+  );
+}
+
+// --- cases -------------------------------------------------------------------
+
+// Child session via the V1 SDK envelope { data: Session }: no injection on any
+// step, one cached lookup, one visibility log.
+async function skipChildEnvelope() {
+  const { client, calls } = makeClient(() => ({ data: { id: 'sess-child', parentID: 'sess-parent' } }));
+  const transform = await loadPlugin(client);
+
+  const step1 = makeOutput('sess-child', 'child session first step');
+  const step2 = makeOutput('sess-child', 'child session second step');
+  await transform({}, step1);
+  await transform({}, step2);
+
+  expect(countBootstrapParts(step1) === 0, `expected no bootstrap in child session step 1, got ${countBootstrapParts(step1)}`);
+  expect(countBootstrapParts(step2) === 0, `expected no bootstrap in child session step 2, got ${countBootstrapParts(step2)}`);
+  expect(calls.length === 1, `expected the child decision to be cached after one lookup, got ${calls.length} lookups`);
+  expect(skipLogs().length === 1, `expected exactly one skip log line, got ${skipLogs().length}`);
+  expectThrowOnError(calls, 'skip-child-envelope');
+}
+
+// Top-level session via the V1 SDK envelope: injection on fresh message
+// arrays, one cached lookup, no skip log.
+async function injectTopLevelEnvelope() {
+  const { client, calls } = makeClient(() => ({ data: { id: 'sess-top' } }));
+  const transform = await loadPlugin(client);
+
+  const step1 = makeOutput('sess-top', 'top-level first step');
+  const step2 = makeOutput('sess-top', 'top-level second step');
+  await transform({}, step1);
+  await transform({}, step2);
+
+  expect(countBootstrapParts(step1) === 1, `expected bootstrap in top-level session step 1, got ${countBootstrapParts(step1)}`);
+  expect(countBootstrapParts(step2) === 1, `expected bootstrap in top-level session step 2, got ${countBootstrapParts(step2)}`);
+  expect(calls.length === 1, `expected the top-level decision to be cached after one lookup, got ${calls.length} lookups`);
+  expect(skipLogs().length === 0, `expected no skip log for top-level session, got ${skipLogs().length}`);
+}
+
+// Child session via a bare V2-style record: no injection.
+async function skipChildBareRecord() {
+  const { client, calls } = makeClient(() => ({ id: 'sess-child-v2', parentID: 'sess-parent' }));
+  const transform = await loadPlugin(client);
+
+  const step = makeOutput('sess-child-v2', 'v2 child session step');
+  await transform({}, step);
+
+  expect(countBootstrapParts(step) === 0, `expected no bootstrap in bare-record child session, got ${countBootstrapParts(step)}`);
+  expect(calls.length === 1, `expected exactly one lookup, got ${calls.length}`);
+  expect(skipLogs().length === 1, `expected exactly one skip log line, got ${skipLogs().length}`);
+}
+
+// Envelope that carries its own parentID key (even undefined) must not
+// defeat detection of data.parentID (#2160 review finding: heuristic hole).
+async function skipChildEnvelopeParentIDKey() {
+  const { client, calls } = makeClient(() => ({ parentID: undefined, data: { id: 'sess-hole', parentID: 'sess-parent' } }));
+  const transform = await loadPlugin(client);
+
+  const step1 = makeOutput('sess-hole', 'envelope hole first step');
+  const step2 = makeOutput('sess-hole', 'envelope hole second step');
+  await transform({}, step1);
+  await transform({}, step2);
+
+  expect(countBootstrapParts(step1) === 0, `expected no bootstrap when envelope carries its own parentID key, got ${countBootstrapParts(step1)}`);
+  expect(countBootstrapParts(step2) === 0, `expected no bootstrap on step 2 for parentID-key envelope, got ${countBootstrapParts(step2)}`);
+  expect(calls.length === 1, `expected exactly one lookup, got ${calls.length}`);
+  expect(skipLogs().length === 1, `expected exactly one skip log line, got ${skipLogs().length}`);
+}
+
+// Non-2xx without throwOnError resolves as { data: undefined, error, response }.
+// That must fail open (inject), NOT poison the cache, and log once — the exact
+// regression from the #2160 review: one transient error would otherwise pin a
+// child session as top-level for its whole life.
+async function errorTupleFailOpenUncached() {
+  const { client, calls } = makeClient(() => ({ data: undefined, error: { name: 'NotFound' }, response: { status: 404 } }));
+  const transform = await loadPlugin(client);
+
+  const steps = [
+    makeOutput('sess-tuple-err', 'tuple error step 1'),
+    makeOutput('sess-tuple-err', 'tuple error step 2'),
+    makeOutput('sess-tuple-err', 'tuple error step 3'),
+  ];
+  for (const step of steps) await transform({}, step);
+
+  steps.forEach((step, i) => {
+    expect(countBootstrapParts(step) === 1, `expected fail-open bootstrap on tuple-error step ${i + 1}, got ${countBootstrapParts(step)}`);
+  });
+  expect(calls.length === 3, `expected failed lookups to stay uncached (3 retries), got ${calls.length} lookups`);
+  expect(errorLogs().length === 1, `expected exactly one lookup-failure log line, got ${errorLogs().length}`);
+  expectThrowOnError(calls, 'error-tuple-fail-open-uncached');
+}
+
+// A rejecting lookup must fail open, stay uncached, and log once (not per step).
+async function throwFailOpenUncached() {
+  const { client, calls } = makeClient(() => ({ __throw: new Error('network unreachable') }));
+  const transform = await loadPlugin(client);
+
+  const steps = [
+    makeOutput('sess-throw', 'throw step 1'),
+    makeOutput('sess-throw', 'throw step 2'),
+    makeOutput('sess-throw', 'throw step 3'),
+  ];
+  for (const step of steps) await transform({}, step);
+
+  steps.forEach((step, i) => {
+    expect(countBootstrapParts(step) === 1, `expected fail-open bootstrap on throw step ${i + 1}, got ${countBootstrapParts(step)}`);
+  });
+  expect(calls.length === 3, `expected failed lookups to stay uncached (3 retries), got ${calls.length} lookups`);
+  expect(errorLogs().length === 1, `expected exactly one lookup-failure log line (not one per step), got ${errorLogs().length}`);
+  expectThrowOnError(calls, 'throw-fail-open-uncached');
+}
+
+// One transient failure followed by a successful child lookup: bootstrap on
+// the failing step, skip afterwards, no cache poisoning from the failure.
+async function transientErrorRecovers() {
+  const { client, calls } = makeClient((_id, callIndex) => (
+    callIndex === 1
+      ? { __throw: new Error('transient') }
+      : { data: { id: 'sess-recover', parentID: 'sess-parent' } }
+  ));
+  const transform = await loadPlugin(client);
+
+  const step1 = makeOutput('sess-recover', 'transient failure step');
+  const step2 = makeOutput('sess-recover', 'recovered step');
+  const step3 = makeOutput('sess-recover', 'steady state step');
+  await transform({}, step1);
+  await transform({}, step2);
+  await transform({}, step3);
+
+  expect(countBootstrapParts(step1) === 1, `expected fail-open bootstrap on the failing step, got ${countBootstrapParts(step1)}`);
+  expect(countBootstrapParts(step2) === 0, `expected no bootstrap after recovery to a child session, got ${countBootstrapParts(step2)}`);
+  expect(countBootstrapParts(step3) === 0, `expected no bootstrap in steady state, got ${countBootstrapParts(step3)}`);
+  expect(calls.length === 2, `expected exactly two lookups (failed + recovered), got ${calls.length}`);
+  expect(errorLogs().length === 1, `expected exactly one lookup-failure log line, got ${errorLogs().length}`);
+  expect(skipLogs().length === 1, `expected exactly one skip log line, got ${skipLogs().length}`);
+}
+
+// Degenerate response shapes must keep injecting (fail-open to top-level).
+async function degenerateShapesInject() {
+  const shapes = [
+    ['sess-degenerate-null', () => ({ data: null })],
+    ['sess-degenerate-parent-null', () => ({ data: { parentID: null } })],
+    ['sess-degenerate-parent-empty', () => ({ data: { parentID: '' } })],
+    ['sess-degenerate-undefined', () => undefined],
+  ];
+
+  let index = 0;
+  for (const [sessionID, respond] of shapes) {
+    index += 1;
+    const { client } = makeClient(respond);
+    const transform = await loadPlugin(client);
+    const step = makeOutput(sessionID, `degenerate shape ${index}`);
+    await transform({}, step);
+    expect(countBootstrapParts(step) === 1, `expected bootstrap for degenerate shape ${index} (${sessionID}), got ${countBootstrapParts(step)}`);
+  }
+}

--- a/tests/opencode/test-child-session-gate.sh
+++ b/tests/opencode/test-child-session-gate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Test: Task-subagent child session gate (#2160)
+# Verifies bootstrap injection skips child (task subagent) sessions, fails
+# open without caching on lookup errors, and logs each decision once.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== Test: Child Session Gate (#2160) ==="
+
+source "$SCRIPT_DIR/setup.sh"
+trap cleanup_test_env EXIT
+
+run_case() {
+    node "$SCRIPT_DIR/test-child-session-gate.mjs" "$SUPERPOWERS_PLUGIN_FILE" "$1"
+}
+
+echo "Test 1: Skips bootstrap in child sessions (V1 envelope)..."
+run_case skip-child-envelope
+echo "  [PASS] Child session gets no controller bootstrap; decision cached; logged once"
+
+echo "Test 2: Injects bootstrap in top-level sessions (V1 envelope)..."
+run_case inject-top-level-envelope
+echo "  [PASS] Top-level session keeps receiving bootstrap on fresh message arrays"
+
+echo "Test 3: Skips bootstrap in child sessions (bare V2-style record)..."
+run_case skip-child-bare-record
+echo "  [PASS] Bare-record child session detected without an envelope"
+
+echo "Test 4: Envelope carrying its own parentID key is still detected as child..."
+run_case skip-child-envelope-parentid-key
+echo "  [PASS] data.parentID wins over a parentID key on the envelope"
+
+echo "Test 5: Non-2xx result tuple fails open, uncached, logged once..."
+run_case error-tuple-fail-open-uncached
+echo "  [PASS] {data: undefined, error} never poisons the child-session cache (#2160 review finding)"
+
+echo "Test 6: Rejecting lookup fails open, uncached, logged once..."
+run_case throw-fail-open-uncached
+echo "  [PASS] Thrown lookup errors keep injecting without per-step log spam"
+
+echo "Test 7: Transient lookup failure recovers on the next step..."
+run_case transient-error-recovers
+echo "  [PASS] Fail-open bootstrap on failure, child skip after recovery"
+
+echo "Test 8: Degenerate response shapes keep injecting..."
+run_case degenerate-shapes-inject
+echo "  [PASS] {data: null}, {data: {parentID: null}}, {data: {parentID: ''}}, undefined all inject"
+
+echo ""
+echo "=== All child session gate tests passed ==="


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GLM-5.3 (zhipuai-coding-plan/glm-5.3) as orchestrator, with one explorer subagent (same model) for API-surface investigation |
| Harness + version | OpenCode V1 (`opencode` 1.18.25) |
| All plugins installed | `superpowers` (working copy of this PR's branch), `oh-my-opencode-slim` (local dist); MCP servers: `exa` (remote), `gh_grep` (remote); `websearch` MCP disabled in config |
| Human partner who reviewed this diff | @GoldJohnKing — reviewed the complete diff in-session across multiple rounds (bug attribution to the V1-era code, split-vs-bundle decision, child-session semantics, `<SUBAGENT-STOP>` retention analysis) and explicitly directed the branch split, push, and this PR |

## What problem are you trying to solve?

#2160. The OpenCode plugin injects the full `using-superpowers` bootstrap into **every** session's first user message, including task subagent (child) sessions. The only guard is the `<SUBAGENT-STOP>` note inside the bootstrap text, which depends on the worker model noticing it and giving it precedence over the strongly-worded skill-first instructions that follow. The reporter reproduced a worker receiving an already-approved atomic implementation task and starting a new `brainstorming` design/approval cycle instead of executing it (OpenCode 1.18.18, Qwen3.6-35B-A3B primary / Muse-Glimmer-30B worker). A collaborator confirmed the diagnosis in the issue.

Verification performed before writing the fix (all against `dev`'s plugin and a live 1.18.25 server):

- **Code**: `experimental.chat.messages.transform` finds the first user message and unshifts the bootstrap with no session discrimination whatsoever.
- **Runtime API**: the 1.18.x bundle invokes the hook as `trigger("experimental.chat.messages.transform", {}, {messages})` — the input is literally empty; the plugin receives zero session identity, so the current code *cannot* distinguish a child session even in principle.
- **Storage**: task children are created as sessions with `parentID` (verified in the TaskTool code embedded in the bundle, and in the local session DB: the subagent sessions dispatched during this very investigation carry `parent_id`).

So the bug is real, structural, and V1-era: it exists on `dev` independent of any V2 work. The reporter's environment was V1.

## What does this PR change?

Before injecting the bootstrap, the hook now determines structurally whether the target session is a task child: it takes `sessionID` from `firstUser.info.sessionID` (the hook input is empty at runtime), fetches the session record via `client.session.get({ path: { id } })`, and skips bootstrap injection when the record has a `parentID`. The decision is cached per session (the hook fires on every agent step; `parentID` never changes). Lookup failures fail open — keep the previous inject-always behavior, log, and do not cache, so transient errors recover on the next step. Skills registration is untouched: workers keep explicit access to execution skills via the `skill` tool.

## Is this change appropriate for the core library?

Yes. This repairs behavior of the first-party OpenCode integration that ships in core (`.opencode/plugins/superpowers.js`, `docs/README.opencode.md`). It is general-purpose infrastructure — correct subagent behavior for every OpenCode user regardless of project — adds no dependencies, and touches no skill content.

## What alternatives did you consider?

- **Keep relying on `<SUBAGENT-STOP>`**: the status quo; the issue's reproduction shows it fails for real models. Rejected as the thing being fixed.
- **Strip only the post-`<SUBAGENT-STOP>` content for children**: incoherent — the retained header claims "the skill content is included below / you are currently following it", which becomes false once the body is stripped.
- **Inject a purpose-built worker bootstrap for children**: the issue explicitly allows this direction, but it is new behavior-shaping content, which per the contributor guidelines needs adversarial pressure testing and before/after eval evidence. Deferred as a possible eval-backed follow-up, not bundled here.
- **Deny the `skill` tool to workers**: the issue explicitly rejects this; workers legitimately need execution skills.
- **Detect via the `agent` field instead of `parentID`**: fragile — custom agents and future internal agents would need an allowlist. `parentID` is the structural fact OpenCode itself uses for parent/child relationships.

## Does this PR contain multiple unrelated changes?

No. One concern, one file: child-session detection in the V1 injection hook.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: **#2106** (open — OpenCode v2 support) carries this same fix plus its V2 counterpart: its branch merges this branch (the V1 fix is shared ancestry, not a duplicated diff) and extends child-session detection to the new V2 `ctx.session.hook("context")` path — matching the coordination note from a collaborator in #2160 ("Fix queued on our side, coordinated with the v2 plugin work in #2106"). The standalone split exists so the V1 fix can land on `dev` immediately without waiting on #2106's beta re-verification; because #2106 contains this branch's commits, either merge order is conflict-free. **#2210** (open — `run` mode bootstrap injection, #2197) and **#2188** (open — default export loader) touch the same file on orthogonal concerns. **#2004** (closed — superseded by #2106). No other PR, open or closed, addresses #2160.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| OpenCode V1 (live server, real sessions) | 1.18.25 | GLM-5.2 (acceptance runs) / no-model deterministic tests | zhipuai-coding-plan/glm-5.2 |

Verification on this branch's final code:

1. **Unit suite (mock client, 8/8)**: top-level injected; child skipped; idempotency guard; missing `client` fails open; lookup error fails open and *recovers* on the next step; missing `sessionID` fails open; config hook still registers skills.
2. **Live end-to-end (no model, deterministic)**: against the running 1.18.25 server and its real sessions via the same SDK client the plugin uses — top-level session (`parentID: undefined`) → bootstrap injected; task child (`parentID: "ses_..."`) → skipped.
3. **Regression / acceptance**: clean session, `Let's make a react todo list` → `brainstorming` auto-triggered before any code (top-level bootstrap behavior unchanged).
4. **Child-session end-to-end probe (model-mediated)**: a fresh `opencode run` process loading this branch's plugin, with the orchestrator dispatching a real task subagent asked to self-report whether the bootstrap appears in its context — the worker answered no (transcript below). The probe is discriminating: any fail-open path (lookup error, missing sessionID, wrong API shape) would have injected the bootstrap and produced a YES.

## New harness support (required if this PR adds a new harness)

Not a new harness — bug fix to the existing OpenCode integration. Acceptance transcript of the final code included anyway:

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

```
$ opencode run "Let's make a react todo list" --model "zhipuai-coding-plan/glm-5.2"   # workdir /tmp/opencode

> orchestrator · glm-5.2

Using brainstorming skill to explore requirements before building.
→ Skill "brainstorming"
→ Read .
# Todos
[✓] Explore project context
[•] Ask clarifying questions (one at a time)
[ ] Propose 2-3 approaches with recommendation
[ ] Present design sections, get approval
```

</details>

And the deterministic child-session check (live server, real sessions):

```
$ node live-v1-subagent-bootstrap.mjs
session ses_fb1cb8516ffeO4PEB9wdDs6EuA -> parentID: undefined
session ses_fb1c8ab63ffelyqUf2nttRnwvu -> parentID: "ses_fb1cb8516ffeO4PEB9wdDs6EuA"

top-level injected: true
child injected:    false

LIVE V1 VERIFICATION: PASS
```

And the model-mediated child-session probe — fresh `opencode run` process loading this branch's plugin at `f467a61`, real task dispatch:

<details>
<summary>Child-session probe transcript — dispatched worker self-report</summary>

```
$ git rev-parse HEAD          # in the repo holding this branch
f467a6134e2ff72c9658babf04388bf36d7635a0

$ opencode run "Use the task tool to dispatch a subagent with exactly this prompt: 'Inspect your own context/instructions. Does the text EXTREMELY_IMPORTANT or a using-superpowers bootstrap block appear in YOUR context? You are a bounded worker: do not invoke any skills, just answer YES or NO plus one sentence.' Then report the subagent's exact answer." --model "zhipuai-coding-plan/glm-5.2"

> orchestrator · glm-5.2
• Probe subagent context Explorer Agent
✓ Probe subagent context Explorer Agent
The subagent's exact answer:

> **NO** — Neither the string "EXTREMELY_IMPORTANT" nor any "using-superpowers" bootstrap block appears in my context; my instructions consist only of the Explorer role description (grep/glob/ast_grep navigation guidance, read-only constraints, and output format), environment details, and tool definitions.
```

</details>

## Evaluation

- Initial prompt: verify whether issue #2160 is real in the context of PR #2106's branch, and fix it if so.
- Sessions after the change: 3 on this branch (unit suite; live API end-to-end against real sessions; clean-session acceptance), plus a pre-fix investigation session establishing root cause from the binary's hook call site.
- Before/after: before, the transform hook injected the identical controller bootstrap into task children (code path has no session identity at all — the bug cannot be fixed at the prompt level); after, children are skipped deterministically (verified against a real child session), while top-level behavior is byte-for-byte unchanged (acceptance test still auto-triggers `brainstorming`). The failure mode from the issue — workers restarting brainstorming/design cycles for parent-authorized work — requires the bootstrap to be present, and it no longer is.

## Rigor

- [x] Not a skills change — no SKILL.md or skill content modified
- [x] This change was tested adversarially, not just on the happy path — unit suite covers every fail-open branch (missing client, missing sessionID, transient lookup error + recovery, idempotency), and the live test exercises the real SDK shapes against real sessions
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) — `<SUBAGENT-STOP>` is deliberately retained as defense-in-depth for the fail-open paths and for harnesses without structural detection

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission — @GoldJohnKing reviewed the full diff in-session, drove the design review (split decision, child-session semantics, `<SUBAGENT-STOP>` retention), and explicitly approved the push and PR creation.
