### PR TITLE
Tell the executor to tick the plan's checkboxes

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -28,7 +28,11 @@ For each task:
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. Run verifications as specified
-4. Mark as completed
+4. Mark as completed — the todo **and** the plan file: edit it and flip this
+   task's steps from `- [ ]` to `- [x]`. The plan is the artifact a human
+   reads to see where things stand, and nothing else in this skill writes
+   back to it. Leave a step unticked only when its deliverable does not exist
+   yet; never tick one you skipped.
 
 ### Step 3: Complete Development
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -438,6 +438,18 @@ message as your other bookkeeping:
 - `Task <N>: complete (commits <base7>..<head7>, <K> parked)` after a
   tripped breaker
 
+In the same message, **edit the plan file and flip this task's steps from
+`- [ ]` to `- [x]`**. The plan is what a human reads to see where the work
+stands; the ledger is yours. Tie the two to this one event so they cannot
+drift — a plan left at 0 while its tasks are done and deployed reads as
+"nothing happened", and nothing downstream will catch it: the task reviewer
+sees a diff, the re-review sees findings, the final review sees the ledger.
+None of them ever opens the plan.
+
+Leave a step unticked only when its deliverable does not exist yet — a step
+that waits on someone else, or on an event that has not happened. Never tick
+a step you skipped.
+
 Then mark the todo complete and move on. Never move to the next task while
 the review has open Critical/Important issues that are neither fixed nor
 parked-with-ruling at the cap.


### PR DESCRIPTION
## The problem

Plans generated by `writing-plans` use `- [ ]` checkboxes per step. In practice they stay unticked
while the work gets done.

In one repo, three plans sat at **0/34, 0/34 and 0/42** with all of their work
finished, applied to a production database, and deployed. A fourth sat at 11/40. Nobody noticed
until someone went back and read the plans, and asked why nothing had been done — the answer was
that everything had been done. Until then the plan files were the only record anyone would have
read, and all of them said the opposite.

## Root cause

The instruction to tick a checkbox **does exist**, but only in a platform adaptation file:

`skills/using-superpowers/references/antigravity-tools.md:20`

> "As you complete each step, edit the artifact to mark it done (`- [x]`)."

`using-superpowers/SKILL.md` only tells you to read that file *"if your harness appears here"*, and
the list is Codex, Pi, Antigravity and Hermes. Anyone on a harness that isn't listed never sees it.

What the other harnesses do get doesn't ask for it:

| Location | Text | Why it doesn't land |
|---|---|---|
| `writing-plans/SKILL.md:61` | "Steps use checkbox (`- [ ]`) syntax for tracking" | Describes the syntax. It also travels *inside* the generated plan, which SDD reads once at setup |
| `subagent-driven-development/SKILL.md:441` | "Then mark the todo complete and move on" | "todo" is the session's todo list, not the file |
| `executing-plans/SKILL.md:31` | "Mark as completed" | Never names a file |

## Nothing downstream catches it

In `subagent-driven-development`, the task reviewer reads a diff and a brief, the scoped re-review
reads findings, and the final whole-branch review is pointed at the ledger. **None of them opens the
plan file.** The skill deliberately replaced plan-file tracking with the ledger (`progress.md`) —
"Track progress in a ledger file, not only in todos" — and nothing reconciles the ledger back into
the plan. The process graph has no node that writes to the plan after setup.

That's the structural part: the completion state exists and is accurate, it just lives somewhere a
human reading the plan will never see.

## The change

Two edits, both attached to the event that already records completion, so the two records can't
drift:

- `subagent-driven-development/SKILL.md`, step 5 "Complete the task" — right where the ledger line
  gets appended.
- `executing-plans/SKILL.md`, step 2.4.

Both also state the rule that makes the marks trustworthy: **don't tick a step you skipped, and
leave unticked any step whose deliverable doesn't exist yet** (one waiting on a human, or on an
event that hasn't happened). Without that, ticking degrades into decoration.

I kept it to prose in the existing voice rather than adding a checklist item, since neither skill
has a numbered "bookkeeping" section to extend.

## What I did not change

- `writing-plans/SKILL.md:61` — the template line is fine as a syntax note; the fix belongs with the
  executor, not the artifact.
- `antigravity-tools.md` — its instruction is correct and stays. This just makes the same rule reach
  the harnesses that don't read platform adaptation files.