### PR TITLE
fix(sdd): let the SDD scripts run before a greenfield Task 1 creates the repo

### DIFF
--- a/skills/subagent-driven-development/scripts/review-package
+++ b/skills/subagent-driven-development/scripts/review-package
@@ -19,6 +19,12 @@ base=$2
 head=$3
 [ -f "$plan" ] || { echo "no such plan file: $plan" >&2; exit 2; }
 
+git rev-parse --git-dir >/dev/null 2>&1 || {
+  echo "error: not a git repository — review-package needs the BASE and HEAD commits of the task under review." >&2
+  echo "A greenfield plan's first task creates the repo itself: run this from inside the repo once that task has committed." >&2
+  exit 2
+}
+
 git rev-parse --verify --quiet "$base" >/dev/null || { echo "bad BASE: $base" >&2; exit 2; }
 git rev-parse --verify --quiet "$head" >/dev/null || { echo "bad HEAD: $head" >&2; exit 2; }
 

--- a/skills/subagent-driven-development/scripts/sdd-workspace
+++ b/skills/subagent-driven-development/scripts/sdd-workspace
@@ -17,6 +17,10 @@
 # Single source of truth for the workspace location, so task-brief and
 # review-package cannot drift to different directories.
 #
+# A greenfield plan's first task is often "create the repo", so there is no
+# repo root to resolve yet: fall back to the current directory rather than
+# failing, since that task is exactly the one needing a brief.
+#
 # Usage: sdd-workspace PLAN_FILE
 set -euo pipefail
 
@@ -32,7 +36,10 @@ slug=$(basename "$plan" .md)
 [ -n "$slug" ] && [ "$slug" != "." ] && [ "$slug" != ".." ] \
   || { echo "cannot derive a workspace name from: $plan" >&2; exit 2; }
 
-root=$(git rev-parse --show-toplevel)
+if ! root=$(git rev-parse --show-toplevel 2>/dev/null); then
+  root=$PWD
+  echo "sdd-workspace: no git repository yet, using $root/.superpowers/sdd until this plan's first task creates one" >&2
+fi
 base="$root/.superpowers/sdd"
 dir="$base/$slug"
 mkdir -p "$dir"

--- a/tests/claude-code/test-sdd-workspace.sh
+++ b/tests/claude-code/test-sdd-workspace.sh
@@ -189,6 +189,73 @@ PLAN
         echo "    status: $wt_status"
     fi
 
+    # --- Greenfield: the scripts run before a repo exists ---
+    # A greenfield plan's Task 1 is "create the repo", so the scripts must
+    # work with no repo to resolve. $TEST_ROOT is outside any repo.
+    local gf="$TEST_ROOT/greenfield"
+    mkdir -p "$gf"
+    cat > "$gf/plan-a.md" <<'PLAN'
+# Plan A
+
+## Task 1: Scaffold the repo
+
+Create the repo.
+PLAN
+    local gf_phys
+    gf_phys="$(cd "$gf" && pwd)"
+
+    local gf_dir gf_rc=0
+    gf_dir="$(cd "$gf" && "$SDD_SCRIPTS/sdd-workspace" plan-a.md 2>/dev/null)" || gf_rc=$?
+    if [[ "$gf_rc" -eq 0 && "$gf_dir" == "$gf_phys/.superpowers/sdd/plan-a" ]]; then
+        pass "sdd-workspace outside a repo degrades to the current directory"
+    else
+        fail "sdd-workspace outside a repo degrades to the current directory"
+        echo "    rc: $gf_rc, got: $gf_dir"
+    fi
+
+    # stdout stays the bare path (task-brief captures it); the notice goes to stderr
+    local gf_err
+    gf_err="$(cd "$gf" && "$SDD_SCRIPTS/sdd-workspace" plan-a.md 2>&1 >/dev/null)"
+    if [[ "$gf_err" == *"no git repository yet"* ]]; then
+        pass "sdd-workspace outside a repo explains itself on stderr"
+    else
+        fail "sdd-workspace outside a repo explains itself on stderr"
+        echo "    stderr: $gf_err"
+    fi
+
+    local tb_rc=0
+    (cd "$gf" && "$SDD_SCRIPTS/task-brief" plan-a.md 1 >/dev/null 2>&1) || tb_rc=$?
+    if [[ "$tb_rc" -eq 0 && -s "$gf_phys/.superpowers/sdd/plan-a/task-1-brief.md" ]]; then
+        pass "task-brief outside a repo writes the brief for Task 1"
+    else
+        fail "task-brief outside a repo writes the brief for Task 1"
+        echo "    rc: $tb_rc"
+    fi
+
+    # review-package genuinely needs SHAs: it must refuse with an actionable
+    # message rather than git's bare "fatal: not a git repository".
+    local rp_rc=0 rp_err
+    rp_err="$(cd "$gf" && "$SDD_SCRIPTS/review-package" plan-a.md HEAD~1 HEAD 2>&1 >/dev/null)" || rp_rc=$?
+    if [[ "$rp_rc" -eq 2 && "$rp_err" == *"not a git repository"* && "$rp_err" == *"BASE and HEAD"* ]]; then
+        pass "review-package outside a repo errors actionably with exit 2"
+    else
+        fail "review-package outside a repo errors actionably with exit 2"
+        echo "    rc: $rp_rc, stderr: $rp_err"
+    fi
+
+    # Once Task 1 creates the repo in place, the workspace path is unchanged,
+    # so briefs written pre-repo are not orphaned.
+    git init -q -b main "$gf"
+    local gf_after
+    gf_after="$(cd "$gf" && "$SDD_SCRIPTS/sdd-workspace" plan-a.md 2>/dev/null)"
+    if [[ "$gf_after" == "$gf_dir" ]]; then
+        pass "workspace path survives the repo being created in place"
+    else
+        fail "workspace path survives the repo being created in place"
+        echo "    before: $gf_dir"
+        echo "    after:  $gf_after"
+    fi
+
     echo ""
     if [[ "$FAILURES" -ne 0 ]]; then
         echo "FAILED: $FAILURES assertion(s)."


### PR DESCRIPTION
> Targets `dev`, as required.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Claude Opus 5 (`claude-opus-5[1m]`) |
| Harness + version | Claude Code 2.1.263 (VS Code extension) |
| All plugins installed | `ponytail@ponytail` 4.9.0; `security-guidance@claude-plugins-official` 2.0.8. (Superpowers itself was not loaded as a plugin in this session — the repo was a plain clone, so no superpowers skill shaped this work.) |
| Human partner who reviewed this diff | @vinay121314, owner of the submitting fork. They read the complete diff — both script changes and all 67 added test lines — and approved submission. |

## What problem are you trying to solve?

Issue #2242: the SDD prep scripts hard-fail when the working directory is not yet a git repository — but a greenfield plan's Task 1 *is* "create the repo". The tooling cannot bootstrap its own first task.

`sdd-workspace` resolved the workspace root with a bare `git rev-parse --show-toplevel`. Outside a repo, git's fatal tripped `set -euo pipefail` and the script died with git's own message. `task-brief` inherits that resolution, so it failed identically. `review-package` printed the same fatal followed by `bad BASE` (its `rev-parse --verify --quiet` suppresses the *unknown revision* error but not git's repo-discovery fatal).

Reproduced on current `dev` (3a8bdc1) before the change, exactly as the issue and @obra's triage comment describe:

```
$ cd /tmp/greenfield && printf '## Task 1: scaffold the repo\n\nCreate files.\n' > plan.md

$ sdd-workspace plan.md
fatal: not a git repository (or any of the parent directories): .git
exit=128

$ task-brief plan.md 1
fatal: not a git repository (or any of the parent directories): .git
exit=128

$ review-package plan.md HEAD~1 HEAD
fatal: not a git repository (or any of the parent directories): .git
bad BASE: HEAD~1
exit=2
```

Nothing in SDD's Setup or `using-git-worktrees` ever creates a repo — both start from an existing one — so a greenfield Task 1 has no path today, and the failure it hits is git's bare fatal rather than anything actionable.

Credit where it is due: this was reported and diagnosed by @rz1989s, who proposed this shape of fix and had it in local use on macOS. @obra reproduced it on `dev` and said a PR would be welcome, targeting `dev` and including a test that runs the scripts from a non-repo directory. This PR is that, tested additionally on Windows/Git Bash, which was previously uncovered. @rz1989s — if you had a branch in flight, say so and I will close this in favour of yours.

## What does this PR change?

`sdd-workspace` degrades to `$PWD` when there is no repo, emitting a one-line notice on stderr and keeping stdout the bare path its callers capture. `review-package` keeps failing — it genuinely needs BASE/HEAD commits — but with an actionable message instead of git's fatal. `task-brief` needs no edit; it inherits the workspace resolution.

## Is this change appropriate for the core library?

Yes. These are core SDD helper scripts, and the fix is domain-agnostic: any greenfield plan in any language hits this on Task 1. No new dependencies, no new skill, no third-party integration, and no change to skill prose or behaviour-shaping content. @obra confirmed the direction in the issue: "either way the current bare-git fatal is not an acceptable message."

## What alternatives did you consider?

1. **Actionable hard error in all three scripts** (no fallback). This is the other half of the design call @obra left open, and it is smaller. Rejected because it leaves greenfield Task 1 with no working path, which is the issue's actual complaint — the controller still could not get a brief for the one task that needs one.
2. **Have SDD Setup run `git init` when there is no repo.** Rejected as a much larger behavioural change: it would make a scratch-resolving helper start creating repositories, and SKILL.md is explicit that implementation must not begin on a main/master branch without the human partner's consent.
3. **Fall back to a temp dir instead of `$PWD`.** Rejected because it orphans artifacts: the brief would land somewhere the post-`git init` invocation would never look again. `$PWD` is chosen precisely because Task 1's `git init` runs *in that directory*, so the resolved path is unchanged once the repo exists — asserted by a test below.
4. **Add the "Greenfield projects" SKILL.md note** the issue floats as optional. Deliberately left out: the scripts now just work, so no instruction is needed, and this repo sets a high bar on skill-content edits. Happy to add it if you want it.

## Does this PR contain multiple unrelated changes?

No. One problem: the scripts cannot run before a repo exists. Both script edits are two halves of that single fix (degrade where it is safe, actionable error where it is not), and the test change is the test @obra asked for.

Deliberately kept out of scope: four assertions in `test-sdd-workspace.sh` fail on Windows Git Bash, and they fail **identically on clean `dev`** (see Environment below). That is a real, separate pre-existing bug and does not belong in this diff. I can file it as its own issue.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none address this. I searched open and closed PRs for `sdd-workspace`, `task-brief`, `review-package`, greenfield, and "not a git repository", and cross-checked every PR referencing #2242 (there are none). Nearby but distinct: #2161 (makes `sdd-workspace`'s `.gitignore` create-only), #2134 and closed #2069 (executable bits on the same scripts, #2040), #1943 (merged; plan-scoped workspace, which introduced the `--show-toplevel` call this patches), #1949 / #1938 / #1952 (workspace scoping). None touch the no-repo path.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Claude Code (VS Code extension) | 2.1.263 | Claude Opus 5 | `claude-opus-5[1m]` |

Platform: Windows 11 Pro 10.0.26200, Git Bash (GNU bash 5.3.15, x86_64-pc-cygwin), git 2.55.0.windows.5. The reporter covered macOS (bash 5.3, git 2.51); this run covers Windows.

`tests/claude-code/test-sdd-workspace.sh` on this box:

- **Before my change (clean `dev`):** 9 pass, 4 fail
- **After my change:** 14 pass, 4 fail — the same 4, unchanged in identity

Those 4 pre-existing failures (`prints <repo-root>/...`, `task-brief writes its brief...`, `review-package writes its diff...`, `linked worktree resolves...`) are a path-normalization mismatch under Cygwin, where the reported `got:` values are in fact correct. **They are not caused by this PR** — I baselined them by stashing the change and re-running. My 5 new assertions all pass, and I wrote them to normalize paths the same way the script does (`cd` + `pwd`) so they do not inherit that platform issue.

Not run: `scripts/lint-shell.sh`. `shellcheck` is not installed on this machine, so the changed scripts got `bash -n` only. Both edits are fully quoted and small, but flagging it rather than implying a clean lint.

## New harness support (required if this PR adds a new harness)

Not applicable — this PR adds no harness support. No transcript is required.

## Evaluation

- **Initial prompt:** my human partner asked for help understanding this codebase and contributing a PR, and directed me to find a real, unclaimed problem to work on. Two candidate issues were ruled out first — one had no actionable problem statement to build from, and one was already implemented by open PR #2274 — so I surveyed the 108 open issues, duplicate-checked ten candidates against open and closed PRs, found only four unclaimed, and selected #2242 because @obra had already reproduced it and invited a PR.
- **Eval sessions run after the change:** none, and none apply. This is a shell-script defect, not behaviour-shaping skill content: there is no prose here for a model to interpret, so an eval session cannot measure it. Verification is deterministic instead — the exact repro from the issue, before and after, plus the 5 new assertions and the stash-baselined regression check described above.
- **How outcomes changed:** before, `task-brief plan.md 1` in a non-repo exited 128 printing `fatal: not a git repository`. After, it writes the Task 1 brief and exits 0, with one stderr line explaining the fallback. `review-package` still refuses (correctly — it needs SHAs) but now says why and what to do. After a simulated Task 1 `git init`, `sdd-workspace` resolves to the identical path and `review-package` works normally, so nothing written pre-repo is orphaned.

## Rigor

- [ ] If this is a skills change: I used `superpowers:writing-skills` and completed adversarial pressure testing (paste results below)
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

The first box is unchecked because this is not a skills change — no SKILL.md, prompt template, or other behaviour-shaping content is touched. The diff is two shell scripts and one test file.

Adversarial cases deliberately tested rather than only the happy path:

- **stdout/stderr contract.** `task-brief` captures `sdd-workspace`'s stdout via `$(...)`. A notice printed to stdout would silently corrupt the path and poison every downstream artifact. Asserted that stdout stays the bare path and the notice goes to stderr.
- **Artifact orphaning across repo creation.** Asserted the resolved workspace path is byte-identical before and after `git init` in the same directory.
- **No regression inside a real repo.** The 9 pre-existing in-repo assertions behave exactly as on clean `dev`; the new `git rev-parse --git-dir` guard is a no-op there.
- **`review-package` still refuses.** Asserted exit 2 *and* the message content, so a future refactor cannot regress it into git's bare fatal and still pass.

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

@vinay121314 read the full diff — both script hunks and all 67 added test lines — along with the before/after repro output, the pre-existing-failure baseline, and the un-run-lint gap, then approved submission. They also directed the two open design calls: to credit @rz1989s and submit rather than wait, and to take the degrade-plus-hard-error direction over a uniform hard error.
