### PR TITLE
fix(finishing): surface surviving Superpowers scratch before worktree removal

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -167,7 +167,33 @@ Step 2, from before that directory change.
 **If `GIT_DIR == GIT_COMMON`:** Normal repo, no worktree to clean up. Done.
 
 **If `WORKTREE_PATH` is under `.worktrees/` or `worktrees/`:** Superpowers
-created this worktree — we own cleanup:
+created this worktree — we own cleanup. First check for surviving
+Superpowers scratch: `scripts/sdd-workspace` gives `.superpowers/sdd/` a
+self-ignoring `.gitignore`, and brainstorm mockups live under
+`.superpowers/brainstorm/`. None of it makes the worktree dirty, so
+removal will not refuse for it:
+
+```bash
+find "$WORKTREE_PATH/.superpowers" -type f 2>/dev/null
+```
+
+**If that lists anything**: the worktree holds plan workspaces, progress
+ledgers, rulings, implementer/reviewer reports, or design mockups that
+exist nowhere else. Show your human partner what is at stake and ask:
+
+```
+Worktree holds Superpowers scratch that was never finished:
+
+<file list>
+
+1. Move it into <main repo root> before cleanup
+2. Keep the worktree in place
+3. Delete it (unrecoverable)
+
+Which?
+```
+
+Carry out the choice — option 2 stops here — then remove the worktree:
 
 ```bash
 git worktree remove "$WORKTREE_PATH"

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -484,6 +484,12 @@ delete this plan's workspace (`rm -rf <workspace>`) — the git history is
 the record now. Sibling directories belong to other plans; leave them
 alone.
 
+If the run ends any other way — abandoned, compacted mid-run, or stopped
+before the final review came back clean — leave this plan's workspace in
+place. The ledger and reports are the only copy of what was decided;
+finishing-a-development-branch preserves a surviving workspace instead of
+silently removing it with the worktree.
+
 Use superpowers:finishing-a-development-branch.
 
 ## Common Rationalizations


### PR DESCRIPTION
## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GLM (GLM-5.3-Flash) |
| Harness + version | ZCode agent CLI (Windows 11, Git Bash, git 2.55.0.windows.2) |
| All plugins installed | None — worked against a plain checkout of `dev` |
| Human partner who reviewed this diff | Oscar (@Oscar-Williams) — reviewed the complete proposed diff and the verification transcript, required a full diff review before submission (which surfaced the `.superpowers/` scope widening and the `find -type f` change), and approved submission |

> Targets `dev`.

Fixes #2207

## What problem are you trying to solve?

Step 6 of `finishing-a-development-branch` protects uncommitted work by relying on `git worktree remove` refusing — but that refusal only covers modified and untracked files. `scripts/sdd-workspace` deliberately gives `.superpowers/sdd/` a self-ignoring `.gitignore`, so a worktree whose only extra content is an SDD workspace reports a clean status, removal succeeds with exit 0, and the plan's progress ledger, rulings, and implementer/reviewer reports are destroyed silently. The issue's repro reproduces exactly as written (status empty → remove exit 0 → `progress.md` gone). Brainstorm mockups under `.superpowers/brainstorm/` hit the same gap when the user ignores `.superpowers/` as the brainstorming skill suggests.

## What does this PR change?

Step 6 now checks for surviving Superpowers scratch under `.superpowers/` *before* `git worktree remove` and shows the human partner the same show-and-ask prompt style the refusal branch already uses (move into the main repo root / keep the worktree / delete). `subagent-driven-development`'s Finish section now says to leave the workspace in place when a run ends any other way. Two files, +33/−1, prose only.

## Is this change appropriate for the core library?

Yes — both files are core skills, the scratch layout is created by core `scripts/sdd-workspace` and the brainstorming skill, and the guard protects any user's unique decision records and mockups, not a specific project or third-party integration.

## What alternatives did you consider?

- Widening the pre-removal check to all ignored content (`git status --porcelain -uall --ignored=matching`): rejected — worktrees routinely hold reconstructable ignored output (dependency trees, caches), and prompting on all of it trains the operator to dismiss the prompt. The issue reporter flagged the same concern; the `.superpowers/`-scoped check kept the noise profile at zero in the tests below.
- Fixing only the SDD §Finish side (what to do when a run ends early): keeps the boundary unguarded whenever the workspace outlives the run for any other reason. The two changes here are complementary; each is one focused block.

## Does this PR contain multiple unrelated changes?

No — both edits close the same gap from its two ends (the boundary guard and the controller's instruction).

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #2024 (merged — introduced the removal-refusal prompt this PR extends to the ignored case), #1223 (closed — Step 1 clean-tree guard and cwd handling, different section and problem). No PR references #2207 or fixes ignored-content loss.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Plain bash + git checkout (no agent harness) | Windows 11, Git Bash | same as disclosed above | — |

## New harness support

N/A — this PR does not add harness support.

## Evaluation
- Initial prompt: triaging #2207 — the issue's 10-line repro is the failing case.
- Behavior-level verification on real worktrees (6 scenarios): ignored-only SDD workspace (check fires, workspace preserved), clean worktree (silent, no false positive), ignored build junk without `.superpowers/` (silent — no noise regression vs. an `--ignored=matching` approach), empty `.superpowers/sdd/` shell left after §Finish (silent), a workspace created by the real upstream `scripts/sdd-workspace` (fires), and brainstorm mockups only (fires).
- Pressure scenario per writing-skills (two subagents, same prompt except the Step 6 text): **without the fix**, the agent removed the worktree with no prompt, treating an earlier "looks good, wrap it up" as covering the scratch — the ledger was destroyed. **With the fix**, the agent ran the check, listed the three scratch files, and stopped at the three-way prompt with the worktree and all files intact.
- Not done: multi-session evals inside a superpowers-enabled harness — the authoring environment has no such harness. The changed decision rule is verified at the git-behavior and subagent level above; the prose around it reuses #2024's existing prompt structure unchanged.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
      — *testing methodology followed from this repo's `skills/writing-skills` (baseline vs. with-skill pressure scenario, §Testing); both runs are pasted under Evaluation. The full authoring workflow was not needed for a guard addition of this size, and no plugin install was available in this environment.*
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement
      — *no tuned table, rationalization row, or existing prompt line was modified; the new block only reuses the existing show-and-ask structure.*

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
      — *Oscar (@Oscar-Williams) reviewed the full diff (patch against `dev` @ 5940bd8) and the verification transcript before this PR was opened, and confirmed submission after the two review fixes.*

**Personal verification (@Oscar-Williams, Windows 11, git 2.55.0.windows.2):** I re-ran the issue's reproduction myself — `git status --porcelain -uall` in the worktree was empty, `git worktree remove` exited 0 without refusal, and the plan's `progress.md` was gone. I then checked out this branch and ran the new pre-removal check (`find "$WORKTREE_PATH/.superpowers" -type f`) against the same setup — it listed the scratch files, so Step 6 now stops and asks instead of deleting.
