### PR TITLE
Add typed trigger phrases (tdd, systematic debug) and sibling cross-routes to debugging/TDD descriptions

### DIFF
--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systematic-debugging
-description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+description: "Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes - including when you say \"systematic debug\", \"debug this properly\", or \"find the root cause first\"; for driving new behavior test-first, use test-driven-development instead"
 ---
 
 # Systematic Debugging

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Use when implementing any feature or bugfix, before writing implementation code
+description: "Use when implementing any feature or bugfix, before writing implementation code - including when you say \"tdd\", \"tdd workflow\", \"write the test first\", or \"red green refactor\"; for diagnosing an existing defect, use systematic-debugging instead"
 ---
 
 # Test-Driven Development (TDD)


### PR DESCRIPTION
## What

Adds typed short-form trigger phrases to two skill descriptions, plus a cross-route to the confusable sibling:

- `systematic-debugging`: + "systematic debug", "debug this properly", "find the root cause first"; routes new-behavior work to test-driven-development.
- `test-driven-development`: + "tdd", "tdd workflow", "write the test first", "red green refactor"; routes existing-defect work to systematic-debugging.

Both keep the original description clause verbatim and stay WHEN-only per writing-skills' own description doctrine (no what-it-does, no workflow summary, well under 500 chars).

## Why

We run a large multi-skill Claude Code environment (300+ skills/commands) and measured skill routing over an extended session corpus. Users who type the common short forms — "tdd" being the clearest case — did not route to these skills: the current descriptions describe the situation but not the phrases people actually type, and nothing in either description separates the pair (new behavior test-first vs existing defect), so bare "tdd"/"debug this properly" utterances had no anchor.

Scope kept deliberately minimal: description-only, original clauses preserved, no body changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjSrPcwcqBA71tTGZGBVDf
