### PR TITLE
fix(hermes): pass each skill's frontmatter description to register_skill

### DIFF
--- a/.hermes-plugin/__init__.py
+++ b/.hermes-plugin/__init__.py
@@ -37,6 +37,25 @@ def _strip_frontmatter(content: str) -> str:
     return (match.group(1) if match else content).strip()
 
 
+def _frontmatter_value(content: str, key: str) -> str:
+    """Return a flat ``key: value`` scalar from a SKILL.md frontmatter block.
+
+    Hermes reads a skill's description from ``register_skill``'s ``description``
+    argument, which defaults to "" — registering only the path left every stock
+    skill with a blank description in the skill catalogue, so the model had
+    nothing to select on. Stock frontmatter is a flat block of single-line
+    scalars, so a line scan covers it without a YAML dependency.
+    """
+    match = re.match(r"^---\n([\s\S]*?)\n---\n", content)
+    if not match:
+        return ""
+    for line in match.group(1).splitlines():
+        name, sep, value = line.partition(":")
+        if sep and name.strip() == key:
+            return value.strip().strip("\"'")
+    return ""
+
+
 def _build_bootstrap(skills_dir: str) -> str:
     with open(
         os.path.join(skills_dir, "using-superpowers", "SKILL.md"),
@@ -82,7 +101,9 @@ def register(ctx):
     for name in sorted(os.listdir(skills_dir)):
         skill_md = os.path.join(skills_dir, name, "SKILL.md")
         if os.path.isfile(skill_md):
-            ctx.register_skill(name, Path(skill_md))
+            with open(skill_md, encoding="utf-8") as f:
+                description = _frontmatter_value(f.read(), "description")
+            ctx.register_skill(name, Path(skill_md), description=description)
 
     # pre_llm_call returning {"context": ...} is the documented injection path
     # (on_session_start return values are ignored, and ctx.inject_message

--- a/tests/hermes/conftest.py
+++ b/tests/hermes/conftest.py
@@ -9,11 +9,12 @@ def mock_ctx():
     ctx = MagicMock()
     ctx._hooks = {}
     ctx._skills = {}
+    ctx._descriptions = {}
 
     def register_hook(event, fn):
         ctx._hooks[event] = fn
 
-    def register_skill(name, path):
+    def register_skill(name, path, description="", frontmatter=None):
         # Mimic hermes' real register_skill, which calls path.exists() and
         # therefore breaks on a str (the bug that silently disabled the whole
         # plugin, found 2026-07-23). Keeping that fidelity here means a
@@ -24,6 +25,7 @@ def mock_ctx():
                 f"register_skill requires a pathlib.Path, got {type(path).__name__}"
             )
         ctx._skills[name] = path
+        ctx._descriptions[name] = description
 
     ctx.register_hook.side_effect = register_hook
     ctx.register_skill.side_effect = register_skill

--- a/tests/hermes/test_plugin.py
+++ b/tests/hermes/test_plugin.py
@@ -1,6 +1,7 @@
 import importlib
 import importlib.util
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -140,3 +141,38 @@ class TestLayoutResolution:
         mod = self._load_from(plugdir)
         with pytest.raises(RuntimeError, match="cannot find the skills"):
             mod.register(mock_ctx)
+
+
+class TestSkillDescriptions:
+    """Hermes builds its skill catalogue from register_skill(description=...),
+    which defaults to "". Registering the path alone left every stock skill
+    blank in that catalogue, so the model had nothing to select on."""
+
+    def test_every_stock_skill_registers_a_description(self, mock_ctx):
+        plugin = _load_plugin()
+        plugin.register(mock_ctx)
+        assert set(mock_ctx._descriptions) == set(mock_ctx._skills)
+        blank = sorted(n for n, d in mock_ctx._descriptions.items() if not d.strip())
+        assert blank == [], f"registered without a description: {blank}"
+
+    def test_descriptions_match_the_skill_frontmatter(self, mock_ctx):
+        plugin = _load_plugin()
+        plugin.register(mock_ctx)
+        skills_dir = Path(plugin._skills_dir())
+        for name, description in mock_ctx._descriptions.items():
+            text = (skills_dir / name / "SKILL.md").read_text(encoding="utf-8")
+            declared = re.search(r"^description:\s*(.+)$", text, re.M).group(1)
+            assert description == declared.strip().strip('"').strip("'")
+
+    @pytest.mark.parametrize(
+        "block, expected",
+        [
+            ('---\nname: demo\ndescription: "Quoted value."\n---\nbody', "Quoted value."),
+            ("---\nname: demo\ndescription: Bare value\n---\nbody", "Bare value"),
+            ("---\nname: demo\n---\nbody", ""),
+            ("no frontmatter at all", ""),
+        ],
+    )
+    def test_frontmatter_value_parsing(self, block, expected):
+        plugin = _load_plugin()
+        assert plugin._frontmatter_value(block, "description") == expected


### PR DESCRIPTION
# What this fixes

Every skill this plugin registers appears in Hermes' skill catalogue with an
**empty description**, so an agent looking at the catalogue cannot tell what any
of the 14 skills do, or when to load one.

Concretely, before this change, a Hermes session registers the plugin and sees:

```
superpowers:brainstorming                 -> ""
superpowers:dispatching-parallel-agents   -> ""
superpowers:systematic-debugging          -> ""
... 14 skills, 14 empty descriptions
```

After:

```
superpowers:brainstorming                 -> "You MUST use this before any creative work - ..."
superpowers:dispatching-parallel-agents   -> "Use when facing 2+ independent tasks that can ..."
superpowers:systematic-debugging          -> "Use when encountering any bug, test failure, or ..."
```

The cause is one argument. Hermes reads a skill's catalogue description from
`register_skill(description=...)`, and that parameter defaults to `""`. The
integration was passing a name and a path and nothing else:

```python
ctx.register_skill(name, Path(skill_md))          # description defaults to ""
```

The skills themselves were never the problem: every `SKILL.md` carries a
description in its frontmatter, it just never reached the catalogue.

# The diff at a glance

| Change | Effect |
|--------|--------|
| New `_frontmatter_value(content, key)` in `.hermes-plugin/__init__.py` | Reads one flat `key: value` scalar out of the frontmatter block. No YAML dependency; same regex approach as the module's existing `_strip_frontmatter`. |
| `ctx.register_skill(name, Path(skill_md), description=description)` | The actual fix: the description now reaches the catalogue. |
| `tests/hermes/conftest.py`: `register_skill(name, path, description="", frontmatter=None)` | The harness double only accepted `(name, path)`, so it could not have caught this drift from the real Hermes signature. |
| `tests/hermes/test_plugin.py`: 6 new tests | One asserts every registered skill carries a description matching its `SKILL.md`; one unit-tests the parser for quoted, bare, missing-key and no-frontmatter cases. |

# Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | `deepseek/deepseek-v4.1-flash:nitro` via OpenRouter |
| Harness + version | Hermes Agent v0.21.1 (2026.9.7), upstream `698ab88a`, CLI on Ubuntu 26.04.1 |
| All plugins installed | `superpowers` 6.3.0 (git, pinned `b36e0829`), `herdr-agent-state` 1.0 |
| Human partner who reviewed this diff | Pepijn Blom (@pepijn-blom) reviewed the complete diff and approved submission (2026-09-11) |

Drafted by an agent under human review, with the environment fully disclosed
above. The bug was found in a live Hermes session, not by trawling the tracker.

# What problem are you trying to solve?

No issue filed; reproducing it in full. Say the word and I'll open one first if
that's the preferred order.

`tools/skills_tool.py` builds the `skills_list` payload from
`list_plugin_skill_metadata()`, which returns the `description` recorded for
each `register_skill` call. Because the argument defaulted to `""`, this
plugin's 14 catalogue entries carried no description at all.

Why it matters rather than being cosmetic: the catalogue is the surface a model
selects from. Shipping 14 skills that are listed with no description means the
agent has nothing to match a task against when deciding which skill applies,
which works directly against what these skills exist for. It is also
self-inconsistent, since the descriptions are right there in the files.

# Is this change appropriate for the core library?

Yes. This is plugin infrastructure shipped to every Hermes user, not repo
behaviour, and the defect is visible to any Hermes session with this plugin
installed. No dependencies are added.

# What alternatives did you consider?

- **Passing the whole parsed frontmatter mapping too.** Rejected as unnecessary
  surface: Hermes reads the catalogue description from the `description`
  argument specifically, and stock frontmatter carries only `name` and
  `description`.
- **Using a YAML parser to read the frontmatter.** Rejected: this repo is
  deliberately harness-agnostic and declares no Python dependencies. The
  existing module already parses frontmatter with a regex.
- **Restructuring the registration loop.** Rejected; the change is three lines
  inside the existing loop, so the diff stays reviewable.

# Does this PR contain multiple unrelated changes?

No. One fix plus its tests. The `conftest.py` change is required by the fix,
not incidental.

# Existing PRs

I reviewed open and closed PRs and issues touching the Hermes integration.
Related but non-overlapping: #2157 / #2162 (stale tool mapping in
`skills/using-superpowers/references/hermes-tools.md`) and #2181 (install
verdict). None touch skill registration or the `description` argument, and this
PR does not modify `hermes-tools.md`.

# Environment tested

| Harness | Harness version | Model | Model version/ID |
|---------|-----------------|-------|------------------|
| Hermes Agent (CLI) | v0.21.1 (2026.9.7), upstream `698ab88a` | n/a for the unit tests | `deepseek/deepseek-v4.1-flash:nitro` via OpenRouter |

`pytest tests/hermes/`: **25 passed**. With only `.hermes-plugin/__init__.py`
reverted and the new tests kept, **all 6 fail** (`test_frontmatter_value_parsing`
on the missing attribute, the two integration tests on blank descriptions).

Verified end-to-end against Hermes' own catalogue API rather than only in unit
tests, since that is the code path users actually hit. Both variants of the
plugin were staged into throwaway `HERMES_HOME` directories and loaded through
the real discovery path (`PluginManager.discover_and_load()`), then read back
with `list_plugin_skill_metadata()`, the same call `tools/skills_tool.py` uses
to build `skills_list`:

```
variant : base  (upstream v6.3.0 module)  ->  skills in catalog: 14   blank descriptions: 14
variant : fixed (this PR)                 ->  skills in catalog: 14   blank descriptions:  0
```

The reproducer is a standalone script; happy to paste it in a comment, or to
contribute it under `tests/hermes/` if you would rather have the end-to-end
check in-tree than only the unit-level one.

# New harness support (required if this PR adds a new harness)

N/A -- this PR does not add a harness. It corrects the existing Hermes
integration.
