### PR TITLE
fix(writing-plans): require produced expected values in verification steps

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -137,6 +137,7 @@ Every step must contain the actual content an engineer needs. These are **plan f
 - "Similar to Task N" (repeat the code — the engineer may be reading tasks out of order)
 - Steps that describe what to do without showing how (code blocks required for code steps)
 - References to types, functions, or methods not defined in any task
+- An expected count, output, or match you did not produce by running the command against the real tree — run it while writing the plan and paste the real value, or describe what to observe and compare two independently derived counts
 
 ## Self-Review
 
@@ -147,6 +148,8 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 **2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
 
 **3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+**4. Self-contradiction check:** for every verification command, ask whether text this plan introduces elsewhere would match it. A step that greps for a word the plan itself adds will return a count the author did not anticipate, or can become unsatisfiable outright.
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 


### PR DESCRIPTION
> Targets `dev`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GLM (GLM-5.3-Flash) |
| Harness + version | ZCode agent CLI (Windows 11, Git Bash, git 2.55.0.windows.2) |
| All plugins installed | None — plain checkout of `dev` |
| Human partner who reviewed this diff | Oscar (@Oscar-Williams) — reviewed the complete diff and the verification transcript, approved submission |

Fixes #2285

## What problem are you trying to solve?

A verification step like `grep -c "pattern" file` / `Expected: 4` asserts the result of a command the plan author never ran. A wrong expectation reports correct work as broken and pressures the implementer to bend working code to match the guess (#2285: four wrong expectations across three plans, two caused by the plan's own inserted text).

## What does this PR change?

Two prose additions to `writing-plans`, as proposed in #2285: the No Placeholders list rejects expected values that were not produced by running the command (paste the real value, or compare two independently derived counts), and Self-Review gains a fourth check for verification commands contradicted by the plan's own text. +3 lines.

## Is this change appropriate for the core library?

Yes — core skill, harness-agnostic rule; `executing-plans` and `subagent-driven-development` consume plans but never author expectations, so the rule belongs upstream.

## What alternatives did you consider?

- A run-time check in executing-plans for unsatisfiable verifications: wrong owner — only the author can produce the real value.
- Requiring pasted command output for every step: too heavy for qualitative verifications, which the new rule allows in descriptive form.

## Does this PR contain multiple unrelated changes?

No — both additions are the authoring-time and review-time halves of one rule.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related: none found for #2285; nearest issues #2092/#2046 are different defects in different mechanisms.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Plain document review (no harness) | Windows 11, Git Bash | same as disclosed above | — |

## New harness support

N/A — no harness support added.

## Evaluation
- Failing case: #2285's own example, built as a two-task plan whose only defects are the two the rule targets.
- Pressure test per writing-skills (two subagents, identical plan and instructions, only the skill text differing): without the fix — "Self-review passed, no issues found"; with the fix — both defects flagged by name (Self-Review #4, No Placeholders) plus a compliant repair (baseline count N, expect N+1).
- Not done: multi-session evals in a superpowers-enabled harness (unavailable here); this was a wording-level micro-test.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
      — *methodology followed from this repo's `skills/writing-skills` (baseline vs. with-skill micro-test); runs pasted under Evaluation.*
- [x] This change was tested adversarially, not just on the happy path
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement
      — *the diff is three added lines; nothing existing was modified or removed.*

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
      — *Oscar (@Oscar-Williams) reviewed the full diff (patch against `dev` @ 5940bd8) and the verification transcript before submission.*
