### PR TITLE
docs(writing-skills): re-resolve and verify relative links when moving content

### DIFF
--- a/skills/writing-skills/SKILL.md
+++ b/skills/writing-skills/SKILL.md
@@ -371,6 +371,35 @@ pptx/
 ```
 When: Reference material too large for inline
 
+### Moving Content Into a Skill
+
+Relative paths mean nothing on their own - they resolve against the file holding them. Moving content to a different depth invalidates every relative reference inside it.
+
+**Re-resolve links mechanically, never by counting `../` by eye:**
+
+```bash
+# From the moved file's directory, assert every relative target exists
+d=$(dirname "$FILE")
+grep -o ']([^)]*)' "$FILE" | sed 's/^](//;s/)$//' | while read -r l; do
+  case "$l" in http*|\#*|mailto:*|"") continue;; esac
+  [ -e "$d/${l%%#*}" ] || echo "DANGLING: $l"
+done
+```
+
+A link that is one `../` short still renders as a link. The count is not something you verify by looking at it.
+
+Read the output - this is a heuristic, not a parser, so `](` inside a fenced code block shows up as a false positive.
+
+**Then grep the moved text for prose cross-references:**
+
+```bash
+grep -n 'above\|below\|earlier\|later' "$FILE"
+```
+
+"The section above" has no referent once that section lives in a different file. No link checker can catch this - only reading can.
+
+**Why this matters:** a dangling link fails silently. The agent follows it, finds nothing, and proceeds without the context it was supposed to have. No error, no failing test.
+
 ## The Iron Law (Same as TDD)
 
 ```
@@ -660,6 +689,7 @@ Deploying untested skills = deploying untested code. It's a violation of quality
 - [ ] Common mistakes section
 - [ ] No narrative storytelling
 - [ ] Supporting files only for tools or heavy reference
+- [ ] Content moved from another file: every relative link re-resolved against the new location and verified to exist; prose cross-references (`above`, `below`, `earlier`, `later`) re-read for lost referents
 
 **Deployment:**
 - [ ] Commit skill to git and push to your fork (if configured)


### PR DESCRIPTION
Closes #2233

Scoped per @obra's triage comment on that issue: this covers **only** the relative-link / prose-reference half. The YAML `Triggers on:` half is deliberately excluded and is already tracked in #955, so closing #2233 on merge drops nothing — it consolidates that half where @obra asked for it. If you'd rather keep #2233 open until #955 lands, drop the `Closes` line and I'll switch it to `Refs`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 5 (`claude-opus-5`). Eval subagents ran Claude Sonnet 5 (`claude-sonnet-5`). |
| Harness + version | Claude Code 2.1.260, desktop app (Code tab), Windows 11 |
| All plugins installed | `superpowers` 6.3.0 via the `claude-plugins-official` marketplace — the only marketplace plugin installed. Plus the Claude Code desktop app's own bundled skills (artifact-design, dataviz, code-review, etc.), which are harness built-ins, not plugins. |
| Human partner who reviewed this diff | @Yash-Chindam — reviewed the complete 30-line diff in-session before submission and required an eval run before approving. |

## What problem are you trying to solve?

Moving Markdown content to a different directory depth silently invalidates every relative reference inside it, and `writing-skills` has no rule anywhere telling an agent to re-resolve and verify.

This repo shipped exactly that failure: #1969, where a deleted reference file left `writing-skills`' own SKILL.md pointing at nothing (fixed in fb7b070).

I reproduced it as a controlled eval rather than asserting it. Fixture: `docs/notes/GUIDE.md` (2 levels deep, 14 relative links of varied depth, plus one prose "the section above") with one section extracted into `skills/retry-policy/references/deep/GUIDE.md` (4 levels deep). Prompt carried realistic release pressure: *"We're mid-release and I'm batching up doc moves — this is the last of twelve files, so keep it quick."* Five reps per arm, fresh context each, **graded mechanically against the filesystem — not from the agents' own reports.**

**Baseline (no guidance):**

| Rep | Dangling links | "the section above" orphaned |
|---|---|---|
| 1 | 0/13 | left in |
| 2 | 0/13 | left in |
| 3 | **13/13** | left in |
| 4 | 0/13 | left in |
| 5 | **13/13** | left in |

Two of five reps shipped **every single link broken**. All five left the orphaned prose reference. **All five reported "Done" with no caveat** — which is the actual danger: the failure is invisible in the agent's own report. Verbatim from rep 3: *"Done — '## Applying the policy' moved ... and removed from the original."*

## What does this PR change?

Adds a "Moving Content Into a Skill" section to `skills/writing-skills/SKILL.md` with a shell loop that resolves each relative target against the moved file's directory, plus a grep for orphaned prose cross-references, and one matching checklist item.

## Is this change appropriate for the core library?

Yes. Relative-link breakage on move is format-level, not domain-level — it applies to anyone authoring or refactoring skills in any project. It adds no dependency: the check is `grep`, `sed` and `test`, all already assumed by the repo. And it targets a failure this repo itself hit (#1969).

## What alternatives did you consider?

1. **A link-checker script committed to the repo.** Rejected — Superpowers is zero-dependency by design, and a script only runs if something invokes it. The failing case is an agent moving content ad hoc, where no CI step is in the loop.
2. **A CI job over all Markdown.** Rejected for this PR: it catches links but is structurally blind to the prose half ("the section above"), which the eval shows fails **5/5** — the more reliable failure of the two. It's also a repo-infrastructure change, not a skill change, so it belongs in its own PR.
3. **Prose-only guidance ("remember to re-check links").** Rejected on `writing-skills`' own "Match the Form to the Failure" guidance: the baseline failure is a *skipped verification step*, so the fix has to be an executable check, not a reminder. Counting `../` by eye is precisely what fails.
4. **Also fixing the YAML half from the issue.** Deliberately excluded — already tracked in #955, and bundling would make this two unrelated changes.

## Does this PR contain multiple unrelated changes?

No. One file, one section, one checklist line, +30 lines.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: **no open or closed PR addresses #2233.** Prior art on the same failure class: **#1970** (CLOSED) fixed dead references to pruned `claude-code-tools.md`/`copilot-tools.md`, and **#1532** (MERGED) fixed one broken anti-patterns link.

#1970 and #1532 each repaired specific dead links after the fact. Neither added a rule to stop the next one being created. This PR is the preventive half, which is why it should not meet #1970's fate: it is not a re-fix of the same links, and it is not speculative — the eval above shows the failure recurring at 40% (links) and 100% (prose) under release pressure.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code (desktop app, Code tab) | 2.1.260 | Claude Opus 5 (authoring) | `claude-opus-5` |
| Claude Code (subagents) | 2.1.260 | Claude Sonnet 5 (20 eval sessions) | `claude-sonnet-5` |

## New harness support (required if this PR adds a new harness)

**N/A — this PR does not add or modify harness support.** It changes one documentation section in an existing skill. No installer, bootstrap, or runtime integration is touched, so the "Let's make a react todo list" acceptance transcript does not apply.

## Evaluation

**Initial prompt that led to this change:** the session was pointed at issue #2233 and asked to act on it following CONTRIBUTING/CLAUDE.md. Scope came from @obra's triage comment on the issue, not from my own framing.

**Eval sessions run AFTER the change: 20 total**, across two scenarios, 5 reps per arm, fresh context each, all graded mechanically against the filesystem.

**Scenario A — small extraction (2 links, prompt cued "standalone document"):**

| Arm | Correct link depth | Prose ref handled |
|---|---|---|
| Control | 5/5 | 5/5 |
| With guidance | 5/5 | 5/5 |

**Null result, reported deliberately.** The control never failed, so the guidance changed nothing. It did change *behavior* — treatment reps ran the mechanical check and said so — but not outcomes. On this scenario alone, `writing-skills`' own rule applies: *"If the control doesn't exhibit the failure, there is nothing to fix."* That is why I built Scenario B rather than stopping at a favourable-looking pass.

**Scenario B — 14 links, varied depth, release pressure, no "standalone" cue** (faithful to the issue's reported conditions):

| Arm | Reps shipping broken links | Reps leaving orphaned prose ref |
|---|---|---|
| Control | **2/5** (13/13 dangling each) | **5/5** |
| With guidance | **0/5** (0/14 dangling, every rep) | **0/5** |

**How outcomes changed:** on the scenario that reproduces the reported failure, link breakage went 2/5 → 0/5 and orphaned prose references went 5/5 → 0/5. Treatment reps converged on the same shape — run the loop, read the output, re-resolve to `../../../../docs/...`, convert "the section above" into an explicit cross-file link — which is the low-variance signal `writing-skills` asks for.

**Honest limits of this eval:**
- Guidance was injected into the prompt, not loaded through the live skill-discovery path.
- Subagents ran Sonnet 5, not Opus 5.
- Scenario A shows no benefit for small moves. The change is not free everywhere; it earns its place on large moves under pressure.
- One treatment rep self-reported "all 11 relative links" when the file has 14. Its output was nonetheless correct (0/14 dangling) — a miscount in its prose, not in its work. I caught this only because I graded files instead of trusting reports, which is the same lesson the section teaches.

**The snippet itself was tested before use**, on a fixture with a correct link, a one-`../`-short link, http/anchor/mailto links, a `#fragment` link, and a `](` inside a code fence. It flagged the short link, skipped the schemes, handled the fragment, and produced only the code-fence false positive the section explicitly warns about.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (results above)
- [x] This change was tested adversarially, not just on the happy path — the deciding scenario used release-time pressure and a bulk-chore framing, and I reported the null result from the easy scenario rather than dropping it
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) — this is additive: one new section plus one checklist line, no existing wording touched

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

@Yash-Chindam reviewed the full 30-line diff in-session, declined to submit on my first pass because the Evaluation section would have read "zero eval sessions", and required the eval above before approving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
