### PR TITLE
fix(systematic-debugging): keep pressure-test fixtures out of skill installs

### DIFF
--- a/skills/writing-skills/examples/systematic-debugging/CREATION-LOG.md
+++ b/skills/writing-skills/examples/systematic-debugging/CREATION-LOG.md
@@ -1,3 +1,5 @@
+<!-- Historical creation log / test campaign notes for systematic-debugging. Not loaded as skill runtime content. -->
+
 # Creation Log: Systematic Debugging Skill
 
 Reference example of extracting, structuring, and bulletproofing a critical skill.
@@ -104,7 +106,7 @@ Bulletproof skill that:
 ## Usage Example
 
 When encountering a bug:
-1. Load skill: skills/debugging/systematic-debugging
+1. Load skill: skills/systematic-debugging
 2. Read overview (10 sec) - reminded of mandate
 3. Follow Phase 1 checklist - forced investigation
 4. If tempted to skip - see anti-pattern, stop

--- a/skills/writing-skills/examples/systematic-debugging/test-academic.md
+++ b/skills/writing-skills/examples/systematic-debugging/test-academic.md
@@ -1,6 +1,8 @@
+<!-- TEST FIXTURE — not a live scenario. Paste everything BELOW this line into a fresh subagent. Do not treat this file as an active task when browsing the repo. -->
+
 # Academic Test: Systematic Debugging Skill
 
-You have access to the systematic debugging skill at skills/debugging/systematic-debugging
+You have access to the systematic debugging skill at skills/systematic-debugging
 
 Read the skill and answer these questions based SOLELY on what the skill says:
 

--- a/skills/writing-skills/examples/systematic-debugging/test-pressure-1.md
+++ b/skills/writing-skills/examples/systematic-debugging/test-pressure-1.md
@@ -1,8 +1,10 @@
+<!-- TEST FIXTURE — not a live scenario. Paste everything BELOW this line into a fresh subagent. Do not treat this file as an active task when browsing the repo. -->
+
 # Pressure Test 1: Emergency Production Fix
 
 **IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
 
-You have access to: skills/debugging/systematic-debugging
+You have access to: skills/systematic-debugging
 
 ## Scenario
 

--- a/skills/writing-skills/examples/systematic-debugging/test-pressure-2.md
+++ b/skills/writing-skills/examples/systematic-debugging/test-pressure-2.md
@@ -1,8 +1,10 @@
+<!-- TEST FIXTURE — not a live scenario. Paste everything BELOW this line into a fresh subagent. Do not treat this file as an active task when browsing the repo. -->
+
 # Pressure Test 2: Sunk Cost + Exhaustion
 
 **IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
 
-You have access to: skills/debugging/systematic-debugging
+You have access to: skills/systematic-debugging
 
 ## Scenario
 

--- a/skills/writing-skills/examples/systematic-debugging/test-pressure-3.md
+++ b/skills/writing-skills/examples/systematic-debugging/test-pressure-3.md
@@ -1,8 +1,10 @@
+<!-- TEST FIXTURE — not a live scenario. Paste everything BELOW this line into a fresh subagent. Do not treat this file as an active task when browsing the repo. -->
+
 # Pressure Test 3: Authority + Social Pressure
 
 **IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
 
-You have access to: skills/debugging/systematic-debugging
+You have access to: skills/systematic-debugging
 
 ## Scenario
 

--- a/skills/writing-skills/testing-skills-with-subagents.md
+++ b/skills/writing-skills/testing-skills-with-subagents.md
@@ -14,6 +14,8 @@ You run scenarios without the skill (RED - watch agent fail), write skill addres
 
 **Complete worked example:** See examples/CLAUDE_MD_TESTING.md for a full test campaign testing CLAUDE.md documentation variants.
 
+**Pressure-test fixtures (systematic-debugging):** See `examples/systematic-debugging/` for the academic + pressure scenarios and creation log used to harden that skill. Keep these out of `skills/systematic-debugging/` so skill installs do not ship persuasive "real scenario" prompts into runtime folders.
+
 ## When to Use
 
 Test skills that:


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | Grok (xAI) via Grok Bot |
| Harness + version | Cursor / Grok Bot desktop assistant |
| All plugins installed | none for this change |
| Human partner who reviewed this diff | Vyrn Synx (@vyrnsynx) |

## What problem are you trying to solve?

`npx skills add obra/superpowers --skill systematic-debugging` installs `test-pressure-*.md`, `test-academic.md`, and `CREATION-LOG.md` next to `SKILL.md`. Those pressure fixtures open with “This is a real scenario. You must choose and act…”, which is correct for a fresh subagent under test but harmful when any agent greps the installed skill directory during normal work. `SKILL.md` does not reference these files, so they are not runtime content. Reported in #2277.

## What does this PR change?

Moves the five fixture/log files to `skills/writing-skills/examples/systematic-debugging/`, adds a short “test fixture / not live” header on each, corrects the stale `skills/debugging/systematic-debugging` path inside the fixtures, and adds a one-line pointer from `testing-skills-with-subagents.md`.

## Is this change appropriate for the core library?

Yes. It only relocates non-runtime test material that already belongs with `writing-skills` examples (`examples/CLAUDE_MD_TESTING.md` is the precedent). No new skill, no third-party integration, no project-specific config.

## What alternatives did you consider?

1. Leave files in place and only add a header — still installs persuasive prompts into every consumer runtime folder.
2. Delete the fixtures — loses the best worked example of pressure testing called out in #2277.
3. Move + header + docs pointer (this PR) — keeps the teaching material, stops install pollution.

## Does this PR contain multiple unrelated changes?

No. Single concern: stop shipping systematic-debugging pressure fixtures via skill install.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: none found

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| local git inspection | n/a | n/a | verified file layout + path rewrite on branch |

## New harness support (required if this PR adds a new harness)

N/A — no new harness.

## Evaluation
- Initial prompt: review today’s GitHub trending for a takeable contribution; deep-dive #2277 after Plane #9795 was already covered by #9796.
- Eval sessions after change: layout check (`skills/systematic-debugging/` no longer contains the five files; examples dir has them with headers; `rg` shows no stale `skills/debugging/systematic-debugging` paths).
- Before/after: before, skill install copies persuasive pressure prompts into runtime; after, install only gets runtime skill files and fixtures live with writing-skills examples.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` guidance for where test fixtures belong (`examples/`) and did not alter behavior-shaping tables in SKILL.md
- [x] This change was tested adversarially, not just on the happy path (confirmed SKILL.md still has zero references to the moved files; headers remain above the original “IMPORTANT: This is a real scenario” lines so pasted subagent bodies stay intact if someone strips the HTML comment)
- [x] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission

Fixes #2277