### PR TITLE
Fix platform-support issue template to apply a label that exists

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform_support.md
+++ b/.github/ISSUE_TEMPLATE/platform_support.md
@@ -1,7 +1,7 @@
 ---
 name: IDE / Platform Support Request
 about: Request support for a new IDE, editor, or AI coding tool
-labels: platform-support
+labels: new-harness
 ---
 
 <!--


### PR DESCRIPTION
> **This PR targets `dev`.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Fable 5.1 (`claude-fable-5-1`) |
| Harness + version | Claude Code 2.1.259 |
| All plugins installed | superpowers@claude-plugins-official 6.3.0, github-triage@github-triage-dev 1.0.0, claude-session-driver@superpowers-marketplace 3.0.2, superpowers-chrome@superpowers-marketplace 3.0.2, superpowers-developing-for-claude-code@superpowers-marketplace 0.3.1, superpowers-lab@superpowers-marketplace 0.3.0, elements-of-style@superpowers-marketplace 1.0.0, episodic-memory@superpowers-marketplace 1.0.15, primeradiant-ops@primeradiant 2.5.0, release-radar@whats-new-marketplace 1.3.0, and from claude-plugins-official: agent-sdk-dev, claude-code-setup, claude-md-management, code-simplifier, context7, frontend-design, gopls-lsp, linear, mcp-server-dev, playground, plugin-dev, rust-analyzer-lsp, security-guidance 2.0.7, swift-lsp, typescript-lsp |
| Human partner who reviewed this diff | Jesse Vincent (@obra) |

## What problem are you trying to solve?

While triaging the open issue queue on 2026-09-03 (a real session, driven by the maintainer), I found 40 open issues with no labels at all. One of them, #2194 (Amazon Q Developer CLI support), was filed through the "IDE / Platform Support Request" issue template, which is supposed to auto-label. It didn't. The template's front matter says `labels: platform-support`, and the repository has no label with that name. GitHub silently ignores template labels that don't exist, so every request filed through that template arrives unlabeled. The label maintainers actually use for these requests is `new-harness`, which currently sits on 8 open issues, all applied by hand.

## What does this PR change?

Changes the auto-applied label in `.github/ISSUE_TEMPLATE/platform_support.md` from `platform-support` to `new-harness`. One line.

## Is this change appropriate for the core library?

Yes. It is repository infrastructure (an issue template), not a skill or a workflow, and it benefits every contributor who files a platform-support request.

## What alternatives did you consider?

Creating a `platform-support` label so the template's existing name resolves. That would leave two labels for one concept, with `new-harness` already carrying the open history and the maintainers' habit. Pointing the template at the existing label is the smaller change.

## Does this PR contain multiple unrelated changes?

No. One file, one line.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found. Searched open and closed PRs for `platform-support`, `platform_support`, and `issue template label`; the hits are all harness-support feature PRs, none touch the template.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code | 2.1.259 | Claude Fable 5.1 | claude-fable-5-1 |

The "test" for a template-metadata change is that the named label exists: `gh label list --repo obra/superpowers --limit 100` shows `new-harness` and no `platform-support`. Nothing under `tests/` or `scripts/` references either name.

## New harness support (required if this PR adds a new harness)

Not applicable. This PR adds no harness.

## Evaluation
- Initial prompt that started the session: "we need to triage the open github issues for superpowers"
- Eval sessions run after the change: 0. This is not a skill change and has no agent-behavior surface.
- Outcome change: the next issue filed through the platform-support template will arrive with `new-harness` applied instead of no label.

## Rigor

- [ ] Not a skills change, so `superpowers:writing-skills` and pressure testing do not apply
- [x] This change was tested adversarially, not just on the happy path: checked that no test, script, or other template depends on the old name, and that the target label exists
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

https://claude.ai/code/session_01UiEfXTZAC5cuH4hgx24mbB
