### PR TITLE
fix(brainstorming): a request for context does not close the open question

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -169,6 +169,7 @@ is the whole process.
 - For appropriately-scoped projects, ask questions one at a time to refine the idea
 - Prefer multiple choice questions when possible, but open-ended is fine too
 - Only one question per message - if a topic needs more exploration, break it into multiple questions
+- A request for context is not an answer - if the user asks for trade-offs, implications, or examples instead of choosing, give them that and then re-ask the same question. It stays the only open question until they decide; don't pair it with a new one
 - Focus on understanding: purpose, constraints, success criteria
 
 **Exploring approaches:**


### PR DESCRIPTION
> Targets `dev`.

Fixes #1989. Eval data and full method posted as a comment on the issue: https://github.com/obra/superpowers/issues/1989#issuecomment-5552534484

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 5 (`claude-opus-5`) |
| Harness + version | Claude Code 2.1.260 (desktop app), Windows 11 |
| All plugins installed | `superpowers@claude-plugins-official` v6.3.0 (`b36e0829c6d0`) — the only plugin installed |
| Human partner who reviewed this diff | @Yash-Chindam |

Coding agents under test for the evals: Codex CLI 0.153.4 (ChatGPT auth) and Claude Code 2.1.260 / Opus 5.

## What problem are you trying to solve?

Reported in #1989 by @iskandersierra, hit in a real Codex session designing phase 1 of a roadmap: the agent asks a design question, the user asks for context instead of answering, the agent supplies the context and then moves to a *different* question. The original decision is still open, but the conversation has advanced past it.

The questioning rules say to ask one question at a time and "Only one question per message", but nothing defines what *closes* a question. A request for clarification is not an answer, and the skill never says so.

I measured how often this actually happens, because "an agent might do this" is not a problem statement. On Codex with the question tool available, the stock skill held the open question in **2 of 15** sessions. The other 13 supplied the trade-offs and then pitched forward — "If you want, I can turn that into a concrete design next" — with the original decision never put back to the user.

## What does this PR change?

Adds one bullet to `skills/brainstorming/SKILL.md`, immediately after the existing `Only one question per message` line, stating that a request for context is not an answer: supply the context, re-ask the same question, and keep it the only open question. One line, one file, no existing text modified.

## Is this change appropriate for the core library?

Yes. It is not tied to a project, domain, repo layout, or third-party tool — it tightens flow control inside the core brainstorming loop, which every user of the skill goes through. It adds no dependency. It extends the existing one-question-at-a-time rule rather than introducing a new workflow, and it sits inline with the bullets it qualifies.

Per the issue's own analysis, the alternative homes were considered and rejected: platform-adaptation docs would scope it to particular harnesses, when the ambiguity is in the brainstorming flow itself.

## What alternatives did you consider?

1. **Leave it as-is.** Rejected on measurement: 13/15 stock Codex sessions advanced past the open question. That is the default behavior, not an edge case.

2. **Treat it purely as a harness bug and close the issue.** This one has real merit and I want to flag it rather than bury it. Codex ships `default_mode_request_user_input` set to `false`; with it off, Codex has no tool to ask a question mid-task, emits `request_user_input is unavailable in Default mode`, and substitutes "If you want, I can…". In that configuration the bullet is worth ~nothing (1/5 vs 0/5) because no wording can make an agent use a tool it does not have. **If maintainers judge that the harness flag is the real fix, this PR should be closed** — I would rather say that here than argue past it. The case for landing the bullet anyway is that it still helps once the tool exists, and costs one line.

3. **Stronger wording from the issue** ("A request for more context is not an answer. It does not satisfy the one-question-at-a-time rule."). I used the shorter form to match the surrounding bullet style and token-efficiency guidance in `writing-skills`. I did not eval the two wordings against each other, so I have no evidence one is better — happy to swap if you prefer the issue's phrasing.

4. **Add it to the Red Flags table or as a standalone section.** Rejected: the failure is a flow-control slip inside the questioning loop, and per "Match the Form to the Failure" the guidance belongs where the rule it qualifies already lives.

## Does this PR contain multiple unrelated changes?

No. One bullet, one file.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: **none open.** #2213 previously proposed nearly identical wording, but it and its author's account now return 404 — the account was removed and GitHub took the PR with it. I verified via `gh api repos/obra/superpowers/pulls/2213` (404) and `gh api users/loulanyue` (404), and no PR cross-references #1989 in its timeline. That PR also targeted `main` and skipped this template; this one targets `dev`, completes the template, and carries the eval evidence that was asked for and never supplied.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Codex CLI | 0.153.4 | GPT-5.x (ChatGPT auth, default) | default for the account |
| Claude Code (desktop app) | 2.1.260 | Claude Opus 5 | `claude-opus-5` |

## Evaluation

**Initial prompt.** My human partner sent me issue #1989 and asked whether they could work on it, then asked me to run the evals the maintainer said would move it.

**Method.** Two arms per harness — stock `dev` @ `fd02874` vs patched — installed as separate plugin roots (`--plugin-dir` for Claude Code; `codex plugin marketplace add <local path>` for Codex), verified before every batch by grepping the installed `SKILL.md` for the bullet (expect 0 / expect 1). Fresh git fixture per run: the empty tasks page from `create_cost_checkbox_page`. Two user turns — the notifications request, then a context request that answers nothing and states no preference. Graded on the load-bearing criterion: was the agent's next request for input the same decision (restated, reworded, or with options), or a new question / a move to design. Offers to advance graded as fails.

**Sessions run after the change: 40 in total** (10 Claude Code, 30 Codex).

| Configuration | Stock | Patched |
|---|---|---|
| Claude Code / Opus 5 | 4/5 held | 4/5 held |
| Codex, `request_user_input` off (default) | 0/5 | 1/5 |
| Codex, `request_user_input` on | **2/15** | **7/15** |

**How outcomes changed.** On Codex with the question tool available, holding the open question went from 13% to 47%. Fisher's exact: p = 0.109 as graded, 0.050 excluding one broken run, 0.215 under the strictest grading. **That is suggestive, not conclusive, and I am not claiming otherwise.** The direction held across two separately-run batches, and an early small-sample reading of 3/5 regressed to 7/15 once I added reps — consistent with a real but modest effect rather than noise, though not proof of one.

On Claude Code the bullet changed nothing (4/5 both arms); the baseline there already holds the question most of the time.

**Representative transcripts.** Stock fail: *"My recommendation: start with in-app notifications… If you want, I can turn that into a concrete v1 design next."* Patched pass: *"Which should I design for: `in-app only`, `in-app + email`, or `in-app + email + push`?"*

**Limitations.** Non-interactive `codex exec`, not the interactive TUI the reporter used. The flag is off by default, so the 15-per-arm rows describe a non-default Codex config. The read-only sandbox derailed a few runs into "give me write access"; `workspace-write` made it worse (Codex began implementing rather than asking), so I kept read-only for comparability and excluded one unusable patched run. I graded my own runs unblinded, with the arms known — the criteria were fixed in advance, but that is not an independent verifier. n=15 per arm is small for behavior this variable.

Raw transcripts for all 40 runs are available on request.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

Adversarial notes: the scenario is built so the user never answers and never hints — it asks only for trade-offs, which is the case the existing rules do not cover. Both arms were run under identical fixtures, prompts, and grading. Runs where the agent never asked a design question at all were treated as unmeasurable rather than quietly counted as passes. I ran the stock arm first and graded it before seeing patched results in the first Codex batch, to limit grading drift. No tuned content was touched — the diff adds a line and changes none.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

@Yash-Chindam reviewed the full diff — a single added line in `skills/brainstorming/SKILL.md`, no deletions, no modifications to existing lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
