### PR TITLE
fix(brainstorm): honor BRAINSTORM_HOST and BRAINSTORM_URL_HOST env vars

### DIFF
--- a/skills/brainstorming/scripts/start-server.sh
+++ b/skills/brainstorming/scripts/start-server.sh
@@ -23,8 +23,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR=""
 FOREGROUND="false"
 FORCE_BACKGROUND="false"
-BIND_HOST="127.0.0.1"
-URL_HOST=""
+BIND_HOST="${BRAINSTORM_HOST:-127.0.0.1}"
+URL_HOST="${BRAINSTORM_URL_HOST:-}"
 IDLE_TIMEOUT_MINUTES=""
 while [[ $# -gt 0 ]]; do
   case "$1" in


### PR DESCRIPTION
> **This PR MUST target the `dev` branch, not `main`.**

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | muse-spark-1.2-contributor-free |
| Harness + version | OpenCode |
| All plugins installed | superpowers@git+https://github.com/obra/superpowers.git (dev) |
| Human partner who reviewed this diff | Daniele Parisi — reviewed complete diff before submission |

## What problem are you trying to solve?

In containerized and remote environments (Docker, dev containers, Codespaces, remote SSH) the brainstorm visual companion needs to bind to a non-loopback interface and advertise a host that is reachable from outside the container. `server.cjs` already honors `BRAINSTORM_HOST`, `BRAINSTORM_URL_HOST`, `BRAINSTORM_PORT` etc. via env, but `skills/brainstorming/scripts/start-server.sh` hardcodes its defaults:

```
BIND_HOST="127.0.0.1"
URL_HOST=""
```

and later derives `URL_HOST=localhost` for loopback binds. It ignores `BRAINSTORM_HOST` / `BRAINSTORM_URL_HOST` env. Users running in containers export `BRAINSTORM_HOST=0.0.0.0` and `BRAINSTORM_URL_HOST=<external-host>` (plus port mappings like `3000:3000`) expecting `start-server.sh --project-dir <path>` to pick them up, but it still binds to `127.0.0.1` and prints `http://localhost:XXXX/?key=...`, which is not reachable from outside the container/network.

## What does this PR change?

2-line env-aware default in `skills/brainstorming/scripts/start-server.sh:26-27`:

```
-BIND_HOST="127.0.0.1"
-URL_HOST=""
+BIND_HOST="${BRAINSTORM_HOST:-127.0.0.1}"
+URL_HOST="${BRAINSTORM_URL_HOST:-}"
```

CLI flags `--host` / `--url-host` still win via the existing `case` parser. When env is unset, defaults remain `127.0.0.1` / `localhost` (backward compatible). When env is set, bare `start-server.sh --project-dir ...` now respects it and prints a URL that is reachable from outside the container without requiring per-invocation flags.

## Is this change appropriate for the core library?

Yes. General-purpose, benefits any Docker/remote/VM user. Follows the existing `BRAINSTORM_*` env contract already used by `server.cjs` (`BRAINSTORM_PORT`, `BRAINSTORM_DIR`, `BRAINSTORM_TOKEN`, etc.). No third-party integration.

## What alternatives did you consider?

- **Wrapper script** translating env → `--host` args without touching upstream. Worse: requires agents to remember the wrapper, not transparent for bare `start-server.sh` calls.
- **Doc-only fix** (“always pass `--host 0.0.0.0 --url-host $HOSTNAME`”). Worse: relies on every harness/LLM remembering flags; env is container-native idiom (like `PORT`).

Chosen: minimal env-aware default, idiomatic for containers, preserves explicit-flag precedence.

## Does this PR contain multiple unrelated changes?

No. Single 2-line change in `start-server.sh`.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found for `BRAINSTORM_HOST` env handling

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| OpenCode | 1.18.x | muse-spark-1.2-contributor-free | opencode-zen/muse-spark-1.2-contributor-free |

## Evaluation

Manual tests (3 sessions):
1. `bash start-server.sh --project-dir /tmp/test1` (no env) → `host 127.0.0.1 url_host localhost` (unchanged) ✓
2. `BRAINSTORM_HOST=0.0.0.0 BRAINSTORM_URL_HOST=example.com bash start-server.sh --project-dir /tmp/test2` → `host 0.0.0.0 url_host example.com` ✓
3. Same env + explicit `--host 127.0.0.1 --url-host localhost` → `host 127.0.0.1 url_host localhost` (explicit wins) ✓

## Rigor

- [x] If this is a skills change: used `superpowers:writing-skills` guidance, no behavior-shaping prose changed (only shell defaults)
- [x] Tested adversarially (env unset, env set, explicit flag override), not just happy path
- [x] Did not modify Red Flags / rationalizations / “human partner” language

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission