### PR TITLE
fix(sdd): record dispatches in the ledger so outages do not re-dispatch committed work

### DIFF
--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -141,8 +141,15 @@ a ledger file, not only in todos.
 - Check for this plan's ledger at `<workspace>/progress.md`. If its first
   line names your plan file, tasks with a `Task <N>: complete` line are DONE
   — do not re-dispatch them; resume at the first task without one. A task
-  whose last line is a fix round is mid-loop: resume the loop at the next
-  round. A ledger whose first line names a different plan file — or a stray
+  whose last line is `Task <N>: dispatched (base <base7>, …)` was
+  interrupted mid-flight — do not re-dispatch it blind. Run
+  `git log <base7>..HEAD` with the base from that line: no commits means
+  the implementer landed nothing, so re-dispatch normally; commits present
+  means the work exists but was never reviewed — do not re-implement.
+  Generate the review package (`scripts/review-package <plan-file> <base7>
+  HEAD`) and dispatch the task reviewer, entering the normal review loop.
+  A task whose last line is a fix round is mid-loop: resume the loop at the
+  next round. A ledger whose first line names a different plan file — or a stray
   ledger at the old flat path `.superpowers/sdd/progress.md` — is another
   plan's progress: leave it in place and start your own, fresh.
 - Create the ledger with its identity as the first line:
@@ -260,6 +267,10 @@ and fix-round diffs need it.
   (5) the report-file path and report contract. Exact values (numbers,
   magic strings, signatures, test cases) appear only in the brief. Never
   make a subagent read the whole plan file.
+- **Ledger the dispatch:** before the implementer starts, append
+  `Task <N>: dispatched (base <base7>, brief <brief-path>)` to the ledger.
+  An outage between dispatch and a clean review must leave the resuming
+  controller a record — the resume rule's `dispatched` state reads it.
 - **Report file:** name the implementer's report file after the brief
   (brief `…/task-N-brief.md` → report `…/task-N-report.md`) and put it in
   the dispatch prompt. The implementer writes the full report there and


### PR DESCRIPTION
> Targets `dev`.

## Who is submitting this PR? (required)

| Field | Value |
|-------|-------|
| Your model + version | GLM (GLM-5.3-Flash) |
| Harness + version | ZCode agent CLI (Windows 11, Git Bash, git 2.55.0.windows.2) |
| All plugins installed | None — plain checkout of `dev` |
| Human partner who reviewed this diff | Oscar (@Oscar-Williams) — reviewed the complete diff and the verification transcript, approved submission |

Fixes #2293

## What problem are you trying to solve?

The ledger only records completions and the resume rule is binary, so a task interrupted between dispatch and a clean review looks like one never started — the resuming controller re-dispatches the implementer against a tree that already holds the task's commits, and BASE dies with the old controller's context, inviting the `HEAD~1` mistake the skill warns against. In my baseline run, the controller re-dispatched and rationalized the already-present Task-2 commits as Task 1's work — the exact "second, divergent implementation" worst case #2293 describes.

## What does this PR change?

Dispatches now append `Task <N>: dispatched (base <base7>, brief <brief-path>)` to the ledger, and the resume rule gains the dispatched state: `git log <base>..HEAD` with no commits means re-dispatch normally; commits present means generate the review package from the recorded base and enter the review loop instead of re-implementing. Append-only and keyword-distinguishable, so existing ledgers need no migration. +13/−2, one file.

## Is this change appropriate for the core library?

Yes — this is the SDD controller's own recovery map, harness-agnostic, and the gap applies to any session that dies mid-task.

## What alternatives did you consider?

- Recovering BASE from `git log` heuristics at resume time: rejected — a resumed controller cannot tell which commits belong to which task, and the skill itself calls the HEAD~1 shortcut a silent dropper.
- Waiting for #2282's dispatch precondition first: the two compose, but recording the dispatch is strictly additive on its own.

## Does this PR contain multiple unrelated changes?

No — the dispatched line and the resume rule are the write and read sides of one mechanism.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related: none found for #2293; #2282 is complementary, #2267 and closed #1936 are different ledger axes, as the issue already sorts out.

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| Plain bash + git checkout (no harness) | Windows 11, Git Bash | same as disclosed above | — |

## New harness support

N/A — no harness support added.

## Evaluation
- Failing case: #2293's outage scenario, staged as a real git rig — Task 1 complete, Task 2 `dispatched (base 877bc95, …)`, HEAD two unreviewed commits past base.
- Pressure test per writing-skills (two subagents resuming the same rig, only the resume rule differing): without the fix — re-dispatched the implementer, bending the ledger's attribution to fit; with the fix — ran `git log 877bc95..HEAD`, found the commits, dispatched the task reviewer with a full review framing, no re-implementation.
- Not done: multi-session evals in a superpowers-enabled harness (unavailable here); behavior-level micro-test of the changed resume rule.

## Rigor

- [x] If this is a skills change: I used `superpowers:writing-skills` and
      completed adversarial pressure testing (paste results below)
      — *methodology followed from this repo's `skills/writing-skills` (baseline vs. with-skill resume decision); results under Evaluation.*
- [x] This change was tested adversarially, not just on the happy path
      — *the rig forced the awkward case: commits present, review never run, bookkeeping uncommitted.*
- [x] I did not modify carefully-tuned content (Red Flags table,
      rationalizations, "human partner" language) without extensive evals
      showing the change is an improvement
      — *completion-line formats, fix-round rule, and stray-ledger rule unchanged; the resume rule gains one state.*

## Human review
- [x] A human has reviewed the COMPLETE proposed diff before submission
      — *Oscar (@Oscar-Williams) reviewed the full diff (patch against `dev` @ 5940bd8) and the verification transcript before submission.*
