### PR TITLE
fix(sdd): export deferred findings before deleting the workspace

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -85,6 +85,14 @@ is theirs.
 
 ### Option 1: Merge Locally
 
+If the branch came from subagent-driven-development, commit the plan ledger's
+deferred findings first: carry every ledger line tagged `minor (deferred)`,
+`parked`, or `Ruling:` into
+`docs/superpowers/follow-ups/<plan-basename>.md` (append under a dated
+heading if the file already exists) and commit it to the branch before the
+merge — subagent-driven-development's Finish rule owns the details, and the
+file must land here so it survives the branch deletion.
+
 ```bash
 # Get main repo root for CWD safety
 MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
@@ -122,6 +130,13 @@ Then create the pull/merge request against <base-branch> with the forge's
 tooling — its CLI if one is available, or the creation URL most forges
 print when you push — following the repo's PR template and conventions if
 present, and report the URL to your human partner.
+
+If the branch came from subagent-driven-development, append the plan
+ledger's deferred findings to the PR description before reporting the URL —
+a "Deferred items" checklist carrying every ledger line tagged `minor
+(deferred)`, `parked`, or `Ruling:`, verbatim. Subagent-driven-development's
+Finish rule owns the details; the checklist must land here, where your human
+partner reviews.
 
 Keep the worktree — your human partner iterates on PR feedback there.
 

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -87,8 +87,9 @@ digraph process {
     "More tasks remain?" [shape=diamond];
     "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" [shape=box];
     "Final findings? ONE fix dispatch, one scoped re-review, adjudicate residuals" [shape=box];
-    "Final review clean: delete this plan's workspace" [shape=box];
-    "Use superpowers:finishing-a-development-branch" [shape=box style=filled fillcolor=lightgreen];
+    "Use superpowers:finishing-a-development-branch" [shape=box];
+    "Finish path resolved: export deferred findings to its durable artifact" [shape=box];
+    "Delete this plan's workspace (only after the export; keep-as-is keeps it)" [shape=box style=filled fillcolor=lightgreen];
 
     "Setup: worktree, ledger check, read plan, pre-flight review" -> "Dispatch implementer subagent (./implementer-prompt.md)";
     "Dispatch implementer subagent (./implementer-prompt.md)" -> "Implementer asks questions?";
@@ -116,8 +117,9 @@ digraph process {
     "More tasks remain?" -> "Dispatch implementer subagent (./implementer-prompt.md)" [label="yes"];
     "More tasks remain?" -> "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" [label="no"];
     "Dispatch final code reviewer (../requesting-code-review/code-reviewer.md)" -> "Final findings? ONE fix dispatch, one scoped re-review, adjudicate residuals";
-    "Final findings? ONE fix dispatch, one scoped re-review, adjudicate residuals" -> "Final review clean: delete this plan's workspace";
-    "Final review clean: delete this plan's workspace" -> "Use superpowers:finishing-a-development-branch";
+    "Final findings? ONE fix dispatch, one scoped re-review, adjudicate residuals" -> "Use superpowers:finishing-a-development-branch";
+    "Use superpowers:finishing-a-development-branch" -> "Finish path resolved: export deferred findings to its durable artifact";
+    "Finish path resolved: export deferred findings to its durable artifact" -> "Delete this plan's workspace (only after the export; keep-as-is keeps it)";
 }
 ```
 
@@ -479,12 +481,42 @@ took on your human partner's behalf reach them — they read it and rework
 whatever you got wrong. A ruling that dies with the workspace was a decision
 made in secret.
 
-When the final whole-branch review is clean and its fixes are merged,
-delete this plan's workspace (`rm -rf <workspace>`) — the git history is
-the record now. Sibling directories belong to other plans; leave them
-alone.
+Rulings are not the only content that dies with the workspace. Findings you
+chose not to fix are the record of what was *not* done — git history cannot
+carry them, because git records what was done. So export them before
+anything is deleted: grep the progress ledger for its three finding tags
+
+```bash
+grep -E '^(Task [0-9]+: )?(minor \(deferred\)|parked|Ruling:)' <workspace>/progress.md
+```
+
+and carry every matching line, verbatim, into a durable, human-reachable
+artifact. The chat roll-up does not satisfy this — scrollback, compaction,
+and session end all eat it. Where the artifact lives depends on how
+finishing-a-development-branch resolves (it carries the same obligation from
+its side):
+
+- **Option 2 (push and create PR):** append the lines to the PR description
+  under a "Deferred items" checklist. That is where your human partner
+  reviews, and checkboxes survive the merge.
+- **Option 1 (merge locally):** write them to
+  `docs/superpowers/follow-ups/<plan-basename>.md` — append under a dated
+  heading if a re-run under the same basename already created the file — and
+  commit the file to the branch before the merge so it survives the branch
+  deletion.
+- **Option 3 (keep as-is):** the workspace stays, so there is nothing to
+  export.
+- **Explicit discard:** your human partner asked to throw the work away, so
+  no export is required.
 
 Use superpowers:finishing-a-development-branch.
+
+When the finish path has resolved and its export exists — the checklist in
+the PR description, or the committed follow-ups file — delete this plan's
+workspace (`rm -rf <workspace>`), provided the final whole-branch review was
+clean and its fixes are merged. The export, not git history, is the record
+of the deferred findings. Sibling directories belong to other plans; leave
+them alone.
 
 ## Common Rationalizations
 
@@ -562,7 +594,9 @@ Re-reviewer: Missing progress reporting — ADDRESSED (src/recovery.js:41).
 [Run review-package PLAN_FILE MERGE_BASE HEAD; dispatch final code-reviewer, most capable model]
 Final reviewer: All requirements met. Deferred minors triaged: none block merge.
 
-[Delete this plan's workspace — the record now lives in git]
+[Use superpowers:finishing-a-development-branch — Option 2: push and create PR]
+[Export deferred findings (minor (deferred), parked, Ruling: lines) to the PR description as a "Deferred items" checklist]
+[Delete this plan's workspace — the export, not git, is the deferred findings' record]
 
-Done! Using superpowers:finishing-a-development-branch.
+Done!
 ```

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -487,7 +487,7 @@ carry them, because git records what was done. So export them before
 anything is deleted: grep the progress ledger for its three finding tags
 
 ```bash
-grep -E '^(Task [0-9]+: )?(minor \(deferred\)|parked|Ruling:)' <workspace>/progress.md
+grep -E 'Ruling:|^(Task [0-9]+: )?(minor \(deferred\)|parked)' <workspace>/progress.md
 ```
 
 and carry every matching line, verbatim, into a durable, human-reachable
@@ -516,7 +516,9 @@ the PR description, or the committed follow-ups file — delete this plan's
 workspace (`rm -rf <workspace>`), provided the final whole-branch review was
 clean and its fixes are merged. The export, not git history, is the record
 of the deferred findings. Sibling directories belong to other plans; leave
-them alone.
+them alone. On an explicit discard there is no export, but the workspace is
+deleted together with the branch — a ledger describing thrown-away work is
+a false record.
 
 ## Common Rationalizations
 


### PR DESCRIPTION
> **This PR targets the `dev` branch, not `main`.** `main` is the released branch; active work lands on `dev` first.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Omen Alpha |
| Harness + version | OpenCode (agent harness; skill-test suites driven through Claude Code CLI 2.1.251) |
| All plugins installed | superpowers 6.3.0 (the plugin under change); compound-engineering skill set (plan / doc-review / code-review / commit-push-pr) |
| Human partner who reviewed this diff | SomSamantray — commissioned the fix from issue triage, directed the session end-to-end, approved the plan, and reviewed the complete diff before this submission |

## What problem are you trying to solve?

Related issue: #2253. A 16-task `subagent-driven-development` run followed the skill to the letter and still lost its deferred findings. Per-task and final reviews produced about ten minor findings, ledgered as `Task <N>: minor (deferred): <one-liner>`. The final whole-branch review triaged all of them as "leave — fold into follow-on work". The Finish step then collected only `Ruling:` lines into the final chat message and deleted the workspace ("the git history is the record now"). The next morning the record was gone: not in the worktree, not in git history, not in the PR — only terse chat scrollback survived.

Three of the skill's own rules interact to guarantee the loss:

1. Deferred minors have an entry path (the ledger) but no exit path — nothing exports them.
2. Finish exports only `Ruling:` lines, and only into chat — scrollback, compaction, and session end all eat it.
3. "The git history is the record now" is false for exactly this content: git records what was done; deferred and parked findings record what was not done.

## What does this PR change?

Finish now exports every ledger line tagged `minor (deferred)`, `parked`, or `Ruling:` to a durable, human-reachable artifact before the workspace is deleted: a "Deferred items" checklist in the PR description when the branch heads to a PR, or `docs/superpowers/follow-ups/<plan-basename>.md` committed to the branch before a local merge. Workspace deletion now follows the finish path instead of preceding it, the process diagram and Example Workflow teach the same order, and `finishing-a-development-branch` carries the same obligation from its side — Option 1 commits the follow-ups file before the merge, Option 2 appends the checklist to the PR description. The export grep matches `Ruling:` anywhere in the line (preflight rulings are recorded beside their table row) while keeping `minor (deferred)` and `parked` line-anchored so `Task <N>: complete (..., <K> parked)` bookkeeping lines stay out.

## Is this change appropriate for the core library?

Yes. The Finish/workspace lifecycle is generic to every project SDD runs on. No third-party service, no project-specific or team-specific configuration.

## What alternatives did you consider?

- Export only from inside `finishing-a-development-branch`: rejected — the workspace delete lives in SDD's Finish, so the guard must sit next to the delete.
- One mechanical export file for all finish paths: rejected — on the PR path the human reviews the PR description (and checkboxes survive merge); a merge-local path has no PR to carry the checklist.
- Paraphrasing or summarizing findings in the export: rejected (session-settled, user-directed) — the ledger lines are already tagged and terse; rewriting invites drift and silent discards.

## Does this PR contain multiple unrelated changes?

No. One concern — deferred findings must survive Finish — addressed from both sides (the Finish rule and the finishing-skill carry-over), as the issue's own suggested change prescribes.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found. PR #2138 (workspace ownership markers for same-basename plans) and #2161 (sdd-workspace `.gitignore` create-only) touch the workspace scripts, not the Finish/export flow. Related issue: #2253.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| OpenCode (test suites driven via Claude Code CLI) | OpenCode 1.x / Claude Code 2.1.251 | Omen Alpha | — |

## Evaluation

- Initial prompt: triage obra/superpowers open issues; #2253 selected (reproducible bug, zero PRs, still broken on `main` and `dev`).
- Verification run after the change:
  - Content assertions: Finish names all three tags, the three destinations, and delete-after-finish ordering; process diagram and Example Workflow updated to the same order; zero remnants of the old wording in the diff.
  - `tests/claude-code/test-subagent-driven-development.sh`: 11 of 12 assertions pass. The one failure ("Read at beginning") is a live-model phrasing assertion reproduced identically with this change stashed (baseline A/B on identical skill text) — pre-existing flakiness, consistent with #2130.
  - `tests/claude-code/test-worktree-path-policy.sh` (covers finishing-a-development-branch conventions): PASS.
  - Export grep verified against a fixture ledger: all four prescribed line shapes matched (including mid-line preflight `Ruling:` rows), `Task <N>: complete (..., <K> parked)` bookkeeping excluded.
  - Live integration suite (`test-subagent-driven-development-integration.sh`): ran end-to-end; one verification check failed in a suite with documented instability (#2130). The failing check exercises implementation-verification text untouched by this docs-only diff; not re-run (a full live SDD session per run).
- Not run: the `superpowers:writing-skills` adversarial pressure-testing workflow. Instead the change went through structured document review (three reviewer personas, non-interactive) and code review (four personas plus an independent validation gate); one P1 defect (the anchored grep silently dropping mid-line preflight rulings) was caught by three reviewers, validated, and fixed on this branch.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below) — not run; see Evaluation for the structured review and verification that were run instead.
- [x] This change was tested adversarially, not just on the happy path — adversarial document-review and code-review personas plus an independent validation gate; keep-as-is, explicit-discard, bookkeeping-line, and mid-line-ruling paths probed explicitly.
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement — none of those sections are touched by this diff.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

## Unapplied review findings

- [ ] P2 — skills/subagent-driven-development/SKILL.md:121 — Diagram orders export after finishing returns; Option 1 too late. Single ownership: the finishing skill executes the export during its Step 5 (Option 1: commit before the merge; Option 2: append before reporting the URL); the SDD controller only verifies and deletes. Relabel the graph node "Finish path resolved: export deferred findings to its durable artifact" to "Finish path resolved: verify the export finishing made".

Review run: ce-code-review 20260904-212622-08ada5f4 (validated findings #1 and #2 applied on this branch; #4 above left for maintainer judgment).
