### PR TITLE
feat(sdd): ledger Discoveries section carries cross-task findings across compaction

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -142,14 +142,21 @@ a ledger file, not only in todos.
   line names your plan file, tasks with a `Task <N>: complete` line are DONE
   — do not re-dispatch them; resume at the first task without one. A task
   whose last line is a fix round is mid-loop: resume the loop at the next
-  round. A ledger whose first line names a different plan file — or a stray
+  round. A resumed controller also reads the ledger's `## Discoveries`
+  section: it holds what completed tasks found that the plan could not
+  know, and it is the source for clause (3) of the next dispatch. A ledger
+  whose first line names a different plan file — or a stray
   ledger at the old flat path `.superpowers/sdd/progress.md` — is another
   plan's progress: leave it in place and start your own, fresh.
 - Create the ledger with its identity as the first line:
   `# SDD ledger — plan: <plan file path>`.
 - The ledger is your recovery map: the commits it names exist in git even
   when your context no longer remembers creating them. After compaction,
-  trust the ledger and `git log` over your own recollection.
+  trust the ledger and `git log` over your own recollection. The ledger's
+  `## Discoveries` section is the same map for knowledge: what earlier tasks
+  found that the plan could not know. A resumed controller composes clause
+  (3) of every dispatch from that section, never from recollection of a
+  context it no longer has.
 - `git clean -fdx` will destroy the workspace (it's git-ignored scratch); if
   that happens, recover from `git log`.
 
@@ -256,10 +263,12 @@ and fix-round diffs need it.
   task fits in the project; (2) the brief path, introduced as "read this
   first — it is your requirements, with the exact values to use verbatim";
   (3) interfaces and decisions from earlier tasks that the brief cannot
-  know; (4) your resolution of any ambiguity you noticed in the brief;
-  (5) the report-file path and report contract. Exact values (numbers,
-  magic strings, signatures, test cases) appear only in the brief. Never
-  make a subagent read the whole plan file.
+  know — read them from the ledger's Discoveries section, not from your
+  memory of past reports: copy the entries the task's interfaces touch, in
+  full, and skip the rest; (4) your resolution of any ambiguity you noticed
+  in the brief; (5) the report-file path and report contract. Exact values
+  (numbers, magic strings, signatures, test cases) appear only in the
+  brief. Never make a subagent read the whole plan file.
 - **Report file:** name the implementer's report file after the brief
   (brief `…/task-N-brief.md` → report `…/task-N-report.md`) and put it in
   the dispatch prompt. The implementer writes the full report there and
@@ -268,7 +277,10 @@ and fix-round diffs need it.
   paste accumulated prior-task summaries ("state after Tasks 1-3") into
   later dispatches — a real session's dispatch hit 42k chars of which 99%
   was pasted history. A fresh subagent needs its task, the interfaces it
-  touches, and the global constraints. Nothing else.
+  touches, and the global constraints. Nothing else. A curated slice copied
+  from the Discoveries section is not pasted history — it is clause (3)
+  above, kept small enough to read in full because each entry is a delta
+  from the plan.
 - The dispatch carries the no-subagents contract (it is in the
   implementer template): the implementer never dispatches subagents —
   not helpers, and never a reviewer. Review arrives from you, after the
@@ -438,6 +450,15 @@ message as your other bookkeeping:
 - `Task <N>: complete (commits <base7>..<head7>, <K> parked)` after a
   tripped breaker
 
+Copy the task's Discoveries into the ledger in the same message, from the
+report's "Discoveries for later tasks" field: append a `### Task <N>`
+heading under the ledger's `## Discoveries` section (create the section on
+first use) with each discovery as one line, or `- None` when the field is
+empty. Keep it a delta from the plan: only what a later task needs and the
+plan could not know — corrections to the plan, negative results, resolved
+unknowns, interfaces discovered in the code. If it does not change what a
+later task does, it does not go in.
+
 Then mark the todo complete and move on. Never move to the next task while
 the review has open Critical/Important issues that are neither fixed nor
 parked-with-ruling at the cap.
@@ -529,6 +550,7 @@ Task reviewer: Spec ✅ - all requirements met, nothing extra.
   Strengths: Good test coverage, clean. Issues: None. Task quality: Approved.
 
 [Ledger: Task 1: complete (commits a1b2c3d..d4e5f6a, review clean)]
+[Ledger: Discoveries — Task 1: hooks dir must be created before install; none other]
 
 Task 2: Recovery modes
 
@@ -555,6 +577,7 @@ Re-reviewer: Missing progress reporting — ADDRESSED (src/recovery.js:41).
 
 [Ledger: Task 2: fix round 1/5 (2 addressed, 0 open; commits d4e5f6a..b7c8d9e)]
 [Ledger: Task 2: complete (commits d4e5f6a..b7c8d9e, review clean)]
+[Ledger: Discoveries — Task 2: None]
 
 ...
 

--- a/skills/subagent-driven-development/implementer-prompt.md
+++ b/skills/subagent-driven-development/implementer-prompt.md
@@ -134,6 +134,12 @@ Subagent (general-purpose):
       - RED: command run, relevant failing output before implementation, and why the failure was expected
       - GREEN: command run and relevant passing output after implementation
     - Files changed
+    - **Discoveries for later tasks:** what you found that a later task
+      needs and the plan could not know — resolved unknowns, corrections
+      to the plan, negative results ("X has no lookup endpoint, so no
+      probe was written"), interfaces you had to inspect in the installed
+      code. Write "None" when the plan already knew everything. The
+      controller copies this into the ledger; be specific.
     - Self-review findings (if any)
     - Any issues or concerns
 


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | z-ai/glm-5.3-free (tokenrouter/z-ai/glm-5.3-free) |
| Harness + version | opencode CLI |
| All plugins installed | @dietrichgebert/ponytail (ponytail mode active) |
| Human partner who reviewed this diff | Honey Tyagi (this session was run at their direction on issue #2267; see Human review below) |

## What problem are you trying to solve?

Issue #2267 (found during a real 18-task subagent-driven-development run, superpowers 6.1.1): the progress ledger records *which* tasks are done (`Task N: complete (commits <base7>..<head7>, review clean)`) but not *what tasks discovered*. Cross-task knowledge has exactly one sanctioned home, clause (3) of the dispatch-composition list ("interfaces and decisions from earlier tasks that the brief cannot know"), and that clause is satisfied entirely from the controller's conversation context — the one thing that does not survive compaction or a usage-limit interruption. On plans longer than one usage window (which #1152 shows is the normal case, not the edge case), a resuming controller reads the ledger, sees "Task 0: complete", and has no idea what Task 0 found. The implementer's report files hold the findings, but they are per-task, unindexed scratch that nothing points a later dispatch at — and reading all N of them defeats the file-handoff design. Negative results ("registry X has no lookup endpoint, so no probe was written") are exactly what a later task needs to not redo the work, and they live nowhere durable.

We read #931 and #2253 as related but distinct: those cover session-handoff slash commands and deferred findings destroyed at finish. This PR adds the ledger's missing channel for cross-task discoveries during execution, as the issue proposes.

## What does this PR change?

Four additions to the subagent-driven-development skill, matching the issue's "small version" proposal:

1. **Write step** (SKILL.md, "Complete the task"): alongside the completion line, the controller copies the implementer report's "Discoveries for later tasks" field into a `## Discoveries` section of the ledger (`### Task <N>` headings, `- None` when empty, delta-from-the-plan only).
2. **Report-contract field** (implementer-prompt.md): the report format gains a mandatory "Discoveries for later tasks (or None)" bullet, so the controller has something to copy rather than infer.
3. **Read step** (SKILL.md, "Dispatch the implementer"): clause (3) now says to read from the ledger's Discoveries section, not from memory — with the instruction to copy only the entries the task's interfaces touch.
4. **Resume step** (SKILL.md, Setup): a resumed controller reads the Discoveries section as the knowledge-recovery map, parallel to the completion lines it already reads.

The Example Workflow shows the ledger entries. The anti-history rule is kept intact and explicitly reaffirmed: a curated slice copied from Discoveries is not pasted session history, because each entry is a delta from the plan.

## Is this change appropriate for the core library?

Yes. This is a durability fix to core SDD process infrastructure, not project-specific. Any plan whose tasks have discovery-shaped work (spikes, negative results, resolved unknowns) and whose length can exceed one usage window benefits, regardless of domain. No third-party dependencies, no new skill.

## What alternatives did you consider?

- **Point later dispatches at earlier report files** (e.g. "read task-0-report.md"): rejected — reports are per-task, unindexed, and scratch; nothing tells a resuming controller which of N reports a given task needs, and reading all of them defeats the file-handoff design (the issue states this directly).
- **Commit the discoveries file to git** rather than keeping it git-ignored scratch: the issue's third suggestion. Not taken in this PR: the skill deliberately deletes the whole workspace at finish ("the git history is the record now"), and the Finish section already surfaces rulings to the human partner. Whether discoveries should outlive the workspace is a maintainer call about the artifact lifecycle; this PR keeps the change minimal and reversible.
- **A sibling discoveries.md file**: rejected — a second file is a second thing to lose, forget, and recover; a section in the ledger keeps one recovery map.

## Does this PR contain multiple unrelated changes?

No. All four edits serve the single mechanism: a durable channel for cross-task discoveries. The report field is the write source, the ledger section is the store, the dispatch clause is the read.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found searching "discoveries", "cross-task", "progress ledger" across open and closed PRs. #1952 (SDD workspace session scoping) and #1862 (executing-plans task graph) touch adjacent durability concerns but neither adds a discoveries channel.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| opencode (CLI) | current | z-ai/glm-5.3-free | tokenrouter/z-ai/glm-5.3-free |

## New harness support (required if this PR adds a new harness)

N/A — no new harness support.

## Evaluation

- Initial prompt: execute a plan with subagent-driven-development starting with a reconnaissance spike (issue #2267's reporter session), 18 tasks.
- This PR was not evaluated in live SDD sessions. The contributing guidelines hold skills changes to a high bar: what we can state is (a) the failure mode is documented from a real session (the issue's 42k-char dispatch and the 18-task interruption), (b) the change adds a mechanical write/copy/read step to contracts that already exist (the report format, the completion bookkeeping, the dispatch list), and (c) the anti-history rule is preserved with an explicit carve-out so the 42k-char failure cannot recur through this channel, because each entry is bounded to a delta from the plan. Before merge we would recommend the maintainers' standard eval: run one plan with a Task 0 spike, compact mid-run, and confirm the resumed controller composes Task 8's dispatch from the Discoveries section without re-reading task-0-report.md.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path — the delta-from-the-plan bound, the "None is a valid entry" case, and the interaction with the anti-history rule were each checked against the issue's failure modes (pasted-history explosion, silent-discard of negative results, report-file sprawl)
- [ ] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement — the touched sections are the ledger mechanics, dispatch composition, and report contract; the behavior-shaping content (anti-history rule, rulings language) is preserved verbatim with only a scoped addition beside it

## Human review

- [ ] A human has reviewed the COMPLETE proposed diff before submission

The full diff (37 insertions, 7 deletions, across SKILL.md and implementer-prompt.md) is shown in the session that produced this PR and needs the human partner's sign-off on the checkbox above before a maintainer should treat this as ready. Honey, please review the diff and confirm.