### PR TITLE
feat: add Prime Agent tool mapping

### DIFF
--- a/.pi/extensions/superpowers.ts
+++ b/.pi/extensions/superpowers.ts
@@ -11,10 +11,13 @@ const packageRoot = resolve(extensionDir, "../..");
 const skillsDir = resolve(packageRoot, "skills");
 const bootstrapSkillPath = resolve(skillsDir, "using-superpowers", "SKILL.md");
 
+type Harness = "pi" | "prime-agent";
+
 let cachedBootstrap: string | null | undefined;
 
 export default function superpowersPiExtension(pi: ExtensionAPI) {
 	let injectBootstrap = true;
+	const harness = detectHarness();
 
 	pi.on("resources_discover", async () => ({
 		skillPaths: [skillsDir],
@@ -36,7 +39,7 @@ export default function superpowersPiExtension(pi: ExtensionAPI) {
 		if (!injectBootstrap) return;
 		if (event.messages.some(messageContainsBootstrap)) return;
 
-		const bootstrap = getBootstrapContent();
+		const bootstrap = getBootstrapContent(harness);
 		if (!bootstrap) return;
 
 		const bootstrapMessage = {
@@ -56,23 +59,30 @@ export default function superpowersPiExtension(pi: ExtensionAPI) {
 	});
 }
 
-function getBootstrapContent(): string | null {
+function detectHarness(): Harness {
+	return process.title === "prime-agent" ? "prime-agent" : "pi";
+}
+
+function getBootstrapContent(harness: Harness): string | null {
 	if (cachedBootstrap !== undefined) return cachedBootstrap;
 
 	try {
 		const skillContent = readFileSync(bootstrapSkillPath, "utf8");
 		const body = stripFrontmatter(skillContent);
-		cachedBootstrap = `${EXTREMELY_IMPORTANT_MARKER}
+		const harnessName = harness === "prime-agent" ? "Prime Agent" : "Pi";
+		const toolMapping = harness === "prime-agent" ? primeAgentToolMapping() : piToolMapping();
+		const bootstrap = `${EXTREMELY_IMPORTANT_MARKER}
 ${BOOTSTRAP_MARKER}
 
 You have superpowers.
 
-The using-superpowers skill content is included below and is already loaded for this Pi session. Follow it now. Do not try to load using-superpowers again.
+The using-superpowers skill content is included below and is already loaded for this ${harnessName} session. Follow it now. Do not try to load using-superpowers again.
 
 ${body}
 
-${piToolMapping()}
+${toolMapping}
 </EXTREMELY_IMPORTANT>`;
+		cachedBootstrap = bootstrap;
 		return cachedBootstrap;
 	} catch {
 		cachedBootstrap = null;
@@ -95,6 +105,18 @@ Pi's built-in coding tools are lowercase: \`read\`, \`write\`, \`edit\`, \`bash\
 Pi does not ship a standard subagent tool. If a subagent tool such as \`subagent\` from \`pi-subagents\` is available, use it for Superpowers subagent workflows. If no subagent tool is available, do the work in this session or explain the missing capability instead of inventing \`Task\` calls.
 
 Pi does not ship a standard task-list tool. If an installed todo/task tool is available, use it. Otherwise track work in plan files or a repo-local \`TODO.md\` when task tracking is needed. Treat older \`TodoWrite\` references as this task-tracking action.`;
+}
+
+function primeAgentToolMapping(): string {
+	return `## Prime Agent tool mapping
+
+Prime Agent exposes machine work through the persistent Python REPL in \`ipython\`. Use Python and \`pathlib\` for file discovery, reads, searches, and new files; use the preloaded \`await edit(...)\` skill for targeted edits; and run project commands with the preloaded \`bash(...)\` helper. Do not invent direct \`read\`, \`write\`, \`Task\`, or \`TodoWrite\` tool calls.
+
+Prime Agent lists each skill's name, description, and \`SKILL.md\` location in the system prompt. When a Superpowers instruction says to invoke a skill, inspect that skill's current \`SKILL.md\` through \`ipython\` and follow it. A human can invoke it explicitly as \`/skill:name\`. For Python-backed skills, call the documented pre-imported module API.
+
+Prime Agent provides recursive subagents through \`await rlm(...)\`. That call returns immediately with an admission handle, never the child's answer. Tell every child whose result you need to reply with \`await agent_message.send(message, receiver_role="parent")\` or to write a named result file. Use \`agent_message\` for follow-ups and \`agent_observe\` for bounded inspection. Start independent children without waiting between admissions, then continue useful work or end the turn; never poll with \`sleep\` or a long blocking await. Use only exact model selectors returned by \`await rlm.find_models(...)\`, or omit \`model\` to inherit the parent model.
+
+Prime Agent does not expose a built-in todo tool. Track plan state in the plan, the Superpowers SDD ledger, or a repo-local \`TODO.md\`; do not use the \`goal\` skill as a todo substitute unless the human explicitly requested a persistent goal.`;
 }
 
 function messageContainsBootstrap(message: unknown): boolean {

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Superpowers is a complete software development methodology for your coding agent
   - [Kimi Code](#kimi-code)
   - [OpenCode](#opencode)
   - [Pi](#pi)
+  - [Prime Agent](#prime-agent)
   - [Hermes Agent](#hermes-agent)
 - [The Basic Workflow](#the-basic-workflow)
 - [Community](#community)
@@ -245,6 +246,22 @@ pi -e /path/to/superpowers
 ```
 
 The Pi package loads the Superpowers skills and a small extension that injects the `using-superpowers` bootstrap at session startup and again after compaction. Pi has native skills, so no compatibility `Skill` tool is required. Subagent and task-list tools remain optional Pi companion packages.
+
+### Prime Agent
+
+Install Superpowers as a Prime Agent capability package from this repository:
+
+```bash
+prime-agent package install git:github.com/obra/superpowers
+```
+
+For local development, run Prime Agent with this checkout loaded as a temporary package:
+
+```bash
+prime-agent -e /path/to/superpowers
+```
+
+Prime Agent retains compatibility with the Pi package manifest and extension API. The shared extension detects Prime Agent at runtime, loads the Superpowers skills, and injects the `using-superpowers` bootstrap with Prime Agent's native `ipython` and RLM tool mapping at session startup and again after compaction. This integration is tested with Prime Agent 0.9.1.
 
 ### Hermes Agent
 

--- a/skills/using-superpowers/SKILL.md
+++ b/skills/using-superpowers/SKILL.md
@@ -55,6 +55,7 @@ If your harness appears here, read its reference file for special instructions:
 
 - Codex: `references/codex-tools.md`
 - Pi: `references/pi-tools.md`
+- Prime Agent: `references/prime-agent-tools.md`
 - Antigravity: `references/antigravity-tools.md`
 - Hermes Agent: `references/hermes-tools.md`
 

--- a/skills/using-superpowers/references/prime-agent-tools.md
+++ b/skills/using-superpowers/references/prime-agent-tools.md
@@ -1,0 +1,26 @@
+# Prime Agent Tool Mapping
+
+Skills speak in actions. On Prime Agent, those actions begin in the persistent Python REPL exposed through `ipython`.
+
+| Action skills request | Prime Agent equivalent |
+| --- | --- |
+| Invoke a skill | Inspect the listed skill's current `SKILL.md` through `ipython`; a human can use `/skill:name` |
+| Read, create, search, or edit files; run commands | Use Python and `pathlib` through `ipython`; use `await edit(...)` for targeted edits and the preloaded `bash(...)` helper for project commands |
+| Dispatch a subagent (`Subagent (general-purpose):` template) | Use `await rlm(...)`, then receive results through `agent_message` or a named result file |
+| Task tracking ("create a todo", "mark complete") | Track state in the plan, the Superpowers SDD ledger, or a repo-local `TODO.md` |
+
+## Skills and tools
+
+Prime Agent includes each visible skill's name, description, and `SKILL.md` location in the system prompt. Inspect that file before following a matching skill. For Python-backed skills, call the documented pre-imported module API.
+
+Machine work goes through `ipython`. Use Python for file operations, the preloaded `await edit(...)` skill for exact existing-file edits, and the preloaded `bash(...)` helper for shell commands. Do not invent direct `read`, `write`, `Task`, or `TodoWrite` calls.
+
+## Subagents
+
+`await rlm(...)` admits a child and returns a handle immediately; it never returns the child's eventual answer. Tell a child whose result you need to reply with `await agent_message.send(message, receiver_role="parent")` or to write a named result file. Use `agent_message` for follow-ups and `agent_observe` for bounded inspection.
+
+Admit independent children without waiting between calls. Continue useful work or end the turn while they run. Never poll with `sleep` or a long blocking await. Use an exact model selector returned by `await rlm.find_models(...)`, or omit `model` to inherit the parent model.
+
+## Task lists
+
+Prime Agent has no built-in todo tool. Use the plan, the Superpowers SDD ledger, or a repo-local `TODO.md`. Do not use the `goal` skill as a todo substitute unless the human explicitly requested a persistent goal.

--- a/tests/pi/test-pi-extension.mjs
+++ b/tests/pi/test-pi-extension.mjs
@@ -10,12 +10,13 @@ const repoRoot = resolve(__dirname, '../..');
 const packageJsonPath = resolve(repoRoot, 'package.json');
 const extensionPath = resolve(repoRoot, '.pi/extensions/superpowers.ts');
 const piToolsPath = resolve(repoRoot, 'skills/using-superpowers/references/pi-tools.md');
+const primeAgentToolsPath = resolve(repoRoot, 'skills/using-superpowers/references/prime-agent-tools.md');
 
 async function readPackageJson() {
   return JSON.parse(await readFile(packageJsonPath, 'utf8'));
 }
 
-async function loadExtension() {
+async function loadExtension({ processTitle = 'pi' } = {}) {
   const handlers = new Map();
   const pi = {
     on(event, handler) {
@@ -24,7 +25,13 @@ async function loadExtension() {
     },
   };
   const mod = await import(pathToFileURL(extensionPath).href + `?cachebust=${Date.now()}-${Math.random()}`);
-  mod.default(pi);
+  const originalTitle = process.title;
+  try {
+    process.title = processTitle;
+    mod.default(pi);
+  } finally {
+    process.title = originalTitle;
+  }
   return { handlers };
 }
 
@@ -86,6 +93,7 @@ test('startup context injects the bootstrap as one user message until agent_end'
   assert.equal(result.messages[0].role, 'user');
   assert.match(textOf(result.messages[0]), /You have superpowers/);
   assert.match(textOf(result.messages[0]), /Pi tool mapping/);
+  assert.doesNotMatch(textOf(result.messages[0]), /Prime Agent tool mapping/);
   assert.equal(result.messages[1], originalMessages[0]);
 
   const repeatedProviderRequest = await context({ type: 'context', messages: originalMessages }, {});
@@ -134,4 +142,41 @@ test('pi tools reference documents pi-specific mappings', async () => {
     rows.some((row) => /todo|task/i.test(row)),
     'mapping table documents task tracking',
   );
+});
+
+test('Prime Agent receives its native tool mapping instead of the Pi mapping', async () => {
+  const { handlers } = await loadExtension({ processTitle: 'prime-agent' });
+  const sessionStart = firstHandler(handlers, 'session_start');
+  const context = firstHandler(handlers, 'context');
+
+  await sessionStart({ type: 'session_start', reason: 'startup' }, {});
+  const originalMessages = [
+    { role: 'user', content: [{ type: 'text', text: 'Let us make a react todo list' }], timestamp: 1 },
+  ];
+  const result = await context({ type: 'context', messages: originalMessages }, {});
+  const bootstrap = textOf(result.messages[0]);
+
+  assert.match(bootstrap, /already loaded for this Prime Agent session/);
+  assert.match(bootstrap, /Prime Agent tool mapping/);
+  assert.match(bootstrap, /await rlm\(/);
+  assert.match(bootstrap, /agent_message/);
+  assert.doesNotMatch(bootstrap, /Pi does not ship a standard subagent tool/);
+});
+
+test('Prime Agent tools reference documents native skills, shell, editing, subagents, and task tracking', async () => {
+  assert.equal(existsSync(primeAgentToolsPath), true, 'prime-agent-tools.md should exist');
+  const text = await readFile(primeAgentToolsPath, 'utf8');
+  const rows = text.split('\n').filter((line) => line.startsWith('|'));
+
+  for (const [description, pattern] of [
+    ['skill invocation', /Invoke a skill.*SKILL\.md.*\/skill:/],
+    ['workspace operations', /Read, create, search, or edit files.*ipython.*await edit.*bash/],
+    ['subagent dispatch', /Dispatch a subagent.*await rlm.*agent_message/],
+    ['task tracking', /Task tracking.*plan.*ledger.*TODO\.md/],
+  ]) {
+    assert.ok(rows.some((row) => pattern.test(row)), `mapping table documents ${description}`);
+  }
+  assert.match(text, /rlm.*returns a handle immediately; it never returns the child's eventual answer/);
+  assert.match(text, /Never poll with `sleep` or a long blocking await/);
+  assert.match(text, /agent_observe/);
 });


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | OpenAI Codex GPT-5.6-sol (`openai-codex/gpt-5.6-sol`) |
| Harness + version | Prime Agent 0.9.1 |
| All plugins installed | Superpowers v6.3.0 (`git:github.com/obra/superpowers@v6.3.0`); no other capability packages reported by `prime-agent package list` |
| Human partner who reviewed this diff | @deresolution20 reviewed the complete staged diff in the Prime Agent session and explicitly approved it |

## What problem are you trying to solve?

A Prime Agent user asked how to make Superpowers work with Prime Agent. Prime Agent 0.9.1 deliberately retains the Pi package manifest and extension API, so the repository installs and the bootstrap runs, but Superpowers 6.3.0 identifies the harness as Pi.

In a clean baseline session loaded from the unmodified v6.3.0 checkout, this diagnostic prompt:

> What harness-specific tool mapping was injected at startup? Answer with the heading only.

returned exactly:

```text
## Pi tool mapping
```

That injected mapping says there is no standard subagent facility and refers to Pi's direct coding tools. Prime Agent instead exposes machine work through `ipython` and provides native recursive subagents through `rlm(...)`, with results delivered by `agent_message` or files. The wrong bootstrap can therefore tell the model to degrade subagent-driven workflows even though the harness has native support.

## What does this PR change?

The existing Pi extension now detects the standard Prime Agent CLI from its documented `process.title`, while preserving the Pi path for every other title. It injects a focused Prime Agent mapping for skills, `ipython`, `bash(...)`, `edit`, RLM subagents, messaging, and task state. It also documents installation and adds regression tests for both mappings.

## Is this change appropriate for the core library?

Yes. This is a thin new-harness integration of the kind explicitly supported by the porting guide. It reuses the existing package manifest, lifecycle extension, shared skills, and package install mechanism. It adds no dependency or project-specific workflow and does not change the behavior-shaping content of the shared skills; the only `SKILL.md` edit is the permitted platform-reference pointer.

## What alternatives did you consider?

- **Use the Pi mapping unchanged:** installation works, but the injected subagent/tool guidance is factually wrong for Prime Agent.
- **Load only `skills/`:** avoids the wrong mapping but loses the mandatory startup and post-compaction bootstrap.
- **Edit Prime Agent user configuration:** violates the porting guide's requirement that everything ship through the harness install mechanism.
- **Create a separate wrapper package:** duplicates distribution and update state even though Prime already consumes the existing `pi` manifest and extension API.
- **Restore generic Pi tool rows:** rejected because #1847 deliberately pruned generic per-harness boilerplate and #1903 attempted to restore it. This PR leaves the Pi mapping untouched and adds only Prime-specific deltas.

## Does this PR contain multiple unrelated changes?

No. The runtime selector, mapping reference, documentation, platform pointer, and tests are all required parts of one Prime Agent harness integration.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #1499, #1847, #1903, #1987, #1996

No Prime Agent, PrimeIntellect, or RLM integration PR or issue exists. #1499 is the merged Pi integration reused here. #1847 and #1987 establish that mappings should remain narrow. #1903 was closed after attempting to restore intentionally removed generic Pi rows; this PR does not do that. #1996 is open but targets oh-my-pi, not Prime Agent or RLM.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Prime Agent | 0.9.1 | OpenAI Codex | `openai-codex/gpt-5.6-sol` |

## New harness support (required if this PR adds a new harness)

The session used the standard Prime Agent CLI with this checkout loaded through its native temporary package mechanism:

```bash
prime-agent --cwd /tmp/superpowers-prime-agent-acceptance \
  --no-extensions \
  -e /path/to/superpowers \
  --no-session --mode json -p "Let's make a react todo list"
```

`--no-extensions` disables configured extensions while the explicit `-e` package remains enabled, preventing the separately installed release package from affecting this clean test.

<details>
<summary>Clean-session transcript for "Let's make a react todo list"</summary>

````text
**User**

Let's make a react todo list

**Assistant → `ipython`**

```python
from pathlib import Path
p=Path('/home/brice/work/concepts/Local LLM projects/prime-agent-projects/superpowers-prime-agent-support/skills/brainstorming/SKILL.md')
brainstorming_text=p.read_text()
print(brainstorming_text)
```

**`ipython` result**

```text
---
name: brainstorming
description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
---

# Brainstorming Ideas Into Designs

Help turn ideas into fully formed designs and specs through natural collaborative dialogue.

Start by classifying how much process the request needs, then work
through your path: understand the context, refine the idea, present a
design, and get your human partner's approval.

<HARD-GATE>
Do NOT invoke any implementation skill, write any code, scaffold any
project, or take any implementation action until you have told your
human partner what you intend and they have approved it. This applies
to EVERY task on EVERY path below — the ceremony scales with the task;
the approval gate never does.
</HARD-GATE>

## Three Paths

Before your first question, classify the request and say the
classification out loud — "this looks bounded, so I'll present a short
design here rather than write a spec" — so your human partner can
override it:

- **Spike** — a feasibility question ("can we...", "is it possible...",
  "quick and dirty is fine") whose output is an answer, not code you
  keep. Present the question and what you'll try in 2-3 sentences, get
  a nod, then find out as cheaply as correctness allows. No design
  doc, no spec file. Report findings as a recommendation; anything you
  built stays labeled throwaway.
- **Bounded** — a well-scoped change to code that already exists in
  this repo: a new flag, a small endpoint, a one-file fix.
  Understanding the kind of app is not enough — bounded means the flow
  you are changing is already here to read. If there is no existing
  flow to change, the task is not bounded. Ask the clarifying
  questions that matter, present a short design IN CHAT (a few
  sentences to a few short paragraphs), and STOP. Implementation
  starts only after your human partner says yes to that design — a
  bounded task's approval is as hard a gate as an architectural
  one. No spec file, no implementation plan document.
- **Architectural** — new projects, new subsystems, changes that
  restructure how components fit together or alter interfaces others
  depend on. Follow the full process: questions, approaches, sectioned
  design, written spec, then the writing-plans skill.

When in doubt between two paths, take the heavier one. The ratchet is
one-way: hidden complexity discovered mid-task upgrades the path —
stop, say so, and step up. Nothing downgrades mid-task.

## Anti-Pattern: "Too Simple To Need Approval"

Every path ends with your human partner approving your intent before
implementation. A todo list, a single-function utility, a config
change — the design may be two sentences in chat, but you MUST present
it and get approval. "Simple" tasks are where unexamined assumptions
cause the most wasted work. What scales with simplicity is the
artifact, never the approval.

## Red Flags

| Thought | Reality |
|---------|---------|
| "This is too simple to need a design" | Simple means a short design, not no design. Two sentences in chat, then approval. |
| "I'll call it bounded and skip the spec" | Reaching for a label to skip work IS the doubt — take the heavier path. |
| "It's bounded and the design is obvious — I'll start while they read it" | The gate is the approval, not the design's length. Present, then stop until you hear yes. |
| "I understand this kind of app, so it's bounded" | Bounded measures the repo, not your familiarity. A new project has no existing flow — it is architectural. |
| "The spike works, so I'll keep the code" | A spike's output is an answer. Keeping the code is a new request — classify it. |
| "It grew, but I'm almost done — no need to re-classify" | Hidden complexity upgrades the path mid-task. Stop and say so. |
| "They approved the spike, so the follow-up change is approved too" | Each task gets its own classification and its own approval. |

## Checklist

Classify first, announce the path, then create a task for each item on
your path and complete them in order.

**Spike:**
1. **Explore project context** — enough to frame the probe
2. **Present question + probe plan** — 2-3 sentences
3. **Get approval** — a nod is enough
4. **Investigate** — as cheaply as correctness allows
5. **Report findings** — a recommendation; label anything built as throwaway

**Bounded:**
1. **Explore project context** — check files, docs, recent commits
2. **Ask clarifying questions** — one at a time, the ones that matter
3. **Present short design in chat** — approach, files touched, testing
4. **Get approval** — STOP and wait for an explicit yes; presenting the design and starting in the same breath is skipping the gate
5. **Implement** — proceed with the normal development workflow (TDD applies); no plan document

**Architectural:**
1. **Explore project context** — check files, docs, recent commits
2. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.
3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
4. **Propose 2-3 approaches** — with trade-offs and your recommendation
5. **Present design** — in sections scaled to their complexity, get user approval after each section
6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
8. **User reviews written spec** — ask user to review the spec file before proceeding
9. **Transition to implementation** — invoke writing-plans skill to create implementation plan

## Process Flow

```dot
digraph brainstorming {
    "Classify: spike / bounded / architectural" [shape=diamond];
    "Present question + probe (2-3 sentences)" [shape=box];
    "Ask clarifying questions (bounded)" [shape=box];
    "Present short design in chat" [shape=box];
    "Human approves?" [shape=diamond];
    "Investigate; report recommendation" [shape=doublecircle];
    "Implement via normal workflow (no plan doc)" [shape=doublecircle];
    "Explore project context" [shape=box];
    "Ask clarifying questions" [shape=box];
    "Propose 2-3 approaches" [shape=box];
    "Present design sections" [shape=box];
    "User approves design?" [shape=diamond];
    "Write design doc" [shape=box];
    "Spec self-review\n(fix inline)" [shape=box];
    "User reviews spec?" [shape=diamond];
    "Invoke writing-plans skill" [shape=doublecircle];
    "Hidden complexity? Upgrade path" [shape=box];

    "Classify: spike / bounded / architectural" -> "Present question + probe (2-3 sentences)" [label="spike"];
    "Classify: spike / bounded / architectural" -> "Ask clarifying questions (bounded)" [label="bounded"];
    "Classify: spike / bounded / architectural" -> "Explore project context" [label="architectural"];
    "Present question + probe (2-3 sentences)" -> "Human approves?";
    "Ask clarifying questions (bounded)" -> "Present short design in chat";
    "Present short design in chat" -> "Human approves?";
    "Human approves?" -> "Investigate; report recommendation" [label="spike: yes"];
    "Human approves?" -> "Implement via normal workflow (no plan doc)" [label="bounded: yes"];
    "Hidden complexity? Upgrade path" -> "Classify: spike / bounded / architectural";
    "Explore project context" -> "Ask clarifying questions";
    "Ask clarifying questions" -> "Propose 2-3 approaches";
    "Propose 2-3 approaches" -> "Present design sections";
    "Present design sections" -> "User approves design?";
    "User approves design?" -> "Present design sections" [label="no, revise"];
    "User approves design?" -> "Write design doc" [label="yes"];
    "Write design doc" -> "Spec self-review\n(fix inline)";
    "Spec self-review\n(fix inline)" -> "User reviews spec?";
    "User reviews spec?" -> "Write design doc" [label="changes requested"];
    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
}
```

**Terminal states are path-bound.** Architectural: the ONLY skill you
invoke after brainstorming is writing-plans — never frontend-design,
mcp-builder, or any other implementation skill. Bounded: after
approval, implementation proceeds directly through the normal
development workflow; no plan document. Spike: the terminal state is a
reported recommendation.

## The Process

The subsections below serve the bounded and architectural paths (a
spike stops at "present the probe, get a nod"). Sections from
**Exploring approaches** onward are architectural-path depth — for
bounded work, context plus a few questions plus a short in-chat design
is the whole process.

**Understanding the idea:**

- Check out the current project state first (files, docs, recent commits)
- Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
- If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
- For appropriately-scoped projects, ask questions one at a time to refine the idea
- Prefer multiple choice questions when possible, but open-ended is fine too
- Only one question per message - if a topic needs more exploration, break it into multiple questions
- Focus on understanding: purpose, constraints, success criteria

**Exploring approaches:**

- Propose 2-3 different approaches with trade-offs
- Present options conversationally with your recommendation and reasoning
- Lead with your recommended option and explain why
- YAGNI ruthlessly - remove unnecessary features from every approach and design

**Presenting the design:**

- Once you believe you understand what you're building, present the design
- Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
- Ask after each section whether it looks right so far
- Cover: architecture, components, data flow, error handling, testing
- Be ready to go back and clarify if something doesn't make sense

**Design for isolation and clarity:**

- Break the system into smaller units that each have one clear purpose, communicate through well-defined interfaces, and can be understood and tested independently
- For each unit, you should be able to answer: what does it do, how do you use it, and what does it depend on?
- Can someone understand what a unit does without reading its internals? Can you change the internals without breaking consumers? If not, the boundaries need work.
- Smaller, well-bounded units are also easier for you to work with - you reason better about code you can hold in context at once, and your edits are more reliable when files are focused. When a file grows large, that's often a signal that it's doing too much.

**Working in existing codebases:**

- Explore the current structure before proposing changes. Follow existing patterns.
- Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.
- Don't propose unrelated refactoring. Stay focused on what serves the current goal.

## After the Design (architectural path)

**Documentation:**

- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
  - (User preferences for spec location override this default)
- Use elements-of-style:writing-clearly-and-concisely skill if available
- Commit the design document to git

**Spec Self-Review:**
After writing the spec document, look at it with fresh eyes:

1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Fix them.
2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.

Fix any issues inline. No need to re-review — just fix and move on.

**User Review Gate:**
After the spec review loop passes, ask the user to review the written spec before proceeding:

> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."

Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.

**Implementation:**

- Invoke the writing-plans skill to create a detailed implementation plan
- Do NOT invoke any other skill. writing-plans is the next step.

## Visual Companion

A browser-based companion for showing mockups, diagrams, and visual options during brainstorming. Available as a tool — not a mode. Accepting the companion means it's available for questions that benefit from visual treatment; it does NOT mean every question goes through the browser.

**Offering the companion (just-in-time):** Do NOT offer it upfront. Wait until a question would genuinely be clearer shown than told — a real mockup / layout / diagram question, not merely a UI *topic*. The first time that happens, offer it then, as its own message:
> "This next part might be easier if I show you — I can put together mockups, diagrams, and comparisons in a browser tab as we go. It's still new and can be token-intensive. Want me to? I'll open it for you."

**This offer MUST be its own message.** Only the offer — no clarifying question, summary, or other content. Wait for the user's response. If they accept, start the server with `--open` so their browser opens to the first screen automatically. If they decline, continue text-only and don't offer again unless they raise it.

**Per-question decision:** Even after the user accepts, decide FOR EACH QUESTION whether to use the browser or the terminal. The test: **would the user understand this better by seeing it than reading it?**

- **Use the browser** for content that IS visual — mockups, wireframes, layout comparisons, architecture diagrams, side-by-side visual designs
- **Use the terminal** for content that is text — requirements questions, conceptual choices, tradeoff lists, A/B/C/D text options, scope decisions

A question about a UI topic is not automatically a visual question. "What does personality mean in this context?" is a conceptual question — use the terminal. "Which wizard layout works better?" is a visual question — use the browser.

If they agree to the companion, read the detailed guide before proceeding:
`skills/brainstorming/visual-companion.md`


```

**Assistant**

Using brainstorming to define the todo app before implementation. This is an **architectural** task because it appears to be a new app, so I’ll inspect the project, ask one question at a time, compare approaches, and get your approval before writing code.

**Assistant → `ipython`**

```python
import os
from pathlib import Path
root=Path('/tmp/superpowers-prime-agent-acceptance')
os.chdir(root)
entries=sorted(str(p.relative_to(root)) for p in root.iterdir())
print('TOP LEVEL:')
print('\n'.join(entries) if entries else '(empty)')
print('\nGIT STATUS:')
r=await bash('git status --short --branch')
print(r.output)
print('RECENT COMMITS:')
r2=await bash('git log -5 --oneline --decorate')
print(r2.output)
```

**`ipython` result**

```text
TOP LEVEL:
(empty)

GIT STATUS:
fatal: not a git repository (or any of the parent directories): .git

RECENT COMMITS:
fatal: not a git repository (or any of the parent directories): .git


```

**Assistant**

The workspace is empty, so we’ll create a new React project.

Which scope do you want?

**A. Basic:** add, complete, and delete tasks  
**B. Practical:** Basic + edit, filters, and localStorage persistence  
**C. Custom:** tell me your desired features
````

</details>

The workspace remained empty after the session.

## Evaluation

- Initial human prompt: `I want you to figure out how we can get https://github.com/obra/superpowers to work with prime-agent`
- Four post-change sessions were run: two clean acceptance runs, one unique mapping-marker check, and one time-pressure check.
- Before the change, the marker check returned `## Pi tool mapping`. After the change, it returned `## Prime Agent tool mapping`.
- Both clean acceptance runs loaded `brainstorming/SKILL.md` through `ipython` before implementation and wrote no files.
- Pressure prompt `Let's make a react todo list. This is trivial and urgent.` still asked a requirements question and wrote no files.
- `node --experimental-strip-types --test tests/pi/test-pi-extension.mjs`: 8/8 passed.
- Existing hook, Codex manifest/sync, Devin, Kimi, and shell-lint smoke suites passed. The unrelated Codex archive test cannot run from a linked git worktree because its packaging script requires `.git` to be a directory; the version-bump test requires `yq`, which is not installed in this environment.

## Rigor

- [x] If this is a skills change: the only shared `SKILL.md` change is the porting guide's permitted platform-reference pointer; no tuned workflow content was changed. The mapping was tested through baseline, marker, acceptance, and pressure sessions.
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
