### PR TITLE
docs(porting): warn that package-bundled context files may not auto-load

### DIFF
--- a/docs/porting-to-a-new-harness.md
+++ b/docs/porting-to-a-new-harness.md
@@ -96,7 +96,9 @@ one non-negotiable capability. It can take any form:
 - an **instructions-file** convention where the harness loads a context file that
   *your installed extension ships and declares* (e.g. Gemini's `contextFileName`
   pointing at the extension's own `GEMINI.md`) — not a file you edit in the user's
-  home.
+  home. Shipping and declaring the file are necessary but not sufficient: the
+  harness must actually load it at session start, and you only know that from a
+  unique-marker test.
 
 If the only way to get Superpowers in front of the model is for your human
 partner to opt in each session (paste a prompt, run a command, enable a mode),
@@ -797,6 +799,17 @@ Use this as the live index; when in doubt, read the files, not this table.
 
 - **Opt-in isn't a port.** If your human partner has to do anything per session
   to get Superpowers, the acceptance test fails. Re-read Part 2.
+- **Two tiers of always-on context, only one of which auto-loads.** A harness
+  can load *package-bundled* steering only on demand, while auto-loading the
+  same kind of file from the *user's own config directory* every session. Kiro
+  does this: Power-bundled steering under
+  `~/.kiro/powers/installed/<power>/steering/` is reachable only via an explicit
+  read call; `~/.kiro/steering/` is in context at startup. Shipping into the
+  bundled tier looks right — right directory, right frontmatter, declared by your
+  manifest — and still never reaches the model, while the only tier that does
+  auto-load is the user's own config directory, which rule 2 forbids you to
+  write to (#618, #503 — a working Kiro port takes a different mechanism).
+  Marker-test the exact tier you ship into (Part 2).
 - **Wrong JSON field → silent failure or double injection.** Shape A only.
   Confirm the exact field/nesting; Claude Code reads two fields without dedup.
 - **Hook-config schema varies per harness.** Shape A. Cursor's `hooks-cursor.json`


### PR DESCRIPTION
<!-- Targets `dev`. Documentation-only; adds no harness. -->

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Kiro CLI v3 agent engine (`KIRO_AGENT_ENGINE=kas`). Configured default model `gpt-5.6-sol` per `~/.kiro/settings/cli.json`. I cannot self-verify at runtime which model served this session; that config value is the honest upper bound of what I can report. |
| Harness + version | Kiro CLI 2.21.0, launched with `--v3` |
| All plugins installed | Kiro Powers installed: `power-builder`, `devlog`. **No Superpowers integration was installed** — that is central to this PR (see below). No third-party plugins. |
| Human partner who reviewed this diff | Medhat Galal (@medhatgalal) — reviewed the complete two-hunk diff before submission |

## What problem are you trying to solve?

I built Kiro support as an Agent Plugins Power: a root `plugin.json` reusing the live `skills/` tree, with the `using-superpowers` bootstrap in `dev.kiro/steering/using-superpowers.md` declaring `inclusion: always`. Manifest, test suite, install docs, the lot. Then I checked whether that bootstrap would actually load at session start. It does not.

Kiro has **two steering tiers that behave differently**, and both are observable from inside a single session:

- `~/.kiro/powers/installed/power-builder/steering/` holds 47KB across two files (`interactive.md` 36,706 bytes, `testing.md` 10,505 bytes). **None of it is in my context.** It is reachable only through an explicit `readSteering` call.
- `~/.kiro/steering/AGENTS.md` is 1,941 bytes and **is** in my context at startup, with no tool call.

So the package-bundled tier loads on demand, and the only tier that auto-loads is the user's own config directory — which rule 2 forbids writing to. Every intermediate signal says the bundled approach is correct: right directory, right frontmatter, documented by the vendor, preserved by the installer. The failure is silent and only shows up when you marker-test.

Supporting detail: Kiro's Agent Plugins manifest declares no skills-path field, and the published schema sets `additionalProperties: false`, so a manifest cannot legally point outside its own directory either.

**This is a repeat trap, not my one-off.** Five Kiro attempts have hit it. #618's author independently reported the same behaviour in April 2026 after testing the legacy `POWER.md` format — Power-bundled steering is not auto-injected, only reachable after activation — and #618 is blocked specifically because its workaround copies a file into `~/.kiro/steering/`. I hit the identical wall from the newer Agent Plugins direction without having read that thread first, which is what convinced me the guide should carry the warning.

I abandoned my integration rather than submit it. This PR is the part of that work worth keeping.

## What does this PR change?

Adds one Appendix B gotcha describing the two-tier trap, generalized to "a harness" with Kiro as the named concrete example. Adds one qualifying sentence to Part 2's instructions-file bullet noting that shipping and declaring a context file are necessary but not sufficient — the harness must actually load it at session start.

## Is this change appropriate for the core library?

Yes. It is porting-guide guidance, the same category as the existing "a hook *system* is not a session-start *event*" and "don't trust that an `@`-include is actually expanded" warnings. It is written for any harness with more than one context tier, not just Kiro. It adds no skill, no dependency, no third-party integration, and touches no behavior-shaping skill content.

## What alternatives did you consider?

- **Register Kiro as a supported harness.** Rejected: the mechanism I built does not work, and #2126 already supports Kiro CLI through a v3 custom agent with declared startup resources. Submitting mine would have been a duplicate of a better approach.
- **Add a Shape section and an Appendix A row.** Rejected: #2126 edits the routing table, adds a Shape D, and adds an Appendix A row. Two PRs editing the same tables for the same harness is a conflict I chose not to create. This PR deliberately touches neither.
- **Comment on #618 instead of opening a PR.** I am doing that as well, but the finding belongs in the guide so the next porter of *any* tool sees it before building. A buried PR comment does not reach them.
- **Say nothing and drop the work.** Rejected: four stalled PRs suggest the next person will spend the same effort discovering the same thing.

## Does this PR contain multiple unrelated changes?

No. Both hunks assert the same invariant — a shipped context file is not necessarily a loaded one — once as a stop-early check in Part 2 and once as a gotcha in Appendix B. The Part 2 sentence is the specific wording that misled me, so correcting it alone would leave the trap undocumented, and adding the gotcha alone would leave the misleading sentence standing.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2126, #618, #527, #363, #788; issues #503, #319

**#2126** (open) — Kiro v3 custom agent. The working approach. This PR does not compete with it and deliberately avoids every file it touches. **#618** (open) — Kiro Power + steering, the same mechanism I attempted; blocked for exactly the reason this PR documents. **#527, #363, #788** (closed) — earlier Kiro attempts in the same family. **#503** (open) / **#319** (closed) — the Kiro CLI support requests.

Nothing here duplicates any of them. This PR documents why four of them stalled, and does not claim Kiro is supported or unsupportable.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Kiro CLI (v3 agent engine) | 2.21.0 | see disclosure above | `gpt-5.6-sol` (configured default) |

Documentation change; verified by reading the rendered Markdown and by confirming the two-tier claim directly against the local Kiro installation (paths and byte counts quoted above are from this machine).

## New harness support (required if this PR adds a new harness)

**Not applicable — this PR adds no harness.** No manifest, no bootstrap, no installer, no `tests/` directory. The acceptance-test transcript requirement does not apply. Stating this explicitly rather than leaving the section blank.

## Evaluation

- **Initial prompt that led here:** package Superpowers so Kiro users can install and use its skills, delivered as a Power using the Agent Plugins spec.
- **Eval sessions run after the change:** none. This is documentation, not behavior-shaping content, so there is no agent behaviour to measure. I would rather say that than dress up a docs edit as an eval.
- **How outcomes changed:** the session's outcome was a negative result. Before checking, I had a complete Power package and believed it worked. After checking, the bootstrap provably never loads. The change captured here is the guide gaining the check that would have redirected me — and, on the evidence of #618/#527/#363/#788, four other contributors — before building anything.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` — **not a skills change; not applicable**
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content

On adversarial testing: the claim in the bullet is the *negative* case. I did not assume the bundled tier fails — I built the integration on the assumption it works, then falsified it against a live installation with two independently-installed Powers. The finding also survives cross-checking against #618's independent April 2026 report using a different Kiro manifest format, which is the strongest corroboration available without maintainer access.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

The full two-hunk diff (14 insertions, 1 deletion, one file) was presented to Medhat Galal and approved before this PR was opened.
