### PR TITLE
Fix SessionStart hook to only fire on startup, not clear/compact

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|clear|compact",
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Bug

`hooks/hooks.json` registers the `SessionStart` hook with matcher
`"startup|clear|compact"`. This hook injects the entire `using-superpowers`
skill body (a multi-KB "you have superpowers" primer) into the model's
context on every fire.

Firing on `startup` makes sense — a fresh process needs to be introduced to
the skill system once. Firing on `clear` and `compact` does not: those
happen *within* an already-running, already-primed session, so the model has
already seen this exact primer once this session, and re-injecting the
identical text on every `/clear` and `/compact` is pure waste with no
benefit.

## Measured impact

Usage measurement across four Claude Code account installations, real
(non-eval) sessions since 2026-08-15: this hook fired 521 times, injecting
**1,736,493 bytes** (~1.74 MB, ~434K tokens) of **byte-identical** text
(verified via md5 hash — every fire is the exact same payload). Breaking
down by `SessionStart` sub-event: `startup` 246 fires, `clear` 171 fires,
`compact` 105 fires — i.e. the large majority of the waste (276 of 521
fires, ~53%) comes specifically from `clear`/`compact` re-injecting content
the model already has in its immediately-preceding, same-session context.

## Fix

One-line change to `hooks/hooks.json`: narrow the matcher from
`"startup|clear|compact"` to `"startup"`. Nothing else touched — the hook
script itself and the `startup` behavior are unchanged.