### PR TITLE
fix(executing-plans): handle plans that are not code changes in a git repo

### DIFF
--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -16,6 +16,9 @@ Load plan, review critically, execute all tasks, report when complete.
 ## The Process
 
 ### Step 1: Load and Review Plan
+
+**Entry check:** does this plan produce code changes in a git-tracked project? If the working directory is not a git repository, or the plan's deliverable is not code changes, skip the worktree step below and skip Step 3 — execute the tasks, then report completion.
+
 1. Ensure an isolated workspace: use superpowers:using-git-worktrees to create one or verify the existing one
 2. Read plan file
 3. Review critically - identify any questions or concerns about the plan
@@ -31,6 +34,8 @@ For each task:
 4. Mark as completed
 
 ### Step 3: Complete Development
+
+Code-change plans in a git-tracked project only (see the Step 1 entry check) — anything else reports completion instead.
 
 After all tasks complete and verified:
 - Announce: "I'm using the finishing-a-development-branch skill to complete this work."


### PR DESCRIPTION
> Targets `dev`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GLM (GLM-5.3-Flash) |
| Harness + version | ZCode agent CLI (Windows 11, Git Bash, git 2.55.0.windows.2) |
| All plugins installed | None — plain checkout of `dev` |
| Human partner who reviewed this diff | Oscar (@Oscar-Williams) — reviewed the complete diff and the verification transcript, approved submission |

Fixes #2290

## What problem are you trying to solve?

Step 1 unconditionally requires a `using-git-worktrees` workspace and Step 3 unconditionally hands off to `finishing-a-development-branch`, so executing a plan whose deliverable is not a code change — or whose working directory is not a git repository — forces the agent to fabricate a git repo or quietly improvise past a required sub-skill. In my baseline run of the exact scenario, the agent ran `git init` in a non-git directory, committed twice, opened and merged a feature branch, and executed the finishing flow — none of it requested.

## What does this PR change?

An entry check at the top of Step 1 ("does this plan produce code changes in a git-tracked project?") routes non-code or non-git plans straight to task execution and a completion report, skipping the worktree step and Step 3; Step 3 states it applies to code-change plans only. +5 lines, prose only — the Step 2 task loop is unchanged, as #2290 notes it is already deliverable-agnostic.

## Is this change appropriate for the core library?

Yes — `executing-plans` is a core skill, and Claude Code's Plan Mode produces plans for any kind of task; the entry condition applies to anyone executing a non-code plan.

## What alternatives did you consider?

- A separate "executing non-code plans" skill: premature — only the git bookends in Steps 1 and 3 differ, per #2290.
- Leaving it to the executing agent's judgment: that is the current state, and it is the failure mode.

## Does this PR contain multiple unrelated changes?

No — both edits are the two ends of the same entry condition (route at Step 1, scope note at Step 3).

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related: none found for #2290; #2241 (open) covers a different gap and is untouched. Open PR #1297 reshapes worktree promotion but is stale (last updated July) and does not edit `executing-plans`.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Plain bash + git checkout (no harness) | Windows 11, Git Bash | same as disclosed above | — |

## New harness support

N/A — no harness support added.

## Evaluation
- Failing case: #2290's scenario, staged as a real non-git directory with a one-task document-deliverable plan.
- Pressure test per writing-skills (two subagents, identical rigs, only the skill text differing): without the fix — `git init -b main` in the non-git directory, two commits, feature branch merged, finishing flow executed unasked; with the fix — routed straight to task execution, `proposal.md` written, completion reported, zero mutating git commands.
- Not done: multi-session evals in a superpowers-enabled harness (unavailable here); behavior-level micro-test of the changed decision rule.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
      — *methodology followed from this repo's `skills/writing-skills` (baseline vs. with-skill runs); results under Evaluation.*
- [x] This change was tested adversarially, not just on the happy path
      — *the plan was fully compliant for every existing check, so only the new entry condition could differ between arms.*
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement
      — *five added lines; nothing existing was modified or removed.*

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
      — *Oscar (@Oscar-Williams) reviewed the full diff (patch against `dev` @ 5940bd8) and the verification transcript before submission.*
