### PR TITLE
fix(skills): align version-control backend ownership

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -7,7 +7,9 @@ description: Use when implementation is complete, all tests pass, and you need t
 
 ## Overview
 
-**Core principle:** Verify tests → Detect environment → Present options → Execute choice → Clean up.
+**Core principle:** Verify tests → Detect environment and version-control backend → Present options → Execute choice → Clean up.
+
+Before any branch, pull, merge, push, delete, or worktree-removal write, load `gitbutler` and preserve one owner. A GitButler-managed checkout uses `but`; a Coding Agent/Orca/Conductor worktree or plain checkout rejected by `but` uses native Git and remains owned by its harness. A `gh stack` stack keeps the full `gh stack` protocol. Do not translate commands midway through an operation.
 
 **Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
 
@@ -82,6 +84,8 @@ discard the work" below). Wait for their answer; the integration decision
 is theirs.
 
 ## Step 5: Execute Choice
+
+The command blocks below are the native-Git implementation. When Step 2 selected GitButler, use the equivalent `but pull`, `but push`, `but pr`, `but land`, and `but branch delete` operations from the `gitbutler` skill. `but land` is allowed only when the user chose direct integration and repository policy permits bypassing a PR. A `gh stack` branch uses `gh stack submit/merge/sync`, never `but` or ordinary `gh pr create`.
 
 ### Option 1: Merge Locally
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -5,6 +5,10 @@ description: Use when executing implementation plans with independent tasks in t
 
 # Subagent-Driven Development
 
+## Version-control backend
+
+Before an implementer commits, pushes, creates a branch/PR, or rewrites history, load `gitbutler` and keep one writer for the workspace. Coding Agent, Orca, Conductor, and IDE-owned linked worktrees use native Git when GitButler rejects them; normal GitButler-managed checkouts use `but`; `gh stack` stacks keep their own complete protocol. Any `git add`/`git commit` examples below are the native-Git form only.
+
 Execute plan by dispatching a fresh implementer subagent per task, a task review (spec compliance + code quality) after each, and a broad whole-branch review at the end.
 
 **Why subagents:** You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -7,9 +7,11 @@ description: Use when starting feature work that needs isolation from current wo
 
 ## Overview
 
-Ensure work happens in an isolated workspace. Prefer your platform's native worktree tools. Fall back to manual git worktrees only when no native tool is available.
+Ensure work happens in an isolated workspace. Prefer your platform's native worktree tools. Fall back to manual worktrees only when no native tool is available and after selecting the version-control backend with the `gitbutler` skill.
 
-**Core principle:** Detect existing isolation first. Then use native tools. Then fall back to git. Never fight the harness.
+**Core principle:** Detect existing isolation first. Then use native tools. Then preserve the selected backend. Never fight the harness.
+
+**Local ownership rule:** Coding Agent, Orca, Conductor, and IDE-created worktrees stay owned by that harness and use native Git inside the linked worktree when GitButler rejects it. In a normal GitButler-managed checkout, do not create a parallel raw-Git worktree; use GitButler's supported branch/worktree surface or ask the operator before converting the workspace. Never run `but setup` inside a harness-owned worktree.
 
 **Announce at start:** "I'm using the using-git-worktrees skill to set up an isolated workspace."
 
@@ -56,9 +58,15 @@ Native tools handle directory placement, branch creation, and cleanup automatica
 
 Only proceed to Step 1b if you have no native worktree tool available.
 
-### 1b. Git Worktree Fallback
+### 1b. Selected-backend fallback
 
-**Only use this if Step 1a does not apply** — you have no native worktree tool available. Create a worktree manually using git.
+**Only use this if Step 1a does not apply** — there is no native worktree tool. Load `gitbutler` before writing state:
+
+- GitButler-managed normal checkout: use GitButler's supported branch/worktree mechanism; do not run raw `git worktree add` against the managed workspace.
+- Plain Git checkout: use the native Git worktree procedure below.
+- Harness-owned linked worktree: do not create a nested worktree; continue in the current harness workspace.
+
+The remaining manual procedure applies only to the plain-Git branch above.
 
 #### Directory Selection
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -5,6 +5,10 @@ description: Use when you have a spec or requirements for a multi-step task, bef
 
 # Writing Plans
 
+## Version-control examples
+
+When a plan includes branch, commit, push, conflict, or PR-creation commands, make backend selection an explicit prerequisite: load `gitbutler`, preserve a harness-owned worktree, and use exactly one writer. Git examples in this skill are the native-Git form only; a GitButler-managed checkout must use equivalent `but` commands, while a `gh stack` stack keeps its own protocol.
+
 ## Overview
 
 Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.


### PR DESCRIPTION
## Summary
- preserve Coding Agent, Orca, Conductor, and IDE-owned worktrees
- select GitButler, native Git, or gh stack once before repository writes
- mark existing Git command blocks as native-backend examples

## Verification
- commit is SSH-signed
- plugin diff contains only four SKILL.md files

This change adds generic multi-backend ownership guidance; it does not include Kamus-specific paths or infrastructure.