### PR TITLE
fix(brainstorming): reduce planning handoff burden

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -133,7 +133,7 @@ your path and complete them in order.
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
 6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+7. **Planning-handoff review** — simulate the next planning stage, rate and inventory its burdens, and take the required bounded branch (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
@@ -154,7 +154,7 @@ digraph brainstorming {
     "Present design sections" [shape=box];
     "User approves design?" [shape=diamond];
     "Write design doc" [shape=box];
-    "Spec self-review\n(fix inline)" [shape=box];
+    "Planning-handoff review\n(rate; burden ledger; bounded branch)" [shape=box];
     "User reviews spec?" [shape=diamond];
     "Invoke writing-plans skill" [shape=doublecircle];
     "Hidden complexity? Upgrade path" [shape=box];
@@ -174,8 +174,8 @@ digraph brainstorming {
     "Present design sections" -> "User approves design?";
     "User approves design?" -> "Present design sections" [label="no, revise"];
     "User approves design?" -> "Write design doc" [label="yes"];
-    "Write design doc" -> "Spec self-review\n(fix inline)";
-    "Spec self-review\n(fix inline)" -> "User reviews spec?";
+    "Write design doc" -> "Planning-handoff review\n(rate; burden ledger; bounded branch)";
+    "Planning-handoff review\n(rate; burden ledger; bounded branch)" -> "User reviews spec?";
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
     "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
 }
@@ -243,15 +243,77 @@ is the whole process.
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
 
-**Spec Self-Review:**
-After writing the spec document, look at it with fresh eyes:
+**Planning-Handoff Review:**
+This is the spec self-review. Before asking for review, set the conversation
+aside and temporarily act as a
+fresh planning agent whose only inputs are the finished spec and the repository.
+Begin mapping how you would turn the spec into an implementation plan, but do not
+write that plan. Trace each affected entry point through the relevant components
+and state transitions. Note each point where planning would require you to
+rediscover design intent or invent a binding decision rather than choose an
+implementation detail. Include placeholders, internal contradictions, scope
+problems, and ambiguous requirements in this assessment; they are handoff seams,
+not a separate review stage.
 
-1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Fix them.
-2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
-3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
-4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+Rate the spec's planning-handoff readiness from 0.0–9.9 and explain what
+prevents the next higher rating using repository and artifact evidence:
+0 = reject; 2 = major redesign; 4 = substantial design rescue; 6 = usable but
+planning must reconstruct a binding decision; 8 = handoff-ready with only
+planning-owned choices; 9.9 = rare exemplary ceiling, never perfection. The
+rating prompts the assessment; it does not decide whether the artifact improves.
 
-Fix any issues inline. No need to re-review — just fix and move on.
+Translate every design-owned reason preventing the next higher rating into a
+burden ledger before editing. One burden is one independent binding decision or
+piece of design reconstruction the planning agent must resolve before it can
+specify implementation work. Record planning-owned choices separately rather
+than counting them as burdens. For each burden, state the repository or artifact
+evidence, what the planner would have to invent, and its weight:
+
+- **minor (1):** a localized clarification or reconstruction;
+- **major (2):** an unresolved binding decision or cross-component design
+  uncertainty. Record contradictions and departures from the approved design
+  separately; they are not ordinary tradeable burdens.
+
+After the initial rating and ledger, take exactly one branch:
+
+- If the rating is below 9.0 **or** the ledger contains any burden, preserve the
+  initial draft, return to the spec-writer role, and make one bounded improvement
+  pass targeting the evidence-based reasons preventing 9.0 and the named
+  burdens. Do not resolve a purely planning-owned choice merely to raise the
+  rating.
+- Only if the rating is at least 9.0 **and** the burden ledger is empty, make no
+  edit.
+
+The bounded pass is the only review-driven editing phase after the first
+complete draft. It may clarify, reconcile, and complete the spec using the
+approved design, stated requirements, and repository evidence; preserve the
+binding decisions already approved in the conversation. When an improvement
+would require a new or changed binding design decision, leave it as a burden
+instead of choosing it.
+
+After the pass, close editing and reassess both versions read-only. Trace every
+concept changed by the pass through the whole spec, including the state model,
+entry points, failure/recovery rules, and acceptance criteria. Give a fresh
+rating, build the final burden ledger from scratch, and compare it with the
+initial ledger. Include burdens that moved or appeared elsewhere. Check
+separately for a newly introduced major burden, contradiction, departure from
+approved design, or scope change. More specific wording is not automatically an
+improvement.
+
+Select the revised draft only when its total weighted burden is lower and it
+introduces no new major burden, contradiction, or design departure. New minor
+burdens are permitted only when the total burden still falls. Otherwise restore
+the preserved initial draft. Restoring the original is the only spec mutation
+permitted after reassessment: do not fix the revised draft or begin another
+pass. Present the selected spec through the normal user review handoff.
+Keep the ratings, burden ledgers, and comparison in your private review; do not
+add them to the spec or require them as a separate handoff artifact.
+If the original was restored, mention briefly that the tentative revision was
+rejected and the original retained; do not add a separate review artifact.
+
+Accept, restore, and report based on burden—not whether the rating rose. The
+review never grants permission to begin planning. Do not produce task sequencing,
+invoke `writing-plans`, or repeat the pass.
 
 **User Review Gate:**
 After the spec review loop passes, ask the user to review the written spec before proceeding:


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|---|---|
| Your model + version | Authoring/controller agent: Codex `gpt-5.6-sol`; behavioral subjects: Codex `gpt-5.6-luna` and `gpt-6-astra`; independent artifact and plan judge: GPT-5.4 |
| Harness + version | Codex desktop app 26.901.51231 on Windows; behavioral subjects through Codex CLI 0.153.4 in WSL Ubuntu; Quorum eval revisions are recorded below |
| All plugins installed | Across the authoring sessions, the environment exposed superpowers-plus 1.0.0, upstream superpowers 6.3.0, frontend-pack 0.1.0, mcp-usage-pack 1.0.0, repo-worker-pack 1.0.0, playwright-toolkit 0.1.0, Build Web Apps 0.1.2, OpenAI Developers 1.2.3, computer-use, visualize, Sites, plugin-management, Adobe, Google Drive, and the OpenAI primary-runtime document, PDF, presentation, spreadsheet, and template skills. Behavioral subjects disabled ambient plugin loading and used only the staged frozen Superpowers candidate. |
| Human partner who reviewed this diff | Harley Bartles reviewed the complete original upstream-facing diff. After upstream PR #2258 merged, the change was rebased onto the new `dev` and the complete resulting diff was presented again for review before submission. |

## What problem are you trying to solve?

During spec-to-plan handoffs, we repeatedly observed agents finish a plausible
spec while leaving repository-visible binding decisions for the planning agent
to rediscover.

The motivating question from the human partner was:

> Can the next agent read your spec and write the plan without needing to
> re-discover the seams the plan should interrogate?

This question originated in [`handoff-gates`](https://github.com/HarleyBartles/agent-asset-marketplace/tree/main/codex-marketplace/plugins/superpowers-plus/skills/handoff-gates), an experimental, field-used meta-skill in the submitter’s Superpowers+ derivative. That prototype applies readiness questions at several workflow boundaries. It motivated this investigation, but it is neither a dependency nor part of the evidence environment: behavioral subjects ran with ambient plugins disabled and only the frozen Superpowers candidate staged.

The upstream-shaped proposal is deliberately narrower. It tests whether the artifact-producing `brainstorming` skill should own its spec-to-plan handoff responsibility directly.

The existing inline self-review checks placeholders, contradictions, scope, and
ambiguous wording, fixes issues once, and moves on. It does not make the spec
writer simulate the next planning stage or test whether its revision reduces
that next agent’s design burden.

The concrete failure that shaped the final safeguard came from a Luna eval. The
producer self-rated a draft 4.1/4.9, changed it, then self-rated the revision
4.7/4.9. A blind judge measured the opposite: weighted planning burden increased
from 1 to 4 because the edit weakened resume eligibility and introduced a
two-step operator flow.

That demonstrated that confidence alone is not evidence and that a bounded
improvement pass needs a read-only select-or-restore decision.

## What does this PR change?

It replaces `brainstorming`’s generic inline spec review with a
planning-handoff review.

The spec writer temporarily adopts a fresh planner’s perspective, rates and
inventories design-owned planning burdens, takes at most one bounded
improvement pass, then reassesses the complete original and tentative revision
read-only. It keeps the revision only when weighted burden falls without a new
major burden, contradiction, or design departure; otherwise it restores the
original.

Private review diagnostics stay out of the saved spec and normal user handoff.

## Is this change appropriate for the core library?

Yes, provisionally.

The failure is general to architectural specs handed to a separate planning
stage. It is not tied to a particular project, domain, team, harness, or
third-party service. The change remains inside the existing `brainstorming`
self-review instead of adding a meta-skill or external dependency.

If this treatment proves useful upstream, it could form a foundation for separately investigating analogous handoff reviews at later workflow boundaries, such as plan-to-execution or execution-to-review. This PR does not implement those extensions and does not assume that the same mechanism, thresholds, or evidence transfer to them. Each boundary would require its own demonstrated deficiency, locally owned treatment, and adversarial proof.

The completed evidence against the pre-#2258 `dev` baseline is the evidence this
submission asks maintainers to assess. It is sufficient, in the submitter’s
judgment, to place the proposal before upstream for acceptance, rejection, or
focused revision. It is not represented as proof of the newly combined
current-base behavior.

No further submitter-funded eval runs are currently planned. The public
instruments are available for maintainers to reproduce, challenge, or extend.
The submitter remains open to a focused request for additional evidence, but
does not present further replication as promised work.

The proposed value is not cheaper planning. It is moving discovery of
planning-critical seams toward the earliest durable artifact, making the
workflow less dependent on where the next agent happens to direct its effort.

## What alternatives did you consider?

- Retaining the standalone `handoff-gates` meta-skill used in Superpowers+.
  Rejected as the upstream implementation shape because it makes artifact
  readiness a separate, skippable workflow boundary. The prototype supplied the
  motivating field hypothesis; this PR tests whether the responsibility belongs
  directly in the artifact-producing skill.
- Post-hoc producer readiness scores as the success oracle. Rejected because
  producer confidence could rise while blind artifact quality fell.
- Independent whole-artifact integer ratings. Rejected after Astra produced a
  legitimate 9/10 baseline and integer scores compressed meaningful differences.
- A generic non-numeric weakness review. Rejected after it closed a local seam
  while missing more important entry-point and cross-component burdens.
- A burden ledger without a numerical readiness trigger. Rejected after two
  byte-identical Luna pilots where the producer declared no major burden while
  the blind judge found weighted burden 4. The 9.0 threshold remains as a
  behavioral elicitation device, not an outcome measure.
- A mandatory outward acceptance record. Rejected after it added workflow
  ceremony, competed with the existing user-review handoff, and still failed to
  prevent a second edit.
- Rejecting every final-only minor burden. Rejected as too strict: replacing a
  major burden with a minor burden is a material improvement. New major burdens,
  contradictions, and design departures remain disqualifying.
- Moving the mechanism into a reference file. Rejected for the required
  behavior: upstream keeps mandatory behavior in `SKILL.md`. Optional expanded
  classification guidance or worked examples could move to a reference later if
  evidence supports it.
- A repeated reviewer or subagent loop. Rejected because the proposal is one
  bounded inline pass and because upstream has previously removed expensive
  review loops that did not show measurable benefit.

## Does this PR contain multiple unrelated changes?

No.

The diff changes only `skills/brainstorming/SKILL.md`. The readiness prompt,
burden ledger, bounded pass, read-only reassessment, restore branch, and privacy
guard are one spec-handoff mechanism.

The supporting eval scenarios, fixtures, derivations, tests, and experiment
ledger are published separately in
[`prime-radiant-inc/superpowers-evals#48`](https://github.com/prime-radiant-inc/superpowers-evals/pull/48).

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2258, #691, #1169, #1473, #2056; adjacent #1062, #1704, and #1185

#2258 has now merged. It establishes shared intent before implementation,
strengthens architectural-stage approval boundaries in `brainstorming`, and
adds explicit human plan review before execution in `writing-plans`.

This proposal addresses a different boundary: whether the completed spec leaves
binding design reconstruction for a fresh planner. #2258 did not modify the
inline spec self-review block replaced by this PR, and this change rebased
without a textual conflict. Its behavioral interaction is nevertheless material
enough to require re-running the affected evals, as disclosed below.

#691 improved the human modify/re-review loop. It was closed because v6 already
shipped that behavior, and its closure explicitly identified automated
self-review beyond the existing single inline pass as a real separate idea.
This PR addresses that separate idea without adding another human approval loop.

#1169 made assumptions and unknowns explicit before handoff. It did not simulate
the next planner, compare a first and revised artifact, or measure downstream
planning effects.

#1473 proposed a heavier plan-review cycle. It was rejected partly because
earlier reviewer loops incurred substantial token and time costs without a
demonstrated quality improvement. This proposal uses one bounded inline pass and
reports both its measured benefit and its adverse cost evidence.

#2056 was rejected on YAGNI grounds despite strong execution because it added
per-plan overhead without an observed downstream failure. This proposal starts
from a concrete observed failure and includes a ten-plan downstream comparison,
including adverse results.

#1062 and #1704 review or verify completed plans. They are downstream of this
proposal and do not test whether the originating spec reduces planning
rediscovery.

#1185 also touches `brainstorming`, but concerns spec paths, commit timing, and a
much broader historical branch rather than planning-handoff burden.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Codex CLI in isolated Quorum fixtures under WSL Ubuntu | 0.153.4 | Luna | `gpt-5.6-luna` |
| Codex CLI in isolated Quorum fixtures under WSL Ubuntu | 0.153.4 | Astra | `gpt-6-astra` |
| Gauntlet blind artifact and plan judge | Local wrapper; exact package version not exposed | GPT | `gpt-5.4` |
| Codex desktop app on Windows | 26.901.51231 | Codex | `gpt-5.6-sol` |

## New harness support (required if this PR adds a new harness)

Not applicable. This PR adds no harness support.

## Evaluation

Initial human framing:

> Can the next agent read your spec and write the plan without needing to
> re-discover the seams the plan should interrogate?

The experiment used an operator-cancellable resumable-import fixture with
repository-visible service, store, control, CLI, worker, fingerprint,
checkpoint, migration, and replay seams that were not disclosed in the user
prompt.

A producer’s first complete and selected final specs were frozen and randomized
as A/B. A separate GPT-5.4 judge received only those files and a repository
snapshot with the produced spec and `.git` removed. It assigned atomic planning
burdens:

- minor/local clarification: 1;
- major binding or cross-component decision: 2.

Only after judgment did an executable derivation reveal the initial/final
labels.

GREEN required lower final weighted burden with no final-only major burden,
contradiction, or design drift. A new minor burden was allowed only when total
burden still fell. Producer ratings were retained as behavioral traces and had
no effect on the outcome. Workflow compliance was graded separately.

The complete public instruments and experiment ledger are in
[`superpowers-evals#48`](https://github.com/prime-radiant-inc/superpowers-evals/pull/48).

### Baseline movement after the completed experiment

The completed behavioral evidence below used candidate
`b256c95c3eccf9c2f71a943a84d0c86d0bc6454b`, whose upstream base was
`fd02874aa5c55ba3c2bca431253b48e0e4c8be5a`.

Immediately before this PR was raised, upstream merged #2258 and moved `dev` to
`929b017964faf3f0ab659ae43d4c2444325fd441`. This proposal was then rebased
cleanly onto that commit as
`858e752df6f69852529820837d2e935aa189ee10`.

The merged change does not alter the spec self-review block this proposal
replaces. It adds shared-intent discovery and write-back earlier in
`brainstorming`, strengthens stage-specific approval boundaries, and adds human
review of the saved plan before execution in `writing-plans`.

The preregistered expectation is therefore:

- the planning-handoff review mechanism should continue to reduce or safely
  preserve artifact burden because its own input, decision rule, and fallback
  are unchanged;
- stronger shared-intent capture may improve untreated first drafts and reduce
  the available treatment headroom;
- the new plan-review handoff occurs after plan generation, so it is not expected
  to change the plan artifact measured by the downstream experiment;
- nevertheless, these are expectations, not current-base results.

All evidence below remains valid evidence about the frozen former baseline. It
must not be represented as proof of the combined current-base behavior.

No further submitter-funded replication is currently planned. This disclosure
is an evidence boundary, not an unfinished-work commitment. The complete
runnable instruments are published in `superpowers-evals#48` so maintainers can
test the combined baseline directly if they consider that necessary. The
submitter is also open to a focused maintainer request, but asks that this
proposal be assessed on the evidence supplied rather than left indefinitely in
Draft awaiting speculative additional work.

### Eligible post-change sessions on the former baseline

The completed evidence uses 26 eligible Coding-Agent sessions:

- 5 Luna artifact-comparison sessions;
- 5 Astra artifact-comparison sessions;
- 5 Luna fallback-selection sessions;
- 1 Luna brainstorming session that legitimately produced the downstream
  untreated/treated fixture pair;
- 10 fresh Luna planning sessions: 5 untreated and 5 treated.

Independent blind artifact, pairwise-plan, and corpus judgments were run
separately from the Coding-Agent subjects.

### Luna artifact series

Candidate `5f58790` produced five consecutive eligible GREENs:

| Run | Initial burden | Final burden |
|---|---:|---:|
| `faaf` | 5 | 3 |
| `df38` | 6 | 1 |
| `7a96` | 2 | 0 |
| `8895` | 2 | 1 |
| `aecb` | 5 | 3 |

All five workflow and deterministic-control sets passed. Every blind judge
preferred the final artifact. No final introduced a major burden,
contradiction, or design drift. Run `8895` replaced one major burden with one
minor burden, exercising the intended asymmetric rule.

### Astra artifact series

Final former-base candidate `b256c95` differs from `5f58790` only by two lines
keeping private ratings and ledgers out of the spec and user handoff.

| Run | Initial burden | Final burden | Result |
|---|---:|---:|---|
| `79ac` | 2 | 0 | GREEN |
| `b83b` | 2 | 0 | GREEN |
| `bf9f` | 0 | 0 | safe no-change tie |
| `1394` | 1 | 0 | GREEN |
| `4e68` | 3 | 1 | GREEN |

All workflows and deterministic controls passed. Four blind judges found lower
final burden; one confirmed that an unchanged first draft already had burden 0.
No final introduced a major burden, contradiction, design drift, or private
review pollution.

### Negative evidence retained

The experiment did not succeed on its first wording. Retained failures include:

- an Astra baseline already scoring 9/10, falsifying the claim that ordinary
  specs universally self-rate below 9;
- rating-only and shallow weakness prompts that did not improve blind scores;
- burden-only prompts where Luna declared no major burden while an independent
  judge found weighted burden 4;
- a producer that raised its confidence while blind burden increased from 1 to
  4;
- a revised artifact with lower net burden but a new contradiction;
- a mandatory outward acceptance record that caused workflow failure;
- an unblinded judge package that exposed the selected artifact;
- transcript-detector, auth, controller, and capture failures retained and
  excluded rather than recoded as behavioral results.

These failures explain why the numerical trigger, bounded pass, whole-artifact
comparison, restore branch, and privacy guard are each present.

### Focused fallback Luna series

A separate selection-stage fixture supplied an approved design, preserved
original, and tempting tentative revision that closed identity/result ambiguity
while moving execution into `ImportControl`. Editing was closed.

Five Luna producers independently identified the boundary regression, restored
the original byte-for-byte, changed only the selected file, and took no second
pass.

| Run | Original burden | Tentative burden | Result |
|---|---:|---:|---|
| `f150` | 3 | 4 | `fallback_green` |
| `a0c7` | 1 | 2 | `fallback_green` |
| `028d` | 1 | 2 | `fallback_green` |
| `7721` | 1 | 2 | `fallback_green` |
| `35f2` | 1 | 2 | `fallback_green` |

All five passed seven deterministic workflow checks. Separately blinded judges
found the tentative-only major control-boundary burden, contradiction, or
design drift before label reveal.

Astra fallback replication was not run. The five-run Luna result is the supplied
evidence for this branch; cross-model fallback behavior remains a declared
boundary.

### Downstream Luna planning effect

One legitimately produced untreated/treated spec pair from candidate `b256c95`
was frozen byte-for-byte. Five fresh Luna planners received the untreated spec
and five received the treated spec against the same repository, prompt,
ordinary `writing-plans` skill, and isolated home. No planning-handoff treatment
was added.

The treated plan won blind pairwise quality review 3–2, with no ties. That
headline understates the mechanism:

- the decisive durable row replay/idempotency seam appeared in 5/5 treated plans
  but only 2/5 untreated plans;
- in all three pairs where the treated plan carried that seam and the untreated
  plan omitted it, the treated plan won blind quality review: 3/3;
- in both pairs where the untreated planner independently found the same seam,
  both plans cleared that important threshold and the untreated plan won on
  other plan-level qualities: 2/2.

A separate blind corpus judge selected the treated corpus as more consistent.
Both corpora covered orchestration, control/status, CLI, worker, and
acceptance-test seams in 5/5 plans. Replay/idempotency coverage was 5/5 versus
2/5.

This supports a narrow claim for that frozen eval: the bounded spec review made
transmission of one material design obligation into downstream planning
reliable rather than stochastic. It does not prove that every treated plan is
better.

Two treated plans lost after introducing unrelated contract or
repository-grounding problems. The corpus judge also retained treated drift
around locator identity and count-only result contracts.

### Planning cost and seam discovery

Across all ten planning runs, the seven plans that covered the important seam
used more resources than the three that missed it:

| Outcome | N | Mean time | Mean tokens |
|---|---:|---:|---:|
| Seam covered | 7 | 265.8s | 455,791 |
| Seam missed | 3 | 175.9s | 296,127 |

That aggregate is confounded by treatment membership: every treated plan
covered the seam, while every miss was untreated.

Looking only within the untreated arm reverses the descriptive relationship:

| Untreated outcome | N | Mean time | Mean tokens |
|---|---:|---:|---:|
| Seam covered | 2 | 168.2s | 240,338 |
| Seam missed | 3 | 175.9s | 296,127 |

Both untreated planners that discovered the seam used fewer tokens than every
untreated planner that missed it. The sample is too small to establish a causal
resource relationship, but it does not support the claim that spontaneous seam
discovery itself was expensive.

Every matched treated planner took longer than its untreated partner, including
the two pairs where both plans found the seam. The added expense therefore
attaches more clearly to treatment-driven planning behavior than to the
intellectual act of noticing the seam.

The evidence supports this narrower interpretation:

> Necessary design work has a cost somewhere in the workflow. This treatment
> does not make that work free or make planning cheaper. It makes the important
> seam more likely to be identified in the earliest durable artifact and carried
> consistently into planning, rather than leaving coverage dependent on where
> the planning agent happens to look.

### Aggregate efficiency

Efficiency moved strongly against the original hypothesis:

| Metric | Untreated | Treated |
|---|---:|---:|
| Mean coding time | 172.8s | 304.9s |
| Median coding time | 169.9s | 305.2s |
| Mean subject tokens | 273,811 | 541,972 |
| Median subject tokens | 254,418 | 466,516 |
| Mean tool calls | 8.8 | 15.8 |
| Median tool calls | 9 | 15 |
| Mean plan bytes | 21,701 | 20,703 |

Every matched treated run took longer. The treated corpus used roughly twice
the tokens and substantially more tool calls without producing longer plans.

The defensible benefit is improved convergence on the important seam,
purchased with materially more Luna planning work—not better-and-cheaper
planning. The treatment appears to direct more planning effort toward an
explicit obligation; it does not demonstrate that the same obligation would
have been costly to discover unaided.

### Declared evidence boundaries

The submission does not claim proof of:

1. artifact behavior on current `dev` after #2258;
2. fallback behavior on current `dev`;
3. downstream planning behavior on current `dev`;
4. Astra fallback selection;
5. Astra downstream planning behavior;
6. reliability across other repositories, domains, or harnesses;
7. whether Luna’s higher planning cost is intrinsic necessary work, broader
   treatment-induced elaboration, or avoidable churn;
8. an independent relationship between planning expenditure and spontaneous
   discovery of the important seam.

These are disclosed limits, not hidden positive assumptions. The proposal
includes the runnable evals needed to investigate them. Maintainers may decide
that the existing evidence is sufficient, run the supplied instruments, reject
the proposal on these limits, or request a specific additional test.

No further submitter-funded runs are currently planned. The submitter remains
open to a focused request where maintainers identify a decision that additional
evidence would resolve.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content without extensive evals showing the change is an improvement

The final former-base candidate was tested with weaker and frontier producers,
an independent blind artifact judge, randomized labels, separate workflow
controls, executable post-reveal derivation, deliberate burden trade-offs,
regressive-revision fallback, and zero-burden no-change behavior.

The downstream experiment used ten fresh planners with ordinary
`writing-plans`, separate blind pairwise judgments, and an independent corpus
consistency judgment. Negative and mixed results are reported alongside wins.

Because #2258 changed the surrounding `brainstorming` and `writing-plans`
workflow after those experiments completed, this submission does not present
the former-base results as current-base proof. The changed base does not touch
the spec self-review block under treatment, and its plan-review addition occurs
after the measured plan artifact is written, so no material change to the
mechanism’s result is expected. Stronger shared-intent capture could,
legitimately, improve untreated specs and reduce treatment headroom. Those are
preregistered expectations, not measured results.

The proposal and its evidence package are complete to the level the submitter
has chosen to fund. This PR is ready for maintainer assessment as an honest
proposal with visible boundaries—not as a claim that every uncertainty has been
eliminated.

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission

Harley Bartles reviewed the complete original one-file diff. After #2258 merged,
the proposal was rebased onto current `dev`, and the resulting complete diff was
presented again for explicit review before submission.