### PR TITLE
fix: define Codex model pool for SDD

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -183,6 +183,11 @@ implementation.
 
 ## Model Selection
 
+**Codex model pool:** map the cheap tier to `gpt-5.6-luna` with
+`reasoning_effort: "xhigh"`; map the standard and most-capable tiers to
+`gpt-5.6-terra` with `reasoning_effort: "xhigh"`. Every Codex subagent
+dispatch must explicitly set both fields to one of these two combinations.
+
 Use the least powerful model that can handle each role to conserve cost and increase speed.
 
 **Mechanical implementation tasks** (isolated functions, clear specs, 1-2 files): use a fast, cheap model. Most implementation tasks are mechanical when the plan is well-specified.


### PR DESCRIPTION
> **This PR targets `dev`, not `main`.** The base repository is
> `obra/superpowers`; the head is `dohyuu:feat/codex-sdd-model-pool`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Codex GPT-5 family; the exact authoring root-model snapshot is not exposed by the harness |
| Harness + version | Codex CLI `0.150.1` |
| All plugins installed | `codex-app-tools@openai-bundled` (enabled); `sites@openai-bundled` (enabled); `browser@openai-bundled` (enabled); `visualize@openai-bundled` (enabled); `career-harness@career-harness-local` (enabled); `dd-ost@dd-ost-local` (enabled); `superpowers@superpowers-dev` (enabled); `voicemode@voicemode` (enabled); `context7@claude-plugins-official` (enabled); `discord@claude-plugins-official` (disabled); `gopls-lsp@claude-plugins-official` (enabled); `plugin-dev@claude-plugins-official` (enabled); `swift-lsp@claude-plugins-official` (enabled); `harness@harness-marketplace` (disabled); `mattpocock-skills@mattpocock` (enabled); `ouroboros@ouroboros` (disabled); `reflect@reflect` (disabled); `elements-of-style@superpowers-marketplace` (enabled); `documents@openai-primary-runtime` (enabled); `pdf@openai-primary-runtime` (enabled); `spreadsheets@openai-primary-runtime` (enabled); `presentations@openai-primary-runtime` (enabled); `template-creator@openai-primary-runtime` (enabled) |
| Human partner who reviewed this diff | dohyu — reviewed the complete five-line diff and explicitly requested PR creation |

## What problem are you trying to solve?

Under combined time, cost, and review-quality pressure, the generic SDD
guidance (cheap / standard / most-capable) produced **0/5 compliant Codex
selections** in fresh-context controls. Agents selected legacy or unavailable
model IDs, used an effort other than `xhigh`, and sometimes selected Sol for the
final review. The resulting dispatches did not reliably express the intended
cost tier or the required review quality.

## What does this PR change?

The SDD Model Selection section now defines the Codex model pool: cheap maps to
`gpt-5.6-luna` with `reasoning_effort: "xhigh"`, while standard and
most-capable map to `gpt-5.6-terra` with `reasoning_effort: "xhigh"`. Every
Codex subagent dispatch must set both fields to one of those combinations;
non-Codex behavior remains generic.

## Is this change appropriate for the core library?

Yes. This is a small correction to the existing, general-purpose SDD guidance
for an already supported first-class harness. It improves model/effort routing
for Codex users working on any kind of project, adds no dependency or service,
and does not introduce project-specific workflow behavior.

## What alternatives did you consider?

- Leaving the generic tier guidance unchanged: the fresh-context control failed
  5/5 under the stated pressure.
- Using Luna for every role: this removes the intended distinction between
  mechanical work and standard or judgment-heavy work.
- Using Terra for every role: this imposes unnecessary cost on mechanical work.

The selected mapping preserves the tier distinction while making both routing
fields concrete and valid for this Codex model pool.

## Does this PR contain multiple unrelated changes?

No. The isolated branch is based on `upstream/dev` and contains one commit,
one file, and five insertions in the SDD Model Selection section. It contains
no upstream-sync or other unrelated changes.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: [#2205](https://github.com/obra/superpowers/pull/2205), [#2193](https://github.com/obra/superpowers/pull/2193), [#2097](https://github.com/obra/superpowers/pull/2097), [#2062](https://github.com/obra/superpowers/pull/2062), [#1948](https://github.com/obra/superpowers/pull/1948)

Searches covered open and closed upstream PRs for
`subagent-driven-development`, `Codex model pool`, `gpt-5.6-luna`,
`gpt-5.6-terra`, and `reasoning_effort` on 2026-08-30. The exact
`Codex model pool` search returned no open or closed PR. The Luna/Terra hits
were unrelated (for example, [#2116](https://github.com/obra/superpowers/pull/2116)
and [#2024](https://github.com/obra/superpowers/pull/2024) mention Luna in
unrelated contexts; the Terra hits likewise do not define this SDD mapping).

- [#2205](https://github.com/obra/superpowers/pull/2205), “fix(codex): derive
  spawns from live capabilities” (open), makes Codex spawn routing
  capability-driven and deliberately does not define a fixed Luna/Terra pool.
- [#2193](https://github.com/obra/superpowers/pull/2193), “fix(skills): require
  explicit model on subagent dispatches outside SDD (#2034)” (open), covers
  dispatch sites outside SDD and does not define these model/effort pairs.
- [#2097](https://github.com/obra/superpowers/pull/2097), “fix(sdd): resolve
  \"most capable available\" to the strict maximum for the final whole-branch
  review” (open), resolves ranking for one final-review rule without naming a
  Codex model pool.
- [#2062](https://github.com/obra/superpowers/pull/2062), “fix(codex): explicit
  model+effort on every spawn, with config backstop” (merged), requires both
  fields but intentionally leaves model names generic and does not define
  Luna/Terra SDD tier mappings.
- [#1948](https://github.com/obra/superpowers/pull/1948), “SDD: add a
  reasoning-effort dimension to subagent dispatch” (closed), adds the effort
  dimension and effort-worker mechanism but does not define this Codex model
  pool.

These are related prior art, not duplicates: none defines the
`gpt-5.6-luna`/`gpt-5.6-terra` plus `xhigh` mapping for SDD.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Codex CLI (authoring root) | `0.150.1` | Codex GPT-5 family | Exact root snapshot not exposed by the harness |
| Codex CLI (PR orchestration subagent) | `0.150.1` | Luna | `gpt-5.6-luna`, `reasoning_effort: "xhigh"` |
| Codex CLI (evaluation subjects) | `0.150.1` | Luna / Terra | `gpt-5.6-luna` / `gpt-5.6-terra`, `reasoning_effort: "xhigh"` |

## New harness support (required if this PR adds a new harness)

N/A. Codex is already supported; this PR only changes model-selection guidance
inside the existing SDD skill. It does not add a harness, alter startup, or
change skill triggering behavior, so no clean-session transcript applies.

<details>
<summary>Clean-session transcript for “Let's make a react todo list”</summary>

```
N/A — this PR adds no harness support and does not change session startup or
bootstrap behavior.
```

</details>

## Evaluation

- Initial prompt (paraphrased): investigate why generic Codex SDD tier guidance
  produces invalid model/effort choices under combined time, cost, and
  authority/quality pressure, then make the smallest evaluated fix.
- Evaluation method: `superpowers:writing-skills` was used. Five fresh-context
  no-guidance control sessions and five fresh-context post-change sessions were
  run under combined time, cost, and authority/quality pressure.
- Before the change, **0/5** control sessions were compliant: selections used
  legacy or unavailable IDs, a non-`xhigh` effort, or Sol for the final review.
- After the change, **5/5** sessions were compliant. The observed mappings were
  A/C → `gpt-5.6-luna` + `reasoning_effort: "xhigh"`; B/D →
  `gpt-5.6-terra` + `reasoning_effort: "xhigh"`.

The result measures the behavior that motivated this five-line rule: every
Codex dispatch expressed an allowed model and the required effort while the
three generic tiers retained their intended distinction.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (results are in Evaluation above)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement

Adversarial pressure testing combined time pressure, cost pressure, and the
authority/quality requirement for the final review. The 0/5 control versus 5/5
post-change result is the before/after outcome. The change is additive in the
Model Selection section; no Red Flags table, rationalization list, or
human-partner wording was modified.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

dohyu reviewed the complete five-line diff in
`skills/subagent-driven-development/SKILL.md` and explicitly requested that
this PR be created.
